### PR TITLE
Some usability improvements

### DIFF
--- a/examples/rc_model.jl
+++ b/examples/rc_model.jl
@@ -14,4 +14,4 @@ rc_eqs = [
           connect(capacitor.n, source.n, ground.g)
          ]
 
-@named rc_model = compose(ODESystem(rc_eqs, t), resistor, capacitor, source, ground)
+@named rc_model = compose(ODESystem(rc_eqs, t), [resistor, capacitor, source, ground])

--- a/src/systems/abstractsystem.jl
+++ b/src/systems/abstractsystem.jl
@@ -849,15 +849,14 @@ Base.:(&)(sys::AbstractSystem, basesys::AbstractSystem; name::Symbol=nameof(sys)
 compose multiple systems together. The resulting system would inherit the first
 system's name.
 """
-compose(syss::AbstractSystem...; name=nameof(first(syss))) = compose(collect(syss); name=name)
-function compose(syss::AbstractArray{<:AbstractSystem}; name=nameof(first(syss)))
-    nsys = length(syss)
-    nsys >= 2 || throw(ArgumentError("There must be at least 2 systems. Got $nsys systems."))
-    sys = first(syss)
+function compose(sys::AbstractSystem, systems::AbstractArray{<:AbstractSystem}; name=nameof(first(syss)))
+    nsys = length(systems)
+    nsys >= 1 || throw(ArgumentError("There must be at least 1 subsystem. Got $nsys subsystems."))
     @set! sys.name = name
-    @set! sys.systems = syss[2:end]
+    @set! sys.systems = systems
     return sys
 end
+compose(syss::AbstractSystem...; name=nameof(first(syss))) = compose(first(syss), collect(syss[2:end]); name=name)
 Base.:(∘)(sys1::AbstractSystem, sys2::AbstractSystem) = compose(sys1, sys2)
 
 UnPack.unpack(sys::ModelingToolkit.AbstractSystem, ::Val{p}) where p = getproperty(sys, p; namespace=false)

--- a/test/components.jl
+++ b/test/components.jl
@@ -20,6 +20,9 @@ sol = solve(prob, Rodas4())
 @test iszero(sol[ground.g.v])
 @test sol[resistor.v] == sol[source.p.v] - sol[capacitor.p.v]
 
+u0 = [
+      capacitor.v => 0.0
+     ]
 prob = ODAEProblem(sys, u0, (0, 10.0))
 sol = solve(prob, Tsit5())
 

--- a/test/direct.jl
+++ b/test/direct.jl
@@ -251,3 +251,9 @@ if VERSION >= v"1.5"
     @named cool_name = foo(;ff)
     @test collect(cool_name) == [pp; :ff => ff]
 end
+
+foo(i; name) = i, name
+@named goo[1:3] = foo(10)
+@test isequal(goo, [(10, Symbol(:goo_, i)) for i in 1:3])
+@named koo 1:3 i -> foo(10i)
+@test isequal(koo, [(10i, Symbol(:koo_, i)) for i in 1:3])


### PR DESCRIPTION
We used to only allow
```julia
compose(ODESystem(eqns, t, vars, []; name=name), mediums...)
```
or
```julia
compose([ODESystem(eqns, t, vars, []; name=name); mediums])
```
. With this PR, we switch to
```julia
compose(ODESystem(eqns, t, vars, []; name=name), mediums)
```
for the array form.

This PR also add vectorized `@named`

```julia
julia> using ModelingToolkit

julia> foo(i; name) = i, name
foo (generic function with 1 method)

julia> x = 41
41

julia> @named y = foo(x)
(41, :y)

julia> @named y[1:3] = foo(x)
3-element Vector{Tuple{Int64, Symbol}}:
 (41, :y_1)
 (41, :y_2)
 (41, :y_3)

julia> @named y 1:3 i -> foo(x*i)
3-element Vector{Tuple{Int64, Symbol}}:
 (41, :y_1)
 (82, :y_2)
 (123, :y_3)
```