### PR TITLE
Tiny typos/consistency fix in docs

### DIFF
--- a/docs/src/basics/ContextualVariables.md
+++ b/docs/src/basics/ContextualVariables.md
@@ -7,7 +7,7 @@ the `@variable` which is defined by
 [Symbolics.jl](https://github.com/JuliaSymbolics/Symbolics.jl). For example:
 
 ```julia
-@variabes x y(x)
+@variables x y(x)
 ```
 
 This is used for the "normal" variable of a given system, like the states of a

--- a/docs/src/tutorials/ode_modeling.md
+++ b/docs/src/tutorials/ode_modeling.md
@@ -13,7 +13,7 @@ But if you want to just see some code and run, here's an example:
 ```julia
 using ModelingToolkit
 
-@variables t, x(t) RHS(t)  # independent and dependent variables
+@variables t x(t) RHS(t)  # independent and dependent variables
 @parameters τ       # parameters
 D = Differential(t) # define an operator for the differentiation w.r.t. time
 
@@ -51,7 +51,7 @@ first set the forcing function to a constant value.
 ```julia
 using ModelingToolkit
 
-@variables t, x(t)  # independent and dependent variables
+@variables t x(t)  # independent and dependent variables
 @parameters τ       # parameters
 D = Differential(t) # define an operator for the differentiation w.r.t. time
 


### PR DESCRIPTION
Fixes a typo and also removes a comma -- you can do `@variables a b c` or `@variables a, b, c` but `@variables a, b c` leaves `c` undefined.