### PR TITLE
Adapt runge_kutta_discretize

### DIFF
--- a/src/systems/control/controlsystem.jl
+++ b/src/systems/control/controlsystem.jl
@@ -160,8 +160,8 @@ function runge_kutta_discretize(sys::ControlSystem,dt,tspan;
     control_equality = reduce(vcat,[control_timeseries[i][end] .~ control_timeseries[i+1][1] for i in 1:n-1])
 
     # Create the loss function
-    losses = [Base.invokelatest(L,states_timeseries[i],control_timeseries[i][1],(ps,),(iv,)) for i in 1:n]
-    losses = vcat(losses,[Base.invokelatest(L,states_timeseries[n+1],control_timeseries[n][end],(ps,),(iv,))])
+    losses = [Base.invokelatest(L,states_timeseries[i],control_timeseries[i][1],ps,iv) for i in 1:n]
+    losses = vcat(losses,[Base.invokelatest(L,states_timeseries[n+1],control_timeseries[n][end],ps,iv)])
 
     # Calculate final pieces
     equalities = vcat(stages,updates,control_equality)

--- a/test/controlsystem.jl
+++ b/test/controlsystem.jl
@@ -1,19 +1,20 @@
 using ModelingToolkit
 
 @variables t x(t) v(t) u(t)
-@parameters p
+@parameters p[1:1]
 @derivatives D'~t
 
 loss = (4-x)^2 + 2v^2 + u^2
 eqs = [
-    D(x) ~ v
-    D(v) ~ p*u^3
+    D(x) ~ v #- p[2]*x
+    D(v) ~ p[1]*u^3 + v
 ]
 
-sys = ControlSystem(loss,eqs,t,[x,v],[u],[p])
+sys = ControlSystem(loss,eqs,t,[x,v],[u],p)
 dt = 0.1
 tspan = (0.0,1.0)
 sys = runge_kutta_discretize(sys,dt,tspan)
 
 u0 = rand(112) # guess for the state values
 prob = OptimizationProblem(sys,u0,[0.1],grad=true)
+

--- a/test/controlsystem.jl
+++ b/test/controlsystem.jl
@@ -1,12 +1,12 @@
 using ModelingToolkit
 
 @variables t x(t) v(t) u(t)
-@parameters p[1:1]
+@parameters p[1:2]
 @derivatives D'~t
 
 loss = (4-x)^2 + 2v^2 + u^2
 eqs = [
-    D(x) ~ v #- p[2]*x
+    D(x) ~ v - p[2]*x
     D(v) ~ p[1]*u^3 + v
 ]
 


### PR DESCRIPTION
I noticed the following problem when working with parameter arrays to build a control system.

Building from the example in `.\test`:

```julia
using ModelingToolkit

@variables t x(t) v(t) u(t)
@parameters p[1:2]
@derivatives D'~t

loss = (4-x)^2 + 2v^2 + u^2
eqs = [
    D(x) ~ v + p[2]*v
    D(v) ~ p[1]*u^3
]

sys = ControlSystem(loss,eqs,t,[x,v],[u],p)
dt = 0.1
tspan = (0.0,1.0)
sys = runge_kutta_discretize(sys,dt,tspan)
``` 

Gives the following output:

```julia
ERROR: LoadError: BoundsError: attempt to access (Sym{ModelingToolkit.Parameter{Real}}[p₁, p₂],)
  at index [2]
Stacktrace:
 [1] getindex(::Tuple, ::Int64) at ./tuple.jl:24
 [2] macro expansion at /home/alcapitan/Documents/code/ModelingToolkit.jl/src/build_function.jl:118 [inlined]
 [3] macro expansion at /home/alcapitan/.julia/packages/RuntimeGeneratedFunctions/uvbuv/src/RuntimeGeneratedFunctions.jl:80 [inlined]
 [4] macro expansion at ./none:0 [inlined]
 [5] generated_callfunc at ./none:0 [inlined]
 [6] (::RuntimeGeneratedFunctions.RuntimeGeneratedFunction{(Symbol("##MTKArg#303"), Symbol("##MTKArg#304"), Symbol("##MTKArg#305"), Symbol("##MTKArg#306")),ModelingToolkit.var"#_RGF_ModTag",(0x02850255, 0x3cad7954, 0x5850eab5, 0xd61311cf, 0xf9289ce4)})(::Array{Term{Real},1}, ::Array{Term{Real},1}, ::Tuple{Array{Sym{ModelingToolkit.Parameter{Real}},1}}, ::Tuple{Sym{Real}}) at /home/alcapitan/.julia/packages/RuntimeGeneratedFunctions/uvbuv/src/RuntimeGeneratedFunctions.jl:68
 [7] #invokelatest#1 at ./essentials.jl:710 [inlined]
 [8] invokelatest at ./essentials.jl:709 [inlined]
 [9] #326 at ./none:0 [inlined]
 [10] iterate at ./generator.jl:47 [inlined]
 [11] collect(::Base.Generator{UnitRange{Int64},ModelingToolkit.var"#326#349"{RuntimeGeneratedFunctions.RuntimeGeneratedFunction{(Symbol("##MTKArg#303"), Symbol("##MTKArg#304"), Symbol("##MTKArg#305"), Symbol("##MTKArg#306")),ModelingToolkit.var"#_RGF_ModTag",(0x02850255, 0x3cad7954, 0x5850eab5, 0xd61311cf, 0xf9289ce4)},Array{Array{Term{Real},1},1},Array{Array{Array{Term{Real},1},1},1},Array{Sym{ModelingToolkit.Parameter{Real}},1},Sym{Real}}}) at ./array.jl:686
 [12] runge_kutta_discretize(::ControlSystem, ::Float64, ::Tuple{Float64,Float64}; tab::DiffEqBase.ImplicitRKTableau{Array{Float64,2},Array{Float64,1}}) at /home/alcapitan/Documents/code/ModelingToolkit.jl/src/systems/control/controlsystem.jl:163
 [13] runge_kutta_discretize(::ControlSystem, ::Float64, ::Tuple{Float64,Float64}) at /home/alcapitan/Documents/code/ModelingToolkit.jl/src/systems/control/controlsystem.jl:132
 [14] top-level scope at /home/alcapitan/Documents/code/ModelingToolkit.jl/test/controlsystem.jl:16
 [15] include_string(::Function, ::Module, ::String, ::String) at ./loading.jl:1091
 [16] invokelatest(::Any, ::Any, ::Vararg{Any,N} where N; kwargs::Base.Iterators.Pairs{Union{},Union{},Tuple{},NamedTuple{(),Tuple{}}}) at ./essentials.jl:710
 [17] invokelatest(::Any, ::Any, ::Vararg{Any,N} where N) at ./essentials.jl:709
 [18] inlineeval(::Module, ::String, ::Int64, ::Int64, ::String; softscope::Bool) at /home/alcapitan/.vscode/extensions/julialang.language-julia-1.0.10/scripts/packages/VSCodeServer/src/eval.jl:185
 [19] (::VSCodeServer.var"#61#65"{String,Int64,Int64,String,Module,Bool,VSCodeServer.ReplRunCodeRequestParams})() at /home/alcapitan/.vscode/extensions/julialang.language-julia-1.0.10/scripts/packages/VSCodeServer/src/eval.jl:144
 [20] withpath(::VSCodeServer.var"#61#65"{String,Int64,Int64,String,Module,Bool,VSCodeServer.ReplRunCodeRequestParams}, ::String) at /home/alcapitan/.vscode/extensions/julialang.language-julia-1.0.10/scripts/packages/VSCodeServer/src/repl.jl:124
 [21] (::VSCodeServer.var"#60#64"{String,Int64,Int64,String,Module,Bool,Bool,VSCodeServer.ReplRunCodeRequestParams})() at /home/alcapitan/.vscode/extensions/julialang.language-julia-1.0.10/scripts/packages/VSCodeServer/src/eval.jl:142
 [22] hideprompt(::VSCodeServer.var"#60#64"{String,Int64,Int64,String,Module,Bool,Bool,VSCodeServer.ReplRunCodeRequestParams}) at /home/alcapitan/.vscode/extensions/julialang.language-julia-1.0.10/scripts/packages/VSCodeServer/src/repl.jl:36
 [23] (::VSCodeServer.var"#59#63"{String,Int64,Int64,String,Module,Bool,Bool,VSCodeServer.ReplRunCodeRequestParams})() at /home/alcapitan/.vscode/extensions/julialang.language-julia-1.0.10/scripts/packages/VSCodeServer/src/eval.jl:110
 [24] with_logstate(::Function, ::Any) at ./logging.jl:408
 [25] with_logger at ./logging.jl:514 [inlined]
 [26] (::VSCodeServer.var"#58#62"{VSCodeServer.ReplRunCodeRequestParams})() at /home/alcapitan/.vscode/extensions/julialang.language-julia-1.0.10/scripts/packages/VSCodeServer/src/eval.jl:109
 [27] #invokelatest#1 at ./essentials.jl:710 [inlined]
 [28] invokelatest(::Any) at ./essentials.jl:709
 [29] macro expansion at /home/alcapitan/.vscode/extensions/julialang.language-julia-1.0.10/scripts/packages/VSCodeServer/src/eval.jl:27 [inlined]
 [30] (::VSCodeServer.var"#56#57")() at ./task.jl:356
in expression starting at /home/alcapitan/Documents/code/ModelingToolkit.jl/test/controlsystem.jl:16
```

With the slight modification introduced, the output is as expected

```julia
OptimizationSystem(((((((((((0 + ((((4 - x₁(t)) ^ 2) + (2 * (v₁(t) ^ 2))) + (u₁ˏ₁(t) ^ 2))) + ((((4 - x₂(t)) ^ 2) + (2 * (v₂(t) ^ 2))) + (u₁ˏ₂(t) ^ 2))) + ((((4 - x₃(t)) ^ 2) + (2 * (v₃(t) ^ 2))) + (u₁ˏ₃(t) ^ 2))) + ((((4 - x₄(t)) ^ 2) + (2 * (v₄(t) ^ 2))) + (u₁ˏ₄(t) ^ 2))) + ((((4 - x₅(t)) ^ 2) + (2 * (v₅(t) ^ 2))) + (u₁ˏ₅(t) ^ 2))) + ((((4 - x₆(t)) ^ 2) + (2 * (v₆(t) ^ 2))) + (u₁ˏ₆(t) ^ 2))) + ((((4 - x₇(t)) ^ 2) + (2 * (v₇(t) ^ 2))) + (u₁ˏ₇(t) ^ 2))) + ((((4 - x₈(t)) ^ 2) + (2 * (v₈(t) ^ 2))) + (u₁ˏ₈(t) ^ 2))) + ((((4 - x₉(t)) ^ 2) + (2 * (v₉(t) ^ 2))) + (u₁ˏ₉(t) ^ 2))) + ((((4 - x₁₀(t)) ^ 2) + (2 * (v₁₀(t) ^ 2))) + (u₁ˏ₁₀(t) ^ 2))) + ((((4 - x₁₁(t)) ^ 2) + (2 * (v₁₁(t) ^ 2))) + (u₃ˏ₁₀(t) ^ 2)), Term{Real}[x₁(t), v₁(t), x₂(t), v₂(t), x₃(t), v₃(t), x₄(t), v₄(t), x₅(t), v₅(t)  …  u₃ˏ₇(t), u₁ˏ₈(t), u₂ˏ₈(t), u₃ˏ₈(t), u₁ˏ₉(t), u₂ˏ₉(t), u₃ˏ₉(t), u₁ˏ₁₀(t), u₂ˏ₁₀(t), u₃ˏ₁₀(t)], Sym{ModelingToolkit.Parameter{Real}}[p₁, p₂], Any[], Equation[], Equation[Equation(ᵏx₁ˏ₁(t), 0.1 * ((v₁(t) + (((0 + (0.19681547722366044 * ᵏv₁ˏ₁(t))) + (-0.06553542585019836 * ᵏv₂ˏ₁(t))) + (0.023770974348220147 * ᵏv₃ˏ₁(t)))) - (p₂ * (x₁(t) + (((0 + (0.19681547722366044 * ᵏx₁ˏ₁(t))) + (-0.06553542585019836 * ᵏx₂ˏ₁(t))) + (0.023770974348220147 * ᵏx₃ˏ₁(t))))))), Equation(ᵏv₁ˏ₁(t), 0.1 * ((p₁ * (u₁ˏ₁(t) ^ 3)) + (v₁(t) + (((0 + (0.19681547722366044 * ᵏv₁ˏ₁(t))) + (-0.06553542585019836 * ᵏv₂ˏ₁(t))) + (0.023770974348220147 * ᵏv₃ˏ₁(t)))))), Equation(ᵏx₂ˏ₁(t), 0.1 * ((v₁(t) + (((0 + (0.39442431473908723 * ᵏv₁ˏ₁(t))) + (0.29207341166522843 * ᵏv₂ˏ₁(t))) + (-0.04154875212599793 * ᵏv₃ˏ₁(t)))) - (p₂ * (x₁(t) + (((0 + (0.39442431473908723 * ᵏx₁ˏ₁(t))) + (0.29207341166522843 * ᵏx₂ˏ₁(t))) + (-0.04154875212599793 * ᵏx₃ˏ₁(t))))))), Equation(ᵏv₂ˏ₁(t), 0.1 * ((p₁ * (u₂ˏ₁(t) ^ 3)) + (v₁(t) + (((0 + (0.39442431473908723 * ᵏv₁ˏ₁(t))) + (0.29207341166522843 * ᵏv₂ˏ₁(t))) + (-0.04154875212599793 * ᵏv₃ˏ₁(t)))))), Equation(ᵏx₃ˏ₁(t), 0.1 * ((v₁(t) + (((0 + (0.37640306270046725 * ᵏv₁ˏ₁(t))) + (0.5124858261884215 * ᵏv₂ˏ₁(t))) + (0.1111111111111111 * ᵏv₃ˏ₁(t)))) - (p₂ * (x₁(t) + (((0 + (0.37640306270046725 * ᵏx₁ˏ₁(t))) + (0.5124858261884215 * ᵏx₂ˏ₁(t))) + (0.1111111111111111 * ᵏx₃ˏ₁(t))))))), Equation(ᵏv₃ˏ₁(t), 0.1 * ((p₁ * (u₃ˏ₁(t) ^ 3)) + (v₁(t) + (((0 + (0.37640306270046725 * ᵏv₁ˏ₁(t))) + (0.5124858261884215 * ᵏv₂ˏ₁(t))) + (0.1111111111111111 * ᵏv₃ˏ₁(t)))))), Equation(ᵏx₁ˏ₂(t), 0.1 * ((v₂(t) + (((0 + (0.19681547722366044 * ᵏv₁ˏ₂(t))) + (-0.06553542585019836 * ᵏv₂ˏ₂(t))) + (0.023770974348220147 * ᵏv₃ˏ₂(t)))) - (p₂ * (x₂(t) + (((0 + (0.19681547722366044 * ᵏx₁ˏ₂(t))) + (-0.06553542585019836 * ᵏx₂ˏ₂(t))) + (0.023770974348220147 * ᵏx₃ˏ₂(t))))))), Equation(ᵏv₁ˏ₂(t), 0.1 * ((p₁ * (u₁ˏ₂(t) ^ 3)) + (v₂(t) + (((0 + (0.19681547722366044 * ᵏv₁ˏ₂(t))) + (-0.06553542585019836 * ᵏv₂ˏ₂(t))) + (0.023770974348220147 * ᵏv₃ˏ₂(t)))))), Equation(ᵏx₂ˏ₂(t), 0.1 * ((v₂(t) + (((0 + (0.39442431473908723 * ᵏv₁ˏ₂(t))) + (0.29207341166522843 * ᵏv₂ˏ₂(t))) + (-0.04154875212599793 * ᵏv₃ˏ₂(t)))) - (p₂ * (x₂(t) + (((0 + (0.39442431473908723 * ᵏx₁ˏ₂(t))) + (0.29207341166522843 * ᵏx₂ˏ₂(t))) + (-0.04154875212599793 * ᵏx₃ˏ₂(t))))))), Equation(ᵏv₂ˏ₂(t), 0.1 * ((p₁ * (u₂ˏ₂(t) ^ 3)) + (v₂(t) + (((0 + (0.39442431473908723 * ᵏv₁ˏ₂(t))) + (0.29207341166522843 * ᵏv₂ˏ₂(t))) + (-0.04154875212599793 * ᵏv₃ˏ₂(t))))))  …  Equation(v₁₁(t), v₁₀(t) + (0.1 * (((0 + (0.37640306270046725 * ᵏv₁ˏ₁₀(t))) + (0.5124858261884215 * ᵏv₂ˏ₁₀(t))) + (0.1111111111111111 * ᵏv₃ˏ₁₀(t))))), Equation(u₃ˏ₁(t), u₁ˏ₂(t)), Equation(u₃ˏ₂(t), u₁ˏ₃(t)), Equation(u₃ˏ₃(t), u₁ˏ₄(t)), Equation(u₃ˏ₄(t), u₁ˏ₅(t)), Equation(u₃ˏ₅(t), u₁ˏ₆(t)), Equation(u₃ˏ₆(t), u₁ˏ₇(t)), Equation(u₃ˏ₇(t), u₁ˏ₈(t)), Equation(u₃ˏ₈(t), u₁ˏ₉(t)), Equation(u₃ˏ₉(t), u₁ˏ₁₀(t))], Any[], Symbol("##OptimizationSystem#268"), OptimizationSystem[])
```

Or was this intentional?