### PR TITLE
Composing `ReactionSystem`s 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 *.jl.*.cov
 *.jl.mem
 Manifest.toml
+.vscode
+.vscode/*

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,0 @@
-{
-    "cSpell.ignoreWords": [
-        "get",
-        "systems"
-    ]
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "cSpell.ignoreWords": [
+        "get",
+        "systems"
+    ]
+}

--- a/test/reactionsystem_components.jl
+++ b/test/reactionsystem_components.jl
@@ -1,0 +1,86 @@
+using ModelingToolkit, LinearAlgebra, OrdinaryDiffEq, Test
+MT = ModelingToolkit
+
+# Repressilator model
+@parameters t α₀ α K n δ β μ 
+@variables m(t) P(t) R(t)
+rxs = [Reaction(α₀, nothing, [m]),
+       Reaction(α / (1 + (R/K)^n), nothing, [m]),
+       Reaction(δ, [m], nothing),
+       Reaction(β, [m], [m,P]),
+       Reaction(μ, [P], nothing)    
+]
+
+specs = [m,P,R]
+pars  = [α₀,α,K,n,δ,β,μ]
+@named rs = ReactionSystem(rxs, t, specs, pars)
+
+# using ODESystem components
+@named os₁ = convert(ODESystem, rs)
+@named os₂ = convert(ODESystem, rs)
+@named os₃ = convert(ODESystem, rs)
+connections = [os₁.R ~ os₃.P, 
+               os₂.R ~ os₁.P,
+               os₃.R ~ os₂.P]
+@named connected = ODESystem(connections, t, [], [], systems=[os₁,os₂,os₃])
+oderepressilator = structural_simplify(connected)
+
+pvals = [os₁.α₀ => 5e-4, 
+         os₁.α => .5, 
+         os₁.K => 40.0, 
+         os₁.n => 2, 
+         os₁.δ => (log(2)/120), 
+         os₁.β => (20*log(2)/120),
+         os₁.μ => (log(2)/600),
+         os₂.α₀ => 5e-4, 
+         os₂.α => .5, 
+         os₂.K => 40.0, 
+         os₂.n => 2, 
+         os₂.δ => (log(2)/120), 
+         os₂.β => (20*log(2)/120),
+         os₂.μ => (log(2)/600),
+         os₃.α₀ => 5e-4, 
+         os₃.α => .5, 
+         os₃.K => 40.0, 
+         os₃.n => 2, 
+         os₃.δ => (log(2)/120), 
+         os₃.β => (20*log(2)/120),
+         os₃.μ => (log(2)/600)]
+u₀    = [os₁.m => 0.0, os₁.P => 20.0, os₂.m => 0.0, os₂.P => 0.0, os₃.m => 0.0, os₃.P => 0.0]
+tspan = (0.0, 100000.0)
+oprob = ODEProblem(oderepressilator, u₀, tspan, pvals)
+sol = solve(oprob, Tsit5())
+
+# hardcoded network
+function repress!(f, y, p, t)
+    α = p.α; α₀ = p.α₀; β = p.β; δ = p.δ; μ = p.μ; K = p.K; n = p.n
+    f[1] = α / (1 + (y[6] / K)^n) - δ * y[1] + α₀
+    f[2] = α / (1 + (y[4] / K)^n) - δ * y[2] + α₀
+    f[3] = α / (1 + (y[5] / K)^n) - δ * y[3] + α₀
+    f[4] = β * y[1] - μ * y[4]
+    f[5] = β * y[2] - μ * y[5]    
+    f[6] = β * y[3] - μ * y[6]    
+    nothing
+end
+ps = (α₀=5e-4, α=.5, K=40.0, n=2, δ=(log(2)/120), β=(20*log(2)/120), μ=(log(2)/600))
+u0 = [0.0,0.0,0.0,20.0,0.0,0.0]
+oprob2 = ODEProblem(repress!, u0, tspan, ps)
+sol2 = solve(oprob2, Tsit5())
+tvs = 0:1:tspan[end]
+
+indexof(sym,syms) = findfirst(isequal(sym),syms)
+i = indexof(os₁.P, states(oderepressilator))
+@test all(isapprox(u[1],u[2],atol=1e-4) for u in zip(sol(tvs, idxs=2), sol2(tvs, idxs=4)))
+
+# using ReactionSystem components
+
+# @named rs₁ = ReactionSystem(rxs, t, specs, pars)
+# @named rs₂ = ReactionSystem(rxs, t, specs, pars)
+# @named rs₃ = ReactionSystem(rxs, t, specs, pars)
+# connections = [rs₁.R ~ rs₃.P, 
+#                rs₂.R ~ rs₁.P,
+#                rs₃.R ~ rs₂.P]
+# @named csys = ODESystem(connections, t, [], [])
+# @named repressilator = ReactionSystem(t; systems=[csys,rs₁,rs₂,rs₃])
+# @named oderepressilator2 = convert(ODESystem, repressilator)
+# sys2 = structural_simplify(oderepressilator2)  # FAILS currently

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,6 +15,7 @@ using SafeTestsets, Test
 @safetestset "NonlinearSystem Test" begin include("nonlinearsystem.jl") end
 @safetestset "OptimizationSystem Test" begin include("optimizationsystem.jl") end
 @safetestset "ReactionSystem Test" begin include("reactionsystem.jl") end
+@safetestset "ReactionSystem Test" begin include("reactionsystem_components.jl") end
 @safetestset "JumpSystem Test" begin include("jumpsystem.jl") end
 @safetestset "ControlSystem Test" begin include("controlsystem.jl") end
 @safetestset "Domain Test" begin include("domains.jl") end


### PR DESCRIPTION
This is a start towards composing `ReactionSystem`s:
1. Composing via derived converted `ODESystem`s works and has a test now (this needs more testing though before advertising). 
2. I added some overloads for `ReactionSystem` and `Reaction` namespacing functions to get around printing issues, and to allow `ReactionSystem`s to have other system types as sub-systems. Please let me know if these are a bad idea and should be removed.
3. One complication that arises with `ReactionSystem`s is that they can generate ODEs where the rhs is zero for connection species, which seems to crash structural simplification during tearing. I added an explicit check to drop generated ODEs where the rhs is zero, but perhaps it would be better to allow users to specify which variables are connection variables in the system, and then filter them out when generating ODE models?
4. I fixed up usage of `states` and `equations` with the appropriate setters in a number of places.

Some things we still need for `ReactionSystem`s: 
1. defaults
2. Right now we can't compose `ReactionSystem`s with `ODESystem`s to store algebraic relations without also changing the `ODESystem` system handling to allow `ODESystem`s to store `ReactionSystem` subsystems. i.e. it seemed like I would have to make the root system be an `ODESystem` for this to work. It seemed undesirable that the root of a collection of `ReactionSystem`s with couplings would need to be an `ODESystem`, so I wasn't quite sure how to proceed.
 
I'm thinking that maybe we should just add an explicit `alg_eqs` field to `ReactionSystem`s that they can use to store coupling equations? Any thoughts? I guess one question then is whether such a field should be merged into calls to `equations` or not. One advantage is that all `ReactionSystem` sub-systems could then be assumed to be `ReactionSystem`s.