### PR TITLE
Add tests for Jumps created through reactions.

### DIFF
--- a/test/reactionsystem.jl
+++ b/test/reactionsystem.jl
@@ -123,6 +123,7 @@ for i = 1:14
   @test jumps[i].net_stoch == maj.net_stoch
 end
 for i = 15:18
+  (i==16) && continue
   crj = MT.assemble_crj(js, js.eqs[i], statetoid)
   @test abs(crj.rate(u0,p,time) - jumps[i].rate(u0,p,time)) < 10*eps()
   fake_integrator1 = (u=zeros(4),p=p,t=0); fake_integrator2 = deepcopy(fake_integrator1);

--- a/test/reactionsystem.jl
+++ b/test/reactionsystem.jl
@@ -123,7 +123,6 @@ for i = 1:14
   @test jumps[i].net_stoch == maj.net_stoch
 end
 for i = 15:18
-  (i==16) && continue
   crj = MT.assemble_crj(js, js.eqs[i], statetoid)
   @test abs(crj.rate(u0,p,time) - jumps[i].rate(u0,p,time)) < 10*eps()
   fake_integrator1 = (u=zeros(4),p=p,t=0); fake_integrator2 = deepcopy(fake_integrator1);


### PR DESCRIPTION
Here comes another set of tests to ensure that jumps created through reactions are working.

There is one error, on line `126`, for `i = 16`:
```julia
crj = MT.assemble_crj(js, js.eqs[i], statetoid)
```
generates a
```error
MethodError: no method matching (::JuliaVariables.var"#IS_SCOPED#64"{IdDict{Expr,Any}})(::JuliaVariables.State, ::JuliaVariables.SymRef)
Closest candidates are:
  IS_SCOPED(::JuliaVariables.State, !Matched::Expr) at /home/torkelloman/.julia/packages/JuliaVariables/PPPMs/src/JuliaVariables.jl:234
in top-level scope at reactionsystem.jl:141
in assemble_crj at dev/ModelingToolkit/src/systems/jumps/jumpsystem.jl:38
in generate_rate_function at dev/ModelingToolkit/src/systems/jumps/jumpsystem.jl:19 
in build_function##kw at dev/ModelingToolkit/src/build_function.jl:61 
in #build_function#184 at dev/ModelingToolkit/src/build_function.jl:61
in  at dev/ModelingToolkit/src/build_function.jl:109
in #_build_function#187 at dev/ModelingToolkit/src/build_function.jl:130
in mk_function at GeneralizedGenerated/YYD7s/src/GeneralizedGenerated.jl:22
in solve at JuliaVariables/PPPMs/src/JuliaVariables.jl:133
in #solve#44 at JuliaVariables/PPPMs/src/JuliaVariables.jl:504
in  at JuliaVariables/PPPMs/src/JuliaVariables.jl:498
in  at JuliaVariables/PPPMs/src/JuliaVariables.jl:375
in ##JuliaVariables 181#441#118 at base/none 
in ##JuliaVariables 183#443#119 at JuliaVariables/PPPMs/src/JuliaVariables.jl:432 
in  at JuliaVariables/PPPMs/src/JuliaVariables.jl:226
in  at JuliaVariables/PPPMs/src/JuliaVariables.jl:206
in  at JuliaVariables/PPPMs/src/JuliaVariables.jl:226
in  at JuliaVariables/PPPMs/src/JuliaVariables.jl:159
in  at JuliaVariables/PPPMs/src/JuliaVariables.jl:436
in ##JuliaVariables 171#431#147 at base/none 
in ##JuliaVariables 173#433#148 at JuliaVariables/PPPMs/src/JuliaVariables.jl:439 
in  at JuliaVariables/PPPMs/src/JuliaVariables.jl:436
in ##JuliaVariables 171#431#147 at base/none 
in ##JuliaVariables 173#433#148 at JuliaVariables/PPPMs/src/JuliaVariables.jl:439 
in  at JuliaVariables/PPPMs/src/JuliaVariables.jl:356
in ##JuliaVariables 202#462#112 at base/none 
in ##JuliaVariables 204#464#113 at JuliaVariables/PPPMs/src/JuliaVariables.jl:357 
in  at JuliaVariables/PPPMs/src/JuliaVariables.jl:196
in  at JuliaVariables/PPPMs/src/JuliaVariables.jl:360
in  at JuliaVariables/PPPMs/src/JuliaVariables.jl:170
in  at JuliaVariables/PPPMs/src/JuliaVariables.jl:277
in ##JuliaVariables 310#570#78 at base/none 
in ##JuliaVariables 312#572#79 at JuliaVariables/PPPMs/src/JuliaVariables.jl:280 
in  at JuliaVariables/PPPMs/src/JuliaVariables.jl:159
in  at JuliaVariables/PPPMs/src/JuliaVariables.jl:436
in ##JuliaVariables 171#431#147 at base/none 
in ##JuliaVariables 173#433#148 at JuliaVariables/PPPMs/src/JuliaVariables.jl:439 
in  at JuliaVariables/PPPMs/src/JuliaVariables.jl:246
in ##JuliaVariables 359#619#66 at base/none 
in ##JuliaVariables 361#621#67 at base/none 
in ##JuliaVariables 367#627#68 at base/none 
in ##JuliaVariables 369#629#69 at JuliaVariables/PPPMs/src/JuliaVariables.jl:253 
```
The corresponding reaction is:
```julia
Reaction(k[16], [A], [B]; only_use_rate=true),             # A -> B with custom rate.
```
and the jump
```julia
jumps[16] = ConstantRateJump((u,p,t) -> p[16], integrator -> (integrator.u[1] -= 1; integrator.u[2] += 1;))
```

I believe that the problem is when you try to make a `ConstantRateJump` with only a constant (here `k[16]`) as the actual rate. This using `assemble_crj()`. @isaacsas Do you know what is going on? Should we skip the test, or is there something fishy going on in `assemble_crj()`? 

