### PR TITLE
Variable scope: don't lose metadata by passing around bare symbols

### DIFF
--- a/src/systems/abstractsystem.jl
+++ b/src/systems/abstractsystem.jl
@@ -345,7 +345,7 @@ function namespace_expr(O,name,iv) where {T}
     if istree(O)
         renamed = map(a->namespace_expr(a,name,iv), arguments(O))
         if operation(O) isa Sym
-            rename(O,getname(renamespace(name, O)))
+            renamespace(name, O)
         else
             similarterm(O,operation(O),renamed)
         end

--- a/test/variable_scope.jl
+++ b/test/variable_scope.jl
@@ -12,6 +12,7 @@ d = GlobalScope(d)
 LocalScope(e.val)
 ParentScope(e.val)
 GlobalScope(e.val)
+@test ModelingToolkit.getname(ModelingToolkit.namespace_expr(ModelingToolkit.namespace_expr(b, :foo, t), :bar, t)) == :bar₊b
 
 renamed(nss, sym) = ModelingToolkit.getname(foldr(ModelingToolkit.renamespace, nss, init=sym))
 


### PR DESCRIPTION
I ran into *another* instance where the code takes a symbolic value, namespaces it, takes the name (discarding metadata) and uses that to rename the original symbol (with the old metadata).

This was not caught in the tests because the tests use `renamespace` directly and mostly used `Sym` rather than `Term` which trigger this code path. I've added a testcase for that now.

I seem to recall there was some test failure in a completely different test, so while I can't see why, I'm semi-expecting a CI failure. Let's see...