### PR TITLE
fix DiscreteProblem varmap usage

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ModelingToolkit"
 uuid = "961ee093-0014-501f-94e3-6117800e7a78"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "4.4.0"
+version = "4.4.1"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"

--- a/src/systems/jumps/jumpsystem.jl
+++ b/src/systems/jumps/jumpsystem.jl
@@ -185,17 +185,8 @@ dprob = DiscreteProblem(js, u₀map, tspan, parammap)
 """
 function DiffEqBase.DiscreteProblem(sys::JumpSystem, u0map, tspan::Tuple,
                                     parammap=DiffEqBase.NullParameters(); kwargs...)
-
-    (u0map isa AbstractVector) || error("For DiscreteProblems u0map must be an AbstractVector.")
-    u0d = Dict( value(u[1]) => u[2] for u in u0map)
-    u0 = [u0d[u] for u in states(sys)]
-    if parammap != DiffEqBase.NullParameters()
-        (parammap isa AbstractVector) || error("For DiscreteProblems parammap must be an AbstractVector.")
-        pd  = Dict( value(u[1]) => u[2] for u in parammap)
-        p  = [pd[u] for u in parameters(sys)]
-    else
-        p = parammap
-    end
+    u0 = varmap_to_vars(u0map, states(sys))
+    p  = varmap_to_vars(parammap, parameters(sys))
     f  = DiffEqBase.DISCRETE_INPLACE_DEFAULT
     df = DiscreteFunction{true,true}(f, syms=Symbol.(states(sys)))
     DiscreteProblem(df, u0, tspan, p; kwargs...)
@@ -207,7 +198,7 @@ function DiffEqBase.DiscreteProblemExpr(sys::JumpSystem, u0map, tspan,
                                     parammap=DiffEqBase.NullParameters; kwargs...)
 ```
 
-Generates a black DiscreteProblem for a JumpSystem to utilize as its
+Generates a blank DiscreteProblem for a JumpSystem to utilize as its
 solving `prob.prob`. This is used in the case where there are no ODEs
 and no SDEs associated with the system.
 


### PR DESCRIPTION
This is causing a test failure for Catalyst and needed to be updated now that `varmap_to_vars` handles a variety of input types.