### PR TITLE
Update utils.jl

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -15,6 +15,7 @@ Base.convert(::Type{Expression}, x::Variable) = convert(Operation,x)
 Base.convert(::Type{Expression}, x::Operation) = x
 Base.convert(::Type{Expression}, x::Symbol) = Operation(Variable(x),[])
 Expression(x::Bool) = Constant(x)
+identity(x::Int64) = Constant(x)
 
 function build_expr(head::Symbol, args)
     ex = Expr(head)


### PR DESCRIPTION
As discussed on Slack, to get rid of the `identity` vs `Constant` issue. 

So far have only seen this for constants, so I only did it for `identity(x::Int64)`. 

(And because I don't want it to have things like `ModelingToolkit.Constant(x)`)