### PR TITLE
Control parameter specification for `AbstractODESystem`, `DiscreteSystem`

### DIFF
--- a/src/ModelingToolkit.jl
+++ b/src/ModelingToolkit.jl
@@ -161,11 +161,13 @@ export Differential, expand_derivatives, @derivatives
 export Equation, ConstrainedEquation
 export Term, Sym
 export SymScope, LocalScope, ParentScope, GlobalScope
-export independent_variable, states, parameters, equations, controls, observed, structure
+export independent_variable, states, parameters, equations, controls, observed, structure, defaults
+export ssmodel, linearize
 export structural_simplify
 export DiscreteSystem, DiscreteProblem
 
 export calculate_jacobian, generate_jacobian, generate_function
+export calculate_control_jacobian
 export calculate_tgrad, generate_tgrad
 export calculate_gradient, generate_gradient
 export calculate_factorized_W, generate_factorized_W

--- a/src/ModelingToolkit.jl
+++ b/src/ModelingToolkit.jl
@@ -161,7 +161,7 @@ export Differential, expand_derivatives, @derivatives
 export Equation, ConstrainedEquation
 export Term, Sym
 export SymScope, LocalScope, ParentScope, GlobalScope
-export independent_variable, states, parameters, equations, controls, observed, structure, defaults
+export independent_variable, states, parameters, equations, controls, observed, structure
 export structural_simplify
 export DiscreteSystem, DiscreteProblem
 

--- a/src/ModelingToolkit.jl
+++ b/src/ModelingToolkit.jl
@@ -167,7 +167,7 @@ export structural_simplify
 export DiscreteSystem, DiscreteProblem
 
 export calculate_jacobian, generate_jacobian, generate_function
-export calculate_control_jacobian
+export calculate_control_jacobian, generate_control_jacobian
 export calculate_tgrad, generate_tgrad
 export calculate_gradient, generate_gradient
 export calculate_factorized_W, generate_factorized_W

--- a/src/ModelingToolkit.jl
+++ b/src/ModelingToolkit.jl
@@ -162,7 +162,6 @@ export Equation, ConstrainedEquation
 export Term, Sym
 export SymScope, LocalScope, ParentScope, GlobalScope
 export independent_variable, states, parameters, equations, controls, observed, structure, defaults
-export ssmodel, linearize
 export structural_simplify
 export DiscreteSystem, DiscreteProblem
 

