### PR TITLE
Add hasproperty implementation

### DIFF
--- a/src/systems/abstractsystem.jl
+++ b/src/systems/abstractsystem.jl
@@ -189,11 +189,11 @@ function Base.hasproperty(sys::AbstractSystem, name::Symbol)
     systems = get_systems(sys)
     !isempty(systems) && any(x->nameof(x)==name,systems) && return true
 
-    any(x->nameof(x)==name,get_states(sys)) && return true
+    any(x->getname(x)==name,get_states(sys)) && return true
 
-    has_ps(sys) && any(x->nameof(x)==name,get_ps(sys)) && return true
+    has_ps(sys) && any(x->getname(x)==name,get_ps(sys)) && return true
 
-    has_observed(sys) && any(x->nameof(x)==name,get_observed(sys)) && return true
+    has_observed(sys) && any(x->getname(x)==name,get_observed(sys)) && return true
 
     return false
 end

--- a/src/systems/abstractsystem.jl
+++ b/src/systems/abstractsystem.jl
@@ -185,6 +185,19 @@ end
 
 rename(x::AbstractSystem, name) = @set x.name = name
 
+function Base.hasproperty(sys::AbstractSystem, name::Symbol)
+    systems = get_systems(sys)
+    !isempty(systems) && any(x->nameof(x)==name,systems) && return true
+
+    any(x->nameof(x)==name,get_states(sys)) && return true
+
+    has_ps(sys) && any(x->nameof(x)==name,get_ps(sys)) && return true
+
+    has_observed(sys) && any(x->nameof(x)==name,get_observed(sys)) && return true
+
+    return false
+end
+
 function Base.getproperty(sys::AbstractSystem, name::Symbol)
     sysname = nameof(sys)
     systems = get_systems(sys)


### PR DESCRIPTION
Currently there is a disconnect between what `hasproperty` says and what `getproperty` returns.

```julia
@variables a b c t
sys = ODESystem(Equation[], t, [a, b, c], [])
hasproperty(sys, :a) # false
sys.a # var"##ODESystem#458₊a"
```

This PR is a simple adaptation of the `getproperty` behavior to match `hasproperty`.