### PR TITLE
Widen type bound on symscope to match symbolics

### DIFF
--- a/src/systems/abstractsystem.jl
+++ b/src/systems/abstractsystem.jl
@@ -271,15 +271,15 @@ end
 abstract type SymScope end
 
 struct LocalScope <: SymScope end
-LocalScope(sym::Union{Num, Sym}) = setmetadata(sym, SymScope, LocalScope())
+LocalScope(sym::Union{Num, Symbolic}) = setmetadata(sym, SymScope, LocalScope())
 
 struct ParentScope <: SymScope
     parent::SymScope
 end
-ParentScope(sym::Union{Num, Sym}) = setmetadata(sym, SymScope, ParentScope(getmetadata(value(sym), SymScope, LocalScope())))
+ParentScope(sym::Union{Num, Symbolic}) = setmetadata(sym, SymScope, ParentScope(getmetadata(value(sym), SymScope, LocalScope())))
 
 struct GlobalScope <: SymScope end
-GlobalScope(sym::Union{Num, Sym}) = setmetadata(sym, SymScope, GlobalScope())
+GlobalScope(sym::Union{Num, Symbolic}) = setmetadata(sym, SymScope, GlobalScope())
 
 function renamespace(namespace, x)
     if x isa Num

--- a/test/variable_scope.jl
+++ b/test/variable_scope.jl
@@ -2,11 +2,16 @@ using ModelingToolkit
 using Test
 
 @parameters t
-@variables a b(t) c d
+@variables a b(t) c d e(t)
 
 b = ParentScope(b)
 c = ParentScope(ParentScope(c))
 d = GlobalScope(d)
+
+# ensure it works on Term too
+LocalScope(e.val)
+ParentScope(e.val)
+GlobalScope(e.val)
 
 renamed(nss, sym) = ModelingToolkit.getname(foldr(ModelingToolkit.renamespace, nss, init=sym))
 


### PR DESCRIPTION
I tried to use this function with a `Term` that was not wrapped in a `Num` and it failed.
`setmetadata` is actually implemented for `Symbolic` and `Num` rather than `Sym` and `Num`.
Matching the type bound makes the function work on bare Term objects and anything else that implements `setmetadata`.