### PR TITLE
Generalize build_function

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,18 +84,18 @@ connected = ODESystem(connections,t,[α],[γ],systems=[lorenz1,lorenz2])
 u0 = [lorenz1.x => 1.0,
       lorenz1.y => 0.0,
       lorenz1.z => 0.0,
-	  lorenz2.x => 0.0,
-	  lorenz2.y => 1.0,
-	  lorenz2.z => 0.0,
-	  α => 2.0]
+      lorenz2.x => 0.0,
+      lorenz2.y => 1.0,
+      lorenz2.z => 0.0,
+      α => 2.0]
 
 p  = [lorenz1.σ => 10.0,
       lorenz1.ρ => 28.0,
       lorenz1.β => 8/3,
-	  lorenz2.σ => 10.0,
-	  lorenz2.ρ => 28.0,
-	  lorenz2.β => 8/3,
-	  γ => 2.0]
+      lorenz2.σ => 10.0,
+      lorenz2.ρ => 28.0,
+      lorenz2.β => 8/3,
+      γ => 2.0]
 
 tspan = (0.0,100.0)
 prob = ODEProblem(connected,u0,tspan,p)

--- a/src/systems/optimization/optimizationsystem.jl
+++ b/src/systems/optimization/optimizationsystem.jl
@@ -43,28 +43,31 @@ function calculate_gradient(sys::OptimizationSystem)
     expand_derivatives.(gradient(equations(sys), [dv() for dv in states(sys)]))
 end
 
-function generate_gradient(sys::OptimizationSystem, vs = states(sys), ps = parameters(sys), expression = Val{true}; kwargs...)
+function generate_gradient(sys::OptimizationSystem, vs = states(sys), ps = parameters(sys); kwargs...)
     grad = calculate_gradient(sys)
-    return build_function(grad, convert.(Variable,vs), convert.(Variable,ps), (), AbstractSysToExpr(sys); kwargs...)
+    return build_function(grad, convert.(Variable,vs), convert.(Variable,ps);
+                          conv = AbstractSysToExpr(sys),kwargs...)
 end
 
 function calculate_hessian(sys::OptimizationSystem)
     expand_derivatives.(hessian(equations(sys), [dv() for dv in states(sys)]))
 end
 
