### PR TITLE
Simplify type handling in non-concrete varmap

### DIFF
--- a/src/systems/reaction/reactionsystem.jl
+++ b/src/systems/reaction/reactionsystem.jl
@@ -487,24 +487,18 @@ end
 
 # ODEProblem from AbstractReactionNetwork
 function DiffEqBase.ODEProblem(rs::ReactionSystem, u0::Union{AbstractArray, Number}, tspan, p=DiffEqBase.NullParameters(), args...; kwargs...)
-    u0 = typeof(u0) <: Array{<:Pair} ? u0 : Pair.(rs.states,u0)
-    p = typeof(p) <: Union{Array{<:Pair},DiffEqBase.NullParameters} ? p : Pair.(rs.ps,p)
     return ODEProblem(convert(ODESystem,rs),u0,tspan,p, args...; kwargs...)
 end
 
 # SDEProblem from AbstractReactionNetwork
 function DiffEqBase.SDEProblem(rs::ReactionSystem, u0::Union{AbstractArray, Number}, tspan, p=DiffEqBase.NullParameters(), args...; noise_scaling=nothing, kwargs...)
     sde_sys = convert(SDESystem,rs,noise_scaling=noise_scaling)
-    u0 = typeof(u0) <: Array{<:Pair} ? u0 : Pair.(rs.states,u0)
-    p = typeof(p) <: Union{Array{<:Pair},DiffEqBase.NullParameters} ? p : Pair.(sde_sys.ps,p)
     p_matrix = zeros(length(rs.states), length(rs.eqs))
     return SDEProblem(sde_sys,u0,tspan,p,args...; noise_rate_prototype=p_matrix,kwargs...)
 end
 
 # DiscreteProblem from AbstractReactionNetwork
 function DiffEqBase.DiscreteProblem(rs::ReactionSystem, u0::Union{AbstractArray, Number}, tspan::Tuple, p=DiffEqBase.NullParameters(), args...; kwargs...)
-    u0 = typeof(u0) <: Array{<:Pair} ? u0 : Pair.(rs.states,u0)
-    p = typeof(p) <: Union{Array{<:Pair},DiffEqBase.NullParameters} ? p : Pair.(rs.ps,p)
     return DiscreteProblem(convert(JumpSystem,rs), u0,tspan,p, args...; kwargs...)
 end
 
@@ -515,8 +509,6 @@ end
 
 # SteadyStateProblem from AbstractReactionNetwork
 function DiffEqBase.SteadyStateProblem(rs::ReactionSystem, u0::Union{AbstractArray, Number}, p=DiffEqBase.NullParameters(), args...; kwargs...)
-    #u0 = typeof(u0) <: Array{<:Pair} ? u0 : Pair.(rs.states,u0)
-    #p = typeof(p) <: Union{Array{<:Pair},DiffEqBase.NullParameters} ? p : Pair.(rs.ps,p)
     return SteadyStateProblem(ODEFunction(convert(ODESystem,rs)),u0,p, args...; kwargs...)
 end
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -271,11 +271,11 @@ function lower_varname(t::Term, iv)
 end
 lower_varname(t::Sym, iv) = t
 
-function lower_mapnames(umap::AbstractArray{<:Pair}) where T
-    [value(k) => value(v) for (k, v) in umap]
+function lower_mapnames(umap::AbstractArray{T}) where {T<:Pair}
+    T[value(k) => value(v) for (k, v) in umap]
 end
-function lower_mapnames(umap::AbstractArray{<:Pair},name) where T
-    [lower_varname(value(k), name) => value(v) for (k, v) in umap]
+function lower_mapnames(umap::AbstractArray{T},name) where {T<:Pair}
+    T[lower_varname(value(k), name) => value(v) for (k, v) in umap]
 end
 lower_mapnames(umap::AbstractArray{<:Number}) = umap # Ambiguity
 lower_mapnames(umap::AbstractArray{<:Number},name) = umap

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -211,8 +211,8 @@ varmap_to_vars(varmap,varlist)
 Takes a list of pairs of variables=>values and an ordered list of variables and
 creates the array of values in the correct order
 """
-function varmap_to_vars(varmap::AbstractArray{<:Pair},varlist)
-    out = similar(varmap,typeof(last(first(varmap))))
+function varmap_to_vars(varmap::AbstractArray{Pair{T,S}},varlist) where {T,S}
+    out = similar(varmap,S)
     for (ivar, ival) in varmap
         j = findfirst(isequal(ivar),varlist)
         if isnothing(j)


### PR DESCRIPTION
It's hard to come up with a useful example, but:

```julia
using OrdinaryDiffEq, Catalyst, DiffEqFlux, ModelingToolkit

NN(S, I, R, p) = FastChain(FastDense(3,10,tanh),FastDense(10,1))([S, I, R], p)[1]
@register NN(S, I, R, p)

rn = @reaction_network begin
    β, S + I --> 2I
    γ, I --> R
    NN(S, I, R, p3n), I --> Q
    δ, Q --> R
end β γ δ p3n

_p3n = Float64.(initial_params(FastChain(FastDense(3,10,tanh),FastDense(10,1))))
@parameters β γ δ p3n
p     = [β=>1.0,γ=>1.0,δ=>1.0,p3n=>_p3n]
tspan = (0.0,250.0)
u0    = [999.0,0.0,1.0,0.0]
op    = ODEProblem(rn, u0, tspan, p)
sol   = solve(op,Tsit5())
```

is such a thing. We can try to handle this better in the future but at least for now it gives `Vector{Pair{Num,Any}}` and keeps `Vector{Any}`.