### PR TITLE
add option to disable rate law scaling for reactions

### DIFF
--- a/src/systems/reaction/reactionsystem.jl
+++ b/src/systems/reaction/reactionsystem.jl
@@ -258,7 +258,6 @@ function jumpratelaw(rx; rxvars=get_variables(rx.rate), scalerate=true)
     if !only_use_rate
         coef = one(eltype(substoich))
         for (i,stoich) in enumerate(substoich)
-            #rl *= isone(stoich) ? var2op(substrates[i].op) : Operation(binomial,[var2op(substrates[i].op),stoich])
             s   = var2op(substrates[i].op)
             rl *= s
             isone(stoich) && continue

--- a/src/systems/reaction/reactionsystem.jl
+++ b/src/systems/reaction/reactionsystem.jl
@@ -163,9 +163,9 @@ the `Operation` that is returned will be `k * (X(t)^2/2) * (Y(t)^3/6)`.
 Notes:
 - Allocates
 - `combinatoric_ratelaw=true` uses factorial scaling factors in calculating the rate
-law, i.e. for `2S -> 0` at rate `k` the ratelaw would be `k*S^2/2!`. If
-`combinatoric_ratelaw=false` then the ratelaw is `k*S^2`, i.e. the scaling factor is 
-ignored.
+    law, i.e. for `2S -> 0` at rate `k` the ratelaw would be `k*S^2/2!`. If
+    `combinatoric_ratelaw=false` then the ratelaw is `k*S^2`, i.e. the scaling factor is 
+    ignored.
 """ 
 function oderatelaw(rx; combinatoric_ratelaw=true)
     @unpack rate, substrates, substoich, only_use_rate = rx

--- a/test/reactionsystem.jl
+++ b/test/reactionsystem.jl
@@ -170,6 +170,12 @@ ModelingToolkit.modified_states!(dep, rxs[2], states(rs))
 @test isequal(ModelingToolkit.oderatelaw(rxs[1]), k1*S*S^2*I^3/12)
 @test isequal(ModelingToolkit.oderatelaw(rxs[1]; scalerate=false), k1*S*S^2*I^3)
 
+#test ODE scaling:
+os = convert(ODESystem,rs)
+@test isequal(simplify(os.eqs[1].rhs),simplify(-2*k1*S*S^2*I^3/12))
+os = convert(ODESystem,rs; scalerates=false)
+@test isequal(simplify(os.eqs[1].rhs),simplify(-2*k1*S*S^2*I^3))
+
 # test ConstantRateJump rate scaling
 js = convert(JumpSystem,rs)
 @test isequal(js.eqs[1].rate, k1*S*S*(S-1)*I*(I-1)*(I-2)/12)

--- a/test/reactionsystem.jl
+++ b/test/reactionsystem.jl
@@ -165,28 +165,31 @@ dep2  = Set([R,I])
 dep = Set{Operation}()
 ModelingToolkit.modified_states!(dep, rxs[2], states(rs))
 @test dep == Set([R,I])
-@test isequal(ModelingToolkit.jumpratelaw(rxs[1]), k1*S*S*(S-1)*I*(I-1)*(I-2)/12)
-@test isequal(ModelingToolkit.jumpratelaw(rxs[1]; scalerate=false), k1*S*S*(S-1)*I*(I-1)*(I-2))
-@test isequal(ModelingToolkit.oderatelaw(rxs[1]), k1*S*S^2*I^3/12)
-@test isequal(ModelingToolkit.oderatelaw(rxs[1]; scalerate=false), k1*S*S^2*I^3)
+
+isequal2(a,b) = isequal(simplify(a), simplify(b))
+
+@test isequal2(ModelingToolkit.jumpratelaw(rxs[1]), k1*S*S*(S-1)*I*(I-1)*(I-2)/12)
+@test isequal2(ModelingToolkit.jumpratelaw(rxs[1]; scalerate=false), k1*S*S*(S-1)*I*(I-1)*(I-2))
+@test isequal2(ModelingToolkit.oderatelaw(rxs[1]), k1*S*S^2*I^3/12)
+@test isequal2(ModelingToolkit.oderatelaw(rxs[1]; scalerate=false), k1*S*S^2*I^3)
 
 #test ODE scaling:
 os = convert(ODESystem,rs)
-@test isequal(simplify(os.eqs[1].rhs),simplify(-2*k1*S*S^2*I^3/12))
+@test isequal2(os.eqs[1].rhs, -2*k1*S*S^2*I^3/12)
 os = convert(ODESystem,rs; scalerates=false)
-@test isequal(simplify(os.eqs[1].rhs),simplify(-2*k1*S*S^2*I^3))
+@test isequal2(os.eqs[1].rhs, -2*k1*S*S^2*I^3)
 
 # test ConstantRateJump rate scaling
 js = convert(JumpSystem,rs)
-@test isequal(js.eqs[1].rate, k1*S*S*(S-1)*I*(I-1)*(I-2)/12)
+@test isequal2(js.eqs[1].rate, k1*S*S*(S-1)*I*(I-1)*(I-2)/12)
 js = convert(JumpSystem,rs;scalerates=false)
-@test isequal(js.eqs[1].rate, k1*S*S*(S-1)*I*(I-1)*(I-2))
+@test isequal2(js.eqs[1].rate, k1*S*S*(S-1)*I*(I-1)*(I-2))
 
 # test MassActionJump rate scaling
 rxs = [Reaction(k1, [S,I], [I], [2,3], [2]),
        Reaction(k2, [I], [R]) ]
 rs = ReactionSystem(rxs, t, [S,I,R], [k1,k2])
 js = convert(JumpSystem, rs)
-@test isequal(js.eqs[1].scaled_rates, k1/12)
+@test isequal2(js.eqs[1].scaled_rates, k1/12)
 js = convert(JumpSystem,rs; scalerates=false)
-@test isequal(js.eqs[1].scaled_rates, k1)
+@test isequal2(js.eqs[1].scaled_rates, k1)

--- a/test/reactionsystem.jl
+++ b/test/reactionsystem.jl
@@ -165,3 +165,22 @@ dep2  = Set([R,I])
 dep = Set{Operation}()
 ModelingToolkit.modified_states!(dep, rxs[2], states(rs))
 @test dep == Set([R,I])
+@test isequal(ModelingToolkit.jumpratelaw(rxs[1]), k1*S*S*(S-1)*I*(I-1)*(I-2)/12)
+@test isequal(ModelingToolkit.jumpratelaw(rxs[1]; scalerate=false), k1*S*S*(S-1)*I*(I-1)*(I-2))
+@test isequal(ModelingToolkit.oderatelaw(rxs[1]), k1*S*S^2*I^3/12)
+@test isequal(ModelingToolkit.oderatelaw(rxs[1]; scalerate=false), k1*S*S^2*I^3)
+
+# test ConstantRateJump rate scaling
+js = convert(JumpSystem,rs)
+@test isequal(js.eqs[1].rate, k1*S*S*(S-1)*I*(I-1)*(I-2)/12)
+js = convert(JumpSystem,rs;scalerates=false)
+@test isequal(js.eqs[1].rate, k1*S*S*(S-1)*I*(I-1)*(I-2))
+
+# test MassActionJump rate scaling
+rxs = [Reaction(k1, [S,I], [I], [2,3], [2]),
+       Reaction(k2, [I], [R]) ]
+rs = ReactionSystem(rxs, t, [S,I,R], [k1,k2])
+js = convert(JumpSystem, rs)
+@test isequal(js.eqs[1].scaled_rates, k1/12)
+js = convert(JumpSystem,rs; scalerates=false)
+@test isequal(js.eqs[1].scaled_rates, k1)

--- a/test/reactionsystem.jl
+++ b/test/reactionsystem.jl
@@ -169,20 +169,20 @@ ModelingToolkit.modified_states!(dep, rxs[2], states(rs))
 isequal2(a,b) = isequal(simplify(a), simplify(b))
 
 @test isequal2(ModelingToolkit.jumpratelaw(rxs[1]), k1*S*S*(S-1)*I*(I-1)*(I-2)/12)
-@test isequal2(ModelingToolkit.jumpratelaw(rxs[1]; scalerate=false), k1*S*S*(S-1)*I*(I-1)*(I-2))
+@test isequal2(ModelingToolkit.jumpratelaw(rxs[1]; combinatoric_ratelaw=false), k1*S*S*(S-1)*I*(I-1)*(I-2))
 @test isequal2(ModelingToolkit.oderatelaw(rxs[1]), k1*S*S^2*I^3/12)
-@test isequal2(ModelingToolkit.oderatelaw(rxs[1]; scalerate=false), k1*S*S^2*I^3)
+@test isequal2(ModelingToolkit.oderatelaw(rxs[1]; combinatoric_ratelaw=false), k1*S*S^2*I^3)
 
 #test ODE scaling:
 os = convert(ODESystem,rs)
 @test isequal2(os.eqs[1].rhs, -2*k1*S*S^2*I^3/12)
-os = convert(ODESystem,rs; scalerates=false)
+os = convert(ODESystem,rs; combinatoric_ratelaws=false)
 @test isequal2(os.eqs[1].rhs, -2*k1*S*S^2*I^3)
 
 # test ConstantRateJump rate scaling
 js = convert(JumpSystem,rs)
 @test isequal2(js.eqs[1].rate, k1*S*S*(S-1)*I*(I-1)*(I-2)/12)
-js = convert(JumpSystem,rs;scalerates=false)
+js = convert(JumpSystem,rs;combinatoric_ratelaws=false)
 @test isequal2(js.eqs[1].rate, k1*S*S*(S-1)*I*(I-1)*(I-2))
 
 # test MassActionJump rate scaling
@@ -191,5 +191,5 @@ rxs = [Reaction(k1, [S,I], [I], [2,3], [2]),
 rs = ReactionSystem(rxs, t, [S,I,R], [k1,k2])
 js = convert(JumpSystem, rs)
 @test isequal2(js.eqs[1].scaled_rates, k1/12)
-js = convert(JumpSystem,rs; scalerates=false)
+js = convert(JumpSystem,rs; combinatoric_ratelaws=false)
 @test isequal2(js.eqs[1].scaled_rates, k1)


### PR DESCRIPTION
We'll need something like this for `ReactionNetworkImporters`. 

I also dropped use of `binomial` in `jumpratelaw`, as this was not simplified down when generating the `rate` functions for `ConstantRateJump`s.