### PR TITLE
avoid promotion of constants to Operation

### DIFF
--- a/src/differentials.jl
+++ b/src/differentials.jl
@@ -77,7 +77,7 @@ function expand_derivatives(O::Operation,simplify=true)
                 derivative(o, i)
             else
                 t1 = derivative(o, i)
-                make_operation(*, [t1, t2])
+                make_operation(*, Expression[t1, t2])
             end
 
             if _iszero(x)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,4 +1,4 @@
-function make_operation(op, args)
+function make_operation(@nospecialize(op), args)
     if op === (*)
         args = filter(!_isone, args)
         if isempty(args)


### PR DESCRIPTION
Before
```julia

julia> a
(((100.0 * (((1.0u₂ˏ₁ˏ₁ + -2.0u₃ˏ₁ˏ₁) + 1.0u₄ˏ₁ˏ₁) + (u₃ˏ₁ˏ₁ * -2.0 + u₃ˏ₂ˏ₁ * 2.0)) + 0.0) - 1.0u₃ˏ₁ˏ₁) - (1.0u₃ˏ₁ˏ₁) * u₃ˏ₁ˏ₂) + 1.0u₃ˏ₁ˏ₃

julia> b
u₃ˏ₁ˏ₁

julia> ModelingToolkit.expand_derivatives(ModelingToolkit.Differential(b)(a), false)
-401.0 + identity(-1) * u₃ˏ₁ˏ₂
```
After
```julia
julia> ModelingToolkit.expand_derivatives(ModelingToolkit.Differential(b)(a), false)
-401.0 + -1u₃ˏ₁ˏ₂
```
Increasingly `simplify` is pretty useless in `expand_derivatives`!