### PR TITLE
implement expand_derivatives for Equation

### DIFF
--- a/src/equations.jl
+++ b/src/equations.jl
@@ -59,3 +59,7 @@ function _eq_unordered(a, b)
     end
     return true
 end
+
+function expand_derivatives(eq::Equation, simplify=true)
+    return Equation(expand_derivatives(eq.lhs, simplify), expand_derivatives(eq.rhs, simplify))
+end

--- a/test/derivatives.jl
+++ b/test/derivatives.jl
@@ -98,3 +98,4 @@ using ModelingToolkit
 L = .5 * ∂ₜ(x)^2 - .5 * x^2
 @test isequal(expand_derivatives(∂ₓ(L)), -1 * x)
 @test isequal(expand_derivatives(Differential(x)(L) - ∂ₜ(Differential(∂ₜ(x))(L))), -1 * (∂ₜ(∂ₜ(x)) + x))
+@test isequal(expand_derivatives(Differential(x)(L) ~ ∂ₜ(Differential(∂ₜ(x))(L))), (-1 * x) ~ ∂ₜ(∂ₜ(x)))


### PR DESCRIPTION
This implements `expand_derivatives` for `Equation` objects as well. Is this a good idea?