### PR TITLE
Add GalacticOptim-compatible OptimizationProblem generation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -60,6 +60,7 @@ julia = "1.2"
 Dagger = "d58978e5-989f-55fb-8d15-ea34adc7bf54"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 GalacticOptim = "a75be94c-b780-496d-a8a9-0878b188d577"
+Optim = "429524aa-4258-5aef-a3af-852621145aeb"
 OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SteadyStateDiffEq = "9672c7b4-1e72-59bd-8a11-6ac3964bc41f"
@@ -67,4 +68,4 @@ StochasticDiffEq = "789caeaf-c7a9-5a7d-9973-96adeb23e2a0"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Dagger", "ForwardDiff", "GalacticOptim", "OrdinaryDiffEq", "Random", "SteadyStateDiffEq", "Test", "StochasticDiffEq"]
+test = ["Dagger", "ForwardDiff", "GalacticOptim", "OrdinaryDiffEq", "Optim", "Random", "SteadyStateDiffEq", "Test", "StochasticDiffEq"]

--- a/Project.toml
+++ b/Project.toml
@@ -59,6 +59,7 @@ julia = "1.2"
 [extras]
 Dagger = "d58978e5-989f-55fb-8d15-ea34adc7bf54"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
+GalacticOptim = "a75be94c-b780-496d-a8a9-0878b188d577"
 OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SteadyStateDiffEq = "9672c7b4-1e72-59bd-8a11-6ac3964bc41f"
@@ -66,4 +67,4 @@ StochasticDiffEq = "789caeaf-c7a9-5a7d-9973-96adeb23e2a0"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Dagger", "ForwardDiff", "OrdinaryDiffEq", "Random", "SteadyStateDiffEq", "Test", "StochasticDiffEq"]
+test = ["Dagger", "ForwardDiff", "GalacticOptim", "OrdinaryDiffEq", "Random", "SteadyStateDiffEq", "Test", "StochasticDiffEq"]

--- a/src/systems/diffeqs/modelingtoolkitize.jl
+++ b/src/systems/diffeqs/modelingtoolkitize.jl
@@ -99,7 +99,7 @@ function modelingtoolkitize(prob::DiffEqBase.OptimizationProblem)
         p = prob.p
     end
 
-    vars = reshape([Variable(:x, i)(t) for i in eachindex(prob.u0)],size(prob.u0))
+    vars = reshape([Variable(:x, i)() for i in eachindex(prob.u0)],size(prob.u0))
     params = p isa DiffEqBase.NullParameters ? [] :
              reshape([Variable(:α,i)() for i in eachindex(p)],size(Array(p)))
 

--- a/src/systems/diffeqs/modelingtoolkitize.jl
+++ b/src/systems/diffeqs/modelingtoolkitize.jl
@@ -84,3 +84,27 @@ function modelingtoolkitize(prob::DiffEqBase.SDEProblem)
 
     de
 end
+
+
+"""
+$(TYPEDSIGNATURES)
+
+Generate `OptimizationSystem`, dependent variables, and parameters from an `OptimizationProblem`.
+"""
+function modelingtoolkitize(prob::DiffEqBase.OptimizationProblem)
+
+    if prob.p isa Tuple || prob.p isa NamedTuple
+        p = [x for x in prob.p]
+    else
+        p = prob.p
+    end
+
+    vars = reshape([Variable(:x, i)(t) for i in eachindex(prob.u0)],size(prob.u0))
+    params = p isa DiffEqBase.NullParameters ? [] :
+             reshape([Variable(:α,i)() for i in eachindex(p)],size(Array(p)))
+
+
+    eqs = prob.f(vars, params)
+    de = OptimizationSystem(eqs,vec(vars),vec(params))
+    de
+end

--- a/src/systems/optimization/optimizationsystem.jl
+++ b/src/systems/optimization/optimizationsystem.jl
@@ -90,10 +90,6 @@ struct AutoModelingToolkit <: DiffEqBase.AbstractADType end
 DiffEqBase.OptimizationProblem(sys::OptimizationSystem,args...;kwargs...) =
     DiffEqBase.OptimizationProblem{true}(sys::OptimizationSystem,args...;kwargs...)
 
-OptimizationProblemExpr(sys::OptimizationSystem,args...;kwargs...) =
-    OptimizationProblemExpr{true}(sys::OptimizationSystem,args...;kwargs...)
-
-
 """
 ```julia
 function DiffEqBase.OptimizationProblem{iip}(sys::OptimizationSystem,
@@ -168,6 +164,9 @@ calculating numerical enhancements.
 """
 struct OptimizationProblemExpr{iip} end
 
