### PR TITLE
default_u0 / default_p with substituted expressions

### DIFF
--- a/src/systems/abstractsystem.jl
+++ b/src/systems/abstractsystem.jl
@@ -543,3 +543,22 @@ Base.showerror(io::IO, e::InvalidSystemException) = print(io, "InvalidSystemExce
 AbstractTrees.children(sys::ModelingToolkit.AbstractSystem) = ModelingToolkit.get_systems(sys)
 AbstractTrees.printnode(io::IO, sys::ModelingToolkit.AbstractSystem) = print(io, nameof(sys))
 AbstractTrees.nodetype(::ModelingToolkit.AbstractSystem) = ModelingToolkit.AbstractSystem
+
+function get_default_u0(sys::AbstractSystem)
+    defs = get_defaults(sys)
+    u0 = filter(e->!isparameter(e.first),defs)
+    obs = Dict([e.lhs=>e.rhs for e in get_observed(sys)])
+    u0s = Dict([k=>substitute(v, obs) for (k,v) in u0])
+    u0s = Dict([k=>substitute(v, defs) for (k,v) in u0s])
+    return u0s
+end
+
+function get_default_p(sys::AbstractSystem)
+    defs = get_defaults(sys)
+    p = filter(e->isparameter(e.first),defs)
+    obs = Dict([e.lhs=>e.rhs for e in get_observed(sys)])
+    ps = Dict([k=>substitute(v, obs) for (k,v) in p])
+    ps = Dict([k=>substitute(v, defs) for (k,v) in ps])
+    return ps
+end
+

--- a/test/simplify.jl
+++ b/test/simplify.jl
@@ -1,7 +1,7 @@
 using ModelingToolkit
 using ModelingToolkit: value, get_defaults, get_default_u0, get_default_p
 using Test
-using DifferentialEquations
+using OrdinaryDiffEq
 
 @parameters t
 @variables x(t) y(t) z(t)
@@ -69,13 +69,13 @@ _p = filter(e->ModelingToolkit.isparameter(e.first),defs)
 prob = ODEProblem(sys,collect(_u0),(0.0,160.0),collect(_p),jac=true)
 
 # SHOULD NOT HAPPEN; TODO: remove this test
-@test_throws StackOverflowError solve(prob)
+@test_throws StackOverflowError solve(prob,Tsit5())
 
 u0 = get_default_u0(sys)
 p = get_default_p(sys)
 @test isequal(u0, Dict([a=>0.1, sub.y=>0.05]))
 @test isequal(p, Dict())
 prob = ODEProblem(sys,collect(u0),(0.0,160.0),collect(p),jac=true)
-sol = solve(prob)
+sol = solve(prob,Tsit5())
 @test isequal(sol[a], sol[sub.x])
 

--- a/test/simplify.jl
+++ b/test/simplify.jl
@@ -1,6 +1,7 @@
 using ModelingToolkit
-using ModelingToolkit: value
+using ModelingToolkit: value, get_defaults, get_default_u0, get_default_p
 using Test
+using DifferentialEquations
 
 @parameters t
 @variables x(t) y(t) z(t)
@@ -46,3 +47,35 @@ term2 = substitute(term, a=>b)
 term3 = substitute(term2, b=>a)
 @test term3 isa Term{ModelingToolkit.Parameter{Real}}
 @test isequal(term3, a)
+
+
+
+
+@parameters t
+D = Differential(t)
+@variables x(t),y(t)
+y0 = x/2
+@named sub = ODESystem([D(y) ~ 2x],t,[x,y],[],defaults=Dict(y=>y0))
+
+@variables a(t)
+@named model = ODESystem([D(a) ~ 1, sub.x ~ a],t,[a],[],defaults=Dict(a=>0.1),systems=[sub])
+
+sys = structural_simplify(model)
+defs = get_defaults(sys)
+
+_u0 = filter(e->!ModelingToolkit.isparameter(e.first),defs)
+_p = filter(e->ModelingToolkit.isparameter(e.first),defs)
+@test isequal(_u0, Dict([a=>0.1, sub.y=>0.5sub.x]))
+prob = ODEProblem(sys,collect(_u0),(0.0,160.0),collect(_p),jac=true)
+
+# SHOULD NOT HAPPEN; TODO: remove this test
+@test_throws StackOverflowError solve(prob)
+
+u0 = get_default_u0(sys)
+p = get_default_p(sys)
+@test isequal(u0, Dict([a=>0.1, sub.y=>0.05]))
+@test isequal(p, Dict())
+prob = ODEProblem(sys,collect(u0),(0.0,160.0),collect(p),jac=true)
+sol = solve(prob)
+@test isequal(sol[a], sol[sub.x])
+


### PR DESCRIPTION
Fix #910

AFAIK, you already have some plans for the get_default_(u0|p) functions. These functions will be available again after it is possible to create variables/parameters with `@variables VAR = 1.0`?

Maybe I've overlooked the description for how to get u0 and p I need for the DEProblem initialization but I added a simple function to split the dict coming from `get_defaults(sys)`