### PR TITLE
[WIP] Utility to move all derivative terms to LHS 

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -100,7 +100,7 @@ end
 function movediffvars(eqn)
 	ops = Vector{Any}()
 	movediffvars(eqn.rhs, ops)
-	Equation(simplify(eqn.lhs + reduce(+, ops)), simplify(eqn.rhs + reduce(+, ops)))
+	Equation(simplify(eqn.lhs + sum(ops)), simplify(eqn.rhs + sum(ops)))
 end
 
 # variable extraction

--- a/test/mass_matrix.jl
+++ b/test/mass_matrix.jl
@@ -31,3 +31,15 @@ prob_mm2 = ODEProblem(f,[1.0,0.0,0.0],(0.0,1e5),(0.04,3e7,1e4))
 sol2 = solve(prob_mm2,Rodas5(),reltol=1e-8,abstol=1e-8)
 
 @test Array(sol) == Array(sol2)
+
+# Moving terms to LHS
+@variables x
+@parameters t
+@derivatives D'~t
+
+eq = x ~ D(x) + Constant(0.5)
+@test simplify(eq) == simplify(ModelingToolkit.movediffvars(eq))
+
+eq = x ~ D(x) * Constant(0.5)
+@test simplify(eq) == simplify(ModelingToolkit.movediffvars(eq))
+

--- a/test/mass_matrix.jl
+++ b/test/mass_matrix.jl
@@ -38,8 +38,8 @@ sol2 = solve(prob_mm2,Rodas5(),reltol=1e-8,abstol=1e-8)
 @derivatives D'~t
 
 eq = x ~ D(x) + Constant(0.5)
-@test simplify(eq) == simplify(ModelingToolkit.movediffvars(eq))
+@test simplify(eq) == simplify(ModelingToolkit.movevars(eq))
 
 eq = x ~ D(x) * Constant(0.5)
-@test simplify(eq) == simplify(ModelingToolkit.movediffvars(eq))
+@test simplify(eq) == simplify(ModelingToolkit.movevars(eq))
 


### PR DESCRIPTION
So far, works on: 
```julia
julia> eq = x ~ D(x) + Constant(0.5)
Equation(x, derivative(x, t) + 0.5)

julia> ModelingToolkit.movediffvars(eq)
Equation(-1 * derivative(x, t) + x, Constant(0.5))

julia> eq = x ~ D(x) * Constant(0.5)
Equation(x, derivative(x, t) * 0.5)

julia> ModelingToolkit.movediffvars(eq)
Equation(-0.5 * derivative(x, t) + x, Constant(0.0))

```

Doesn't work on: 
```julia
eq = x ~ Constant(5.0) * (D(x) + Constant(0.5))
```
Would be nice to have simplification based on distributive rule (https://github.com/JuliaSymbolics/SymbolicUtils.jl/pull/95)