### PR TITLE
Add support for symbolic parameters

### DIFF
--- a/src/systems/abstractsystem.jl
+++ b/src/systems/abstractsystem.jl
@@ -184,7 +184,7 @@ end
 function Base.setproperty!(sys::AbstractSystem, prop::Symbol, val)
     param = Sym{Parameter{Real}}(prop)
     if param in parameters(sys)
-        sys.default_p[param] = val
+        sys.default_p[param] = value(val)
     else
         setfield!(sys, prop, val)
     end
@@ -212,7 +212,7 @@ end
 
 function namespace_default_p(sys)
     d_p = default_p(sys)
-    Dict(parameters(sys, k) => namespace_expr(d_p[k], nameof(sys), []) for k in keys(d_p))
+    Dict(parameters(sys, k) => namespace_expr(d_p[k], nameof(sys), independent_variable(sys)) for k in keys(d_p))
 end
 
 function namespace_equations(sys::AbstractSystem)

--- a/src/systems/abstractsystem.jl
+++ b/src/systems/abstractsystem.jl
@@ -182,9 +182,10 @@ function Base.getproperty(sys::AbstractSystem, name::Symbol)
 end
 
 function Base.setproperty!(sys::AbstractSystem, prop::Symbol, val)
-    param = Sym{Parameter{Real}}(prop)
-    if param in parameters(sys)
-        sys.default_p[param] = value(val)
+    if (pa = Sym{Parameter{Real}}(prop); pa in parameters(sys))
+        sys.default_p[pa] = value(val)
+    elseif (st = Sym{Real}(prop); st in states(sys))
+        sys.default_u0[st] = value(val)
     else
         setfield!(sys, prop, val)
     end

--- a/src/systems/abstractsystem.jl
+++ b/src/systems/abstractsystem.jl
@@ -181,6 +181,15 @@ function Base.getproperty(sys::AbstractSystem, name::Symbol)
     throw(error("Variable $name does not exist"))
 end
 
+function Base.setproperty!(sys::AbstractSystem, prop::Symbol, val)
+    param = Sym{Parameter{Real}}(prop)
+    if param in parameters(sys)
+        sys.default_p[param] = val
+    else
+        setfield!(sys, prop, val)
+    end
+end
+
 function renamespace(namespace, x)
     if x isa Num
         renamespace(namespace, value(x))
@@ -203,7 +212,7 @@ end
 
 function namespace_default_p(sys)
     d_p = default_p(sys)
-    Dict(parameters(sys, k) => d_p[k] for k in keys(d_p))
+    Dict(parameters(sys, k) => namespace_expr(d_p[k], nameof(sys), []) for k in keys(d_p))
 end
 
 function namespace_equations(sys::AbstractSystem)

--- a/src/systems/abstractsystem.jl
+++ b/src/systems/abstractsystem.jl
@@ -184,7 +184,8 @@ end
 function Base.setproperty!(sys::AbstractSystem, prop::Symbol, val)
     if (pa = Sym{Parameter{Real}}(prop); pa in parameters(sys))
         sys.default_p[pa] = value(val)
-    elseif (st = Sym{Real}(prop); st in states(sys))
+    # comparing a Sym returns a symbolic expression
+    elseif (st = Sym{Real}(prop); any(s->s.name==st.name, states(sys)))
         sys.default_u0[st] = value(val)
     else
         setfield!(sys, prop, val)

--- a/src/systems/abstractsystem.jl
+++ b/src/systems/abstractsystem.jl
@@ -208,7 +208,7 @@ namespace_parameters(sys::AbstractSystem) = parameters(sys, parameters(sys))
 
 function namespace_default_u0(sys)
     d_u0 = default_u0(sys)
-    Dict(states(sys, k) => d_u0[k] for k in keys(d_u0))
+    Dict(states(sys, k) => namespace_expr(d_u0[k], nameof(sys), independent_variable(sys)) for k in keys(d_u0))
 end
 
 function namespace_default_p(sys)

