### PR TITLE
[WIP] @named macro for adding name=:var keyword argument

### DIFF
--- a/src/ModelingToolkit.jl
+++ b/src/ModelingToolkit.jl
@@ -221,6 +221,7 @@ include("solve.jl")
 include("direct.jl")
 include("domains.jl")
 include("register_function.jl")
+include("named.jl")
 
 include("systems/abstractsystem.jl")
 
@@ -295,5 +296,6 @@ export build_function
 export @register
 export modelingtoolkitize
 export @variables, @parameters
+export @named
 
 end # module

--- a/src/named.jl
+++ b/src/named.jl
@@ -1,0 +1,18 @@
+"""
+named(ex):
+
+Used for naming an AbstractODESystem from an expression of the form `var = value`.
+A keyword argument (name = :var) is added as the first keyword argument.
+
+example:
+
+`@named sys = ODESystem(eqs, args...; kwargs...)`
+
+"""
+macro named(ex)
+    if !(ex isa Expr && ex.head == :(=))
+      throw(ArgumentError("expression should be of the form `var = value`"))
+    end
+    pushfirst!(ex.args[2].args[2].args, :(name = :foo))
+    :($(esc(ex.args[1])) = $(esc(ex.args[2])))
+end

--- a/src/systems/diffeqs/abstractodesystem.jl
+++ b/src/systems/diffeqs/abstractodesystem.jl
@@ -420,3 +420,22 @@ end
 
 isdifferential(expr) = istree(expr) && operation(expr) isa Differential
 isdiffeq(eq) = isdifferential(eq.lhs)
+
+"""
+named(ex):
+
+Used for naming an AbstractODESystem from an expression of the form `var = value`.
+A keyword argument (name = :var) is added as the first keyword argument.
+
+example:
+
+`@named sys = ODESystem(eqs, args...; kwargs...)`
+
+"""
+macro named(ex)
+    if !(ex isa Expr && ex.head == :(=))
+      throw(ArgumentError("expression should be of the form `var = value`"))
+    end
+    pushfirst!(ex.args[2].args[2].args, :(name = :foo))
+    :($(esc(ex.args[1])) = $(esc(ex.args[2])))
+end

--- a/src/systems/diffeqs/abstractodesystem.jl
+++ b/src/systems/diffeqs/abstractodesystem.jl
@@ -420,22 +420,3 @@ end
 
 isdifferential(expr) = istree(expr) && operation(expr) isa Differential
 isdiffeq(eq) = isdifferential(eq.lhs)
-
-"""
-named(ex):
-
-Used for naming an AbstractODESystem from an expression of the form `var = value`.
-A keyword argument (name = :var) is added as the first keyword argument.
-
-example:
-
-`@named sys = ODESystem(eqs, args...; kwargs...)`
-
-"""
-macro named(ex)
-    if !(ex isa Expr && ex.head == :(=))
-      throw(ArgumentError("expression should be of the form `var = value`"))
-    end
-    pushfirst!(ex.args[2].args[2].args, :(name = :foo))
-    :($(esc(ex.args[1])) = $(esc(ex.args[2])))
-end


### PR DESCRIPTION
Below is a MWE for where I got in adding @named in reference to #813 
The issue is that `@named` only works if the kwarg is a literal symbol.
Replacing `:foo` with `$(esc(ex.args[1]))` in the macro gives `ERROR: syntax: invalid syntax (escape (outerref bar))`.


```julia
using ModelingToolkit
@parameters t r
@variables x(t)
D = Differential(t)

eqs = [D(x) ~ r * (x - x^2)]

kw  = (default_u0 = [x => 0.], default_p = [r => 0.])
sys = ODESystem(eqs; kw...)

macro named(ex)
    if !(ex isa Expr && ex.head == :(=))
      throw(ArgumentError("expression should be of the form `var = value`"))
    end
    pushfirst!(ex.args[2].args[2].args, :(name = :foo))
    :($(esc(ex.args[1])) = $(esc(ex.args[2])))
end

julia> @named bar = ODESystem(eqs; kw...)
Model foo with 1 equations
States (1):
  x(t) [defaults to 0.0]
Parameters (1):
  r [defaults to 0.0]

julia> @macroexpand @named baz = ODESystem(eqs; kw...)
:(baz = ODESystem(eqs; $(Expr(:(=), :name, :(:foo))), kw...))
```
After replacing `:foo` in `@named`:
```julia
julia> @named bar = ODESystem(eqs; kw...)
ERROR: syntax: invalid syntax (escape (outerref bar))
Stacktrace:
 [1] top-level scope
   @ REPL[15]:1

julia> @macroexpand @named baz = ODESystem(eqs; kw...)
:(baz = ODESystem(eqs; $(Expr(:(=), :name, :($(Expr(:escape, :baz))))), kw...))
```

I believe the issue is related to `gensym` and macro hygiene, but I'm not sure what the idiomatic way to assign a value to the lhs of the expr, and use it's symbol in the `pushfirst!`.

potentially related docs and posts from discourse:
https://docs.julialang.org/en/v1/manual/metaprogramming/#Hygiene
https://discourse.julialang.org/t/why-use-gensym-in-this-particular-example/43733
