### PR TITLE
Update DiffEqJump version for recent bug fixes

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -29,7 +29,7 @@ Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 [compat]
 ArrayInterface = "2.8"
 DiffEqBase = "6.28"
-DiffEqJump = "6.6.2"
+DiffEqJump = "6.7.5"
 DiffRules = "0.1, 1.0"
 DocStringExtensions = "0.7, 0.8"
 GeneralizedGenerated = "0.1.4, 0.2"


### PR DESCRIPTION
The recent bugs are serious enough we should manually update the DiffEqJump version.