### PR TITLE
Offset fix for ctarget matrix equations

### DIFF
--- a/src/build_function.jl
+++ b/src/build_function.jl
@@ -536,7 +536,7 @@ function _build_function(target::CTarget, eqs::Array{<:Equation}, args...;
     count(lhs_in_rhs) ∈ (0, length(lhs_in_rhs)) || throw(ArgumentError("If one output is included in the state vector, all must be."))
     offsets = [val ? -1 : i-2 for (i, val) ∈ enumerate(lhs_in_rhs)]
     differential_equation = string(join([numbered_expr(eq,args...,lhsname=lhsname,
-                                  rhsnames=rhsnames,offset=-1) for
+                                  rhsnames=rhsnames,offset=offsets[i]) for
                                   (i, eq) ∈ enumerate(eqs)],";\n  "),";")
 
     argstrs = join(vcat("double* $(lhsname)",[typeof(args[i])<:Array ? "double* $(rhsnames[i])" : "double $(rhsnames[i])" for i in 1:length(args)]),", ")

--- a/test/build_targets.jl
+++ b/test/build_targets.jl
@@ -24,6 +24,15 @@ eqs = [D(x) ~ a*x - x*y,
   }
   """
 
+@test let 
+  @variables x[1:2,1:2] y[1:4]
+  eqs = x[:] .~ y
+  build_function(eqs, y, target=ModelingToolkit.CTarget()) == 
+    """
+    void diffeqf(double* du, double* RHS1) {\n  du[0] = RHS1[0];\n  du[1] = RHS1[1];\n  du[2] = RHS1[2];\n  du[3] = RHS1[3];\n}\n
+    """
+end
+
 @test ModelingToolkit.build_function(eqs,[x,y],[a],t,target = ModelingToolkit.MATLABTarget()) ==
   """
   diffeqf = @(t,internal_var___u) [internal_var___p(1) * internal_var___u(1) + -1 * internal_var___u(1) * internal_var___u(2); internal_var___u(1) * internal_var___u(2) + -3 * internal_var___u(2)];"""


### PR DESCRIPTION
## Overview

* Closes #735 
* Adds one helper function, `get_symnumber` (just a copy of existing code, moved to a function)
* Adds some offset math for handling matrix equations in `_build_function(::CTarget)`.

## More Detail

Before this PR (`master`), calling the following code would result in an error.

```Julia
julia> @variables x[1:2,1:2] y[1:4]
julia> eqs = x[:] .~ y

julia> build_function(eqs, y, target=ModelingToolkit.CTarget())
ERROR: MethodError: no method matching +(::Nothing, ::Int64)
Closest candidates are:
  +(::Any, ::Any, ::Any, ::Any...) at operators.jl:538
  +(::ChainRulesCore.One, ::Any) at /home/joe/.julia/packages/ChainRulesCore/cpHLu/src/differential_arithmetic.jl:94
  +(::ChainRulesCore.Zero, ::Any) at /home/joe/.julia/packages/ChainRulesCore/cpHLu/src/differential_arithmetic.jl:63
```

Upon further inspection, this issue was caused on `master:build_function.jl:500`. 

```Julia
# build_function.jl:500
i = findfirst(x->isequal(tosymbol(x isa Sym ? x : operation(x), escape=false), tosymbol(var, escape=false)),varordering)
```

Because the none of the output variables `x` appear in the state vector provided (here the state vector provided is the second argument to `build_function`, `y`), the `findfirst` call returns `nothing`.

## Changes
* I used the above `findfirst` code in one new place, so I moved it to a new function called `get_symnumber`, and replaced that line (line 500) with a call to `get_symnumber`
* In `numbered_expr(::Equation...)`, I changed the `lhs` and `rhs` offsets to the following logic:
  * If the output variable is not found in the provided state vector, `lhs` offset is equal to `1 + the index of the output vector element`, and `rhs` offset is equal to the index of each state vector element
  * If the output variable _is_ found in the provided state vector, then the previous logic was used
* In `_build_function(::CTarget...)`, I added the following logic at the top:
  * If no output is in the provided state vector, use new logic (`offset = index of output - 2`)
  * If all outputs are in the provided state vector, use previous logic (`offset = -1`)

## Conclusion
I'm definintely open to other implementations, but this was the least-optrusive solution I could think of. With this PR, the output of the following code block is as expected.

```Julia
julia> @variables x[1:2,1:2] y[1:4]
julia> eqs = x[:] .~ y

julia> build_function(eqs, y, target=ModelingToolkit.CTarget())
"void diffeqf(double* du, double* RHS1) {\n  du[0] = RHS1[0];\n  du[1] = RHS1[1];\n  du[2] = RHS1[2];\n  du[3] = RHS1[3];\n}\n"
```

