### PR TITLE
Require systems kwarg to ODESystem constructor to have unique names (#808) 

### DIFF
--- a/src/systems/diffeqs/odesystem.jl
+++ b/src/systems/diffeqs/odesystem.jl
@@ -97,7 +97,7 @@ function ODESystem(
     jac = RefValue{Any}(Matrix{Num}(undef, 0, 0))
     Wfact   = RefValue(Matrix{Num}(undef, 0, 0))
     Wfact_t = RefValue(Matrix{Num}(undef, 0, 0))
-    sysnames = getfield.(systems, :name)
+    sysnames = nameof.(systems)
     if length(unique(sysnames)) != length(sysnames)
         throw(ArgumentError("System names must be unique."))
     end

--- a/src/systems/diffeqs/odesystem.jl
+++ b/src/systems/diffeqs/odesystem.jl
@@ -57,7 +57,7 @@ struct ODESystem <: AbstractODESystem
     """
     name::Symbol
     """
-    systems: The internal systems
+    systems: The internal systems. These are required to have unique names.
     """
     systems::Vector{ODESystem}
     """
@@ -97,6 +97,10 @@ function ODESystem(
     jac = RefValue{Any}(Matrix{Num}(undef, 0, 0))
     Wfact   = RefValue(Matrix{Num}(undef, 0, 0))
     Wfact_t = RefValue(Matrix{Num}(undef, 0, 0))
+    sysnames = getfield.(systems, :name)
+    if length(unique(sysnames)) != length(sysnames)
+        throw(ArgumentError("System names must be unique."))
+    end
     ODESystem(deqs, iv′, dvs′, ps′, observed, tgrad, jac, Wfact, Wfact_t, name, systems, default_u0, default_p, nothing)
 end
 

--- a/test/odesystem.jl
+++ b/test/odesystem.jl
@@ -282,3 +282,24 @@ D = Differential(t)
 eq = D(x) ~ r*x
 ode = ODESystem(eq)
 @test equations(ode) == [eq]
+# issue #808
+@testset "Combined system name collisions" begin
+    function makesys(name)
+        @parameters t a
+        @variables x(t) f(t)
+        D = Differential(t)
+
+        ODESystem([D(x) ~ -a*x + f], name=name)
+    end
+
+    function issue808()
+        sys1 = makesys(:sys1)
+        sys2 = makesys(:sys1)
+
+        @parameters t
+        D = Differential(t)
+        @test_throws ArgumentError ODESystem([sys2.f ~ sys1.x, D(sys1.f) ~ 0], t, systems=[sys1, sys2])
+    end
+    issue808()
+
+end


### PR DESCRIPTION
Sorry, somehow the original PR #811  was auto-closed, I think I did something silly on my end. This should be good to go.