### PR TITLE
Automatic state detection and some performance optimization

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ModelingToolkit"
 uuid = "961ee093-0014-501f-94e3-6117800e7a78"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "3.6.2"
+version = "3.6.3"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"

--- a/src/ModelingToolkit.jl
+++ b/src/ModelingToolkit.jl
@@ -6,6 +6,7 @@ using Latexify, Unitful, ArrayInterface
 using MacroTools
 using UnPack: @unpack
 using DiffEqJump
+using DataStructures: OrderedDict, OrderedSet
 
 using Base.Threads
 import MacroTools: splitdef, combinedef, postwalk, striplines

--- a/src/systems/diffeqs/first_order_transform.jl
+++ b/src/systems/diffeqs/first_order_transform.jl
@@ -1,4 +1,3 @@
-using DataStructures: OrderedDict
 function lower_varname(var::Variable, idv, order)
     order == 0 && return var
     name = Symbol(var.name, :ˍ, string(idv.name)^order)

--- a/src/systems/diffeqs/odesystem.jl
+++ b/src/systems/diffeqs/odesystem.jl
@@ -77,19 +77,47 @@ end
 var_from_nested_derivative(x) = var_from_nested_derivative(x,0)
 var_from_nested_derivative(x::Constant) = (missing, missing)
 var_from_nested_derivative(x,i) = x.op isa Differential ? var_from_nested_derivative(x.args[1],i+1) : (x.op,i)
+
+function extract_eqs_states_ps(eqs::AbstractArray{<:Equation}, iv)
+    # NOTE: this assumes that the order of algebric equations doesn't matter
+    diffvars = OrderedSet{Variable}()
+    allstates = OrderedSet{Variable}()
+    ps = OrderedSet{Variable}()
+    # reorder equations such that it is in the form of `diffeq, algeeq`
+    diffeq = Equation[]
+    algeeq = Equation[]
+    for eq in eqs
+        for var in vars(eq.rhs for eq ∈ eqs)
+            var isa Variable || continue
+            if isparameter(var)
+                isequal(var, iv) || push!(ps, var)
+            else
+                push!(allstates, var)
+            end
+        end
+        if eq.lhs isa Constant
+            push!(algeeq, eq)
+        else
+            diffvar = first(var_from_nested_derivative(eq.lhs))
+            diffvar in diffvars && throw(ArgumentError("The differential variable $diffvar is not unique in the system of equations."))
+            push!(diffvars, diffvar)
+            push!(diffeq, eq)
+        end
+    end
+    algevars = setdiff(allstates, diffvars)
+    # the orders here are very important!
+    return append!(diffeq, algeeq), vcat(collect(diffvars), collect(algevars)), ps
+end
+
 iv_from_nested_derivative(x) = x.op isa Differential ? iv_from_nested_derivative(x.args[1]) : x.args[1].op
 iv_from_nested_derivative(x::Constant) = missing
 
 function ODESystem(eqs; kwargs...)
     ivs = unique(skipmissing(iv_from_nested_derivative(eq.lhs) for eq ∈ eqs))
-    length(ivs) == 1 || throw(ArgumentError("one independent variable currently supported"))
+    length(ivs) == 1 || throw(ArgumentError("An ODESystem can only have one independent variable."))
     iv = first(ivs)
-
-    dvs = unique(skipmissing(var_from_nested_derivative(eq.lhs)[1] for eq ∈ eqs))
-    ps = filter(vars(eq.rhs for eq ∈ eqs)) do x
-        isparameter(x) & !isequal(x, iv)
-    end |> collect
-    ODESystem(eqs, iv, dvs, ps; kwargs...)
+    eqs, dvs, ps = extract_eqs_states_ps(eqs, iv)
+    return ODESystem(eqs, iv, dvs, ps; kwargs...)
 end
 
 Base.:(==)(sys1::ODESystem, sys2::ODESystem) =

--- a/test/odesystem.jl
+++ b/test/odesystem.jl
@@ -1,4 +1,5 @@
 using ModelingToolkit, StaticArrays, LinearAlgebra
+using OrdinaryDiffEq
 using DiffEqBase
 using Test
 
@@ -209,6 +210,11 @@ p  = [k₁ => 0.04,
       k₂ => 3e7,
       k₃ => 1e4]
 tspan = (0.0,100000.0)
-prob = ODEProblem(sys,u0,tspan,p)
-sol = solve(prob, Rodas5())
-@test all(x->sum(x) ≈ 1.0, sol.u)
+prob1 = ODEProblem(sys,u0,tspan,p)
+prob2 = ODEProblem(sys,u0,tspan,p,jac=true)
+# Wfact version is not very stable because of the lack of pivoting
+prob3 = ODEProblem(sys,u0,tspan,p,Wfact=true,Wfact_t=true)
+for (prob, atol) in [(prob1, 1e-12), (prob2, 1e-12), (prob3, 0.1)]
+    sol = solve(prob, Rodas5())
+    @test all(x->≈(sum(x), 1.0, atol=atol), sol.u)
+end


### PR DESCRIPTION
This PR adds automatic state detection for semi-implicit DAE systems. Also, I optimized `ODESystem` construction.

Fix #389

Here is an interesting finding. When we use `Wfact_t` or `Wfact` on ROBER, it can cause instability because of the lack of partial pivoting.

Plot:
![rober_wfact](https://user-images.githubusercontent.com/17304743/82776083-bf59ef00-9e17-11ea-851f-df590fefc6c8.png)

See also https://github.com/SciML/ModelingToolkit.jl/blob/8cc5d0ea2a510c980a88fba5da724ddeccc0e4d3/test/odesystem.jl#L215-L217