### PR TITLE
More reasonable transformation variable names

### DIFF
--- a/src/ModelingToolkit.jl
+++ b/src/ModelingToolkit.jl
@@ -81,6 +81,18 @@ include("variables.jl")
 include("context_dsl.jl")
 include("operations.jl")
 include("differentials.jl")
+
+function Base.convert(::Type{Variable},x::Operation)
+    if x.op isa Variable
+        x.op
+    elseif x.op isa Differential
+        var = x.args[1].op
+        rename(var,Symbol(var.name,:ˍ,x.args[1].args[1].op.name))
+    else
+        throw(error("This Operation is not a Variable"))
+    end
+end
+
 include("equations.jl")
 include("function_registration.jl")
 include("simplify.jl")

--- a/src/operations.jl
+++ b/src/operations.jl
@@ -66,9 +66,6 @@ Operation(x) = convert(Operation, x)
 #convert to Expr
 Base.Expr(op::Operation) = simplified_expr(op)
 Base.convert(::Type{Expr},x::Operation) = Expr(x)
-function Base.convert(::Type{Variable},x::Operation)
-    x.op isa Variable ? x.op : throw(error("This Operation is not a Variable"))
-end
 
 # promotion
 Base.promote_rule(::Type{<:Constant}, ::Type{<:Operation}) = Operation

--- a/src/systems/abstractsystem.jl
+++ b/src/systems/abstractsystem.jl
@@ -25,7 +25,7 @@ function Base.getproperty(sys::AbstractSystem, name::Symbol)
     throw(error("Variable $name does not exist"))
 end
 
-renamespace(namespace,name) = Symbol(string(namespace)*"′"*string(name))
+renamespace(namespace,name) = Symbol(string(namespace)*"₊"*string(name))
 
 function namespace_variables(sys::AbstractSystem)
     [rename(x,renamespace(sys.name,x.name)) for x in states(sys)]
@@ -62,22 +62,22 @@ end
 
 function states(sys::AbstractSystem,name::Symbol)
     x = sys.states[findfirst(x->x.name==name,sys.states)]
-    Variable(Symbol(string(sys.name)*"′"*string(x.name)))(sys.iv())
+    Variable(Symbol(string(sys.name)*"₊"*string(x.name)))(sys.iv())
 end
 
 function parameters(sys::AbstractSystem,name::Symbol)
     x = sys.ps[findfirst(x->x.name==name,sys.ps)]
-    Variable(Symbol(string(sys.name)*"′"*string(x.name)))(sys.iv())
+    Variable(Symbol(string(sys.name)*"₊"*string(x.name)))(sys.iv())
 end
 
 function states(sys::AbstractSystem,args...)
     name = last(args)
-    extra_names = reduce(*,["′$(x.name)" for x in args[1:end-1]])
-    Variable(Symbol(string(sys.name)*extra_names*"′"*string(name)))(sys.iv())
+    extra_names = reduce(*,["₊$(x.name)" for x in args[1:end-1]])
+    Variable(Symbol(string(sys.name)*extra_names*"₊"*string(name)))(sys.iv())
 end
 
 function parameters(sys::AbstractSystem,args...)
     name = last(args)
-    extra_names = reduce(*,["′$(x.name)" for x in args[1:end-1]])
-    Variable(Symbol(string(sys.name)*extra_names*"′"*string(name)))(sys.iv())
+    extra_names = reduce(*,["₊$(x.name)" for x in args[1:end-1]])
+    Variable(Symbol(string(sys.name)*extra_names*"₊"*string(name)))(sys.iv())
 end

--- a/src/systems/abstractsystem.jl
+++ b/src/systems/abstractsystem.jl
@@ -25,7 +25,7 @@ function Base.getproperty(sys::AbstractSystem, name::Symbol)
     throw(error("Variable $name does not exist"))
 end
 
