### PR TITLE
Enable noise scaling in convert(SDESystem,::ReactionSystem)

### DIFF
--- a/src/systems/reaction/reactionsystem.jl
+++ b/src/systems/reaction/reactionsystem.jl
@@ -418,11 +418,12 @@ function DiffEqBase.ODEProblem(rs::ReactionSystem, u0::Union{AbstractArray, Numb
 end
 
 # SDEProblem from AbstractReactionNetwork
-function DiffEqBase.SDEProblem(rs::ReactionSystem, u0::Union{AbstractArray, Number}, tspan, p, args...; kwargs...)
-    u0 = typeof(u0) <: Array{<:Pair} ? u0 : Pair.(rs.states,u0)
-    p = typeof(p) <: Array{<:Pair} ? p : Pair.(rs.ps,p)
-    p_matrix = zeros(length(rs.states), length(rs.eqs))
-    return SDEProblem(convert(SDESystem,rs),u0,tspan,p,args...; noise_rate_prototype=p_matrix,kwargs...)
+function DiffEqBase.SDEProblem(rs::ReactionSystem, u0::Union{AbstractArray, Number}, tspan, p, args... ;noise_scaling_parameter=:internal___no___noise___scalling::Symbol, kwargs...)
+    sde_sys = convert(SDESystem,rs,noise_scaling_parameter=noise_scaling_parameter)
+    u0 = typeof(u0) <: Array{<:Pair} ? u0 : Pair.(sde_sys.states,u0)
+    p = typeof(p) <: Array{<:Pair} ? p : Pair.(sde_sys.ps,p)
+    p_matrix = zeros(length(sde_sys.states), length(sde_sys.eqs))
+    return SDEProblem(sde_sys,u0,tspan,p,args...; noise_rate_prototype=p_matrix,kwargs...)
 end
 
 # DiscreteProblem from AbstractReactionNetwork

--- a/src/systems/reaction/reactionsystem.jl
+++ b/src/systems/reaction/reactionsystem.jl
@@ -360,7 +360,7 @@ Base.convert(::Type{<:SDESystem},rs::ReactionSystem)
 Convert a ReactionSystem to a SDESystem.
 """
 function Base.convert(::Type{<:SDESystem},rs::ReactionSystem;noise_scaling=nothing::Union{Vector{Symbol},Symbol,Nothing})
-    (typeof(noise_scaling) <: Vector{Symbol}) && (typeof(noise_scaling)!=length(rs.eqs)) && error("The number of elements in 'noise_scaling' must be equal to the number of reactions in the reaction system.")
+    (typeof(noise_scaling) <: Vector{Symbol}) && (length(noise_scaling)!=length(rs.eqs)) && error("The number of elements in 'noise_scaling' must be equal to the number of reactions in the reaction system.")
     (typeof(noise_scaling) <: Symbol) && (noise_scaling = fill(noise_scaling,length(rs.eqs)))
     eqs = assemble_drift(rs)
     noiseeqs = assemble_diffusion(rs,noise_scaling)

--- a/src/systems/reaction/reactionsystem.jl
+++ b/src/systems/reaction/reactionsystem.jl
@@ -415,7 +415,7 @@ function DiffEqBase.ODEProblem(rs::ReactionSystem, u0::Union{AbstractArray, Numb
     p = typeof(p) <: Array{<:Pair} ? p : Pair.(rs.ps,p)
     return ODEProblem(convert(ODESystem,rs),u0,tspan,p, args...; kwargs...)
 end
-gensym(:no_noise_scalling)
+
 # SDEProblem from AbstractReactionNetwork
 function DiffEqBase.SDEProblem(rs::ReactionSystem, u0::Union{AbstractArray, Number}, tspan, p, args... ;noise_scaling_parameter=nothing::Union{Symbol,Nothing}, kwargs...)
     sde_sys = convert(SDESystem,rs,noise_scaling_parameter=noise_scaling_parameter)

--- a/src/systems/reaction/reactionsystem.jl
+++ b/src/systems/reaction/reactionsystem.jl
@@ -360,7 +360,8 @@ Base.convert(::Type{<:SDESystem},rs::ReactionSystem)
 Convert a ReactionSystem to a SDESystem.
 """
 function Base.convert(::Type{<:SDESystem},rs::ReactionSystem;noise_scaling_param=nothing::Union{Vector{Symbol},Symbol,Nothing})
-    (typeof(noise_scaling_param) <: Symbol) && (noise_scaling_param = fill(noise_scaling_param,length(rs.eqs)));
+    (typeof(noise_scaling_param) <: Vector{Symbol}) && (typeof(noise_scaling_param)!=length(rs.eqs)) && error("The number of elements in 'noise_scaling_param' must be equal to the number of reactions in the reaction system.")
+    (typeof(noise_scaling_param) <: Symbol) && (noise_scaling_param = fill(noise_scaling_param,length(rs.eqs)))
     eqs = assemble_drift(rs)
     noiseeqs = assemble_diffusion(rs,noise_scaling_param)
     SDESystem(eqs,noiseeqs,rs.iv,rs.states,(noise_scaling_param==nothing) ? rs.ps : vcat(rs.ps,Variable.(unique(noise_scaling_param))),

--- a/src/systems/reaction/reactionsystem.jl
+++ b/src/systems/reaction/reactionsystem.jl
@@ -205,7 +205,7 @@ function assemble_diffusion(rs,noise_scaling_param)
 
     for (j,rx) in enumerate(rs.eqs)
         rlsqrt = sqrt(oderatelaw(rx))
-        (noise_scaling_param!=nothing) && (rlsqrt *= var2op(Variable(noise_scaling_param[j])))
+        (noise_scaling_param!==nothing) && (rlsqrt *= var2op(Variable(noise_scaling_param[j])))
         for (spec,stoich) in rx.netstoich
             i            = species_to_idx[spec]
             signedrlsqrt = (stoich > zero(stoich)) ? rlsqrt : -rlsqrt
@@ -364,7 +364,7 @@ function Base.convert(::Type{<:SDESystem},rs::ReactionSystem;noise_scaling_param
     (typeof(noise_scaling_param) <: Symbol) && (noise_scaling_param = fill(noise_scaling_param,length(rs.eqs)))
     eqs = assemble_drift(rs)
     noiseeqs = assemble_diffusion(rs,noise_scaling_param)
-    SDESystem(eqs,noiseeqs,rs.iv,rs.states,(noise_scaling_param==nothing) ? rs.ps : vcat(rs.ps,Variable.(unique(noise_scaling_param))),
+    SDESystem(eqs,noiseeqs,rs.iv,rs.states,(noise_scaling_param===nothing) ? rs.ps : vcat(rs.ps,Variable.(unique(noise_scaling_param))),
               name=rs.name,systems=convert.(SDESystem,rs.systems))
 end
 

--- a/test/reactionsystem.jl
+++ b/test/reactionsystem.jl
@@ -86,7 +86,17 @@ p  = rand(length(k)+1)
 u  = rand(length(k))
 t  = 0.
 G  = p[21]*sdenoise(u,p,t)
-sdesys_noise_scaling = convert(SDESystem,rs;noise_scaling_parameter=:η)
+sdesys_noise_scaling = convert(SDESystem,rs;noise_scaling_param=:η)
+sf = SDEFunction{false}(sdesys_noise_scaling, states(rs), parameters(sdesys_noise_scaling))
+G2 = sf.g(u,p,t)
+@test norm(G-G2) < 100*eps()
+
+# tests the noise_scaling_parameter vector argument.
+p  = rand(length(k)+3)
+u  = rand(length(k))
+t  = 0.
+G  = vcat(fill(p[21],8),fill(p[22],3),fill(p[23],9))' .* sdenoise(u,p,t)
+sdesys_noise_scaling = convert(SDESystem,rs;noise_scaling_param=vcat(fill(:η1,8),fill(:η2,3),fill(:η3,9)))
 sf = SDEFunction{false}(sdesys_noise_scaling, states(rs), parameters(sdesys_noise_scaling))
 G2 = sf.g(u,p,t)
 @test norm(G-G2) < 100*eps()

--- a/test/reactionsystem.jl
+++ b/test/reactionsystem.jl
@@ -81,6 +81,16 @@ du2 = sf.f(u,p,t)
 G2 = sf.g(u,p,t)
 @test norm(G-G2) < 100*eps()
 
+# tests the noise_scaling_parameter argument.
+p  = rand(length(k)+1)
+u  = rand(length(k))
+t  = 0.
+G  = p[21]*sdenoise(u,p,t)
+sdesys_noise_scaling = convert(SDESystem,rs;noise_scaling_parameter=η)
+sf = SDEFunction{false}(sdesys, states(rs), parameters(rs))
+G2 = sf.g(u,p,t)
+@test norm(G-G2) < 100*eps()
+
 # test with JumpSystem
 js = convert(JumpSystem, rs)
 
@@ -142,7 +152,7 @@ end
 
 
 # test for https://github.com/SciML/ModelingToolkit.jl/issues/436
-@parameters t 
+@parameters t
 @variables S I
 rxs = [Reaction(1,[S],[I]), Reaction(1.1,[S],[I])]
 rs = ReactionSystem(rxs, t, [S,I], [])

--- a/test/reactionsystem.jl
+++ b/test/reactionsystem.jl
@@ -81,22 +81,22 @@ du2 = sf.f(u,p,t)
 G2 = sf.g(u,p,t)
 @test norm(G-G2) < 100*eps()
 
-# tests the noise_scaling_parameter argument.
+# tests the noise_scaling argument.
 p  = rand(length(k)+1)
 u  = rand(length(k))
 t  = 0.
 G  = p[21]*sdenoise(u,p,t)
-sdesys_noise_scaling = convert(SDESystem,rs;noise_scaling_param=:η)
+sdesys_noise_scaling = convert(SDESystem,rs;noise_scaling=:η)
 sf = SDEFunction{false}(sdesys_noise_scaling, states(rs), parameters(sdesys_noise_scaling))
 G2 = sf.g(u,p,t)
 @test norm(G-G2) < 100*eps()
 
-# tests the noise_scaling_parameter vector argument.
+# tests the noise_scaling vector argument.
 p  = rand(length(k)+3)
 u  = rand(length(k))
 t  = 0.
 G  = vcat(fill(p[21],8),fill(p[22],3),fill(p[23],9))' .* sdenoise(u,p,t)
-sdesys_noise_scaling = convert(SDESystem,rs;noise_scaling_param=vcat(fill(:η1,8),fill(:η2,3),fill(:η3,9)))
+sdesys_noise_scaling = convert(SDESystem,rs;noise_scaling=vcat(fill(:η1,8),fill(:η2,3),fill(:η3,9)))
 sf = SDEFunction{false}(sdesys_noise_scaling, states(rs), parameters(sdesys_noise_scaling))
 G2 = sf.g(u,p,t)
 @test norm(G-G2) < 100*eps()

--- a/test/reactionsystem.jl
+++ b/test/reactionsystem.jl
@@ -86,8 +86,8 @@ p  = rand(length(k)+1)
 u  = rand(length(k))
 t  = 0.
 G  = p[21]*sdenoise(u,p,t)
-sdesys_noise_scaling = convert(SDESystem,rs;noise_scaling_parameter=η)
-sf = SDEFunction{false}(sdesys, states(rs), parameters(rs))
+sdesys_noise_scaling = convert(SDESystem,rs;noise_scaling_parameter=:η)
+sf = SDEFunction{false}(sdesys_noise_scaling, states(rs), parameters(sdesys_noise_scaling))
 G2 = sf.g(u,p,t)
 @test norm(G-G2) < 100*eps()
 


### PR DESCRIPTION
This adds a kwarg to the function:
```julia
convert(::Type{<:SDESystem},rs::ReactionSystem;noise_scaling_parameter=:internal___no___noise___scalling::Symbol)
```
if the argument is set to anything but its default, a variable with that name will be created and added to the parameter vector of the outputted SDESystem. This parameter will linearly scale the noise in the created chemical Langevin equation.

Can also use it as input when creating `SDEProblems`
```julia
SDEProblem(rs::ReactionSystem, u0::Union{AbstractArray, Number}, tspan, p, args... ;noise_scaling_parameter=:internal___no___noise___scalling::Symbol, kwargs...)
```