### PR TITLE
Depwarns 2: Resurrection

### DIFF
--- a/test/odesystem.jl
+++ b/test/odesystem.jl
@@ -250,6 +250,6 @@ eqs = [
    0 ~ x1 - x2,
 ]
 sys = ODESystem(eqs, t)
-@test isequal(sys.iv, t)
+@test isequal(get_iv(sys), t)
 @test isequal(states(sys), [x1, x2])
 @test isempty(parameters(sys))


### PR DESCRIPTION
These ones will fail because the depwarn points to a function that doesn't exist.