### PR TITLE
provide iszero for Operation to help sparse matrix addition and multiplication

### DIFF
--- a/src/operations.jl
+++ b/src/operations.jl
@@ -54,6 +54,11 @@ Base.isequal(::Variable , ::Operation) = false
 Base.isequal(::Operation, ::Constant ) = false
 Base.isequal(::Constant , ::Operation) = false
 
+# provide iszero for Operations to help sparse addition and multiplication
+Base.iszero(O::Operation) = ((O.op == identity) && iszero(O.args[1])) ||
+                            ((O.op == +) && all(iszero(arg) for arg in O.args)) ||
+                            ((O.op == *) && any(iszero(arg) for arg in O.args))
+
 Base.show(io::IO, O::Operation) = print(io, convert(Expr, O))
 
 # For inv
@@ -72,13 +77,5 @@ Base.convert(::Type{Expr},x::Operation) = Expr(x)
 # promotion
 Base.promote_rule(::Type{<:Constant}, ::Type{<:Operation}) = Operation
 Base.promote_rule(::Type{<:Operation}, ::Type{<:Constant}) = Operation
-
-# Fix Sparse MatMul
-Base.:*(A::SparseMatrixCSC{Operation,S}, x::StridedVector{Operation}) where {S} =
-    (T = Operation; mul!(similar(x, T, A.m), A, x, true, false))
-Base.:*(A::SparseMatrixCSC{Tx,S}, x::StridedVector{Operation}) where {Tx,S} =
-    (T = LinearAlgebra.promote_op(LinearAlgebra.matprod, Operation, Tx); mul!(similar(x, T, A.m), A, x, true, false))
-Base.:*(A::SparseMatrixCSC{Operation,S}, x::StridedVector{Tx}) where {Tx,S} =
-    (T = LinearAlgebra.promote_op(LinearAlgebra.matprod, Operation, Tx); mul!(similar(x, T, A.m), A, x, true, false))
 
 LinearAlgebra.lu(O::AbstractMatrix{<:Operation};kwargs...) = lu(O,Val(false);kwargs...)

--- a/src/operations.jl
+++ b/src/operations.jl
@@ -55,9 +55,8 @@ Base.isequal(::Operation, ::Constant ) = false
 Base.isequal(::Constant , ::Operation) = false
 
 # provide iszero for Operations to help sparse addition and multiplication
-Base.iszero(O::Operation) = ((O.op == identity) && iszero(O.args[1])) ||
-                            ((O.op == +) && all(iszero(arg) for arg in O.args)) ||
-                            ((O.op == *) && any(iszero(arg) for arg in O.args))
+# e.g. we want to tell the sparse library that iszero(zero(Operation) + zero(Operation)) == true
+Base.iszero(x::Operation) = (_x = simplify(x); _x isa Constant && iszero(_x.value))
 
 Base.show(io::IO, O::Operation) = print(io, convert(Expr, O))
 

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -89,7 +89,8 @@ Get the value of a [`ModelingToolkit.Constant`](@ref).
 """
 Base.get(c::Constant) = c.value
 
-Base.iszero(ex::Expression) = isa(ex, Constant) && iszero(ex.value)
+Base.iszero(c::Constant) = iszero(c.value)
+
 Base.isone(ex::Expression)  = isa(ex, Constant) && isone(ex.value)
 
 # Variables use isequal for equality since == is an Operation

--- a/test/operation_overloads.jl
+++ b/test/operation_overloads.jl
@@ -1,7 +1,34 @@
 using ModelingToolkit
 using LinearAlgebra
+using SparseArrays: sparse
+using Test
+
 @variables a,b,c,d
+
+# test some matrix operations don't throw errors
 X = [a b;c d]
 det(X)
 lu(X)
 inv(X)
+
+# test operations with sparse arrays and Operations
+# note `isequal` instead of `==` because `==` would give another Operation
+
+# test that we can create a sparse array of Operation
+Oarray = zeros(Operation, 2,2)
+Oarray[2,2] = a
+@test isequal(sparse(Oarray), sparse([2], [2], [a]))
+
+# test Operation * sparse
+@test isequal(a * sparse([2], [2], [1]), sparse([2], [2], [a * 1]))
+
+# test sparse{Operation} + sparse{Operation}
+A = sparse([2], [2], [a])
+B = sparse([2], [2], [b])
+@test isequal(A + B, sparse([2], [2], [a+b]))
+
+# test sparse{Operation} * sparse{Operation}
+C = sparse([1, 2], [2, 1], [c, c])
+D = sparse([1, 2], [2, 1], [d, d])
+
+@test isequal(C * D, sparse([1,2], [1,2], [c * d, c * d]))


### PR DESCRIPTION
I was poking around at adding supporting for `*(Operation,Sparse)` for #381 and I think we can easily support everything if we just provide `iszero(O::Operation)`.  In the `SparseArrays` stdlib [_noshapecheck_map](https://github.com/JuliaLang/julia/blob/3995a02e14db043ee337676cca00c9f3b55e1518/stdlib/SparseArrays/src/higherorderfns.jl#L158) is trying to figure out whether the function applied to zeros of the element types will also give a zero. If it does then it can return another sparse array. If we provide an `iszero(O::Operation)` then it will just do the right thing. Although I'm probably missing what other damage this will cause. 

E.g.
```julia 
@parameters Δ
Hdrift = zeros(Operation, 3,3)
Hdrift[3,3] = Δ
sparse(Hdrift)
3×3 SparseArrays.SparseMatrixCSC{Operation,Int64} with 1 stored entry:
  [3, 3]  =  Δ
```

or
```julia
@parameters ω
X = Float64[[0 1]; [1 0]]

Htot = ω * sparse(X)
display(Htot)

@parameters U[1:2,1:2]

display(-1im*Htot*U)
```

gives

```
2×2 SparseArrays.SparseMatrixCSC{Operation,Int64} with 2 stored entries:
  [2, 1]  =  ω * 1.0
  [1, 2]  =  ω * 1.0
2×2 Array{Operation,2}:
 identity(0) + ((0-1im) * (ω * 1.0)) * (U₂ˏ₁ * true)  …  identity(0) + ((0-1im) * (ω * 1.0)) * (U₂ˏ₂ * true)
 identity(0) + ((0-1im) * (ω * 1.0)) * (U₁ˏ₁ * true)     identity(0) + ((0-1im) * (ω * 1.0)) * (U₁ˏ₂ * true)
```



Fixes #381 