### PR TITLE
WIP: use dict instead of dispatch for derivative

### DIFF
--- a/src/differentials.jl
+++ b/src/differentials.jl
@@ -181,19 +181,18 @@ sin(x())
 ```
 """
 derivative_idx(O::Any, ::Any) = 0
+
+# Indicate that no derivative is defined.
+struct NoDeriv
+end
 function derivative_idx(O::Term, idx)
-    d = derivatives[O.op]
+    d = get(derivatives, O.op, (args, i)->NoDeriv())
     if d isa Dict
         d[idx](O.args)
     else
         d(O.args, idx)
     end
 end
-
-# Indicate that no derivative is defined.
-struct NoDeriv
-end
-derivative(f, args, v) = NoDeriv()
 
 const derivatives = Dict{Function, Union{Function, Dict{Int,Function}}}()
 # Pre-defined derivatives

--- a/src/extra_functions.jl
+++ b/src/extra_functions.jl
@@ -3,14 +3,15 @@
 @register Base.binomial(n,k)
 
 @register Base.signbit(x)
-ModelingToolkit.derivative(::typeof(signbit), args::NTuple{1,Any}, ::Val{1}) = 0
+ModelingToolkit.derivatives[signbit] =  (args,i) -> 0
 
-ModelingToolkit.derivative(::typeof(abs), args::NTuple{1,Any}, ::Val{1}) = IfElse.ifelse(signbit(args[1]),-one(args[1]),one(args[1]))
+ModelingToolkit.derivatives[abs] = (args, i) -> IfElse.ifelse(signbit(args[1]),-one(args[1]),one(args[1]))
 
 @register IfElse.ifelse(x,y,z::Any)
-ModelingToolkit.derivative(::typeof(IfElse.ifelse), args::NTuple{3,Any}, ::Val{1}) = 0
-ModelingToolkit.derivative(::typeof(IfElse.ifelse), args::NTuple{3,Any}, ::Val{2}) = IfElse.ifelse(args[1],1,0)
-ModelingToolkit.derivative(::typeof(IfElse.ifelse), args::NTuple{3,Any}, ::Val{3}) = IfElse.ifelse(args[1],0,1)
+ModelingToolkit.derivatives[IfElse.ifelse] = Dict(1=>args -> 0,
+                                                  2=>args -> IfElse.ifelse(args[1],1,0),
+                                                  3=>args -> IfElse.ifelse(args[1],0,1))
+
 
 ModelingToolkit.@register Base.rand(x)
 ModelingToolkit.@register Base.randn(x)


### PR DESCRIPTION
it's faster:

```
julia> @btime ModelingToolkit.expand_derivatives(D(atan(sin(x)*cos(x))), false)
  12.658 μs (163 allocations: 7.27 KiB)
((1 + ((sin(x) * cos(x)) ^ 2)) ^ -1) * ((cos(x) * cos(x)) + (sin(x) * (-sin(x))))

julia> @btime ModelingToolkit.expand_derivatives(D(atan(sin(x)*cos(x))), false)
  21.009 μs (175 allocations: 7.61 KiB)
((1 + ((sin(x) * cos(x)) ^ 2)) ^ -1) * ((cos(x) * cos(x)) + (sin(x) * (-sin(x))))

```