### PR TITLE
Limit vertical height of individual states and parameters

### DIFF
--- a/src/systems/abstractsystem.jl
+++ b/src/systems/abstractsystem.jl
@@ -535,7 +535,9 @@ function Base.show(io::IO, ::MIME"text/plain", sys::AbstractSystem)
         if defs !== nothing
             val = get(defs, s, nothing)
             if val !== nothing
-                print(io, " [defaults to $val]")
+                print(io, " [defaults to ")
+                show(IOContext(io, :compact=>true, :limit=>true, :displaysize=>(1,displaysize(io)[2])), val)
+                print(io, "]")
             end
         end
     end
@@ -553,7 +555,9 @@ function Base.show(io::IO, ::MIME"text/plain", sys::AbstractSystem)
         if defs !== nothing
             val = get(defs, s, nothing)
             if val !== nothing
-                print(io, " [defaults to $val]")
+                print(io, " [defaults to ")
+                show(IOContext(io, :compact=>true, :limit=>true, :displaysize=>(1,displaysize(io)[2])), val)
+                print(io, "]")
             end
         end
     end


### PR DESCRIPTION
Changes the `IOContext` parameters to limit the display of Array-based variables to one printing row for individual states and parameters.