### PR TITLE
Do not inject getproperty when the module is Base and make simpler

### DIFF
--- a/src/function_registration.jl
+++ b/src/function_registration.jl
@@ -135,8 +135,8 @@ function inject_registered_module_functions(expr)
         if !isnothing(f_name)
             # Set the calling module to the module that registered it.
             mod = get(registered_external_functions, f_name, f_module)
-            if !isnothing(mod)
-                x.args[1] = :(getproperty($mod, $(Meta.quot(f_name))))
+            if !isnothing(mod) && mod != Base
+                x.args[1] = :($mod.$f_name)
             end
         end
 


### PR DESCRIPTION
```julia
using ModelingToolkit
@variables x y

module MyModule
  f(x) = 3x
end
using .MyModule
@register MyModule.f(x)

to_compute = [MyModule.f(x^2 + y), y^2 + x]
f_expr = clipboard(build_function(to_compute,[x,y])[2])
```

Before:

```julia
(var"##MTIIPVar#290", var"##MTKArg#288")->begin
        @inbounds begin
                begin
                    (ModelingToolkit.fill_array_with_zero!)(var"##MTIIPVar#290")
                    let (x, y) = (var"##MTKArg#288"[1], var"##MTKArg#288"[2])
                        var"##MTIIPVar#290"[1] = (getproperty(Main.MyModule, :f))((getproperty(Base, :+))(x ^ 2, y))
                        var"##MTIIPVar#290"[2] = (getproperty(Base, :+))(y ^ 2, x)
                    end
                end
            end
        nothing
    end
```

After:

```julia
f2 = (var"##MTIIPVar#300", var"##MTKArg#298")->begin
        @inbounds begin
                begin
                    (ModelingToolkit.fill_array_with_zero!)(var"##MTIIPVar#300")
                    let (x, y) = (var"##MTKArg#298"[1], var"##MTKArg#298"[2])
                        var"##MTIIPVar#300"[1] = (Main.MyModule).f(x ^ 2 + y)
                        var"##MTIIPVar#300"[2] = y ^ 2 + x
                    end
                end
            end
        nothing
    end
```