### PR TITLE
WIP: speed up JumpProblem conversion 2

### DIFF
--- a/src/systems/abstractsystem.jl
+++ b/src/systems/abstractsystem.jl
@@ -199,9 +199,14 @@ namespace_expr(O,name,ivname) = O
 
 independent_variable(sys::AbstractSystem) = sys.iv
 function states(sys::AbstractSystem)
-    unique(isempty(sys.systems) ?
-           setdiff(sys.states, value.(sys.pins)) :
-           [sys.states;reduce(vcat,namespace_variables.(sys.systems))])
+    sts = sys.states
+    if !isempty(sys.pins)
+        sts = setdiff(sts, sys.pins)
+    end
+    if !isempty(sys.systems)
+        sts = unique([sts; reduce(vcat,namespace_variables.(sys.systems))])
+    end
+    sts
 end
 parameters(sys::AbstractSystem) = isempty(sys.systems) ? sys.ps : [sys.ps;reduce(vcat,namespace_parameters.(sys.systems))]
 pins(sys::AbstractSystem) = isempty(sys.systems) ? sys.pins : [sys.pins;reduce(vcat,namespace_pins.(sys.systems))]

--- a/src/systems/dependency_graphs.jl
+++ b/src/systems/dependency_graphs.jl
@@ -46,6 +46,7 @@ function equation_dependencies(sys::AbstractSystem; variables=states(sys))
     deps = Set()
     depeqs_to_vars = Vector{Vector}(undef,length(eqs))
 
+    variables = Set(variables)
     for (i,eq) in enumerate(eqs)
         get_variables!(deps, eq, variables)
         depeqs_to_vars[i] = [value(v) for v in deps]