-function generate_hessian(sys::OptimizationSystem, vs = states(sys), ps = parameters(sys), expression = Val{true};
+function generate_hessian(sys::OptimizationSystem, vs = states(sys), ps = parameters(sys);
                           sparse = false, kwargs...)
     hes = calculate_hessian(sys)
     if sparse
         hes = sparse(hes)
     end
-    return build_function(hes, convert.(Variable,vs), convert.(Variable,ps), (), AbstractSysToExpr(sys); kwargs...)
+    return build_function(hes, convert.(Variable,vs), convert.(Variable,ps);
+                          conv = AbstractSysToExpr(sys),kwargs...)
 end
 
-function generate_function(sys::OptimizationSystem, vs = states(sys), ps = parameters(sys), expression = Val{true}; kwargs...)
+function generate_function(sys::OptimizationSystem, vs = states(sys), ps = parameters(sys); kwargs...)
     vs′ = convert.(Variable,vs)
     ps′ = convert.(Variable,ps)
-    return build_function(equations(sys), vs′, ps′, (), AbstractSysToExpr(sys), expression; kwargs...)
+    return build_function(equations(sys), vs′, ps′;
+                          conv = AbstractSysToExpr(sys),kwargs...)
 end
 
 equations(sys::OptimizationSystem) = isempty(sys.systems) ? sys.op : sys.op + reduce(+,namespace_operation.(sys.systems))
@@ -95,7 +98,7 @@ function DiffEqBase.OptimizationProblem{iip}(sys::OptimizationSystem,
     ps = parameters(sys)
 
     f = generate_function(sys,checkbounds=checkbounds,linenumbers=linenumbers,
-                              multithread=multithread)
+                              multithread=multithread,expression=Val{false})
     u0 = varmap_to_vars(u0,dvs)
     p = varmap_to_vars(parammap,ps)
     lb = varmap_to_vars(lb,dvs)

--- a/test/build_function.jl
+++ b/test/build_function.jl
@@ -1,0 +1,56 @@
+using ModelingToolkit, Test
+@variables a b c1 c2 c3 d e g
+
+# Multiple argument matrix
+h = [a + b + c1 + c2; c3 + d + e + g] # uses the same number of arguments as our application
+h_julia(a, b, c, d, e, g) = [a[1] + b[1] + c[1] + c[2]; c[3] + d[1] + e[1] + g[1]]
+function h_julia!(out, a, b, c, d, e, g)
+    out .= [a[1] + b[1] + c[1] + c[2]; c[3] + d[1] + e[1] + g[1]]
+end
+
+h_str = ModelingToolkit.build_function(h, [a], [b], ([c1, c2, c3], [d], [e], [g]))
+h_oop = eval(h_str[1])
+h_ip! = eval(h_str[2])
+inputs = ([1], [2], [3, 4, 5], [6], [7], [8])
+
+@test h_oop(inputs...) == h_julia(inputs...)
+out_1 = Array{Int64}(undef, 2)
+out_2 = similar(out_1)
+h_ip!(out_1, inputs...)
+h_julia!(out_2, inputs...)
+@test out_1 == out_2
+
+# Multiple input matrix, some unused arguments
+h_skip = [a + b + c1; c2 + c3 + g] # skip d, e
+h_julia_skip(a, b, c, d, e, g) = [a[1] + b[1] + c[1]; c[2] + c[3] + g[1]]
+function h_julia_skip!(out, a, b, c, d, e, g)
+    out .= [a[1] + b[1] + c[1]; c[2] + c[3] + g[1]]
+end
+
+h_str_skip = ModelingToolkit.build_function(h_skip, [a], [b], ([c1, c2, c3], [], [], [g]))
+h_oop_skip = eval(h_str[1])
+h_ip!_skip = eval(h_str[2])
+inputs_skip = ([1], [2], [3, 4, 5], [], [], [8])
+
+@test h_oop_skip(inputs_skip...) == h_julia_skip(inputs_skip...)
+out_1_skip = Array{Int64}(undef, 2)
+out_2_skip = similar(out_1_skip)
+h_ip!_skip(out_1_skip, inputs_skip...)
+h_julia!_skip(out_2_skip, inputs_skip...)
+@test out_1_skip == out_2_skip
+
+# Same as above, except test ability to call with non-matrix arguments (i.e., for `nt`)
+inputs_skip_2 = ([1], [2], [3, 4, 5], [], (a = 1, b = 2), [8])
+@test h_oop_skip_2(inputs_skip_2...) == h_julia_skip_2(inputs_skip_2...)
+out_1_skip_2 = Array{Int64}(undef, 2)
+out_2_skip_2 = similar(out_1_skip_2)
+h_ip!_skip_2(out_1_skip_2, inputs_skip_2...)
+h_julia!_skip_2(out_2_skip_2, inputs_skip_2...)
+@test out_1_skip_2 == out_2_skip_2
+
+# Multiple input scalar
+h_scalar = a + b + c1 + c2 + c3 + d + e + g
+h_julia_scalar(a, b, c, d, e, g) = a[1] + c[1]; c[2] + c[3] + d[1] + e[1] + g[1]
+h_str_scalar = ModelingToolkit.build_function(h_scalar, [a], [b], ([c1, c2, c3], [d], [e], [g]))
+h_oop_scalar = eval(h_str[1])
+@test h_oop_scalar(inputs...) == h_julia_scalar(inputs...)

--- a/test/build_function.jl
+++ b/test/build_function.jl
@@ -8,7 +8,7 @@ function h_julia!(out, a, b, c, d, e, g)
     out .= [a[1] + b[1] + c[1] + c[2]; c[3] + d[1] + e[1] + g[1]]
 end
 
-h_str = ModelingToolkit.build_function(h, [a], [b], ([c1, c2, c3], [d], [e], [g]))
+h_str = ModelingToolkit.build_function(h, [a], [b], [c1, c2, c3], [d], [e], [g])
 h_oop = eval(h_str[1])
 h_ip! = eval(h_str[2])
 inputs = ([1], [2], [3, 4, 5], [6], [7], [8])
@@ -27,30 +27,30 @@ function h_julia_skip!(out, a, b, c, d, e, g)
     out .= [a[1] + b[1] + c[1]; c[2] + c[3] + g[1]]
 end
 
-h_str_skip = ModelingToolkit.build_function(h_skip, [a], [b], ([c1, c2, c3], [], [], [g]))
-h_oop_skip = eval(h_str[1])
-h_ip!_skip = eval(h_str[2])
+h_str_skip = ModelingToolkit.build_function(h_skip, [a], [b], [c1, c2, c3], [], [], [g], checkbounds=true)
+h_oop_skip = eval(h_str_skip[1])
+h_ip!_skip = eval(h_str_skip[2])
 inputs_skip = ([1], [2], [3, 4, 5], [], [], [8])
 
 @test h_oop_skip(inputs_skip...) == h_julia_skip(inputs_skip...)
 out_1_skip = Array{Int64}(undef, 2)
 out_2_skip = similar(out_1_skip)
 h_ip!_skip(out_1_skip, inputs_skip...)
-h_julia!_skip(out_2_skip, inputs_skip...)
+h_julia_skip!(out_2_skip, inputs_skip...)
 @test out_1_skip == out_2_skip
 
 # Same as above, except test ability to call with non-matrix arguments (i.e., for `nt`)
 inputs_skip_2 = ([1], [2], [3, 4, 5], [], (a = 1, b = 2), [8])
-@test h_oop_skip_2(inputs_skip_2...) == h_julia_skip_2(inputs_skip_2...)
+@test h_oop_skip(inputs_skip_2...) == h_julia_skip(inputs_skip_2...)
 out_1_skip_2 = Array{Int64}(undef, 2)
 out_2_skip_2 = similar(out_1_skip_2)
-h_ip!_skip_2(out_1_skip_2, inputs_skip_2...)
-h_julia!_skip_2(out_2_skip_2, inputs_skip_2...)
+h_ip!_skip(out_1_skip_2, inputs_skip_2...)
+h_julia_skip!(out_2_skip_2, inputs_skip_2...)
 @test out_1_skip_2 == out_2_skip_2
 
 # Multiple input scalar
 h_scalar = a + b + c1 + c2 + c3 + d + e + g
-h_julia_scalar(a, b, c, d, e, g) = a[1] + c[1]; c[2] + c[3] + d[1] + e[1] + g[1]
-h_str_scalar = ModelingToolkit.build_function(h_scalar, [a], [b], ([c1, c2, c3], [d], [e], [g]))
-h_oop_scalar = eval(h_str[1])
+h_julia_scalar(a, b, c, d, e, g) = a[1] + b[1] + c[1] + c[2] + c[3] + d[1] + e[1] + g[1]
+h_str_scalar = ModelingToolkit.build_function(h_scalar, [a], [b], [c1, c2, c3], [d], [e], [g])
+h_oop_scalar = eval(h_str_scalar)
 @test h_oop_scalar(inputs...) == h_julia_scalar(inputs...)

--- a/test/direct.jl
+++ b/test/direct.jl
@@ -26,25 +26,25 @@ for i in 1:3
     ∇ = ModelingToolkit.gradient(eqs[i],[x,y,z])
     @test isequal(∂[i,:],∇)
 end
-                   
+
 @test all(isequal.(ModelingToolkit.gradient(eqs[1],[x,y,z]),[σ * -1,σ,0]))
 @test all(isequal.(ModelingToolkit.hessian(eqs[1],[x,y,z]),0))
 
-Joop,Jiip = eval.(ModelingToolkit.build_function(∂,[x,y,z],[σ,ρ,β],[t.op.name]))
+Joop,Jiip = eval.(ModelingToolkit.build_function(∂,[x,y,z],[σ,ρ,β],t))
 J = Joop([1.0,2.0,3.0],[1.0,2.0,3.0],1.0)
 @test J isa Matrix
 J2 = copy(J)
 Jiip(J2,[1.0,2.0,3.0],[1.0,2.0,3.0],1.0)
 @test J2 == J
 
-Joop,Jiip = eval.(ModelingToolkit.build_function(vcat(∂,∂),[x,y,z],[σ,ρ,β],[t.op.name]))
+Joop,Jiip = eval.(ModelingToolkit.build_function(vcat(∂,∂),[x,y,z],[σ,ρ,β],t))
 J = Joop([1.0,2.0,3.0],[1.0,2.0,3.0],1.0)
 @test J isa Matrix
 J2 = copy(J)
 Jiip(J2,[1.0,2.0,3.0],[1.0,2.0,3.0],1.0)
 @test J2 == J
 
-Joop,Jiip = eval.(ModelingToolkit.build_function(hcat(∂,∂),[x,y,z],[σ,ρ,β],[t.op.name]))
+Joop,Jiip = eval.(ModelingToolkit.build_function(hcat(∂,∂),[x,y,z],[σ,ρ,β],t))
 J = Joop([1.0,2.0,3.0],[1.0,2.0,3.0],1.0)
 @test J isa Matrix
 J2 = copy(J)
@@ -52,7 +52,7 @@ Jiip(J2,[1.0,2.0,3.0],[1.0,2.0,3.0],1.0)
 @test J2 == J
 
 ∂3 = cat(∂,∂,dims=3)
-Joop,Jiip = eval.(ModelingToolkit.build_function(∂3,[x,y,z],[σ,ρ,β],[t.op.name]))
+Joop,Jiip = eval.(ModelingToolkit.build_function(∂3,[x,y,z],[σ,ρ,β],t))
 J = Joop([1.0,2.0,3.0],[1.0,2.0,3.0],1.0)
 @test size(J) == (3,3,2)
 J2 = copy(J)
@@ -61,7 +61,7 @@ Jiip(J2,[1.0,2.0,3.0],[1.0,2.0,3.0],1.0)
 
 s∂ = sparse(∂)
 @test nnz(s∂) == 8
-Joop,Jiip = eval.(ModelingToolkit.build_function(s∂,[x,y,z],[σ,ρ,β],[t.op.name]))
+Joop,Jiip = eval.(ModelingToolkit.build_function(s∂,[x,y,z],[σ,ρ,β],t,linenumbers=true))
 J = Joop([1.0,2.0,3.0],[1.0,2.0,3.0],1.0)
 @test length(nonzeros(s∂)) == 8
 J2 = copy(J)
@@ -89,7 +89,7 @@ function test_worldage()
    eqs = [σ*(y-x),
           x*(ρ-z)-y,
           x*y - β*z]
-   f, f_iip = ModelingToolkit.build_function(eqs,[x,y,z],[σ,ρ,β],(),ModelingToolkit.simplified_expr,Val{false})
+   f, f_iip = ModelingToolkit.build_function(eqs,[x,y,z],[σ,ρ,β];expression=Val{false})
    out = [1.0,2,3]
    o1 = f([1.0,2,3],[1.0,2,3])
    f_iip(out,[1.0,2,3],[1.0,2,3])
@@ -114,7 +114,7 @@ function test_worldage()
    eqs = [(y-x)^2,
           x*(x-z)-y,
           x*y - y*z]
-   f, f_iip = ModelingToolkit.build_function(eqs,[x,y,z],(),(),ModelingToolkit.simplified_expr,Val{false})
+   f, f_iip = ModelingToolkit.build_function(eqs,[x,y,z];expression=Val{false})
    out = zeros(3)
    o1 = f([1.0,2,3])
    f_iip(out,[1.0,2,3])

--- a/test/odesystem.jl
+++ b/test/odesystem.jl
@@ -16,6 +16,7 @@ ModelingToolkit.simplified_expr.(eqs)[1]
 :(derivative(x(t), t) = σ * (y(t) - x(t))).args
 de = ODESystem(eqs)
 
+generate_function(de)
 
 function _clean(O::Operation)
     @assert isa(O.op, Variable)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,6 +5,7 @@ using SafeTestsets, Test
 @safetestset "Simplify Test" begin include("simplify.jl") end
 @safetestset "Operation Overloads Test" begin include("operation_overloads.jl") end
 @safetestset "Direct Usage Test" begin include("direct.jl") end
+@safetestset "Build Function Test" begin include("build_function.jl") end
 @safetestset "ODESystem Test" begin include("odesystem.jl") end
 @safetestset "Mass Matrix Test" begin include("mass_matrix.jl") end
 @safetestset "SDESystem Test" begin include("sdesystem.jl") end


### PR DESCRIPTION
No longer requires u,p and treats those two arguments differently. Now it's just a list of arguments, which can understand if a variable is scalar or not.

Fixes https://github.com/SciML/ModelingToolkit.jl/issues/260