### PR TITLE
namespace_expr should not change type

### DIFF
--- a/src/systems/abstractsystem.jl
+++ b/src/systems/abstractsystem.jl
@@ -188,11 +188,11 @@ function namespace_expr(O::Sym,name,ivname)
     O.name == ivname ? O : rename(O,renamespace(name,O.name))
 end
 
-function namespace_expr(O::Term,name,ivname)
+function namespace_expr(O::Term{T},name,ivname) where {T}
     if O.op isa Sym
-        Term{Real}(rename(O.op,renamespace(name,O.op.name)),namespace_expr.(O.args,name,ivname))
+        Term{T}(rename(O.op,renamespace(name,O.op.name)),namespace_expr.(O.args,name,ivname))
     else
-        Term{Real}(O.op,namespace_expr.(O.args,name,ivname))
+        Term{T}(O.op,namespace_expr.(O.args,name,ivname))
     end
 end
 namespace_expr(O,name,ivname) = O

--- a/test/variable_utils.jl
+++ b/test/variable_utils.jl
@@ -11,3 +11,14 @@ expr = (((1 / β - 1) + δ) / α) ^ (1 / (α - 1))
 sol = ModelingToolkit.substitute(expr, s)
 new = (((1 / β - 1) + δ) / γ) ^ (1 / (γ - 1))
 @test iszero(sol - new)
+
+# test namespace_expr
+@parameters t a p(t)
+pterm = p.val
+pnsp = ModelingToolkit.namespace_expr(pterm, :namespace, :t)
+@test typeof(pterm) == typeof(pnsp)
+@test ModelingToolkit.getname(pnsp) == Symbol("namespace₊p")
+asym = a.val
+ansp = ModelingToolkit.namespace_expr(asym, :namespace, :t)
+@test typeof(asym) == typeof(ansp)
+@test ModelingToolkit.getname(ansp) == Symbol("namespace₊a")


### PR DESCRIPTION
If one changes the namespace of an `Term` symbolic, the type parameter get lost. This leads to strange behaviour, for example one can't performe substitutions on namespaced equations as expected:
```julia
using ModelingToolkit
using ModelingToolkit: getname, renamespace, rename
@parameters t p(t) pnew(t)
@variables x(t)
ode = ODESystem([x ~ p], name=:ode)
eq = namespace_equations(ode)[1]
substitute(eq.rhs, ode.p=>pnew)
# ode₊p(t) without patch
# pnew(t) with patch
```