### PR TITLE
Ensure explicit time-dependence for all ODESystem variables

### DIFF
--- a/src/systems/diffeqs/odesystem.jl
+++ b/src/systems/diffeqs/odesystem.jl
@@ -75,21 +75,14 @@ struct ODESystem <: AbstractODESystem
     connection_type::Any
 
     function ODESystem(deqs, iv, dvs, ps, observed, tgrad, jac, Wfact, Wfact_t, name, systems, defaults, structure, connection_type)
-        check_differentials(deqs,iv)
+        check_dependence(dvs,iv)
         new(deqs, iv, dvs, ps, observed, tgrad, jac, Wfact, Wfact_t, name, systems, defaults, structure, connection_type)
     end
 end
 
-function check_differentials(eqs,iv)
-    diffvars = OrderedSet()
-    for eq in eqs
-        if isdiffeq(eq)
-            lhs = eq.lhs
-            diffvar, _ = var_from_nested_derivative(eq.lhs)
-            isequal(iv, iv_from_nested_derivative(lhs)) || throw(ArgumentError("Differential variable $diffvar is not a function of independent variable $iv."))
-            diffvar in diffvars && throw(ArgumentError("The differential variable $diffvar is not unique in the system of equations."))
-            push!(diffvars, diffvar)
-        end
+function check_dependence(dvs,iv)
+    for dv in dvs
+        isequal(iv, iv_from_nested_derivative(dv)) || throw(ArgumentError("Variable $dv is not a function of independent variable $iv."))
     end
 end 
 

--- a/src/systems/diffeqs/odesystem.jl
+++ b/src/systems/diffeqs/odesystem.jl
@@ -73,7 +73,25 @@ struct ODESystem <: AbstractODESystem
     type: type of the system
     """
     connection_type::Any
+
+    function ODESystem(deqs, iv, dvs, ps, observed, tgrad, jac, Wfact, Wfact_t, name, systems, defaults, structure, connection_type)
+        check_differentials(deqs,iv)
+        new(deqs, iv, dvs, ps, observed, tgrad, jac, Wfact, Wfact_t, name, systems, defaults, structure, connection_type)
+    end
 end
+
+function check_differentials(eqs,iv)
+    diffvars = OrderedSet()
+    for eq in eqs
+        if isdiffeq(eq)
+            lhs = eq.lhs
+            diffvar, _ = var_from_nested_derivative(eq.lhs)
+            isequal(iv, iv_from_nested_derivative(lhs)) || throw(ArgumentError("Differential variable $diffvar is not a function of independent variable $iv."))
+            diffvar in diffvars && throw(ArgumentError("The differential variable $diffvar is not unique in the system of equations."))
+            push!(diffvars, diffvar)
+        end
+    end
+end 
 
 function ODESystem(
                    deqs::AbstractVector{<:Equation}, iv, dvs, ps;

--- a/test/lowering_solving.jl
+++ b/test/lowering_solving.jl
@@ -48,7 +48,7 @@ eqs = [D(x) ~ σ*(y-x),
 lorenz1 = ODESystem(eqs,name=:lorenz1)
 lorenz2 = ODESystem(eqs,name=:lorenz2)
 
-@variables α
+@variables α(t)
 @parameters γ
 connections = [0 ~ lorenz1.x + lorenz2.y + α*γ]
 connected = ODESystem(connections,t,[α],[γ],systems=[lorenz1,lorenz2])

--- a/test/odesystem.jl
+++ b/test/odesystem.jl
@@ -318,6 +318,16 @@ ode = ODESystem(eq)
 
 end
 
+#Issue 998
+@parameters t 
+pars = []
+vars = @variables((u1,))
+der = Differential(t)
+eqs = [
+  der(u1) ~ 1,
+]
+@test_throws ArgumentError ODESystem(eqs,t,vars,pars)
+
 @variables x(t)
 D = Differential(t)
 @parameters M b k

--- a/test/reactionsystem.jl
+++ b/test/reactionsystem.jl
@@ -189,7 +189,7 @@ end
 
 # test for https://github.com/SciML/ModelingToolkit.jl/issues/436
 @parameters t
-@variables S I
+@variables S(t) I(t)
 rxs = [Reaction(1,[S],[I]), Reaction(1.1,[S],[I])]
 rs = ReactionSystem(rxs, t, [S,I], [])
 js = convert(JumpSystem, rs)
@@ -202,7 +202,7 @@ jprob = JumpProblem(rs, dprob, Direct(), save_positions=(false,false))
 
 
 @parameters k1 k2
-@variables R
+@variables R(t)
 rxs = [Reaction(k1*S, [S,I], [I], [2,3], [2]),
        Reaction(k2*R, [I], [R]) ]
 rs = ReactionSystem(rxs, t, [S,I,R], [k1,k2])


### PR DESCRIPTION
Related to #998  and [PR#1061](https://github.com/SciML/ModelingToolkit.jl/pull/1061).  This provides an inner constructor for ODESystem that errors if any dependent variable is not a function of the independent variable.