-renamespace(namespace,name) = Symbol(string(namespace)*"₊"*string(name))
+renamespace(namespace,name) = Symbol(namespace,:₊,name)
 
 function namespace_variables(sys::AbstractSystem)
     [rename(x,renamespace(sys.name,x.name)) for x in states(sys)]
@@ -62,22 +62,24 @@ end
 
 function states(sys::AbstractSystem,name::Symbol)
     x = sys.states[findfirst(x->x.name==name,sys.states)]
-    Variable(Symbol(string(sys.name)*"₊"*string(x.name)))(sys.iv())
+    rename(x,renamespace(sys.name,x.name))(sys.iv())
 end
 
 function parameters(sys::AbstractSystem,name::Symbol)
     x = sys.ps[findfirst(x->x.name==name,sys.ps)]
-    Variable(Symbol(string(sys.name)*"₊"*string(x.name)))(sys.iv())
+    rename(x,renamespace(sys.name,x.name))()
 end
 
 function states(sys::AbstractSystem,args...)
     name = last(args)
-    extra_names = reduce(*,["₊$(x.name)" for x in args[1:end-1]])
-    Variable(Symbol(string(sys.name)*extra_names*"₊"*string(name)))(sys.iv())
+    extra_names = reduce(Symbol,[Symbol(:₊,x.name) for x in args[1:end-1]])
+    newname = renamespace(extra_names,name)
+    rename(x,renamespace(sys.name,newname))(sys.iv())
 end
 
 function parameters(sys::AbstractSystem,args...)
     name = last(args)
-    extra_names = reduce(*,["₊$(x.name)" for x in args[1:end-1]])
-    Variable(Symbol(string(sys.name)*extra_names*"₊"*string(name)))(sys.iv())
+    extra_names = reduce(Symbol,[Symbol(:₊,x.name) for x in args[1:end-1]])
+    newname = renamespace(extra_names,name)
+    rename(x,renamespace(sys.name,newname))()
 end

--- a/src/systems/diffeqs/first_order_transform.jl
+++ b/src/systems/diffeqs/first_order_transform.jl
@@ -1,6 +1,6 @@
 function lower_varname(var::Variable, idv, order)
     order == 0 && return var
-    name = Symbol(var.name, :_, string(idv.name)^order)
+    name = Symbol(var.name, :ˍ, string(idv.name)^order)
     return Variable{vartype(var)}(name)
 end
 

--- a/test/components.jl
+++ b/test/components.jl
@@ -42,7 +42,7 @@ prob = ODEProblem(connected1,u0map,(0.0,100.0),parammap,jac=true)
 @test prob.p == [7.0,1.0,2.0,3.0,4.0,5.0,6.0]
 @test prob.u0 isa Vector
 @test prob.p isa SVector
