### PR TITLE
add DiscreteProblem with u0/param maps

### DIFF
--- a/src/ModelingToolkit.jl
+++ b/src/ModelingToolkit.jl
@@ -103,7 +103,8 @@ include("build_function.jl")
 export ODESystem, ODEFunction
 export SDESystem, SDEFunction
 export JumpSystem
-export ODEProblem, SDEProblem, NonlinearProblem, OptimizationProblem, JumpProblem
+export ODEProblem, SDEProblem, NonlinearProblem, OptimizationProblem
+export JumpProblem, DiscreteProblem
 export NonlinearSystem, OptimizationSystem
 export ode_order_lowering
 export PDESystem

--- a/src/systems/jumps/jumpsystem.jl
+++ b/src/systems/jumps/jumpsystem.jl
@@ -42,6 +42,22 @@ function assemble_crj(js, crj, statetoid)
     ConstantRateJump(rate, affect)
 end
 
+
+"""
+```julia
+function DiffEqBase.DiscreteProblem(sys::AbstractSystem, u0map, tspan, 
+                                    parammap=DiffEqBase.NullParameters; kwargs...)
+```
+
+Generates a DiscreteProblem from an AbstractSystem
+"""
+function DiffEqBase.DiscreteProblem(sys::AbstractSystem, u0map, tspan::Tuple, 
+                                    parammap=DiffEqBase.NullParameters(); kwargs...)
+    u0 = varmap_to_vars(u0map, states(sys))
+    p = varmap_to_vars(parammap, parameters(sys))
+    DiscreteProblem(u0, tspan, p; kwargs...)
+end
+
 """
 ```julia
 function DiffEqBase.JumpProblem(js::JumpSystem, prob, aggregator; kwargs...)

--- a/test/jumpsystem.jl
+++ b/test/jumpsystem.jl
@@ -56,7 +56,9 @@ affect₃ = [I ~ I - 1, R ~ R + 1]
 j₃ = ConstantRateJump(rate₃,affect₃)
 js2 = JumpSystem([j₁,j₃], t, [S,I,R], [β,γ])
 u₀ = [999,1,0]; p = (0.1/1000,0.01); tspan = (0.,250.)
-dprob = DiscreteProblem(u₀,tspan,p)
+u₀map = [S => 999, I => 1, R => 0]
+parammap = [β => .1/1000, γ => .01]
+dprob = DiscreteProblem(js2, u₀map, tspan, parammap)
 jprob = JumpProblem(js2, dprob, Direct(), save_positions=(false,false))
 Nsims = 10000
 function getmean(jprob,Nsims)


### PR DESCRIPTION
Adds a `DiscreteProblem` taking u0 and parameter maps so that initialization is consistent with ODE and SDE problems.