### PR TITLE
Add check to avoid accidental singulatity error after structural_simplify

### DIFF
--- a/src/systems/diffeqs/abstractodesystem.jl
+++ b/src/systems/diffeqs/abstractodesystem.jl
@@ -304,7 +304,7 @@ function process_DEProblem(constructor, sys::AbstractODESystem,u0map,parammap;
         p = ps
     end
 
-    @assert length(dvs) == length(u0) "states and initial conditions are of different lengths"
+    length(dvs) == length(u0) || throw(ArgumentError("States ($(length(dvs))) and initial conditions ($(length(u0))) are of different lengths."))
 
     f = constructor(sys,dvs,ps,u0;tgrad=tgrad,jac=jac,checkbounds=checkbounds,
                     linenumbers=linenumbers,parallel=parallel,simplify=simplify,

--- a/src/systems/diffeqs/abstractodesystem.jl
+++ b/src/systems/diffeqs/abstractodesystem.jl
@@ -304,6 +304,8 @@ function process_DEProblem(constructor, sys::AbstractODESystem,u0map,parammap;
         p = ps
     end
 
+    @assert length(dvs) == length(u0) "states and initial conditions are of different lengths"
+
     f = constructor(sys,dvs,ps,u0;tgrad=tgrad,jac=jac,checkbounds=checkbounds,
                     linenumbers=linenumbers,parallel=parallel,simplify=simplify,
                     sparse=sparse,eval_expression=eval_expression,kwargs...)

--- a/src/systems/nonlinear/nonlinearsystem.jl
+++ b/src/systems/nonlinear/nonlinearsystem.jl
@@ -223,6 +223,8 @@ function process_NonlinearProblem(constructor, sys::NonlinearSystem,u0map,paramm
         p = ps
     end
 
+    @assert length(dvs) == length(u0) "states and initial conditions are of different lengths"
+
     f = constructor(sys,dvs,ps,u0;jac=jac,checkbounds=checkbounds,
                     linenumbers=linenumbers,parallel=parallel,simplify=simplify,
                     sparse=sparse,eval_expression=eval_expression,kwargs...)

--- a/src/systems/nonlinear/nonlinearsystem.jl
+++ b/src/systems/nonlinear/nonlinearsystem.jl
@@ -223,7 +223,7 @@ function process_NonlinearProblem(constructor, sys::NonlinearSystem,u0map,paramm
         p = ps
     end
 
-    @assert length(dvs) == length(u0) "states and initial conditions are of different lengths"
+    length(dvs) == length(u0) || throw(ArgumentError("States ($(length(dvs))) and initial conditions ($(length(u0))) are of different lengths."))
 
     f = constructor(sys,dvs,ps,u0;jac=jac,checkbounds=checkbounds,
                     linenumbers=linenumbers,parallel=parallel,simplify=simplify,

--- a/test/nonlinearsystem.jl
+++ b/test/nonlinearsystem.jl
@@ -75,6 +75,8 @@ prob = NonlinearProblem(ns,ones(3),ones(3))
 sol = solve(prob,NewtonRaphson())
 @test sol.u[1] ≈ sol.u[2]
 
+@test_throws ArgumentError NonlinearProblem(ns,ones(4),ones(3))
+
 @variables u F s a
 eqs1 = [
         0 ~ σ*(y-x) + F,

--- a/test/odesystem.jl
+++ b/test/odesystem.jl
@@ -230,6 +230,7 @@ for (prob, atol) in [(prob1, 1e-12), (prob2, 1e-12), (prob3, 1e-12)]
     sol = solve(prob, Rodas5())
     @test all(x->≈(sum(x), 1.0, atol=atol), sol.u)
 end
+@test_throws ArgumentError ODEProblem(sys,zeros(5),tspan,p)
 
 @test ModelingToolkit.construct_state(SArray{Tuple{3,3}}(rand(3,3)), [1,2]) == SVector{2}([1, 2])
 


### PR DESCRIPTION
Currently the following will give a singularity error
```julia
u0 = zeros(length(states(sys)))
sys = structural_simplify(sys)
prob = NonlinearProblem(sys, u0)
sol = solve(prob, NewtonRaphson())
```
This is because structural simplify removed redundant states, and now u0 is too big, resulting in zeros in the jacobian which cause a singularity error. This PR stops you from making that mistake.

I'm not sure if other types of systems also need this check because I don't really know what they do. (jumpsystem etc)