### PR TITLE
Implement variable scope

### DIFF
--- a/src/ModelingToolkit.jl
+++ b/src/ModelingToolkit.jl
@@ -158,6 +158,7 @@ export Differential, expand_derivatives, @derivatives
 export IntervalDomain, ProductDomain, ⊗, CircleDomain
 export Equation, ConstrainedEquation
 export Term, Sym
+export SymScope, LocalScope, ParentScope, GlobalScope
 export independent_variable, states, parameters, equations, controls, observed, structure
 export structural_simplify
 

--- a/src/systems/abstractsystem.jl
+++ b/src/systems/abstractsystem.jl
@@ -226,14 +226,14 @@ function Base.getproperty(sys::AbstractSystem, name::Symbol; namespace=true)
     i = findfirst(x->getname(x) == name, sts)
 
     if i !== nothing
-        return namespace ? rename(sts[i],renamespace(sysname,name)) : sts[i]
+        return namespace ? renamespace(sysname,sts[i]) : sts[i]
     end
 
     if has_ps(sys)
         ps = get_ps(sys)
         i = findfirst(x->getname(x) == name,ps)
         if i !== nothing
-            return namespace ? rename(ps[i],renamespace(sysname,name)) : ps[i]
+            return namespace ? renamespace(sysname,ps[i]) : ps[i]
         end
     end
 
@@ -241,7 +241,7 @@ function Base.getproperty(sys::AbstractSystem, name::Symbol; namespace=true)
         obs = get_observed(sys)
         i = findfirst(x->getname(x.lhs)==name,obs)
         if i !== nothing
-            return namespace ? rename(obs[i].lhs,renamespace(sysname,name)) : obs[i]
+            return namespace ? renamespace(sysname,obs[i]) : obs[i]
         end
     end
 
@@ -321,7 +321,7 @@ function namespace_equation(eq::Equation,name,iv)
 end
 
 function namespace_expr(O::Sym,name,iv)
-    isequal(O, iv) ? O : rename(O,renamespace(name,nameof(O)))
+    isequal(O, iv) ? O : renamespace(name,O)
 end
 
 _symparam(s::Symbolic{T}) where {T} = T

--- a/src/systems/abstractsystem.jl
+++ b/src/systems/abstractsystem.jl
@@ -330,7 +330,7 @@ function namespace_expr(O,name,iv) where {T}
     if istree(O)
         renamed = map(a->namespace_expr(a,name,iv), arguments(O))
         if operation(O) isa Sym
-            renamed_op = rename(O,renamespace(name, getname(O)))
+            rename(O,getname(renamespace(name, O)))
         else
             similarterm(O,operation(O),renamed)
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 using SafeTestsets, Test
 
+@safetestset "Varialbe scope tests" begin include("variable_scope.jl") end
 @safetestset "Symbolic parameters test" begin include("symbolic_parameters.jl") end
 @safetestset "Parsing Test" begin include("variable_parsing.jl") end
 @safetestset "Simplify Test" begin include("simplify.jl") end

--- a/test/variable_scope.jl
+++ b/test/variable_scope.jl
@@ -1,0 +1,13 @@
+using ModelingToolkit
+using Test
+
+@variables a b c
+
+b = ParentScope(ParentScope(b))
+c = GlobalScope(c)
+
+renamed(nss, sym) = nameof(foldr(ModelingToolkit.renamespace, nss, init=sym))
+
+@test renamed([:foo :bar :baz], a) == :foo₊bar₊baz₊a
+@test renamed([:foo :bar :baz], b) == :foo₊b
+@test renamed([:foo :bar :baz], c) == :c

--- a/test/variable_scope.jl
+++ b/test/variable_scope.jl
@@ -1,13 +1,14 @@
 using ModelingToolkit
 using Test
 
-@variables a b c d
+@parameters t
+@variables a b(t) c d
 
 b = ParentScope(b)
 c = ParentScope(ParentScope(c))
 d = GlobalScope(d)
 
-renamed(nss, sym) = nameof(foldr(ModelingToolkit.renamespace, nss, init=sym))
+renamed(nss, sym) = ModelingToolkit.getname(foldr(ModelingToolkit.renamespace, nss, init=sym))
 
 @test renamed([:foo :bar :baz], a) == :foo₊bar₊baz₊a
 @test renamed([:foo :bar :baz], b) == :foo₊bar₊b
@@ -26,7 +27,7 @@ eqs = [
 @named sub1 = NonlinearSystem([], [], [], systems=[sub2])
 @named sys = NonlinearSystem([], [], [], systems=[sub1])
 
-names = nameof.(states(sys))
+names = ModelingToolkit.getname.(states(sys))
 @test :d in names
 @test :sub1₊c in names
 @test :sub1₊sub2₊b in names

--- a/test/variable_scope.jl
+++ b/test/variable_scope.jl
@@ -1,13 +1,34 @@
 using ModelingToolkit
 using Test
 
-@variables a b c
+@variables a b c d
 
-b = ParentScope(ParentScope(b))
-c = GlobalScope(c)
+b = ParentScope(b)
+c = ParentScope(ParentScope(c))
+d = GlobalScope(d)
 
 renamed(nss, sym) = nameof(foldr(ModelingToolkit.renamespace, nss, init=sym))
 
 @test renamed([:foo :bar :baz], a) == :foo₊bar₊baz₊a
-@test renamed([:foo :bar :baz], b) == :foo₊b
-@test renamed([:foo :bar :baz], c) == :c
+@test renamed([:foo :bar :baz], b) == :foo₊bar₊b
+@test renamed([:foo :bar :baz], c) == :foo₊c
+@test renamed([:foo :bar :baz], d) == :d
+
+eqs = [
+    0 ~ a
+    0 ~ b
+    0 ~ c
+    0 ~ d
+]
+@named sub4 = NonlinearSystem(eqs, [a, b, c, d], [])
+@named sub3 = NonlinearSystem(eqs, [a, b, c, d], [])
+@named sub2 = NonlinearSystem([], [], [], systems=[sub3, sub4])
+@named sub1 = NonlinearSystem([], [], [], systems=[sub2])
+@named sys = NonlinearSystem([], [], [], systems=[sub1])
+
+names = nameof.(states(sys))
+@test :d in names
+@test :sub1₊c in names
+@test :sub1₊sub2₊b in names
+@test :sub1₊sub2₊sub3₊a in names
+@test :sub1₊sub2₊sub4₊a in names


### PR DESCRIPTION
In hierarchical systems, it is possible that a subsystem needs to depend on a parameter or state that is from a parent system or even a global. Currently the only way to express this is to manually alias local paramters and states from the outside.

I've been told this feature is analogous to outer variables in Modelica.

I have implemented it by defining a `SymScope` type that is stored in the symbol metadata. The default scope is `LocalScope`, but it is possible to make variables of wider scopes. `GlobalScope(a)` causes `a` to never be namespaced at all, while `ParentScope(a)` makes `a` belong to one level up in the hierarchy. `ParentScope` can be nested to refer to variables higher up the hierarchy. I have added some tests that demonstrate the behavior.

The problem I'm facing is that most calls to `renamespace` don't pass the `Num` or the `Sym` but the _name_ of the `Sym`. This means that the metadata is not available to correctly namespace outer variables, hence I'm marking this as a draft.

In most places this probably comes down to replacing `renamespace(namespace,nameof(x))` with `nameof(renamespace(namespace,x))`, which is a bit involved operation, so I thought it'd be good to post the result so far.

This PR also depends on https://github.com/JuliaSymbolics/SymbolicUtils.jl/pull/240 because it uses `getmetadata(sys, type, default)` which did not work for me.