### PR TITLE
Fast Jacobian Sparsity

### DIFF
--- a/src/differentials.jl
+++ b/src/differentials.jl
@@ -49,7 +49,7 @@ function expand_derivatives(O::Operation,simplify=true)
         isa(o.op, Variable) && return O
 
         l = length(o.args)
-        exprs = []
+        exprs = Expression[]
         c = 0
 
         for i in 1:l
@@ -62,7 +62,10 @@ function expand_derivatives(O::Operation,simplify=true)
             else
                 derivative(o, i) * t2
             end
-            if x isa Expression
+
+            if _iszero(x)
+                continue
+            elseif x isa Expression
                 push!(exprs, x)
             else
                 c += x

--- a/src/differentials.jl
+++ b/src/differentials.jl
@@ -48,19 +48,33 @@ function expand_derivatives(O::Operation,simplify=true)
         isa(o, Operation)   || return O
         isa(o.op, Variable) && return O
 
-        x = sum(1:length(o.args)) do i
+        l = length(o.args)
+        exprs = []
+        c = 0
+
+        for i in 1:l
             t2 = expand_derivatives(D(o.args[i]),false)
 
-            if _iszero(t2)
-                return t2
+            x = if _iszero(t2)
+                t2
             elseif _isone(t2)
-                return derivative(o, i)
+                derivative(o, i)
             else
-                return derivative(o, i) * t2
+                derivative(o, i) * t2
+            end
+            if x isa Expression
+                push!(exprs, x)
+            else
+                c += x
             end
         end
 
-        return simplify ? ModelingToolkit.simplify(x) : x
+        if isempty(exprs)
+            return c
+        else
+            x = Operation(+, !iszero(c) ? vcat(c, exprs) : exprs)
+            return simplify ? ModelingToolkit.simplify(x) : x
+        end
     end
 
     return simplify ? ModelingToolkit.simplify(O) : O


### PR DESCRIPTION
From 121 seconds to:
```
julia> @time jac = ModelingToolkit.jacobian_sparsity(vec(du),vec(u))
  0.401049 seconds (2.62 M allocations: 61.215 MiB, 2.42% gc time)
3072×3072 SparseMatrixCSC{Bool,Int64} with 13184 stored entries:
```
on https://github.com/JuliaSymbolics/SymbolicUtils.jl/issues/61#issuecomment-653410335