+OptimizationProblemExpr(sys::OptimizationSystem,args...;kwargs...) =
+    OptimizationProblemExpr{true}(sys::OptimizationSystem,args...;kwargs...)
+    
 function OptimizationProblemExpr{iip}(sys::OptimizationSystem, u0,
                                           parammap=DiffEqBase.NullParameters();
                                           lb=nothing, ub=nothing,

--- a/src/systems/optimization/optimizationsystem.jl
+++ b/src/systems/optimization/optimizationsystem.jl
@@ -134,7 +134,7 @@ function DiffEqBase.OptimizationProblem{iip}(sys::OptimizationSystem, u0,
         _hess = nothing
     end
 
-    _f = OptimizationFunction{iip,typeof(f),typeof(_grad),typeof(_hess),Nothing,Nothing,Nothing,Nothing}(f,_grad,_hess,nothing,AutoModelingToolkit(),nothing,nothing,nothing,0)
+    _f = DiffEqBase.OptimizationFunction{iip,AutoModelingToolkit,typeof(f),typeof(_grad),typeof(_hess),Nothing,Nothing,Nothing,Nothing}(f,AutoModelingToolkit(),_grad,_hess,nothing,nothing,nothing,nothing,0)
 
     p = varmap_to_vars(parammap,ps)
     lb = varmap_to_vars(lb,dvs)
@@ -205,7 +205,7 @@ function OptimizationProblemExpr{iip}(sys::OptimizationSystem, u0,
 end
 
 function OptimizationFunction(f, x, ::AutoModelingToolkit,p = DiffEqBase.NullParameters();
-                              grad=nothing, hess=nothing, cons = nothing, cons_j = nothing, cons_h = nothing,
+                              grad=false, hess=false, cons = nothing, cons_j = nothing, cons_h = nothing,
                               num_cons = 0, chunksize = 1, hv = nothing)
 
     sys = modelingtoolkitize(OptimizationProblem(f,x,p))
@@ -215,5 +215,5 @@ function OptimizationFunction(f, x, ::AutoModelingToolkit,p = DiffEqBase.NullPar
     else
         parammap = parameters(sys) .=> p
     end
-    OptimiationProblem(sys,u0map,parammap,grad=grad,hess=hess)
+    OptimizationProblem(sys,u0map,parammap,grad=grad,hess=hess).f
 end

--- a/src/systems/optimization/optimizationsystem.jl
+++ b/src/systems/optimization/optimizationsystem.jl
@@ -86,6 +86,9 @@ hessian_sparsity(sys::OptimizationSystem) =
 
 struct AutoModelingToolkit <: DiffEqBase.AbstractADType end
 
+DiffEqBase.OptimizationProblem(sys::OptimizationSystem,args...;kwargs...) =
+    DiffEqBase.OptimizationProblem{true}(sys::OptimizationSystem,args...;kwargs...)
+
 """
 ```julia
 function DiffEqBase.OptimizationProblem{iip}(sys::OptimizationSystem,
@@ -120,7 +123,7 @@ function DiffEqBase.OptimizationProblem{iip}(sys::OptimizationSystem, u0,
         grad_oop,grad_iip = generate_gradient(sys,checkbounds=checkbounds,linenumbers=linenumbers,
                                   parallel=parallel,expression=Val{false})
         _grad(u,p) = grad_oop(u,p)
-        _grad(J,u,p) = grad_iip(J,u,p)
+        _grad(J,u,p) = (grad_iip(J,u,p); J)
     else
         _grad = nothing
     end
@@ -129,7 +132,7 @@ function DiffEqBase.OptimizationProblem{iip}(sys::OptimizationSystem, u0,
         hess_oop,hess_iip = generate_hessian(sys,checkbounds=checkbounds,linenumbers=linenumbers,
                                  sparse=sparse,parallel=parallel,expression=Val{false})
        _hess(u,p) = hess_oop(u,p)
-       _hess(J,u,p) = hess_iip(J,u,p)
+       _hess(J,u,p) = (hess_iip(J,u,p); J)
     else
         _hess = nothing
     end

--- a/test/controlsystem.jl
+++ b/test/controlsystem.jl
@@ -13,4 +13,7 @@ eqs = [
 sys = ControlSystem(loss,eqs,t,[x,v],[u],[p])
 dt = 0.1
 tspan = (0.0,1.0)
-runge_kutta_discretize(sys,dt,tspan)
+sys = runge_kutta_discretize(sys,dt,tspan)
+
+u0 = rand(112) # guess for the state values
+prob = OptimizationProblem(sys,u0,[0.1],grad=true)

--- a/test/modelingtoolkitize.jl
+++ b/test/modelingtoolkitize.jl
@@ -48,13 +48,14 @@ x0 = zeros(2)
 p  = [1.0,100.0]
 
 prob = OptimizationProblem(rosenbrock,x0,p)
-sys = modelingtoolkitize(prob)
-x0map = states(sys) .=> x0
-parammap = parameters(sys) .=> p
+sys = modelingtoolkitize(prob) # symbolicitize me captain!
 
-prob = OptimizationProblem(sys,x0map,parammap,grad=true)
+prob = OptimizationProblem(sys,x0,p,grad=true,hess=true)
 sol = solve(prob,NelderMead())
 @test sol.minimum < 1e-8
 
 sol = solve(prob,BFGS())
+@test sol.minimum < 1e-8
+
+sol = solve(prob,Newton())
 @test sol.minimum < 1e-8

--- a/test/modelingtoolkitize.jl
+++ b/test/modelingtoolkitize.jl
@@ -1,4 +1,6 @@
-using OrdinaryDiffEq, ModelingToolkit
+using OrdinaryDiffEq, ModelingToolkit, Test
+using GalacticOptim, Optim
+
 const N = 32
 const xyd_brusselator = range(0,stop=1,length=N)
 brusselator_f(x, y, t) = (((x-0.3)^2 + (y-0.6)^2) <= 0.1^2) * (t >= 1.1) * 5.
@@ -38,3 +40,21 @@ prob_ode_brusselator_2d = ODEProblem(brusselator_2d_loop,
                                      u0,(0.,11.5),p)
 
 modelingtoolkitize(prob_ode_brusselator_2d)
+
+## Optimization
+
+rosenbrock(x,p) =  (p[1] - x[1])^2 + p[2] * (x[2] - x[1]^2)^2
+x0 = zeros(2)
+p  = [1.0,100.0]
+
+prob = OptimizationProblem(rosenbrock,x0,p)
+sys = modelingtoolkitize(prob)
+
+prob = OptimizationProblem(ModelingToolkit.OptimizationFunction(
+                    rosenbrock,x0,ModelingToolkit.AutoModelingToolkit(),p,
+                                     grad = true), x0,p)
+sol = solve(prob,NelderMead())
+@test sol.minimum < 1e-8
+
+sol = solve(prob,BFGS())
+@test_broken sol.minimum < 1e-8

--- a/test/modelingtoolkitize.jl
+++ b/test/modelingtoolkitize.jl
@@ -49,12 +49,12 @@ p  = [1.0,100.0]
 
 prob = OptimizationProblem(rosenbrock,x0,p)
 sys = modelingtoolkitize(prob)
+x0map = states(sys) .=> x0
+parammap = parameters(sys) .=> p
 
-prob = OptimizationProblem(ModelingToolkit.OptimizationFunction(
-                    rosenbrock,x0,ModelingToolkit.AutoModelingToolkit(),p,
-                                     grad = true), x0,p)
+prob = OptimizationProblem(sys,x0map,parammap,grad=true)
 sol = solve(prob,NelderMead())
 @test sol.minimum < 1e-8
 
 sol = solve(prob,BFGS())
-@test_broken sol.minimum < 1e-8
+@test sol.minimum < 1e-8

--- a/test/optimizationsystem.jl
+++ b/test/optimizationsystem.jl
@@ -1,4 +1,4 @@
-using ModelingToolkit, SparseArrays
+using ModelingToolkit, SparseArrays, Test, GalacticOptim, Optim
 
 @variables x y
 @parameters a b
@@ -36,7 +36,13 @@ p = [
     sys2.b => 9.0
     β => 10.0
 ]
-prob = OptimizationProblem(combinedsys,u0,p,grad=true)
 
-using GalacticOptim, Optim
-solve(prob,BFGS())
+prob = OptimizationProblem(combinedsys,u0,p,grad=true)
+sol = solve(prob,NelderMead())
+@test sol.minimum < -1e5
+
+prob2 = remake(prob,u0=sol.minimizer)
+sol = solve(prob,BFGS(initial_stepnorm=0.0001),allow_f_increases=true)
+@test sol.minimum < -1e8
+sol = solve(prob2,BFGS(initial_stepnorm=0.0001),allow_f_increases=true)
+@test sol.minimum < -1e9

--- a/test/optimizationsystem.jl
+++ b/test/optimizationsystem.jl
@@ -21,3 +21,22 @@ generate_function(combinedsys)
 generate_gradient(combinedsys)
 generate_hessian(combinedsys)
 ModelingToolkit.hessian_sparsity(combinedsys)
+
+u0 = [
+    sys1.x=>1.0
+    sys1.y=>2.0
+    sys2.x=>3.0
+    sys2.y=>4.0
+    z=>5.0
+]
+p = [
+    sys1.a => 6.0
+    sys1.b => 7.0
+    sys2.a => 8.0
+    sys2.b => 9.0
+    β => 10.0
+]
+prob = OptimizationProblem(combinedsys,u0,p,grad=true)
+
+using GalacticOptim, Optim
+solve(prob,BFGS())


### PR DESCRIPTION
Requires hoisting OptimizationProblem/OptimizationFunction back to DiffEqBase (which was intended anyways), and then defines a new AD version here that defines the OptimizationProblem from the symbolic code.

Requires https://github.com/SciML/DiffEqBase.jl/pull/590 and https://github.com/SciML/GalacticOptim.jl/pull/52