--- a/src/systems/diffeqs/abstractodesystem.jl
+++ b/src/systems/diffeqs/abstractodesystem.jl
@@ -256,9 +256,12 @@ function process_DEProblem(constructor, sys::AbstractODESystem,u0map,parammap;
     u0map′ = lower_mapnames(u0map,sys.iv)
     u0 = varmap_to_vars(u0map′,dvs; defaults=default_u0(sys))
 
+    defp = default_p(sys)
     if !(parammap isa DiffEqBase.NullParameters)
         parammap′ = lower_mapnames(parammap)
-        p = varmap_to_vars(parammap′,ps; defaults=default_p(sys))
+        p = varmap_to_vars(parammap′,ps; defaults=defp)
+    elseif !isempty(defp)
+        p = varmap_to_vars(Dict(),ps; defaults=defp)
     else
         p = ps
     end

--- a/src/systems/nonlinear/nonlinearsystem.jl
+++ b/src/systems/nonlinear/nonlinearsystem.jl
@@ -213,10 +213,13 @@ function process_NonlinearProblem(constructor, sys::NonlinearSystem,u0map,paramm
     ps = parameters(sys)
     u0map′ = lower_mapnames(u0map)
     u0 = varmap_to_vars(u0map′,dvs; defaults=default_u0(sys))
+    defp = default_p(sys)
 
     if !(parammap isa DiffEqBase.NullParameters)
         parammap′ = lower_mapnames(parammap)
-        p = varmap_to_vars(parammap′,ps; defaults=default_p(sys))
+        p = varmap_to_vars(parammap′,ps; defaults=defp)
+    elseif !isempty(defp)
+        p = varmap_to_vars(Dict(),ps; defaults=defp)
     else
         p = ps
     end

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -213,6 +213,10 @@ applicable.
 function varmap_to_vars(varmap::Dict, varlist; defaults=Dict())
     varmap = merge(defaults, varmap) # prefers the `varmap`
     varmap = Dict(value(k)=>value(varmap[k]) for k in keys(varmap))
+    # resolve symbolic parameter expressions
+    for (p, v) in pairs(varmap)
+        varmap[p] = fixpoint_sub(v, varmap)
+    end
     T′ = eltype(values(varmap))
     T = Base.isconcretetype(T′) ? T′ : Base.promote_typeof(values(varmap)...)
     out = Vector{T}(undef, length(varlist))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 using SafeTestsets, Test
 
+@safetestset "Symbolic parameters test" begin include("symbolic_parameters.jl") end
 @safetestset "Parsing Test" begin include("variable_parsing.jl") end
 @safetestset "Differentiation Test" begin include("derivatives.jl") end
 @safetestset "Simplify Test" begin include("simplify.jl") end

--- a/test/symbolic_parameters.jl
+++ b/test/symbolic_parameters.jl
@@ -1,0 +1,35 @@
+using ModelingToolkit
+using NonlinearSolve
+using Test
+
+@variables x y z
+@parameters σ ρ β
+
+eqs = [0 ~ σ*(y-x),
+       0 ~ x*(ρ-z)-y,
+       0 ~ x*y - β*z]
+
+par = [
+    σ => 1,
+    ρ => 0.1+σ,
+    β => ρ*1.1
+]
+ns = NonlinearSystem(eqs, [x,y,z],[σ,ρ,β], name=:ns, default_p=par)
+ModelingToolkit.default_p(ns)
+resolved = ModelingToolkit.varmap_to_vars(Dict(), parameters(ns), defaults=ModelingToolkit.default_p(ns))
+@test resolved == [1, 0.1+1, (0.1+1)*1.1]
+
+prob = NonlinearProblem(ns, ones(3), Pair[])
+@show sol = solve(prob,NewtonRaphson())
+
+@variables a
+@parameters b
+top = NonlinearSystem([0 ~ -a + ns.x+1], [a], [b], systems=[ns], name=:top)
+flat = flatten(top)
+flat.b = ns.σ*0.5
+
+flatres = ModelingToolkit.varmap_to_vars(Dict(), parameters(flat), defaults=ModelingToolkit.default_p(flat))
+@test flatres == [0.5, 1, 0.1+1, (0.1+1)*1.1]
+
+prob = NonlinearProblem(flat, ones(4), Pair[])
+@show sol = solve(prob,NewtonRaphson())


### PR DESCRIPTION
With this change you can express parameters as an expression of another parameter
```
par = [
    σ => 1,
    ρ => 0.1+σ,
    β => ρ*1.1
]
```
In combination with `flatten` this allows to express parameter dependencies across different levels, where you can define a slew of lower level parameter in terms of a single top-level definition for example.

To make this usage more convenient I have added assignment to parameters to set the default. Currently there does not appear to be an API to generate symbol names in the flattened system other than by specifying the full path with `\_+` or using the hierarchical model to get it, which might be fine.

I'm currently not checking parameters for cycles.

I'm not 100% sure if my usage of `namespace_expr` is correct because of the unused `iv` parameter.

I could not find a way to properly test the `NonlinearProblem` parameters and solution. So I've resorted to manually calling `varmap_to_vars` and just running the solver to see that nothing breaks.