### PR TITLE
Namespacing broken due to Num wrapping

### DIFF
--- a/src/systems/abstractsystem.jl
+++ b/src/systems/abstractsystem.jl
@@ -307,6 +307,7 @@ end
 
 _symparam(s::Symbolic{T}) where {T} = T
 function namespace_expr(O,name,iv) where {T}
+    O = value(O)
     if istree(O)
         renamed = map(a->namespace_expr(a,name,iv), arguments(O))
         if operation(O) isa Sym


### PR DESCRIPTION
When namespacing a rather large expression, `namespace_expr` fails to recurse all the way into the expression because everything is wrapped in `Num` and the `istree` check always returns false. In the end this leads to variables not being namespaced, then not being escaped, and resulting in errors that a variables does not exist.

```julia
using ModelingToolkit
using IfElse: ifelse

macro nanify(expr)
    :(try
        $(esc(expr))
    catch DomainError
        NaN
    end)
end
if_less_than(val1, val2, lt, gt) = ifelse(signbit(val1 - val2), lt, gt)

function diode_charge(vd, cdiff; M=1, AREA=1, PJ=0, CJO=0, CJP=0, MJ=0.5, MJSW=0.33, PB=0.8, PHP=PB)
    PJeff = PJ * M
    CJPeff = PJeff * CJP
    AREAeff = AREA * M
    CJeff = CJO * AREAeff
    cdep = if_less_than(vd, 0,
        @nanify(CJeff * (1 - vd/PB)^(-MJ) + CJPeff * (1 - vd/PHP)^(-MJSW)),
        @nanify(CJeff * (1 + MJ * vd/PB) + CJPeff * (1 + MJSW*vd/PHP))
    )
    c = (cdep + cdiff)
    return vd*c
end

function Pin(;name)
    @parameters t
    @variables v(t) i(t)
    ODESystem(Equation[], t, [v, i], [], name=name)
end

function nonlinear_capacitor(f::Function; name, states=[], parameters=[])
    @named p = Pin()
    @named n = Pin()
    @parameters t
    @variables q(t)
    D = Differential(t)
    eqns = [
        0 ~ -q + f(p.v - n.v)
        D(q) ~ n.i
        0 ~ p.i + n.i
    ]
    push!(states, q)
    ODESystem(eqns, t,states, parameters; systems=[p, n], name=name)
end

@parameters t
@variables cdiff(t) q(t) cdiff(t)
params = collect(@parameters AREA M PJ CJO CJP MJ MJSW PB PHP)
kwparams = Dict(zip(map(s->nameof(ModelingToolkit.value(s)), params), params))
name = :diode
sys = nonlinear_capacitor(vc->diode_charge(vc, cdiff; kwparams...); name, parameters=params)
nseq = ModelingToolkit.namespace_equations(sys)
# 3-element Vector{Equation}:
#  0 ~ (diode₊cdiff(t) + IfElse.ifelse(signbit(diode₊p₊v(t) - diode₊n₊v(t)), AREA*CJO*M*((1 - ((PB^-1)*(p₊v(t) - n₊v(t))))^(-MJ)) + CJP*M*PJ*((1 - ((PHP^-1)*(p₊v(t) - n₊v(t))))^(-MJSW)), AREA*CJO*M*(1 + MJ*(PB^-1)*(p₊v(t) - n₊v(t))) + CJP*M*PJ*(1 + MJSW*(PHP^-1)*(p₊v(t) - n₊v(t)))))*(diode₊p₊v(t) - diode₊n₊v(t)) - diode₊q(t)
#  Differential(t)(diode₊q(t)) ~ diode₊n₊i(t)
#  0 ~ diode₊n₊i(t) + diode₊p₊i(t)
```

The fix I applied it just to unwrap all the `Num`. I'm not sure if this is a correct solution, but it works for me so far. Consider it a starting point for discussion, rather than a complete PR. To be honest, I do not fully understand when something should or should not be wrapped in `Num`.