### PR TITLE
Enable creation of JumpSystems from ReactionSystems

### DIFF
--- a/src/systems/reaction/reactionsystem.jl
+++ b/src/systems/reaction/reactionsystem.jl
@@ -147,7 +147,7 @@ function assemble_jumps(rs)
 end
 
 # Calculate the Jump rate law (like ODE, but uses X instead of X(t).
-# The former geenrates a "MethodError: objects of type Int64 are not callable" when trying to solve the problem.
+# The former generates a "MethodError: objects of type Int64 are not callable" when trying to solve the problem.
 function jumpratelaw(rx)
     @unpack rate, substrates, substoich, only_use_rate = rx
     rl = deepcopy(rate)

--- a/src/systems/reaction/reactionsystem.jl
+++ b/src/systems/reaction/reactionsystem.jl
@@ -121,6 +121,10 @@ function assemble_diffusion(rs)
     eqs
 end
 
+function assemble_jumps(rs)
+
+end
+
 function Base.convert(::Type{<:ODESystem},rs::ReactionSystem)
     eqs = assemble_drift(rs)
     ODESystem(eqs,rs.iv,rs.states,rs.ps,name=rs.name,
@@ -132,4 +136,10 @@ function Base.convert(::Type{<:SDESystem},rs::ReactionSystem)
     noiseeqs = assemble_diffusion(rs)
     SDESystem(eqs,noiseeqs,rs.iv,rs.states,rs.ps,
               name=rs.name,systems=convert.(SDESystem,rs.systems))
+end
+
+function Base.convert(::Type{<:JumpSystem},rs::ReactionSystem)
+    eqs = assemble_jumps(rs)
+    JumpSystem(eqs,rs.iv,rs.states,rs.ps,name=rs.name,
+              systems=convert.(JumpSystem,rs.systems))
 end

--- a/src/systems/reaction/reactionsystem.jl
+++ b/src/systems/reaction/reactionsystem.jl
@@ -135,8 +135,8 @@ function assemble_jumps(rs)
         elseif rx.only_use_rate || any([isequal(state,r_op) for state in rs.states, r_op in getfield.(get_variables(rx.rate),:op)])
             push!(eqs,ConstantRateJump(rl,affect))
         else
-            reactant_stoch = Pair.(var2op.(getfield.(rx.substrates,:op)),rx.substoich)
-            net_stoch = isempty(rx.substoich) ? [0 => 1]  : map(p -> Pair(var2op(p[1]),p[2]),rx.netstoich)
+            reactant_stoch = isempty(rx.substoich) ? [0 => 1] : Pair.(var2op.(getfield.(rx.substrates,:op)),rx.substoich)
+            net_stoch = map(p -> Pair(var2op(p[1]),p[2]),rx.netstoich)
             push!(eqs,MassActionJump(rx.rate, reactant_stoch, net_stoch))
         end
     end

--- a/src/systems/reaction/reactionsystem.jl
+++ b/src/systems/reaction/reactionsystem.jl
@@ -131,14 +131,11 @@ function assemble_jumps(rs)
             push!(affect,var2op(spec) ~ var2op(spec) + stoich)
         end
         if any(isequal.(var2op(rs.iv),get_variables(rx.rate)))
-            println("Var Jump")
             push!(eqs,VariableRateJump(rl,affect))
-        elseif any([isequal(state,r_op) for state in rs.states, r_op in getfield.(get_variables(rx.rate),:op)])
-            println("Const")
+        elseif rx.only_use_rate || any([isequal(state,r_op) for state in rs.states, r_op in getfield.(get_variables(rx.rate),:op)])
             push!(eqs,ConstantRateJump(rl,affect))
         else
             reactant_stoch = Pair.(var2op.(getfield.(rx.substrates,:op)),rx.substoich)
-                println("MA Jump")
             net_stoch = isempty(rx.substoich) ? [0 => 1]  : map(p -> Pair(var2op(p[1]),p[2]),rx.netstoich)
             push!(eqs,MassActionJump(rx.rate, reactant_stoch, net_stoch))
         end


### PR DESCRIPTION
- convert(JumpSystem,rs::ReactionSystem) should now work.
- Type of Jump (Variable Rate, ConstantRate, MassAction) should now be correctly identified.
