### PR TITLE
[WIP] Differential Equation Function Transformations #141

### DIFF
--- a/src/ModelingToolkit.jl
+++ b/src/ModelingToolkit.jl
@@ -153,7 +153,7 @@ export JumpProblem, DiscreteProblem
 export NonlinearSystem, OptimizationSystem
 export ControlSystem
 export alias_elimination, flatten, connect, @connector
-export ode_order_lowering, liouville_transform
+export ode_order_lowering, liouville_transform, changeofvariables
 export runge_kutta_discretize
 export PDESystem
 export Reaction, ReactionSystem, ismassaction, oderatelaw, jumpratelaw

--- a/test/changeofvariables.jl
+++ b/test/changeofvariables.jl
@@ -1,0 +1,88 @@
+using ModelingToolkit, OrdinaryDiffEq
+using Test, LinearAlgebra
+
+
+# Change of variables: z = exp(x)
+
+@parameters t α
+@variables x(t)
+D = Differential(t)
+eqs = [D(x) ~ α*x]
+
+tspan = (0., 1.)
+u0 = [x => 1.0]
+p = [α => -0.5]
+
+sys = ODESystem(eqs; defaults=u0)
+prob = ODEProblem(sys, [], tspan, p)
+sol = solve(prob, Tsit5())
+
+@variables z(t)
+forward_subs  = [exp(x) => z]
+backward_subs = [x => log(z)]
+new_sys = changeofvariables(sys, forward_subs, backward_subs)
+@test equations(new_sys)[1] == (D(z) ~ α*z*log(z))
+
+new_prob = ODEProblem(new_sys, [], tspan, p)
+new_sol = solve(new_prob, Tsit5())
+
+@test isapprox(new_sol[x][end], sol[x][end], atol=1e-4)
+
+
+
+# Riccatti equation
+@parameters t α
+@variables x(t)
+D = Differential(t)
+eqs = [D(x) ~ t^2 + α - x^2]
+sys = ODESystem(eqs, defaults=[x=>1.])
+
+@variables z(t)
+forward_subs  = [t + α/(x+t) =>    z       ]
+backward_subs = [       x    => α/(z-t) - t]
+
+new_sys = changeofvariables(sys, forward_subs, backward_subs; simplify=true, t0=0.)
+# output should be equivalent to
+# t^2 + α - z^2 + 2   (but this simplification is not found automatically)
+
+tspan = (0., 1.)
+p = [α => 1.]
+prob = ODEProblem(sys,[],tspan,p)
+new_prob = ODEProblem(new_sys,[],tspan,p)
+
+sol = solve(prob, Tsit5())
+new_sol = solve(new_prob, Tsit5())
+
+@test isapprox(sol[x][end], new_sol[x][end], rtol=1e-4)
+
+
+# Linear transformation to diagonal system
+@parameters t
+@variables x[1:3](t)
+D = Differential(t)
+A = [0. -1. 0.; -0.5 0.5 0.; 0. 0. -1.]
+eqs = D.(x) .~ A*x
+
+tspan = (0., 10.)
+u0 = x .=> [1.0, 2.0, -1.0]
+
+sys = ODESystem(eqs; defaults=u0)
+prob = ODEProblem(sys,[],tspan)
+sol = solve(prob, Tsit5())
+
+T = eigen(A).vectors
+
+@variables z[1:3](t)
+forward_subs  = T \ x .=> z
+backward_subs = x     .=> T*z
+
+new_sys = changeofvariables(sys, forward_subs, backward_subs; simplify=true)
+
+new_prob = ODEProblem(new_sys, [], tspan, p)
+new_sol = solve(new_prob, Tsit5())
+
+# test RHS
+new_rhs = [eq.rhs for eq in equations(new_sys)]
+new_A = Symbolics.value.(Symbolics.jacobian(new_rhs, z))
+@test isapprox(diagm(eigen(A).values), new_A, rtol = 1e-10)
+@test isapprox( new_sol[x[1],end], sol[x[1],end], rtol=1e-4)


### PR DESCRIPTION
For https://github.com/SciML/ModelingToolkit.jl/issues/141
I'm not quite done yet, but I wanted to ask for feedback to check that the direction is alright.

For example, the change of variables `z = exp(x)` looks currently like this:
```
eqs = [D(x) ~ α*x]
u0 = [x => 1.0]
sys = ODESystem(eqs; defaults=u0)

@variables z(t)
forward_subs  = [exp(x) => z]
backward_subs = [x => log(z)]
new_sys = changeofvariables(sys, forward_subs, backward_subs)
@test equations(new_sys)[1] == (D(z) ~ α*z*log(z))
```
Since there is not symbolic way (AFAIK) to get the inverse of general nonlinear function, one has to
provide both: the forward and backward substitution (`forward_subs` and `backward_subs`).

In the test file, I also added a Riccati ODE and a 3D linear transformation as examples.

Details:
- If `sys.defaults` exists, then those will be transformed as well.
- The substituted variables become observables.
- Transformation can depend on time. (For transformation if initial data, one needs to provide `t0`)
- It only works for first-order ODEs

Questions:
- Is the function interface ok? I picked this form, since it looks mathematically correct. I use expressions instead of `Function`s because everything else is also symbolic.

----

Things I will add for final PR/known bugs:
- [ ] support cases where `length(forward_subs) < length(states(sys))`, i.e. keep old state variables.
- [ ] add proper doc string once the interface is fixed.

Optional ideas:
- [ ] compute forward/backward substitution automatically if possible (but I don't know where to get inveres from). One could use inverse function theorem, but then the transformed ODEs are ugly/too complex.
- [ ] allow to pass known invariants, to cover cases like Riccati equations better.
