### PR TITLE
Enable the creation of Problems from ReactionSystems

### DIFF
--- a/src/systems/reaction/reactionsystem.jl
+++ b/src/systems/reaction/reactionsystem.jl
@@ -353,6 +353,6 @@ function DiffEqBase.DiscreteProblem(rs::ReactionSystem, u0::Union{AbstractArray,
 end
 
 # JumpProblem from AbstractReactionNetwork
-function DiffEqJump.JumpProblem(prob, aggregator, rs::ReactionSystem, args...; kwargs...)
+function DiffEqJump.JumpProblem(rs::ReactionSystem, prob, aggregator, args...; kwargs...)
     return JumpProblem(convert(JumpSystem,rs), prob, aggregator, args...; kwargs...)
 end

--- a/src/systems/reaction/reactionsystem.jl
+++ b/src/systems/reaction/reactionsystem.jl
@@ -327,3 +327,26 @@ function make_sub!(eq,states_swaps)
 	end
 	return eq
 end
+
+### Converts a reaxction system to ODe or SDE problems ###
+
+# ODEProblem from AbstractReactionNetwork
+function DiffEqBase.ODEProblem(rs::ReactionSystem, u0::Union{AbstractArray, Number}, tspan, p, args...; kwargs...)
+    return ODEProblem(convert(ODESystem,rs),Pair.(rs.states,u0),tspan,Pair.(rs.ps,p), args...; kwargs...)
+end
+
+# SDEProblem from AbstractReactionNetwork
+function DiffEqBase.SDEProblem(rs::ReactionSystem, u0::Union{AbstractArray, Number}, tspan, p, args...; kwargs...)
+    p_matrix = zeros(length(rs.states), length(rs.eqs))
+    return SDEProblem(convert(SDESystem,rs),Pair.(rs.states,u0),tspan,Pair.(rs.ps,p),args...; noise_rate_prototype=p_matrix,kwargs...)
+end
+
+# DiscreteProblem from AbstractReactionNetwork
+function DiffEqBase.DiscreteProblem(rs::ReactionSystem, u0, tspan::Tuple, p=nothing, args...; kwargs...)
+    return DiscreteProblem(convert(JumpSystem,rs), Pair.(rs.states,u0),tspan,Pair.(rs.ps,p), args...; kwargs...)
+end
+
+# JumpProblem from AbstractReactionNetwork
+function DiffEqJump.JumpProblem(prob, aggregator, rs::ReactionSystem, args...; kwargs...)
+    return JumpProblem(convert(JumpSystem,rs), prob, aggregator, args...; kwargs...)
+end

--- a/src/systems/reaction/reactionsystem.jl
+++ b/src/systems/reaction/reactionsystem.jl
@@ -328,7 +328,8 @@ function make_sub!(eq,states_swaps)
 	return eq
 end
 
-### Converts a reaxction system to ODe or SDE problems ###
+### Converts a reaction system to ODE or SDE problems ###
+
 
 # ODEProblem from AbstractReactionNetwork
 function DiffEqBase.ODEProblem(rs::ReactionSystem, u0::Union{AbstractArray, Number}, tspan, p, args...; kwargs...)

--- a/src/systems/reaction/reactionsystem.jl
+++ b/src/systems/reaction/reactionsystem.jl
@@ -332,7 +332,6 @@ end
 
 # ODEProblem from AbstractReactionNetwork
 function DiffEqBase.ODEProblem(rs::ReactionSystem, u0::Union{AbstractArray, Number}, tspan, p, args...; kwargs...)
-    println("HERE")
     u0 = typeof(u0) <: Array{<:Pair} ? u0 : Pair.(rs.states,u0)
     p = typeof(p) <: Array{<:Pair} ? p : Pair.(rs.ps,p)
     return ODEProblem(convert(ODESystem,rs),u0,tspan,p, args...; kwargs...)

--- a/src/systems/reaction/reactionsystem.jl
+++ b/src/systems/reaction/reactionsystem.jl
@@ -332,18 +332,25 @@ end
 
 # ODEProblem from AbstractReactionNetwork
 function DiffEqBase.ODEProblem(rs::ReactionSystem, u0::Union{AbstractArray, Number}, tspan, p, args...; kwargs...)
-    return ODEProblem(convert(ODESystem,rs),Pair.(rs.states,u0),tspan,Pair.(rs.ps,p), args...; kwargs...)
+    println("HERE")
+    u0 = typeof(u0) <: Array{<:Pair} ? u0 : Pair.(rs.states,u0)
+    p = typeof(p) <: Array{<:Pair} ? p : Pair.(rs.ps,p)
+    return ODEProblem(convert(ODESystem,rs),u0,tspan,p, args...; kwargs...)
 end
 
 # SDEProblem from AbstractReactionNetwork
 function DiffEqBase.SDEProblem(rs::ReactionSystem, u0::Union{AbstractArray, Number}, tspan, p, args...; kwargs...)
+    u0 = typeof(u0) <: Array{<:Pair} ? u0 : Pair.(rs.states,u0)
+    p = typeof(p) <: Array{<:Pair} ? p : Pair.(rs.ps,p)
     p_matrix = zeros(length(rs.states), length(rs.eqs))
-    return SDEProblem(convert(SDESystem,rs),Pair.(rs.states,u0),tspan,Pair.(rs.ps,p),args...; noise_rate_prototype=p_matrix,kwargs...)
+    return SDEProblem(convert(SDESystem,rs),u0,tspan,p,args...; noise_rate_prototype=p_matrix,kwargs...)
 end
 
 # DiscreteProblem from AbstractReactionNetwork
-function DiffEqBase.DiscreteProblem(rs::ReactionSystem, u0, tspan::Tuple, p=nothing, args...; kwargs...)
-    return DiscreteProblem(convert(JumpSystem,rs), Pair.(rs.states,u0),tspan,Pair.(rs.ps,p), args...; kwargs...)
+function DiffEqBase.DiscreteProblem(rs::ReactionSystem, u0::Union{AbstractArray, Number}, tspan::Tuple, p=nothing, args...; kwargs...)
+    u0 = typeof(u0) <: Array{<:Pair} ? u0 : Pair.(rs.states,u0)
+    p = typeof(p) <: Array{<:Pair} ? p : Pair.(rs.ps,p)
+    return DiscreteProblem(convert(JumpSystem,rs), u0,tspan,p, args...; kwargs...)
 end
 
 # JumpProblem from AbstractReactionNetwork


### PR DESCRIPTION
Enable the creation of ODE, SDE, Discrete, and Jump Problems from a `ReactionSystem`s. The input u0/p arrays can either be of the form `[x=10.]` or simply `[10.]`.

Example code
```julia
using ModelingToolkit
using DifferentialEquations
using Plots

@parameters t p d
@variables X(t)
rxs = [Reaction(p, nothing, [X])
       Reaction(d, [X], nothing)]
rs  = ReactionSystem(rxs, t, [X], [p,d])

o_prob = ODEProblem(rs,[10.],(0.,10.),[100.,5.])
sol = solve(o_prob)
plot(sol)

s_prob = SDEProblem(rs,[10.],(0.,10.),[100.,5.])
sol = solve(s_prob)
plot(sol)

d_prob = DiscreteProblem(rs, [20],(0.,10.),[100.,5.])
j_prob = JumpProblem(d_prob,Direct(),rs)
sol = solve(j_prob,SSAStepper())

o_prob = ODEProblem(rs,[X => 10.],(0.,10.),[p => 100., d => 5.])
sol = solve(o_prob)
plot(sol)

s_prob = SDEProblem(rs,[10.],(0.,10.),[p => 100., d =>5.])
sol = solve(s_prob)
plot(sol)

d_prob = DiscreteProblem(rs, [X => 20],(0.,10.),[100.,5.])
j_prob = JumpProblem(d_prob,Direct(),rs)
sol = solve(j_prob,SSAStepper())
```