### PR TITLE
Provide as_expression=false option to ODEs/SDEs, for specific use cases that need to avoid world age issues (generally not needed)

### DIFF
--- a/src/systems/diffeqs/abstractodesystem.jl
+++ b/src/systems/diffeqs/abstractodesystem.jl
@@ -142,7 +142,7 @@ function DiffEqBase.ODEFunction{iip}(sys::AbstractODESystem, dvs = states(sys),
                                      ps = parameters(sys), u0 = nothing;
                                      version = nothing, tgrad=false,
                                      jac = false, Wfact = false,
-                                     sparse = false, eval_expression=true,
+                                     sparse = false, eval_expression = true,
                                      kwargs...) where {iip}
 
     f_gen = generate_function(sys, dvs, ps; expression=Val{eval_expression}, kwargs...)
@@ -291,6 +291,7 @@ function DiffEqBase.ODEProblem{iip}(sys::AbstractODESystem,u0map,tspan,
                                     jac = false, Wfact = false,
                                     checkbounds = false, sparse = false,
                                     linenumbers = true, parallel=SerialForm(),
+                                    eval_expression = true,
                                     kwargs...) where iip
     dvs = states(sys)
     ps = parameters(sys)
@@ -298,7 +299,7 @@ function DiffEqBase.ODEProblem{iip}(sys::AbstractODESystem,u0map,tspan,
     p = varmap_to_vars(parammap,ps)
     f = ODEFunction{iip}(sys,dvs,ps,u0;tgrad=tgrad,jac=jac,Wfact=Wfact,checkbounds=checkbounds,
                         linenumbers=linenumbers,parallel=parallel,
-                        sparse=sparse)
+                        sparse=sparse,eval_expression=eval_expression)
     ODEProblem{iip}(f,u0,tspan,p;kwargs...)
 end
 

--- a/test/sdesystem.jl
+++ b/test/sdesystem.jl
@@ -70,3 +70,11 @@ prob = SDEProblem(de,u0map,(0.0,100.0),parammap,sparsenoise=true)
 @test size(prob.noise_rate_prototype) == (3,3)
 @test prob.noise_rate_prototype isa SparseMatrixCSC
 sol = solve(prob,EM(),dt=0.001)
+
+# Test eval_expression=false
+function test_SDEFunction_no_eval()
+    # Need to test within a function scope to trigger world age issues
+    f = SDEFunction(de, eval_expression=false)
+    @test f([1.0,0.0,0.0], (10.0,26.0,2.33), (0.0,100.0)) ≈ [-10.0, 26.0, 0.0]
+end
+test_SDEFunction_no_eval()


### PR DESCRIPTION
New option that restores the GeneralizedGenerated functions in ODEFunction, for some very specific use cases:

* Building an ODEFunction during precompilation (albeit still with long "evaluating into a closed module/incremental compilation may be fatally broken" warnings).
* Building an ODEFunction and calling it from within the same non-global scope.