### PR TITLE
remove to_mtk in substitute

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -116,7 +116,7 @@ function _substitute(expr, ks, vs)
 end
 
 function _substitute(expr, dict::Dict)
-    to_mtk(simplify(SymbolicUtils.substitute(expr, dict)))
+    simplify(SymbolicUtils.substitute(expr, dict))
 end
 
 @deprecate substitute_expr!(expr,s) substitute(expr,s)


### PR DESCRIPTION
you don't need it if you're calling ModelingToolkit.substitute.

this was causing results to be wrapped in a `Constant` because `Expression <: Number` and there's a `to_mtk(x::Number) = Constant(x)` method.