--- a/src/systems/abstractsystem.jl
+++ b/src/systems/abstractsystem.jl
@@ -36,6 +36,18 @@ function calculate_jacobian end
 
 """
 ```julia
+calculate_control_jacobian(sys::AbstractSystem)
+```
+
+Calculate the jacobian matrix of a system with respect to the system's controls.
+
+Returns a matrix of [`Num`](@ref) instances. The result from the first
+call will be cached in the system object.
+"""
+function calculate_control_jacobian end
+
+"""
+```julia
 calculate_factorized_W(sys::AbstractSystem)
 ```
 
@@ -140,10 +152,12 @@ for prop in [
              :iv
              :states
              :ps
+             :ctrl
              :defaults
              :observed
              :tgrad
              :jac
+             :ctrl_jac
              :Wfact
              :Wfact_t
              :systems
@@ -346,11 +360,17 @@ function states(sys::AbstractSystem)
            sts :
            [sts;reduce(vcat,namespace_variables.(systems))])
 end
+
 function parameters(sys::AbstractSystem)
     ps = get_ps(sys)
     systems = get_systems(sys)
     isempty(systems) ? ps : [ps;reduce(vcat,namespace_parameters.(systems))]
 end
+
+function controls(sys::AbstractSystem)
+    get_ctrl(sys)
+end
+
 function observed(sys::AbstractSystem)
     iv = independent_variable(sys)
     obs = get_observed(sys)

--- a/src/systems/abstractsystem.jl
+++ b/src/systems/abstractsystem.jl
@@ -368,7 +368,7 @@ function parameters(sys::AbstractSystem)
 end
 
 function controls(sys::AbstractSystem)
-    get_ctrl(sys)
+    get_ctrl(flatten(sys))
 end
 
 function observed(sys::AbstractSystem)

--- a/src/systems/abstractsystem.jl
+++ b/src/systems/abstractsystem.jl
@@ -152,7 +152,7 @@ for prop in [
              :iv
              :states
              :ps
-             :ctrl
+             :ctrls
              :defaults
              :observed
              :tgrad
@@ -315,6 +315,7 @@ end
 
 namespace_variables(sys::AbstractSystem) = states(sys, states(sys))
 namespace_parameters(sys::AbstractSystem) = parameters(sys, parameters(sys))
+namespace_controls(sys::AbstractSystem) = controls(sys, controls(sys))
 
 function namespace_defaults(sys)
     defs = defaults(sys)
@@ -358,17 +359,19 @@ function states(sys::AbstractSystem)
     systems = get_systems(sys)
     unique(isempty(systems) ?
            sts :
-           [sts;reduce(vcat,namespace_variables.(systems))])
+           [sts; reduce(vcat,namespace_variables.(systems))])
 end
 
 function parameters(sys::AbstractSystem)
     ps = get_ps(sys)
     systems = get_systems(sys)
-    isempty(systems) ? ps : [ps;reduce(vcat,namespace_parameters.(systems))]
+    isempty(systems) ? ps : [ps; reduce(vcat,namespace_parameters.(systems))]
 end
 
 function controls(sys::AbstractSystem)
-    get_ctrl(flatten(sys))
+    ctrls = get_ctrls(sys)
+    systems = get_systems(sys)
+    isempty(systems) ? ctrls : [ctrls; reduce(vcat,namespace_controls.(systems))]
 end
 
 function observed(sys::AbstractSystem)

--- a/src/systems/control/controlsystem.jl
+++ b/src/systems/control/controlsystem.jl
@@ -1,6 +1,6 @@
 abstract type AbstractControlSystem <: AbstractSystem end
 
-function namespace_controls(sys::AbstractSystem)
+function namespace_controls(sys::AbstractControlSystem)
     [rename(x,renamespace(nameof(sys),nameof(x))) for x in controls(sys)]
 end
 

--- a/src/systems/diffeqs/abstractodesystem.jl
+++ b/src/systems/diffeqs/abstractodesystem.jl
@@ -78,25 +78,6 @@ function generate_control_jacobian(sys::AbstractODESystem, dvs = states(sys), ps
     return build_function(jac, dvs, ps, get_iv(sys); kwargs...)
 end
 
-"""
-```julia
-generate_linearization(sys::ODESystem, dvs = states(sys), ps = parameters(sys), ctrls = controls(sys), point = defaults(sys), expression = Val{true}; sparse = false, kwargs...)
-```
-
-Generates a function for the linearized state space model of the system. Extra arguments
-control the arguments to the internal [`build_function`](@ref) call.
-"""
-function generate_linearization(sys::AbstractSystem, dvs = states(sys), ps = parameters(sys), ctrls = controls(sys);
-                                simplify=false, sparse=false, kwargs...) 
-    ops = map(eq -> eq.rhs, equations(sys)) 
-    
-    jac = calculate_jacobian(sys;simplify=simplify,sparse=sparse)
-
-    A = @views J[1:length(states(sys)), 1:length(states(sys))]
-    B = @views J[1:length(states(sys)), length(states(sys))+1:end]
-
-    return A, B
-end
 @noinline function throw_invalid_derivative(dervar, eq)
     msg = "The derivative variable must be isolated to the left-hand " *
     "side of the equation like `$dervar ~ ...`.\n Got $eq."

--- a/src/systems/diffeqs/abstractodesystem.jl
+++ b/src/systems/diffeqs/abstractodesystem.jl
@@ -72,6 +72,12 @@ function generate_jacobian(sys::AbstractODESystem, dvs = states(sys), ps = param
     return build_function(jac, dvs, ps, get_iv(sys); kwargs...)
 end
 
+function generate_control_jacobian(sys::AbstractODESystem, dvs = states(sys), ps = parameters(sys);
+                                   simplify=false, sparse = false, kwargs...)
+    jac = calculate_control_jacobian(sys;simplify=simplify,sparse=sparse)
+    return build_function(jac, dvs, ps, get_iv(sys); kwargs...)
+end
+
 """
 ```julia
 generate_linearization(sys::ODESystem, dvs = states(sys), ps = parameters(sys), ctrls = controls(sys), point = defaults(sys), expression = Val{true}; sparse = false, kwargs...)

--- a/src/systems/diffeqs/odesystem.jl
+++ b/src/systems/diffeqs/odesystem.jl
@@ -31,7 +31,7 @@ struct ODESystem <: AbstractODESystem
     states::Vector
     """Parameter variables. Must not contain the independent variable."""
     ps::Vector
-    ctrl::Vector
+    ctrls::Vector
     observed::Vector{Equation}
     """
     Time-derivative matrix. Note: this field will not be defined until
@@ -115,13 +115,14 @@ function ODESystem(
 
     tgrad = RefValue(Vector{Num}(undef, 0))
     jac = RefValue{Any}(Matrix{Num}(undef, 0, 0))
+    ctrl_jac = RefValue{Any}(Matrix{Num}(undef, 0, 0))
     Wfact   = RefValue(Matrix{Num}(undef, 0, 0))
     Wfact_t = RefValue(Matrix{Num}(undef, 0, 0))
     sysnames = nameof.(systems)
     if length(unique(sysnames)) != length(sysnames)
         throw(ArgumentError("System names must be unique."))
     end
-    ODESystem(deqs, iv′, dvs′, ps′, ctrl′, observed, tgrad, jac, Wfact, Wfact_t, name, systems, defaults, nothing, connection_type)
+    ODESystem(deqs, iv′, dvs′, ps′, ctrl′, observed, tgrad, jac, ctrl_jac, Wfact, Wfact_t, name, systems, defaults, nothing, connection_type)
 end
 
 vars(x::Sym) = Set([x])

--- a/src/systems/diffeqs/odesystem.jl
+++ b/src/systems/diffeqs/odesystem.jl
@@ -82,11 +82,11 @@ struct ODESystem <: AbstractODESystem
     """
     connection_type::Any
 
-    function ODESystem(deqs, iv, dvs, ps, observed, tgrad, jac, Wfact, Wfact_t, name, systems, defaults, structure, connection_type)
+    function ODESystem(deqs, iv, dvs, ps, ctrls, observed, tgrad, jac, ctrl_jac, Wfact, Wfact_t, name, systems, defaults, structure, connection_type)
         check_variables(dvs,iv)
         check_parameters(ps,iv)
         check_equations(deqs,iv)
-        new(deqs, iv, dvs, ps, observed, tgrad, jac, Wfact, Wfact_t, name, systems, defaults, structure, connection_type)
+        new(deqs, iv, dvs, ps, ctrls, observed, tgrad, jac, ctrl_jac, Wfact, Wfact_t, name, systems, defaults, structure, connection_type)
     end
 end
 

--- a/src/systems/diffeqs/odesystem.jl
+++ b/src/systems/diffeqs/odesystem.jl
@@ -31,7 +31,9 @@ struct ODESystem <: AbstractODESystem
     states::Vector
     """Parameter variables. Must not contain the independent variable."""
     ps::Vector
+    """Control parameters (some subset of `ps`)."""
     ctrls::Vector
+    """Observed states."""
     observed::Vector{Equation}
     """
     Time-derivative matrix. Note: this field will not be defined until

--- a/src/systems/diffeqs/sdesystem.jl
+++ b/src/systems/diffeqs/sdesystem.jl
@@ -84,11 +84,11 @@ struct SDESystem <: AbstractODESystem
     """
     connection_type::Any
 
-    function SDESystem(deqs, neqs, iv, dvs, ps, observed, tgrad, jac, Wfact, Wfact_t, name, systems, defaults, connection_type)
+    function SDESystem(deqs, neqs, iv, dvs, ps, ctrls, observed, tgrad, jac, ctrl_jac, Wfact, Wfact_t, name, systems, defaults, connection_type)
         check_variables(dvs,iv)
         check_parameters(ps,iv)
         check_equations(deqs,iv)
-        new(deqs, neqs, iv, dvs, ps, observed, tgrad, jac, Wfact, Wfact_t, name, systems, defaults, connection_type)
+        new(deqs, neqs, iv, dvs, ps, ctrls, observed, tgrad, jac, ctrl_jac, Wfact, Wfact_t, name, systems, defaults, connection_type)
     end
 end
 

--- a/src/systems/discrete_system/discrete_system.jl
+++ b/src/systems/discrete_system/discrete_system.jl
@@ -30,6 +30,9 @@ struct DiscreteSystem <: AbstractSystem
     states::Vector
     """Parameter variables. Must not contain the independent variable."""
     ps::Vector
+    """Control parameters (some subset of `ps`)."""
+    ctrls::Vector
+    """Observed states."""
     observed::Vector{Equation}
     """
     Name: the name of the system
@@ -63,6 +66,7 @@ Constructs a DiscreteSystem.
 """
 function DiscreteSystem(
                    discreteEqs::AbstractVector{<:Equation}, iv, dvs, ps;
+                   controls = Num[],
                    observed = Num[],
                    systems = DiscreteSystem[],
                    name=gensym(:DiscreteSystem),
@@ -72,6 +76,7 @@ function DiscreteSystem(
     iv′ = value(iv)
     dvs′ = value.(dvs)
     ps′ = value.(ps)
+    ctrl′ = value.(controls)
 
     default_u0 isa Dict || (default_u0 = Dict(default_u0))
     default_p isa Dict || (default_p = Dict(default_p))
@@ -82,7 +87,7 @@ function DiscreteSystem(
     if length(unique(sysnames)) != length(sysnames)
         throw(ArgumentError("System names must be unique."))
     end
-    DiscreteSystem(discreteEqs, iv′, dvs′, ps′, observed, name, systems, default_u0, default_p)
+    DiscreteSystem(discreteEqs, iv′, dvs′, ps′, ctrl′, observed, name, systems, default_u0, default_p)
 end
 
 """

--- a/src/systems/discrete_system/discrete_system.jl
+++ b/src/systems/discrete_system/discrete_system.jl
@@ -52,10 +52,10 @@ struct DiscreteSystem <: AbstractSystem
     in `DiscreteSystem`.
     """
     default_p::Dict
-    function DiscreteSystem(discreteEqs, iv, dvs, ps, observed, name, systems, default_u0, default_p)
-        check_variables(dvs, iv)
-        check_parameters(ps, iv)
-        new(discreteEqs, iv, dvs, ps, observed, name, systems, default_u0, default_p)
+    function DiscreteSystem(discreteEqs, iv, dvs, ps, ctrls, observed, name, systems, default_u0, default_p)
+        check_variables(dvs,iv)
+        check_parameters(ps,iv)
+        new(discreteEqs, iv, dvs, ps, ctrls, observed, name, systems, default_u0, default_p)
     end
 end
 

--- a/test/direct.jl
+++ b/test/direct.jl
@@ -75,7 +75,7 @@ end
 @variables a,b
 X = [a,b]
 
-spoly(x) = simplify(x, polynorm=true)
+spoly(x) = simplify(x, expand=true)
 rr = rosenbrock(X)
 
 reference_hes = ModelingToolkit.hessian(rr, X)

--- a/test/discretesystem.jl
+++ b/test/discretesystem.jl
@@ -22,7 +22,7 @@ eqs = [next_S ~ S-infection,
        next_R ~ R+recovery]
 
 # System
-sys = DiscreteSystem(eqs,t,[S,I,R],[c,nsteps,δt,β,γ])
+sys = DiscreteSystem(eqs,t,[S,I,R],[c,nsteps,δt,β,γ]; controls = [β, γ])
 
 # Problem
 u0 = [S => 990.0, I => 10.0, R => 0.0]

--- a/test/odesystem.jl
+++ b/test/odesystem.jl
@@ -370,13 +370,18 @@ let
     δ = Differential(t)
     
     eqs = [δ(x) ~ ẋ, δ(ẋ) ~ f - k*x - d*ẋ]
-    sys = ODESystem(eqs, t, [x, ẋ], [f, d, k])
+    sys = ODESystem(eqs, t, [x, ẋ], [f, d, k]; controls = [f])
 
     calculate_control_jacobian(sys)
 
     @test isequal(
-        sys.ctrl_jac,
-        Num[0, 1]
+        ModelingToolkit.get_ctrl_jac(sys)[][1],
+        reshape(Num[0,1], 2, 1)
+    )
+
+    @test isequal(
+        ModelingToolkit.get_ctrl_jac(sys)[][1],
+        calculate_control_jacobian(sys)
     )
 
 end

--- a/test/odesystem.jl
+++ b/test/odesystem.jl
@@ -375,13 +375,8 @@ let
     calculate_control_jacobian(sys)
 
     @test isequal(
-        ModelingToolkit.get_ctrl_jac(sys)[][1],
+        calculate_control_jacobian(sys),
         reshape(Num[0,1], 2, 1)
-    )
-
-    @test isequal(
-        ModelingToolkit.get_ctrl_jac(sys)[][1],
-        calculate_control_jacobian(sys)
     )
 
 end

--- a/test/odesystem.jl
+++ b/test/odesystem.jl
@@ -362,3 +362,21 @@ eqs = [D(x1) ~ -x1]
 sys = ODESystem(eqs,t,[x1,x2],[])
 @test_throws ArgumentError ODEProblem(sys, [1.0,1.0], (0.0,1.0))
 prob = ODEProblem(sys, [1.0,1.0], (0.0,1.0), check_length=false)
+
+# check inputs
+let 
+    @parameters t f k d
+    @variables x(t) ẋ(t)
+    δ = Differential(t)
+    
+    eqs = [δ(x) ~ ẋ, δ(ẋ) ~ f - k*x - d*ẋ]
+    sys = ODESystem(eqs, t, [x, ẋ], [f, d, k])
+
+    calculate_control_jacobian(sys)
+
+    @test isequal(
+        sys.ctrl_jac,
+        Num[0, 1]
+    )
+
+end

--- a/test/reduction.jl
+++ b/test/reduction.jl
@@ -27,7 +27,7 @@ ref_eq = [
 @variables x(t) y(t) z(t) a(t) u(t) F(t)
 D = Differential(t)
 
-test_equal(a, b) = @test isequal(simplify(a, polynorm=true), simplify(b, polynorm=true))
+test_equal(a, b) = @test isequal(simplify(a, expand=true), simplify(b, expand=true))
 
 eqs = [
        D(x) ~ σ*(y-x)


### PR DESCRIPTION
Adds control parameter specification, related to #1041. Also adds a control Jacobian cached reference and an associated function. If the `calculate_jacobian` function generates a state space model `A` matrix, then the new `calculate_control_jacobian` function calculates the `B` matrix. 

@ChrisRackauckas @YingboMa what do you think about this design? __Thoughts before I proceed? Should I proceed?__ The rules are...

1. Control parameters are specified with a `kwarg` to `ODESystem`, and are empty by default
2. Control parameters __must__ be some subset of the `parameters` of a system (I think this makes sense, since we don't want the control parameters to have their own dynamics)
3. Users can call `calculate_control_jacobian` to calculate the Jacobian of the system's dynamics _with respect to the control parameters_, __not__ with respect to the state variables as is the case in `calculate_jacobian`

It would be nice to add a `generate_statespace` function to produce expressions for calculating the tuple `A,B`. That way, users can easily linearize an `ODESystem` about any operating point. 

 