@@ -194,6 +195,7 @@ function variable_dependencies(sys::AbstractSystem; variables=states(sys), varia
 
     deps = Set()
     badjlist = Vector{Vector{Int}}(undef, length(eqs))    
+    variables = Set(variables)
     for (eidx,eq) in enumerate(eqs)
         modified_states!(deps, eq, variables)
         badjlist[eidx] = sort!([vtois[var] for var in deps])

--- a/src/systems/diffeqs/abstractodesystem.jl
+++ b/src/systems/diffeqs/abstractodesystem.jl
@@ -12,7 +12,7 @@ function calculate_tgrad(sys::AbstractODESystem;
       tgrad = ModelingToolkit.simplify.(notime_tgrad)
   end
   xs = states(sys)
-  rule = Dict(map((x, xt) -> x=>xt, detime_dvs.(xs), xs))
+  rule = Dict(detime_dvs(x)=>x for x in xs)
   tgrad = substitute.(tgrad, Ref(rule))
   sys.tgrad[] = tgrad
   return tgrad

--- a/src/systems/jumps/jumpsystem.jl
+++ b/src/systems/jumps/jumpsystem.jl
@@ -284,7 +284,7 @@ function get_variables!(dep, jump::Union{ConstantRateJump,VariableRateJump}, var
     dep
 end
 
-function get_variables!(dep, jump::MassActionJump, variables::Set)
+function get_variables!(dep, jump::MassActionJump, variables::AbstractSet)
     sr = value(jump.scaled_rates)
     (sr isa Symbolic) && get_variables!(dep, sr, variables)
     for varasop in jump.reactant_stoch

--- a/src/systems/jumps/jumpsystem.jl
+++ b/src/systems/jumps/jumpsystem.jl
@@ -288,7 +288,7 @@ function get_variables!(dep, jump::MassActionJump, variables::AbstractSet)
     sr = value(jump.scaled_rates)
     (sr isa Symbolic) && get_variables!(dep, sr, variables)
     for varasop in jump.reactant_stoch
-        isequal(varasop[1]) in variables && push!(dep, varasop[1])
+        varasop[1] in variables && push!(dep, varasop[1])
     end
     dep
 end

--- a/src/systems/jumps/jumpsystem.jl
+++ b/src/systems/jumps/jumpsystem.jl
@@ -280,30 +280,30 @@ end
 
 
 ### Functions to determine which states a jump depends on
-function get_variables!(dep, jump::Union{ConstantRateJump,VariableRateJump}, variables)
+function get_variables!(dep, jump::Union{ConstantRateJump,VariableRateJump}, variables::AbstractSet)
     (jump.rate isa Symbolic) && get_variables!(dep, jump.rate, variables)
     dep
 end
 
-function get_variables!(dep, jump::MassActionJump, variables)
+function get_variables!(dep, jump::MassActionJump, variables::Set)
     sr = value(jump.scaled_rates)
     (sr isa Symbolic) && get_variables!(dep, sr, variables)
     for varasop in jump.reactant_stoch
-        any(isequal(varasop[1]), variables) && push!(dep, varasop[1])
+        isequal(varasop[1]) in variables && push!(dep, varasop[1])
     end
     dep
 end
 
 ### Functions to determine which states are modified by a given jump
-function modified_states!(mstates, jump::Union{ConstantRateJump,VariableRateJump}, sts)
+function modified_states!(mstates, jump::Union{ConstantRateJump,VariableRateJump}, sts::AbstractSet)
     for eq in jump.affect!
         st = eq.lhs
-        any(isequal(st), sts) && push!(mstates, st)
+        st in sts && push!(mstates, st)
     end
 end
 
-function modified_states!(mstates, jump::MassActionJump, sts)
+function modified_states!(mstates, jump::MassActionJump, sts::AbstractSet)
     for (state,stoich) in jump.net_stoch
-        any(isequal(state), sts) && push!(mstates, state)
+        state in sts && push!(mstates, state)
     end
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -68,7 +68,12 @@ get_variables!(vars, e::Number, varlist=nothing) = vars
 
 function get_variables!(vars, e::Symbolic, varlist=nothing)
     if is_singleton(e)
-        if isnothing(varlist) || any(isequal(e), varlist)
+        if !isnothing(varlist)
+            @assert varlist isa AbstractSet
+            if e in varlist
+                push!(vars, e)
+            end
+        else
             push!(vars, e)
         end
     else

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -89,22 +89,14 @@ modified_states!(mstates, e::Equation, statelist=nothing) = get_variables!(mstat
 # variable substitution
 # Piracy but mild
 """
-substitute(expr, s::Pair)
-substitute(expr, s::Dict)
-substitute(expr, s::Vector)
+substitute(expr::Num, s::Dict)
 
-Performs the substitution `Num => val` on the `expr` Num.
+Substitute all keys of `s` appearing in `expr` with the corresponding values.
+
+Note that the dictionary may not itself contain `Num`, construct it after unwrapping
+with `value`.
 """
-substitute(expr::Num, s::Union{Pair, Vector, Dict}; kw...) = Num(substituter(s)(value(expr); kw...))
-# TODO: move this to SymbolicUtils
-substitute(expr::Term, s::Pair; kw...) = substituter([s[1] => s[2]])(expr; kw...)
-substitute(expr::Term, s::Vector; kw...) = substituter(s)(expr; kw...)
-
-substituter(pair::Pair) = substituter((pair,))
-function substituter(pairs)
-    dict = Dict(to_symbolic(k) => to_symbolic(v)  for (k, v) in pairs)
-    (expr; kw...) -> SymbolicUtils.substitute(expr, dict; kw...)
-end
+substitute(expr::Num, s::Dict; kw...) = Num(substitute(value(expr), s; kw...))
 
 macro showarr(x)
     n = string(x)

--- a/test/reactionsystem.jl
+++ b/test/reactionsystem.jl
@@ -150,9 +150,9 @@ jumps[19] = VariableRateJump((u,p,t) -> p[19]*u[1]*t, integrator -> (integrator.
 jumps[20] = VariableRateJump((u,p,t) -> p[20]*t*u[1]*binomial(u[2],2)*u[3], integrator -> (integrator.u[2] -= 2; integrator.u[3] -= 1; integrator.u[4] += 2))
 
 statetoid = Dict(state => i for (i,state) in enumerate(states(js)))
-parammap = map((x,y)->Pair(x,y),parameters(js),pars)
+parammap = Dict(map((x,y)->x=>y,parameters(js),pars))
 for i in midxs
-  maj = MT.assemble_maj(js.eqs[i], statetoid, ModelingToolkit.substituter(parammap),eltype(pars))
+  maj = MT.assemble_maj(js.eqs[i], statetoid, parammap,eltype(pars))
   @test abs(jumps[i].scaled_rates - maj.scaled_rates) < 100*eps()
   @test jumps[i].reactant_stoch == maj.reactant_stoch
   @test jumps[i].net_stoch == maj.net_stoch

--- a/test/variable_utils.jl
+++ b/test/variable_utils.jl
@@ -1,13 +1,14 @@
 using ModelingToolkit, Test
+using ModelingToolkit: value
 @parameters α β δ
 expr = (((1 / β - 1) + δ) / α) ^ (1 / (α - 1))
 ref = [β, δ, α]
 sol = Num.(ModelingToolkit.get_variables(expr))
 @test all(simplify, sol[i] == ref[i] for i in 1:3)
 
+s = value(α) => value(γ)
 @parameters γ
-s = α => γ
 expr = (((1 / β - 1) + δ) / α) ^ (1 / (α - 1))
-sol = ModelingToolkit.substitute(expr, s)
+sol = ModelingToolkit.substitute(expr, Dict(s))
 new = (((1 / β - 1) + δ) / γ) ^ (1 / (γ - 1))
 @test iszero(sol - new)


### PR DESCRIPTION
https://gist.github.com/isaacsas/593f9ce7f40adf05b6969ace8fe8a831

with

```julia
const nedgess = 30
const nvertss = 1000
```
gives

```julia
  0.000425 seconds (14.00 k allocations: 641.219 KiB)
Completed: ReactionSystem
  0.033972 seconds (519.34 k allocations: 16.500 MiB)
Completed: convert(JumpSystem)
  0.025654 seconds (585.68 k allocations: 15.495 MiB)
Completed: DiscreteProblem
  2.788977 seconds (2.35 M allocations: 2.143 GiB, 5.16% gc time)
Completed: JumpProblem
  0.000594 seconds (30 allocations: 353.297 KiB)
```

This is probably really bad. I'm thinking of better hash-table operations for the purposes here, hopefully we can turn something from `O(n^2)` to `O(n)`