### PR TITLE
unflatten long operations in build_function

### DIFF
--- a/src/build_function.jl
+++ b/src/build_function.jl
@@ -376,7 +376,8 @@ function _build_function(target::JuliaTarget, rhss, args...;
         dagwrap(ex::Expr) = dagwrap(ex, Val(ex.head))
         dagwrap(ex::Expr, ::Val) = ex
         dagwrap(ex::Expr, ::Val{:call}) = :(Dagger.delayed($(ex.args[1]))($(dagwrap.(ex.args[2:end])...)))
-        new_rhss = dagwrap.(conv.(rhss))
+
+        new_rhss = dagwrap.(conv.(Array(rhss)))
         delayed_exprs = build_expr(:block, [:($(Symbol(computevars[i])) = Dagger.delayed(identity)($(new_rhss[i]))) for i in axes(computevars,1)])
         # TODO: treereduce?
         reduce_expr = quote

--- a/src/build_function.jl
+++ b/src/build_function.jl
@@ -257,7 +257,7 @@ function _build_function(target::JuliaTarget, rhss, args...;
         rhs_length = length(rhss.nzval)
         rhss = SparseMatrixCSC(rhss.m, rhss.m, rhss.colptr, rhss.rowval, map(unflatten_long_ops, rhss.nzval))
     else
-        length(rhss)
+        rhs_length = length(rhss)
         rhss = map(unflatten_long_ops, rhss)
     end
 

--- a/src/build_function.jl
+++ b/src/build_function.jl
@@ -258,7 +258,7 @@ function _build_function(target::JuliaTarget, rhss, args...;
         rhss = SparseMatrixCSC(rhss.m, rhss.m, rhss.colptr, rhss.rowval, map(unflatten_long_ops, rhss.nzval))
     else
         rhs_length = length(rhss)
-        rhss = Expression[unflatten_long_ops(r) for r in rhss]
+        rhss = [unflatten_long_ops(r) for r in rhss]
     end
 
 	if parallel isa DistributedForm

--- a/test/build_function.jl
+++ b/test/build_function.jl
@@ -64,3 +64,10 @@ h_julia_scalar(a, b, c, d, e, g) = a[1] + b[1] + c[1] + c[2] + c[3] + d[1] + e[1
 h_str_scalar = ModelingToolkit.build_function(h_scalar, [a], [b], [c1, c2, c3], [d], [e], [g])
 h_oop_scalar = eval(h_str_scalar)
 @test h_oop_scalar(inputs...) == h_julia_scalar(inputs...)
+
+@variables z[1:100]
+@test isequal(simplify(ModelingToolkit.unflatten_long_ops(sum(z))),
+              simplify(sum(z)))
+
+@test isequal(simplify(ModelingToolkit.unflatten_long_ops(prod(z))),
+              simplify(prod(z)))


### PR DESCRIPTION
fixes #551 

```julia
julia> @btime fastf(dx0, x0)    # 2.107 μs (102 allocations: 2.38 KiB)
  116.814 ns (0 allocations: 0 bytes)
```