### PR TITLE
fix modelingtoolkize to only return the system

### DIFF
--- a/src/systems/diffeqs/modelingtoolkitize.jl
+++ b/src/systems/diffeqs/modelingtoolkitize.jl
@@ -24,5 +24,5 @@ function modelingtoolkitize(prob::DiffEqBase.ODEProblem)
     eqs = vcat([rhs[i] ~ lhs[i] for i in eachindex(prob.u0)]...)
     de = ODESystem(eqs,t,vars,params)
 
-    de, vars, params
+    de
 end

--- a/test/odesystem.jl
+++ b/test/odesystem.jl
@@ -178,8 +178,8 @@ function lotka(u,p,t)
 end
 
 prob = ODEProblem(ODEFunction{false}(lotka),[1.0,1.0],(0.0,1.0),[1.5,1.0,3.0,1.0])
-de, vars, params = modelingtoolkitize(prob)
-ODEFunction(de, vars, params)(similar(prob.u0), prob.u0, prob.p, 0.1)
+de = modelingtoolkitize(prob)
+ODEFunction(de)(similar(prob.u0), prob.u0, prob.p, 0.1)
 
 function lotka(du,u,p,t)
   x = u[1]
@@ -190,5 +190,5 @@ end
 
 prob = ODEProblem(lotka,[1.0,1.0],(0.0,1.0),[1.5,1.0,3.0,1.0])
 
-de, vars, params = modelingtoolkitize(prob)
-ODEFunction(de, vars, params)(similar(prob.u0), prob.u0, prob.p, 0.1)
+de = modelingtoolkitize(prob)
+ODEFunction(de)(similar(prob.u0), prob.u0, prob.p, 0.1)


### PR DESCRIPTION
This is somewhat of a funny case, because we document it as only returning the system, but it was still doing the old thing of returning the states and parameters as well (which is redundant). So I'm going to call it not breaking as we changed the docs awhile ago, so it's moreso just a weird error that the package was updated after the docs.