### PR TITLE
define modelingtoolkitize for SDESystem with conversion tests

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -57,9 +57,10 @@ julia = "1.2"
 Dagger = "d58978e5-989f-55fb-8d15-ea34adc7bf54"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SteadyStateDiffEq = "9672c7b4-1e72-59bd-8a11-6ac3964bc41f"
 StochasticDiffEq = "789caeaf-c7a9-5a7d-9973-96adeb23e2a0"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Dagger", "ForwardDiff", "OrdinaryDiffEq", "SteadyStateDiffEq", "Test", "StochasticDiffEq"]
+test = ["Dagger", "ForwardDiff", "OrdinaryDiffEq", "Random", "SteadyStateDiffEq", "Test", "StochasticDiffEq"]

--- a/src/ModelingToolkit.jl
+++ b/src/ModelingToolkit.jl
@@ -140,6 +140,7 @@ export calculate_gradient, generate_gradient
 export calculate_factorized_W, generate_factorized_W
 export calculate_hessian, generate_hessian
 export calculate_massmatrix, generate_diffusion_function
+export stochastic_integral_transform
 
 export BipartiteGraph, equation_dependencies, variable_dependencies
 export eqeq_dependencies, varvar_dependencies

--- a/src/systems/diffeqs/modelingtoolkitize.jl
+++ b/src/systems/diffeqs/modelingtoolkitize.jl
@@ -26,3 +26,79 @@ function modelingtoolkitize(prob::DiffEqBase.ODEProblem)
 
     de
 end
+
+
+
+"""
+$(TYPEDSIGNATURES)
+
+Generate `SDESystem`, dependent variables, and parameters from an `SDEProblem`.
+Choose correction_factor=-1//2 (1//2) to converte Ito -> Stratonovich (Stratonovich->Ito).
+The default correction_factor is `nothing`.
+"""
+function modelingtoolkitize(prob::DiffEqBase.SDEProblem; correction_factor=nothing)
+    prob.f isa DiffEqBase.AbstractParameterizedFunction &&
+                            return (prob.f.sys, prob.f.sys.states, prob.f.sys.ps)
+    @parameters t
+    vars = reshape([Variable(:x, i)(t) for i in eachindex(prob.u0)],size(prob.u0))
+    params = prob.p isa DiffEqBase.NullParameters ? [] :
+             reshape([Variable(:α,i)() for i in eachindex(prob.p)],size(prob.p))
+    @derivatives D'~t
+
+    rhs = [D(var) for var in vars]
+
+    if DiffEqBase.isinplace(prob)
+        lhs = similar(vars, Any)
+        prob.f(lhs, vars, params, t)
+
+        if DiffEqBase.is_diagonal_noise(prob)
+            neqs = similar(vars, Any)
+            prob.g(neqs, vars, params, t)
+        else
+            neqs = similar(vars, Any, size(prob.noise_rate_prototype))
+            prob.g(neqs, vars, params, t)
+        end
+    else
+        lhs = prob.f(vars, params, t)
+        if DiffEqBase.is_diagonal_noise(prob)
+            neqs = prob.g(vars, params, t)
+        else
+            neqs = prob.g(vars, params, t)
+        end
+    end
+
+    if correction_factor!=nothing
+        # use the general interface
+        if DiffEqBase.is_diagonal_noise(prob)
+            eqs = vcat([rhs[i] ~ neqs[i] for i in eachindex(prob.u0)]...)
+            de = ODESystem(eqs,t,vec(vars),vec(params))
+
+            jac = calculate_jacobian(de, sparse=false, simplify=true)
+            ∇σσ′ = simplify.(jac*neqs)
+
+            deqs = vcat([rhs[i] ~ lhs[i] + correction_factor*∇σσ′[i] for i in eachindex(prob.u0)]...)
+        else
+            dimstate, m = size(prob.noise_rate_prototype)
+            eqs = vcat([rhs[i] ~ neqs[i] for i in eachindex(prob.u0)]...)
+            de = ODESystem(eqs,t,vec(vars),vec(params))
+
+            jac = calculate_jacobian(de, sparse=false, simplify=true)
+            ∇σσ′ = simplify.(jac*neqs[:,1])
+            for k = 2:m
+                eqs = vcat([rhs[i] ~ neqs[Int(i+(k-1)*dimstate)] for i in eachindex(prob.u0)]...)
+                de = ODESystem(eqs,t,vec(vars),vec(params))
+
+                jac = calculate_jacobian(de, sparse=false, simplify=true)
+                ∇σσ′ = ∇σσ′ + simplify.(jac*neqs[:,k])
+            end
+
+            deqs = vcat([rhs[i] ~ lhs[i] + correction_factor*∇σσ′[i] for i in eachindex(prob.u0)]...)
+        end
+    else
+        deqs = vcat([rhs[i] ~ lhs[i] for i in eachindex(prob.u0)]...)
+    end
+
+    de = SDESystem(deqs,neqs,t,vec(vars),vec(params))
+
+    de
+end

