### PR TITLE
Place algebraic equations after differential equations

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ModelingToolkit"
 uuid = "961ee093-0014-501f-94e3-6117800e7a78"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "3.6.1"
+version = "3.6.2"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"

--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "3.6.1"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
+DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
 DiffEqJump = "c894b116-72e5-5b58-be3c-e6d8d4ac2b12"
 DiffRules = "b552c78f-8df3-52c6-915a-8e097449b14b"
@@ -28,6 +29,7 @@ Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [compat]
 ArrayInterface = "2.8"
+DataStructures = "0.17"
 DiffEqBase = "6.28"
 DiffEqJump = "6.7.5"
 DiffRules = "0.1, 1.0"

--- a/src/systems/diffeqs/first_order_transform.jl
+++ b/src/systems/diffeqs/first_order_transform.jl
@@ -59,6 +59,7 @@ function ode_order_lowering(eqs, iv, states)
         end
     end
 
+    # we want to order the equations and variables to be `(diff, alge)`
     return (vcat(diff_eqs, alge_eqs), vcat(diff_vars, alge_vars))
 end
 

--- a/test/lowering_solving.jl
+++ b/test/lowering_solving.jl
@@ -1,15 +1,24 @@
-using ModelingToolkit, OrdinaryDiffEq, Test
+using ModelingToolkit, OrdinaryDiffEq, Test, LinearAlgebra
 
 @parameters t σ ρ β
-@variables x(t) y(t) z(t)
+@variables x(t) y(t) z(t) k(t)
 @derivatives D'~t
 
 eqs = [D(D(x)) ~ σ*(y-x),
        D(y) ~ x*(ρ-z)-y,
        D(z) ~ x*y - β*z]
 
-sys = ODESystem(eqs)
-sys = ode_order_lowering(sys)
+sys′ = ODESystem(eqs)
+sys = ode_order_lowering(sys′)
+
+eqs2 = [0 ~ x*y - k,
+        D(D(x)) ~ σ*(y-x),
+        D(y) ~ x*(ρ-z)-y,
+        D(z) ~ x*y - β*z]
+sys2 = ODESystem(eqs2, t, [x, y, z, k], sys′.ps)
+sys2 = ode_order_lowering(sys2)
+# test equation/varible ordering
+ModelingToolkit.calculate_massmatrix(sys2) == Diagonal([1, 1, 1, 1, 0])
 
 u0 = [D(x) => 2.0,
 	  x => 1.0,


### PR DESCRIPTION
This PR orders algebraic equations after differential equations in the `ode_order_lowering` pass, also made some small performance optimizations.