-@test prob.f.syms == [:a,:lorenz1′x,:lorenz1′y,:lorenz1′z,:lorenz2′x,:lorenz2′y,:lorenz2′z]
+@test prob.f.syms == [:a,:lorenz1₊x,:lorenz1₊y,:lorenz1₊z,:lorenz2₊x,:lorenz2₊y,:lorenz2₊z]
 
 eqs_flat = [D(a) ~ a*lorenz1.x,
             D(lorenz1.x) ~ lorenz1.σ*(lorenz1.y-lorenz1.x),
@@ -56,19 +56,19 @@ eqs_flat = [D(a) ~ a*lorenz1.x,
 @test parameters(connected1) == convert.(Variable,[α,lorenz1.σ,lorenz1.ρ,lorenz1.β,lorenz2.σ,lorenz2.ρ,lorenz2.β])
 @test eqs_flat == equations(connected1)
 
-@variables lorenz1′x(t) lorenz1′y(t) lorenz1′z(t) lorenz2′x(t) lorenz2′y(t) lorenz2′z(t)
-@parameters lorenz1′σ lorenz1′ρ lorenz1′β lorenz2′σ lorenz2′ρ lorenz2′β
+@variables lorenz1₊x(t) lorenz1₊y(t) lorenz1₊z(t) lorenz2₊x(t) lorenz2₊y(t) lorenz2₊z(t)
+@parameters lorenz1₊σ lorenz1₊ρ lorenz1₊β lorenz2₊σ lorenz2₊ρ lorenz2₊β
 
-eqs_flat2 = [D(a) ~ a*lorenz1′x,
-            D(lorenz1′x) ~ lorenz1′σ*(lorenz1′y-lorenz1′x),
-            D(lorenz1′y) ~ lorenz1′x*(lorenz1′ρ-lorenz1′z)-lorenz1′y,
-            0 ~ lorenz1′x + lorenz1′y + lorenz1′β*lorenz1′z,
-            D(lorenz2′x) ~ lorenz2′σ*(lorenz2′y-lorenz2′x),
-            D(lorenz2′y) ~ lorenz2′x*(lorenz2′ρ-lorenz2′z)-lorenz2′y,
-            0 ~ lorenz2′x + lorenz2′y + lorenz2′β*lorenz2′z]
+eqs_flat2 = [D(a) ~ a*lorenz1₊x,
+            D(lorenz1₊x) ~ lorenz1₊σ*(lorenz1₊y-lorenz1₊x),
+            D(lorenz1₊y) ~ lorenz1₊x*(lorenz1₊ρ-lorenz1₊z)-lorenz1₊y,
+            0 ~ lorenz1₊x + lorenz1₊y + lorenz1₊β*lorenz1₊z,
+            D(lorenz2₊x) ~ lorenz2₊σ*(lorenz2₊y-lorenz2₊x),
+            D(lorenz2₊y) ~ lorenz2₊x*(lorenz2₊ρ-lorenz2₊z)-lorenz2₊y,
+            0 ~ lorenz2₊x + lorenz2₊y + lorenz2₊β*lorenz2₊z]
 
-@test [x.name for x in states(connected1)] == [:a,:lorenz1′x,:lorenz1′y,:lorenz1′z,:lorenz2′x,:lorenz2′y,:lorenz2′z]
-@test [x.name for x in parameters(connected1)] == [:α,:lorenz1′σ,:lorenz1′ρ,:lorenz1′β,:lorenz2′σ,:lorenz2′ρ,:lorenz2′β]
+@test [x.name for x in states(connected1)] == [:a,:lorenz1₊x,:lorenz1₊y,:lorenz1₊z,:lorenz2₊x,:lorenz2₊y,:lorenz2₊z]
+@test [x.name for x in parameters(connected1)] == [:α,:lorenz1₊σ,:lorenz1₊ρ,:lorenz1₊β,:lorenz2₊σ,:lorenz2₊ρ,:lorenz2₊β]
 @test eqs_flat == equations(connected1)
 
 connected2 = ODESystem(connnectedeqs,t,[a],[α],systems=[lorenz1,lorenz2],name=:connected2)
@@ -104,32 +104,32 @@ eqs_flat = [D(g) ~ g*connected1.lorenz1.x,
 @test eqs_flat == equations(doublelevel)
 
 @test [x.name for x in states(doublelevel)] == [:g,
-                                                :connected1′a,:connected1′lorenz1′x,:connected1′lorenz1′y,:connected1′lorenz1′z,:connected1′lorenz2′x,:connected1′lorenz2′y,:connected1′lorenz2′z,
-                                                :connected2′a,:connected2′lorenz1′x,:connected2′lorenz1′y,:connected2′lorenz1′z,:connected2′lorenz2′x,:connected2′lorenz2′y,:connected2′lorenz2′z]
+                                                :connected1₊a,:connected1₊lorenz1₊x,:connected1₊lorenz1₊y,:connected1₊lorenz1₊z,:connected1₊lorenz2₊x,:connected1₊lorenz2₊y,:connected1₊lorenz2₊z,
+                                                :connected2₊a,:connected2₊lorenz1₊x,:connected2₊lorenz1₊y,:connected2₊lorenz1₊z,:connected2₊lorenz2₊x,:connected2₊lorenz2₊y,:connected2₊lorenz2₊z]
 @test [x.name for x in parameters(doublelevel)] == [:γ,
-                                                   :connected1′α,:connected1′lorenz1′σ,:connected1′lorenz1′ρ,:connected1′lorenz1′β,:connected1′lorenz2′σ,:connected1′lorenz2′ρ,:connected1′lorenz2′β,
-                                                   :connected2′α,:connected2′lorenz1′σ,:connected2′lorenz1′ρ,:connected2′lorenz1′β,:connected2′lorenz2′σ,:connected2′lorenz2′ρ,:connected2′lorenz2′β]
+                                                   :connected1₊α,:connected1₊lorenz1₊σ,:connected1₊lorenz1₊ρ,:connected1₊lorenz1₊β,:connected1₊lorenz2₊σ,:connected1₊lorenz2₊ρ,:connected1₊lorenz2₊β,
+                                                   :connected2₊α,:connected2₊lorenz1₊σ,:connected2₊lorenz1₊ρ,:connected2₊lorenz1₊β,:connected2₊lorenz2₊σ,:connected2₊lorenz2₊ρ,:connected2₊lorenz2₊β]
 
-@variables connected1′a(t) connected1′lorenz1′x(t) connected1′lorenz1′y(t) connected1′lorenz1′z(t) connected1′lorenz2′x(t) connected1′lorenz2′y(t) connected1′lorenz2′z(t)
-@variables connected2′a(t) connected2′lorenz1′x(t) connected2′lorenz1′y(t) connected2′lorenz1′z(t) connected2′lorenz2′x(t) connected2′lorenz2′y(t) connected2′lorenz2′z(t)
-@parameters connected1′α connected1′lorenz1′σ connected1′lorenz1′ρ connected1′lorenz1′β connected1′lorenz2′σ connected1′lorenz2′ρ connected1′lorenz2′β
-@parameters connected2′α connected2′lorenz1′σ connected2′lorenz1′ρ connected2′lorenz1′β connected2′lorenz2′σ connected2′lorenz2′ρ connected2′lorenz2′β
+@variables connected1₊a(t) connected1₊lorenz1₊x(t) connected1₊lorenz1₊y(t) connected1₊lorenz1₊z(t) connected1₊lorenz2₊x(t) connected1₊lorenz2₊y(t) connected1₊lorenz2₊z(t)
+@variables connected2₊a(t) connected2₊lorenz1₊x(t) connected2₊lorenz1₊y(t) connected2₊lorenz1₊z(t) connected2₊lorenz2₊x(t) connected2₊lorenz2₊y(t) connected2₊lorenz2₊z(t)
+@parameters connected1₊α connected1₊lorenz1₊σ connected1₊lorenz1₊ρ connected1₊lorenz1₊β connected1₊lorenz2₊σ connected1₊lorenz2₊ρ connected1₊lorenz2₊β
+@parameters connected2₊α connected2₊lorenz1₊σ connected2₊lorenz1₊ρ connected2₊lorenz1₊β connected2₊lorenz2₊σ connected2₊lorenz2₊ρ connected2₊lorenz2₊β
 
-eqs_flat2 = [D(g) ~ g*connected1′lorenz1′x,
-            D(connected1′a) ~ connected1′a*connected1′lorenz1′x,
-            D(connected1′lorenz1′x) ~ connected1′lorenz1′σ*(connected1′lorenz1′y-connected1′lorenz1′x),
-            D(connected1′lorenz1′y) ~ connected1′lorenz1′x*(connected1′lorenz1′ρ-connected1′lorenz1′z)-connected1′lorenz1′y,
-            0 ~ connected1′lorenz1′x + connected1′lorenz1′y + connected1′lorenz1′β*connected1′lorenz1′z,
-            D(connected1′lorenz2′x) ~ connected1′lorenz2′σ*(connected1′lorenz2′y-connected1′lorenz2′x),
-            D(connected1′lorenz2′y) ~ connected1′lorenz2′x*(connected1′lorenz2′ρ-connected1′lorenz2′z)-connected1′lorenz2′y,
-            0 ~ connected1′lorenz2′x + connected1′lorenz2′y + connected1′lorenz2′β*connected1′lorenz2′z,
-            D(connected2′a) ~ connected2′a*connected2′lorenz1′x,
-            D(connected2′lorenz1′x) ~ connected2′lorenz1′σ*(connected2′lorenz1′y-connected2′lorenz1′x),
-            D(connected2′lorenz1′y) ~ connected2′lorenz1′x*(connected2′lorenz1′ρ-connected2′lorenz1′z)-connected2′lorenz1′y,
-            0 ~ connected2′lorenz1′x + connected2′lorenz1′y + connected2′lorenz1′β*connected2′lorenz1′z,
-            D(connected2′lorenz2′x) ~ connected2′lorenz2′σ*(connected2′lorenz2′y-connected2′lorenz2′x),
-            D(connected2′lorenz2′y) ~ connected2′lorenz2′x*(connected2′lorenz2′ρ-connected2′lorenz2′z)-connected2′lorenz2′y,
-            0 ~ connected2′lorenz2′x + connected2′lorenz2′y + connected2′lorenz2′β*connected2′lorenz2′z]
+eqs_flat2 = [D(g) ~ g*connected1₊lorenz1₊x,
+            D(connected1₊a) ~ connected1₊a*connected1₊lorenz1₊x,
+            D(connected1₊lorenz1₊x) ~ connected1₊lorenz1₊σ*(connected1₊lorenz1₊y-connected1₊lorenz1₊x),
+            D(connected1₊lorenz1₊y) ~ connected1₊lorenz1₊x*(connected1₊lorenz1₊ρ-connected1₊lorenz1₊z)-connected1₊lorenz1₊y,
+            0 ~ connected1₊lorenz1₊x + connected1₊lorenz1₊y + connected1₊lorenz1₊β*connected1₊lorenz1₊z,
+            D(connected1₊lorenz2₊x) ~ connected1₊lorenz2₊σ*(connected1₊lorenz2₊y-connected1₊lorenz2₊x),
+            D(connected1₊lorenz2₊y) ~ connected1₊lorenz2₊x*(connected1₊lorenz2₊ρ-connected1₊lorenz2₊z)-connected1₊lorenz2₊y,
+            0 ~ connected1₊lorenz2₊x + connected1₊lorenz2₊y + connected1₊lorenz2₊β*connected1₊lorenz2₊z,
+            D(connected2₊a) ~ connected2₊a*connected2₊lorenz1₊x,
+            D(connected2₊lorenz1₊x) ~ connected2₊lorenz1₊σ*(connected2₊lorenz1₊y-connected2₊lorenz1₊x),
+            D(connected2₊lorenz1₊y) ~ connected2₊lorenz1₊x*(connected2₊lorenz1₊ρ-connected2₊lorenz1₊z)-connected2₊lorenz1₊y,
+            0 ~ connected2₊lorenz1₊x + connected2₊lorenz1₊y + connected2₊lorenz1₊β*connected2₊lorenz1₊z,
+            D(connected2₊lorenz2₊x) ~ connected2₊lorenz2₊σ*(connected2₊lorenz2₊y-connected2₊lorenz2₊x),
+            D(connected2₊lorenz2₊y) ~ connected2₊lorenz2₊x*(connected2₊lorenz2₊ρ-connected2₊lorenz2₊z)-connected2₊lorenz2₊y,
+            0 ~ connected2₊lorenz2₊x + connected2₊lorenz2₊y + connected2₊lorenz2₊β*connected2₊lorenz2₊z]
 
 @test eqs_flat2 == equations(doublelevel)
 
@@ -140,11 +140,11 @@ M[12,12] = false
 M[15,15] = false
 @test calculate_massmatrix(doublelevel) == M
 
-jac = [connected1′lorenz1′x 0 g zeros(1,12)
+jac = [connected1₊lorenz1₊x 0 g zeros(1,12)
        zeros(7,1) calculate_jacobian(connected1) zeros(Expression,7,7)
        zeros(Expression,7,8) calculate_jacobian(connected2)]
 
-jac2 = [connected1′lorenz1′x 0 g zeros(1,12)
+jac2 = [connected1₊lorenz1₊x 0 g zeros(1,12)
         zeros(7,1) ModelingToolkit.namespace_operation.(calculate_jacobian(connected1),connected1.name,:t) zeros(Expression,7,7)
         zeros(Expression,7,8) ModelingToolkit.namespace_operation.(calculate_jacobian(connected2),connected2.name,:t)]
 

--- a/test/odesystem.jl
+++ b/test/odesystem.jl
@@ -123,25 +123,25 @@ end
 # Conversion to first-order ODEs #17
 @derivatives D3'''~t
 @derivatives D2''~t
-@variables u(t) u_tt(t) u_t(t) x_t(t)
+@variables u(t) uˍtt(t) uˍt(t) xˍt(t)
 eqs = [D3(u) ~ 2(D2(u)) + D(u) + D(x) + 1
        D2(x) ~ D(x) + 2]
 de = ODESystem(eqs)
 de1 = ode_order_lowering(de)
-lowered_eqs = [D(u_tt) ~ 2u_tt + u_t + x_t + 1
-               D(x_t)  ~ x_t + 2
-               D(u_t)  ~ u_tt
-               D(u)    ~ u_t
-               D(x)    ~ x_t]
+lowered_eqs = [D(uˍtt) ~ 2uˍtt + uˍt + xˍt + 1
+               D(xˍt)  ~ xˍt + 2
+               D(uˍt)  ~ uˍtt
+               D(u)    ~ uˍt
+               D(x)    ~ xˍt]
 
 @test de1 == ODESystem(lowered_eqs)
 
 # issue #219
 @test de1.states == [ModelingToolkit.var_from_nested_derivative(eq.lhs)[1] for eq in de1.eqs] == ODESystem(lowered_eqs).states
 
-test_diffeq_inference("first-order transform", de1, t, [u_tt, x_t, u_t, u, x], [])
+test_diffeq_inference("first-order transform", de1, t, [uˍtt, xˍt, uˍt, u, x], [])
 du = zeros(5)
-ODEFunction(de1, [u_tt, x_t, u_t, u, x], [])(du, ones(5), nothing, 0.1)
+ODEFunction(de1, [uˍtt, xˍt, uˍt, u, x], [])(du, ones(5), nothing, 0.1)
 @test du == [5.0, 3.0, 1.0, 1.0, 1.0]
 
 # Internal calculations


### PR DESCRIPTION
The recent changes that added a problem mapping interface really opened up our opportunities for backend variable naming options, because now we do not expect the users to ever have to know the names that we are creating. In order for sane debugging, it's good to create variable names that look nice and close enough, but the user doesn't interact directly with said symbols, so we are free to choose unicode characters. However, since Julia doesn't allow punctuation characters, we do have to make some concessions.

## Subsystem Referencing

Looking at http://xahlee.info/comp/unicode_math_operators.html, the ₊ looked the closest to a period, since we aren't allowed to use punctuation. Also it kind of makes sense because it's a form of unioning two symbols, so I think that works.

## Order Lowering

For lowering, I chose https://www.fileformat.info/info/unicode/char/02cd/index.htm since ˍ looks fairly close to _ but is weird enough that we have a vanishingly low probability of collisions.