### PR TITLE
update docstring example for ODESystem

### DIFF
--- a/src/systems/diffeqs/odesystem.jl
+++ b/src/systems/diffeqs/odesystem.jl
@@ -19,7 +19,7 @@ eqs = [D(x) ~ σ*(y-x),
        D(y) ~ x*(ρ-z)-y,
        D(z) ~ x*y - β*z]
 
-de = ODESystem(eqs,[x,y,z],[σ,ρ,β])
+de = ODESystem(eqs,t,[x,y,z],[σ,ρ,β])
 ```
 """
 struct ODESystem <: AbstractODESystem


### PR DESCRIPTION
The constructor takes independent variable as second argument. We could also use the `ODESystem(eqs)` constructor if preferable. 