### PR TITLE
New `calculate_statespace` function for AbstractODESystem

### DIFF
--- a/src/ModelingToolkit.jl
+++ b/src/ModelingToolkit.jl
@@ -167,6 +167,7 @@ export DiscreteSystem, DiscreteProblem
 
 export calculate_jacobian, generate_jacobian, generate_function
 export calculate_control_jacobian, generate_control_jacobian
+export calculate_statespace
 export calculate_tgrad, generate_tgrad
 export calculate_gradient, generate_gradient
 export calculate_factorized_W, generate_factorized_W

--- a/src/systems/diffeqs/abstractodesystem.jl
+++ b/src/systems/diffeqs/abstractodesystem.jl
@@ -738,15 +738,15 @@ function calculate_statespace(sys::AbstractODESystem, subs::Dict = sys.defaults;
     J = calculate_jacobian(sys)
     C = calculate_control_jacobian(sys)
 
-    A = Matrix{matrix_eltype}(undef, size(J)...)
-    B = Matrix{matrix_eltype}(undef, size(C)...)
+    A = Matrix{T}(undef, size(J))
+    B = Matrix{T}(undef, size(C))
 
     for I in CartesianIndices(A)
-        A[I] = (value ∘ substitute)(J[I], subs)
+        A[I] = value(substitute(J[I], subs))
     end
 
     for I in CartesianIndices(B)
-        B[I] = (value ∘ substitute)(C[I], subs)
+        B[I] = value(substitute(C[I], subs))
     end
 
     return A,B

--- a/src/systems/diffeqs/abstractodesystem.jl
+++ b/src/systems/diffeqs/abstractodesystem.jl
@@ -733,7 +733,7 @@ isdiffeq(eq) = isdifferential(eq.lhs)
 
 Returns a tuple of the linearized `A` and `B` matrices for a state space model. 
 """
-function calculate_statespace(sys::AbstractODESystem, subs::Dict = sys.defaults; matrix_eltype::Type{T} = Float64) where T
+function calculate_statespace(sys::AbstractODESystem, subs::Dict = defaults(sys); matrix_eltype::Type{T} = Float64) where T
     
     J = calculate_jacobian(sys)
     C = calculate_control_jacobian(sys)

--- a/src/systems/diffeqs/abstractodesystem.jl
+++ b/src/systems/diffeqs/abstractodesystem.jl
@@ -727,3 +727,27 @@ end
 
 isdifferential(expr) = istree(expr) && operation(expr) isa Differential
 isdiffeq(eq) = isdifferential(eq.lhs)
+
+"""
+    calculate_statespace(sys::AbstractODESystem, subs::Dict = sys.defaults; matrix_eltype::Type{T} = Float64) where T
+
+Returns a tuple of the linearized `A` and `B` matrices for a state space model. 
+"""
+function calculate_statespace(sys::AbstractODESystem, subs::Dict = sys.defaults; matrix_eltype::Type{T} = Float64) where T
+    
+    J = calculate_jacobian(sys)
+    C = calculate_control_jacobian(sys)
+
+    A = Matrix{matrix_eltype}(undef, size(J)...)
+    B = Matrix{matrix_eltype}(undef, size(C)...)
+
+    for I in CartesianIndices(A)
+        A[I] = (value ∘ substitute)(J[I], subs)
+    end
+
+    for I in CartesianIndices(B)
+        B[I] = (value ∘ substitute)(C[I], subs)
+    end
+
+    return A,B
+end

--- a/test/odesystem.jl
+++ b/test/odesystem.jl
@@ -380,3 +380,21 @@ let
     )
 
 end
+
+# check statespace
+let 
+    @parameters t f k d
+    @variables x(t) ẋ(t)
+    δ = Differential(t)
+    
+    eqs = [δ(x) ~ ẋ, δ(ẋ) ~ f - k*x - d*ẋ]
+    sys = ODESystem(eqs, t, [x, ẋ], [f, d, k]; controls = [f])
+
+    A = reshape(Float64[0, -1, 1, -2], 2, 2)
+    B = reshape(Float64[0, 1], 2, 1)
+    @test isequal(
+        calculate_statespace(sys, Dict([k => 1, d => 2]); matrix_eltype=Float64),
+        (A, B)
+    )
+
+end

--- a/test/odesystem.jl
+++ b/test/odesystem.jl
@@ -396,5 +396,4 @@ let
         calculate_statespace(sys, Dict([k => 1, d => 2]); matrix_eltype=Float64),
         (A, B)
     )
-
 end


### PR DESCRIPTION
As mentioned in #1059, we can now generate the `A` and `B` matrices of linear state space models for any `AbstractODESystem` because we have the new `calculate_control_jacobian` function. 

Users can `generate_jacobian` and `generate_control_jacobian` for fast functions which return the system's `A` and `B` matrices. Still, it would be nice to have a convenience function which simply returns the linearizations for any `AbstractODESystem`. Users could call `calculate_statespace(sys::AbstractODESystem, subs::Dict)` to return the linearization __evaluated__ at the points in the `Dict` `subs`. 

That's what this PR adds. One additional test has been added, which passes. 

The reason I did __not__ use `generate_jacobian` and `generate_control_jacobian` in `calculate_statespace` is because I did not want `calculate_statespace` to have to compile functions with every call, and it doesn't seem right to cache `RuntimeGeneratedFunction`s in every concrete `AbstractODESystem` type.

Anyone have any opinions / thoughts on whether this should be included? I'd find it useful for `PolynomialGTM.jl`.