### PR TITLE
change latexify test to make sure -1*x is rendered as -x

### DIFF
--- a/test/latexify.jl
+++ b/test/latexify.jl
@@ -30,12 +30,11 @@ eqs = [D(x) ~ σ*(y-x)*D(x-y)/D(z),
 # Latexify.@generate_test latexify(eqs)
 @test latexify(eqs) == replace(
 raw"\begin{align}
-\frac{dx(t)}{dt} =& \sigma \frac{d\left(x\left( t \right) -1 \cdot y\left( t \right)\right)}{dt} \left( y\left( t \right) -1 x\left( t \right) \right) \left( \frac{dz(t)}{dt} \right)^{-1} \\
-0 =& -1 y\left( t \right) + 0.1 \sigma x\left( t \right) \left( \rho -1 z\left( t \right) \right) \\
-\frac{dz(t)}{dt} =& x\left( t \right) \left( y\left( t \right) \right)^{\frac{2}{3}} -1 \beta z\left( t \right)
+\frac{dx(t)}{dt} =& \sigma \frac{d\left(x\left( t \right) - y\left( t \right)\right)}{dt} \left( y\left( t \right) - x\left( t \right) \right) \left( \frac{dz(t)}{dt} \right)^{-1} \\
+0 =&  - y\left( t \right) + 0.1 \sigma x\left( t \right) \left( \rho - z\left( t \right) \right) \\
+\frac{dz(t)}{dt} =& x\left( t \right) \left( y\left( t \right) \right)^{\frac{2}{3}} - \beta z\left( t \right)
 \end{align}
 ", "\r\n"=>"\n")
-
 
 @variables u[1:3](t)
 @parameters p[1:3]
@@ -45,9 +44,9 @@ eqs = [D(u[1]) ~ p[3]*(u[2]-u[1]),
 
 @test latexify(eqs) == replace(
 raw"\begin{align}
-\frac{du{_1}(t)}{dt} =& p{_3} \left( \mathrm{u{_2}}\left( t \right) -1 \mathrm{u{_1}}\left( t \right) \right) \\
-0 =& -1 \mathrm{u{_2}}\left( t \right) + 0.1 p{_2} p{_3} \mathrm{u{_1}}\left( t \right) \left( p{_1} -1 \mathrm{u{_1}}\left( t \right) \right) \\
-\frac{du{_3}(t)}{dt} =& \mathrm{u{_1}}\left( t \right) \left( \mathrm{u{_2}}\left( t \right) \right)^{\frac{2}{3}} -1 p{_3} \mathrm{u{_3}}\left( t \right)
+\frac{du{_1}(t)}{dt} =& p{_3} \left( \mathrm{u{_2}}\left( t \right) - \mathrm{u{_1}}\left( t \right) \right) \\
+0 =&  - \mathrm{u{_2}}\left( t \right) + 0.1 p{_2} p{_3} \mathrm{u{_1}}\left( t \right) \left( p{_1} - \mathrm{u{_1}}\left( t \right) \right) \\
+\frac{du{_3}(t)}{dt} =& \mathrm{u{_1}}\left( t \right) \left( \mathrm{u{_2}}\left( t \right) \right)^{\frac{2}{3}} - p{_3} \mathrm{u{_3}}\left( t \right)
 \end{align}
 ", "\r\n"=>"\n")
 
@@ -57,12 +56,11 @@ eqs = [D(u[1]) ~ p[3]*(u[2]-u[1]),
 
 @test latexify(eqs) == replace(
 raw"\begin{align}
-\frac{du{_1}(t)}{dt} =& p{_3} \left( \mathrm{u{_2}}\left( t \right) -1 \mathrm{u{_1}}\left( t \right) \right) \\
-\frac{du{_2}(t)}{dt} =& -1 \mathrm{u{_2}}\left( t \right) + 0.1 p{_2} p{_3} \mathrm{u{_1}}\left( t \right) \left( p{_1} -1 \mathrm{u{_1}}\left( t \right) \right) \\
-\frac{du{_3}(t)}{dt} =& \mathrm{u{_1}}\left( t \right) \left( \mathrm{u{_2}}\left( t \right) \right)^{\frac{2}{3}} -1 p{_3} \mathrm{u{_3}}\left( t \right)
+\frac{du{_1}(t)}{dt} =& p{_3} \left( \mathrm{u{_2}}\left( t \right) - \mathrm{u{_1}}\left( t \right) \right) \\
+\frac{du{_2}(t)}{dt} =&  - \mathrm{u{_2}}\left( t \right) + 0.1 p{_2} p{_3} \mathrm{u{_1}}\left( t \right) \left( p{_1} - \mathrm{u{_1}}\left( t \right) \right) \\
+\frac{du{_3}(t)}{dt} =& \mathrm{u{_1}}\left( t \right) \left( \mathrm{u{_2}}\left( t \right) \right)^{\frac{2}{3}} - p{_3} \mathrm{u{_3}}\left( t \right)
 \end{align}
 ", "\r\n"=>"\n")
-
 
 @parameters t
 @variables x(t)


### PR DESCRIPTION
Originally `Symbolics.jl` renders the negative of a variable as `-1*x`, I have made a PR(https://github.com/JuliaSymbolics/Symbolics.jl/pull/179) so that it can be rendered as `-x`. So I would like to change the tests here to reflect the change.