--- a/src/systems/diffeqs/modelingtoolkitize.jl
+++ b/src/systems/diffeqs/modelingtoolkitize.jl
@@ -33,10 +33,8 @@ end
 $(TYPEDSIGNATURES)
 
 Generate `SDESystem`, dependent variables, and parameters from an `SDEProblem`.
-Choose correction_factor=-1//2 (1//2) to converte Ito -> Stratonovich (Stratonovich->Ito).
-The default correction_factor is `nothing`.
 """
-function modelingtoolkitize(prob::DiffEqBase.SDEProblem; correction_factor=nothing)
+function modelingtoolkitize(prob::DiffEqBase.SDEProblem)
     prob.f isa DiffEqBase.AbstractParameterizedFunction &&
                             return (prob.f.sys, prob.f.sys.states, prob.f.sys.ps)
     @parameters t
@@ -66,38 +64,8 @@ function modelingtoolkitize(prob::DiffEqBase.SDEProblem; correction_factor=nothi
             neqs = prob.g(vars, params, t)
         end
     end
-
-    if correction_factor!=nothing
-        # use the general interface
-        if DiffEqBase.is_diagonal_noise(prob)
-            eqs = vcat([rhs[i] ~ neqs[i] for i in eachindex(prob.u0)]...)
-            de = ODESystem(eqs,t,vec(vars),vec(params))
-
-            jac = calculate_jacobian(de, sparse=false, simplify=true)
-            ∇σσ′ = simplify.(jac*neqs)
-
-            deqs = vcat([rhs[i] ~ lhs[i] + correction_factor*∇σσ′[i] for i in eachindex(prob.u0)]...)
-        else
-            dimstate, m = size(prob.noise_rate_prototype)
-            eqs = vcat([rhs[i] ~ neqs[i] for i in eachindex(prob.u0)]...)
-            de = ODESystem(eqs,t,vec(vars),vec(params))
-
-            jac = calculate_jacobian(de, sparse=false, simplify=true)
-            ∇σσ′ = simplify.(jac*neqs[:,1])
-            for k = 2:m
-                eqs = vcat([rhs[i] ~ neqs[Int(i+(k-1)*dimstate)] for i in eachindex(prob.u0)]...)
-                de = ODESystem(eqs,t,vec(vars),vec(params))
-
-                jac = calculate_jacobian(de, sparse=false, simplify=true)
-                ∇σσ′ = ∇σσ′ + simplify.(jac*neqs[:,k])
-            end
-
-            deqs = vcat([rhs[i] ~ lhs[i] + correction_factor*∇σσ′[i] for i in eachindex(prob.u0)]...)
-        end
-    else
-        deqs = vcat([rhs[i] ~ lhs[i] for i in eachindex(prob.u0)]...)
-    end
-
+    deqs = vcat([rhs[i] ~ lhs[i] for i in eachindex(prob.u0)]...)
+    
     de = SDESystem(deqs,neqs,t,vec(vars),vec(params))
 
     de

--- a/test/sdesystem.jl
+++ b/test/sdesystem.jl
@@ -109,13 +109,13 @@ fdif!(du,u0,p,t)
 @test du == p[2]*u0
 
 # Ito -> Strat
-sys = modelingtoolkitize(prob,correction_factor=-1//2)
-fdrift = eval(generate_function(sys)[1])
-fdif = eval(generate_diffusion_function(sys)[1])
+sys2 = stochastic_integral_transform(sys,-1//2)
+fdrift = eval(generate_function(sys2)[1])
+fdif = eval(generate_diffusion_function(sys2)[1])
 @test fdrift(u0,p,t) == p[1]*u0 - 1//2*p[2]^2*u0
 @test fdif(u0,p,t) == p[2]*u0
-fdrift! = eval(generate_function(sys)[2])
-fdif! = eval(generate_diffusion_function(sys)[2])
+fdrift! = eval(generate_function(sys2)[2])
+fdif! = eval(generate_diffusion_function(sys2)[2])
 du = similar(u0)
 fdrift!(du,u0,p,t)
 @test  du == p[1]*u0 - 1//2*p[2]^2*u0
@@ -123,13 +123,13 @@ fdif!(du,u0,p,t)
 @test du == p[2]*u0
 
 # Strat -> Ito
-sys = modelingtoolkitize(prob,correction_factor=1//2)
-fdrift = eval(generate_function(sys)[1])
-fdif = eval(generate_diffusion_function(sys)[1])
+sys2 = stochastic_integral_transform(sys,1//2)
+fdrift = eval(generate_function(sys2)[1])
+fdif = eval(generate_diffusion_function(sys2)[1])
 @test fdrift(u0,p,t) == p[1]*u0 + 1//2*p[2]^2*u0
 @test fdif(u0,p,t) == p[2]*u0
-fdrift! = eval(generate_function(sys)[2])
-fdif! = eval(generate_diffusion_function(sys)[2])
+fdrift! = eval(generate_function(sys2)[2])
+fdif! = eval(generate_diffusion_function(sys2)[2])
 du = similar(u0)
 fdrift!(du,u0,p,t)
 @test  du == p[1]*u0 + 1//2*p[2]^2*u0
@@ -157,13 +157,13 @@ fdif!(du,u0,p,t)
 @test du == pi .+ atan.(u0)
 
 # Ito -> Strat
-sys = modelingtoolkitize(prob,correction_factor=-1//2)
-fdrift = eval(generate_function(sys)[1])
-fdif = eval(generate_diffusion_function(sys)[1])
+sys2 = stochastic_integral_transform(sys,-1//2)
+fdrift = eval(generate_function(sys2)[1])
+fdif = eval(generate_diffusion_function(sys2)[1])
 @test fdrift(u0,p,t) ==  @. sin(t) + cos(u0) - 1//2*1/(1 + u0^2)*(pi + atan(u0))
 @test fdif(u0,p,t) == pi .+ atan.(u0)
-fdrift! = eval(generate_function(sys)[2])
-fdif! = eval(generate_diffusion_function(sys)[2])
+fdrift! = eval(generate_function(sys2)[2])
+fdif! = eval(generate_diffusion_function(sys2)[2])
 du = similar(u0)
 fdrift!(du,u0,p,t)
 @test  du ==  @. sin(t) + cos(u0) - 1//2*1/(1 + u0^2)*(pi + atan(u0))
@@ -171,13 +171,13 @@ fdif!(du,u0,p,t)
 @test du == pi .+ atan.(u0)
 
 # Strat -> Ito
-sys = modelingtoolkitize(prob,correction_factor=1//2)
-fdrift = eval(generate_function(sys)[1])
-fdif = eval(generate_diffusion_function(sys)[1])
+sys2 = stochastic_integral_transform(sys,1//2)
+fdrift = eval(generate_function(sys2)[1])
+fdif = eval(generate_diffusion_function(sys2)[1])
 @test fdrift(u0,p,t) ==  @. sin(t) + cos(u0) + 1//2*1/(1 + u0^2)*(pi + atan(u0))
 @test fdif(u0,p,t) == pi .+ atan.(u0)
-fdrift! = eval(generate_function(sys)[2])
-fdif! = eval(generate_diffusion_function(sys)[2])
+fdrift! = eval(generate_function(sys2)[2])
+fdif! = eval(generate_diffusion_function(sys2)[2])
 du = similar(u0)
 fdrift!(du,u0,p,t)
 @test  du ==  @. sin(t) + cos(u0) + 1//2*1/(1 + u0^2)*(pi + atan(u0))
@@ -215,13 +215,13 @@ fdif!(du,u0,p,t)
 @test du ==  reverse(u0)
 
 # Ito -> Strat
-sys = modelingtoolkitize(prob,correction_factor=-1//2)
-fdrift = eval(generate_function(sys)[1])
-fdif = eval(generate_diffusion_function(sys)[1])
+sys2 = stochastic_integral_transform(sys,-1//2)
+fdrift = eval(generate_function(sys2)[1])
+fdif = eval(generate_diffusion_function(sys2)[1])
 @test fdrift(u0,p,t) == u0*0
 @test fdif(u0,p,t) == reverse(u0)
-fdrift! = eval(generate_function(sys)[2])
-fdif! = eval(generate_diffusion_function(sys)[2])
+fdrift! = eval(generate_function(sys2)[2])
+fdif! = eval(generate_diffusion_function(sys2)[2])
 du = similar(u0)
 fdrift!(du,u0,p,t)
 @test  du == u0*0
@@ -229,13 +229,13 @@ fdif!(du,u0,p,t)
 @test du == reverse(u0)
 
 # Strat -> Ito
-sys = modelingtoolkitize(prob,correction_factor=1//2)
-fdrift = eval(generate_function(sys)[1])
-fdif = eval(generate_diffusion_function(sys)[1])
+sys2 = stochastic_integral_transform(sys,1//2)
+fdrift = eval(generate_function(sys2)[1])
+fdif = eval(generate_diffusion_function(sys2)[1])
 @test fdrift(u0,p,t) == u0
 @test fdif(u0,p,t) == reverse(u0)
-fdrift! = eval(generate_function(sys)[2])
-fdif! = eval(generate_diffusion_function(sys)[2])
+fdrift! = eval(generate_function(sys2)[2])
+fdif! = eval(generate_diffusion_function(sys2)[2])
 du = similar(u0)
 fdrift!(du,u0,p,t)
 @test  du == u0
@@ -267,13 +267,13 @@ fdif!(du,u0,p,t)
 @test du == p[2]*u0
 
 # Ito -> Strat
-sys = modelingtoolkitize(prob,correction_factor=-1//2)
-fdrift = eval(generate_function(sys)[1])
-fdif = eval(generate_diffusion_function(sys)[1])
+sys2 = stochastic_integral_transform(sys,-1//2)
+fdrift = eval(generate_function(sys2)[1])
+fdif = eval(generate_diffusion_function(sys2)[1])
 @test fdrift(u0,p,t) == p[1]*u0 - 1//2*p[2]^2*u0
 @test fdif(u0,p,t) == p[2]*u0
-fdrift! = eval(generate_function(sys)[2])
-fdif! = eval(generate_diffusion_function(sys)[2])
+fdrift! = eval(generate_function(sys2)[2])
+fdif! = eval(generate_diffusion_function(sys2)[2])
 du = similar(u0)
 fdrift!(du,u0,p,t)
 @test  du == p[1]*u0 - 1//2*p[2]^2*u0
@@ -281,13 +281,13 @@ fdif!(du,u0,p,t)
 @test du == p[2]*u0
 
 # Strat -> Ito
-sys = modelingtoolkitize(prob,correction_factor=1//2)
-fdrift = eval(generate_function(sys)[1])
-fdif = eval(generate_diffusion_function(sys)[1])
+sys2 = stochastic_integral_transform(sys,1//2)
+fdrift = eval(generate_function(sys2)[1])
+fdif = eval(generate_diffusion_function(sys2)[1])
 @test fdrift(u0,p,t) == p[1]*u0 + 1//2*p[2]^2*u0
 @test fdif(u0,p,t) == p[2]*u0
-fdrift! = eval(generate_function(sys)[2])
-fdif! = eval(generate_diffusion_function(sys)[2])
+fdrift! = eval(generate_function(sys2)[2])
+fdif! = eval(generate_diffusion_function(sys2)[2])
 du = similar(u0)
 fdrift!(du,u0,p,t)
 @test  du == p[1]*u0 + 1//2*p[2]^2*u0
@@ -327,14 +327,14 @@ fdif!(du,u0,p,t)
              p[4]*u0[1]   p[5]*u0[2]  ]
 
 # Ito -> Strat
-sys = modelingtoolkitize(prob,correction_factor=-1//2)
-fdrift = eval(generate_function(sys)[1])
-fdif = eval(generate_diffusion_function(sys)[1])
+sys2 = stochastic_integral_transform(sys,-1//2)
+fdrift = eval(generate_function(sys2)[1])
+fdif = eval(generate_diffusion_function(sys2)[1])
 @test fdrift(u0,p,t) == [p[1]*u0[1] - 1//2*(p[2]^2*u0[1]+p[3]^2*u0[1]), p[1]*u0[2] - 1//2*(p[2]*p[4]*u0[1]+p[5]^2*u0[2])]
 @test fdif(u0,p,t) == [p[2]*u0[1]   p[3]*u0[1]
                       p[4]*u0[1]     p[5]*u0[2] ]
-fdrift! = eval(generate_function(sys)[2])
-fdif! = eval(generate_diffusion_function(sys)[2])
+fdrift! = eval(generate_function(sys2)[2])
+fdif! = eval(generate_diffusion_function(sys2)[2])
 du = similar(u0)
 fdrift!(du,u0,p,t)
 @test  du == [p[1]*u0[1] - 1//2*(p[2]^2*u0[1]+p[3]^2*u0[1]), p[1]*u0[2] - 1//2*(p[2]*p[4]*u0[1]+p[5]^2*u0[2])]
@@ -344,14 +344,14 @@ fdif!(du,u0,p,t)
             p[4]*u0[1]     p[5]*u0[2] ]
 
 # Strat -> Ito
-sys = modelingtoolkitize(prob,correction_factor=1//2)
-fdrift = eval(generate_function(sys)[1])
-fdif = eval(generate_diffusion_function(sys)[1])
+sys2 = stochastic_integral_transform(sys,1//2)
+fdrift = eval(generate_function(sys2)[1])
+fdif = eval(generate_diffusion_function(sys2)[1])
 @test fdrift(u0,p,t) == [p[1]*u0[1] + 1//2*(p[2]^2*u0[1]+p[3]^2*u0[1]), p[1]*u0[2] + 1//2*(p[2]*p[4]*u0[1]+p[5]^2*u0[2])]
 @test fdif(u0,p,t) == [p[2]*u0[1]   p[3]*u0[1]
                       p[4]*u0[1]     p[5]*u0[2] ]
-fdrift! = eval(generate_function(sys)[2])
-fdif! = eval(generate_diffusion_function(sys)[2])
+fdrift! = eval(generate_function(sys2)[2])
+fdif! = eval(generate_diffusion_function(sys2)[2])
 du = similar(u0)
 fdrift!(du,u0,p,t)
 @test  du == [p[1]*u0[1] + 1//2*(p[2]^2*u0[1]+p[3]^2*u0[1]), p[1]*u0[2] + 1//2*(p[2]*p[4]*u0[1]+p[5]^2*u0[2])]
@@ -397,14 +397,14 @@ fdif!(du,u0,p,t)
                         sin(p[1])*sin(u0[1])   sin(p[1])*cos(u0[1])    cos(p[1])*sin(u0[2])    cos(p[1])*cos(u0[2])]
 
 # Ito -> Strat
-sys = modelingtoolkitize(prob,correction_factor=-1//2)
-fdrift = eval(generate_function(sys)[1])
-fdif = eval(generate_diffusion_function(sys)[1])
+sys2 = stochastic_integral_transform(sys,-1//2)
+fdrift = eval(generate_function(sys2)[1])
+fdif = eval(generate_diffusion_function(sys2)[1])
 @test fdrift(u0,p,t) == 0*u0
 @test fdif(u0,p,t) == [ cos(p[1])*sin(u0[1])   cos(p[1])*cos(u0[1])   -sin(p[1])*sin(u0[2])   -sin(p[1])*cos(u0[2])
                         sin(p[1])*sin(u0[1])   sin(p[1])*cos(u0[1])    cos(p[1])*sin(u0[2])    cos(p[1])*cos(u0[2])]
-fdrift! = eval(generate_function(sys)[2])
-fdif! = eval(generate_diffusion_function(sys)[2])
+fdrift! = eval(generate_function(sys2)[2])
+fdif! = eval(generate_diffusion_function(sys2)[2])
 du = similar(u0)
 fdrift!(du,u0,p,t)
 @test  du ==  0*u0
@@ -414,14 +414,14 @@ fdif!(du,u0,p,t)
               sin(p[1])*sin(u0[1])   sin(p[1])*cos(u0[1])    cos(p[1])*sin(u0[2])    cos(p[1])*cos(u0[2])]
 
 # Strat -> Ito
-sys = modelingtoolkitize(prob,correction_factor=1//2)
-fdrift = eval(generate_function(sys)[1])
-fdif = eval(generate_diffusion_function(sys)[1])
+sys2 = stochastic_integral_transform(sys,1//2)
+fdrift = eval(generate_function(sys2)[1])
+fdif = eval(generate_diffusion_function(sys2)[1])
 @test fdrift(u0,p,t) ==  0*u0
 @test fdif(u0,p,t) ==  [ cos(p[1])*sin(u0[1])   cos(p[1])*cos(u0[1])   -sin(p[1])*sin(u0[2])   -sin(p[1])*cos(u0[2])
                          sin(p[1])*sin(u0[1])   sin(p[1])*cos(u0[1])    cos(p[1])*sin(u0[2])    cos(p[1])*cos(u0[2])]
-fdrift! = eval(generate_function(sys)[2])
-fdif! = eval(generate_diffusion_function(sys)[2])
+fdrift! = eval(generate_function(sys2)[2])
+fdif! = eval(generate_diffusion_function(sys2)[2])
 du = similar(u0)
 fdrift!(du,u0,p,t)
 @test  du ==  0*u0


### PR DESCRIPTION
This PR adds a dispatch for `modelingtoolkitize` of an SDESystem and allows us to convert the drift term from Ito to Stratonovich sense and vice versa.  This should be useful to support also SDE adjoints for Ito SDEs, see https://github.com/SciML/DiffEqSensitivity.jl/issues/279 .

The conversion factor of 1//2 is not strictly fixed, as in the adjoints, one needs to apply the correction term two times. Therefore, this could now be handled by 

`sys = modelingtoolkitize(prob,correction_factor=-1)`