### PR TITLE
Let SymbolicUtils figure out types of expressions

### DIFF
--- a/src/simplify.jl
+++ b/src/simplify.jl
@@ -29,16 +29,14 @@ SymbolicUtils.symtype(x::Variable) = _vartype(x) # needed for a()
 SymbolicUtils.symtype(x::SymbolicUtils.Sym{<:Parameter{T}}) where {T} = T
 
 # returning Any causes SymbolicUtils to infer the type using `promote_symtype`
-# But we are OK with Number here for now I guess
-SymbolicUtils.symtype(x::Expression) = Number
-
-
-# SymbolicUtils -> ModelingToolkit
+SymbolicUtils.symtype(x::Expression) = Any
 
 simplify(expr::Expression) = SymbolicUtils.simplify(expr) |> to_mtk
 simplify(expr) = expr |> to_mtk
 
 @deprecate simplify_constants(ex) simplify(ex)
+
+# SymbolicUtils -> ModelingToolkit
 
 to_mtk(x) = x
 to_mtk(x::Number) = Constant(x)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -116,7 +116,7 @@ function _substitute(expr, ks, vs)
 end
 
 function _substitute(expr, dict::Dict)
-    simplify(SymbolicUtils.substitute(expr, dict))
+    SymbolicUtils.simplify(SymbolicUtils.substitute(expr, dict)) |> to_mtk
 end
 
 @deprecate substitute_expr!(expr,s) substitute(expr,s)


### PR DESCRIPTION
This allows

```julia
julia> expr = (((1 / β - 1) + δ) / α) ^ (1 / (α - 1))
(((1 / β - 1) + δ) / α) ^ (1 / (α - 1))

julia> expr2  = (((1 / β - 1) + δ) / γ) ^ (1 / (γ - 1))
(((1 / β - 1) + δ) / γ) ^ (1 / (γ - 1))

julia> substitute(expr == expr2, α => γ)
ModelingToolkit.Constant(true)
```

Because symutils applies bool rules only on expressions of type `Bool`.