### PR TITLE
Add support for simple deduplication of terms (for improved performance) when building functions

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -213,7 +213,7 @@ Symbol("z⦗t⦘")
 ```
 """
 function tosymbol(t::Term; states=nothing, escape=true)
-    if t.op isa Sym
+    if t.op isa Union{Sym, Function}
         if states !== nothing && !(any(isequal(t), states))
             return nameof(t.op)
         end

--- a/test/deduplication_terms_test.jl
+++ b/test/deduplication_terms_test.jl
@@ -1,4 +1,3 @@
-using Revise # DELETE ME
 
 using Test
 using ModelingToolkit

--- a/test/deduplication_terms_test.jl
+++ b/test/deduplication_terms_test.jl
@@ -1,0 +1,46 @@
+using Revise # DELETE ME
+
+using Test
+using ModelingToolkit
+using LinearAlgebra.BLAS
+
+@parameters t
+@variables vars[1:10]
+@derivatives D'~t
+
+const sleep_time = 0.1
+function untrace_dupe_f(a::Float64, t::Float64)
+    # This is a function that is both expensive and untraceable (symbolically),
+    # and whose result is used several times in our ODE system of equations.
+    sleep(sleep_time)  # Expensive function!
+    BLAS.dot(10, fill(a, 10), 1, fill(t, 20), 2)  # Untraceable result!
+end
+@test untrace_dupe_f(5., 12.) == 600.0
+
+# Confirm that our function cannot be traced symbolically...
+@test_throws MethodError untrace_dupe_f(vars[1], t)
+
+# Register the function so we can now use it without having to trace it.
+@register untrace_dupe_f(a, t)
+
+# Build an ODE system of equations that uses several duplicated, untraceable terms.
+dupe_terms = (untrace_dupe_f(x, t) for x in vars)
+eqs = (D.(vars) .~ prod(dupe_terms))
+@test length(eqs) == length(vars)
+
+# Build the ODE functions.
+ode_system = ODESystem(eqs, t, vars, [])
+ode_function_naive = ODEFunction(ode_system; jac=false, tgrad=false, eval_expression=false)
+ode_function_deduplicated = ODEFunction(ode_system; jac=false, tgrad=false, eval_expression=false, deduplicate_terms=dupe_terms)
+
+# Run both functions and compare...
+u0 = rand(Float64, length(x))
+t0 = 10.0
+result_naive = ode_function_naive(u0, [], t0)
+result_deduplicated = ode_function_deduplicated(u0, [], t0)
+@test result_naive == result_deduplicated
+
+# The deduplicated version should run much faster, since it does not need to recompute the terms multiple times.
+fuzzy_factor = 0.9
+expected_speedup = fuzzy_factor * length(eqs)
+@test @elapsed(ode_function_naive(u0, [], t0)) > (expected_speedup * @elapsed(ode_function_deduplicated(u0, [], t0)))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -33,3 +33,4 @@ using SafeTestsets, Test
 println("Last test requires gcc available in the path!")
 @safetestset "C Compilation Test" begin include("ccompile.jl") end
 @safetestset "Latexify recipes Test" begin include("latexify.jl") end
+@safetestset "Deduplication of Terms Test" begin include("deduplication_terms_test.jl") end


### PR DESCRIPTION
This adds a `deduplicate_terms` argument to `build_function()` that allows the user to provide a list of `Term`s that they want to "deduplicate". Essentially, these `Term`s will be computed upfront before the system equations, and their values are substituted in to the system equations, thereby potentially saving a lot of extra processing. These are computed **inside** the `iip`/`oop`'s `let` block, so the user has access to their variable names (e.g. they can use `t`).

A test is provided demonstrating the use and showing the speed up afforded.

NOTE: I've only added support for non-parallel, non-scalar output Julia-target functions. It will throw an error if a user tries to provide both a `parallel`/`multithread` and `deduplicate_terms`.