### PR TITLE
Allow indicating variables as input/output

### DIFF
--- a/src/variables.jl
+++ b/src/variables.jl
@@ -2,10 +2,14 @@ struct VariableUnit end
 struct VariableConnectType end
 struct VariabelNoiseType end
 struct VariabelDescriptionType end
+struct VariabelInput end
+struct VariabelOutput end
 Symbolics.option_to_metadata_type(::Val{:unit}) = VariableUnit
 Symbolics.option_to_metadata_type(::Val{:connect}) = VariableConnectType
 Symbolics.option_to_metadata_type(::Val{:noise}) = VariabelNoiseType
 Symbolics.option_to_metadata_type(::Val{:description}) = VariabelDescriptionType
+Symbolics.option_to_metadata_type(::Val{:input}) = VariabelInput
+Symbolics.option_to_metadata_type(::Val{:output}) = VariabelOutput
 
 """
 $(SIGNATURES)

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -1,15 +1,15 @@
 struct VariableUnit end
 struct VariableConnectType end
-struct VariabelNoiseType end
-struct VariabelDescriptionType end
-struct VariabelInput end
-struct VariabelOutput end
+struct VariableNoiseType end
+struct VariableDescriptionType end
+struct VariableInput end
+struct VariableOutput end
 Symbolics.option_to_metadata_type(::Val{:unit}) = VariableUnit
 Symbolics.option_to_metadata_type(::Val{:connect}) = VariableConnectType
-Symbolics.option_to_metadata_type(::Val{:noise}) = VariabelNoiseType
-Symbolics.option_to_metadata_type(::Val{:description}) = VariabelDescriptionType
-Symbolics.option_to_metadata_type(::Val{:input}) = VariabelInput
-Symbolics.option_to_metadata_type(::Val{:output}) = VariabelOutput
+Symbolics.option_to_metadata_type(::Val{:noise}) = VariableNoiseType
+Symbolics.option_to_metadata_type(::Val{:description}) = VariableDescriptionType
+Symbolics.option_to_metadata_type(::Val{:input}) = VariableInput
+Symbolics.option_to_metadata_type(::Val{:output}) = VariableOutput
 
 """
 $(SIGNATURES)

--- a/test/inputoutput.jl
+++ b/test/inputoutput.jl
@@ -38,8 +38,7 @@ simplifyeqs(eqs) = Equation.((x->x.lhs).(eqs), simplify.((x->x.rhs).(eqs)))
 
 @test isequal(simplifyeqs(equations(connected)), simplifyeqs(collapsed_eqs))
 
-# Test if variables indicated to be input/output are not eliminated by structural_simplify
-
+# Variables indicated to be input/output 
 @variables x [input=true]
 @test hasmetadata(x, Symbolics.option_to_metadata_type(Val(:input)))
 @test getmetadata(x, Symbolics.option_to_metadata_type(Val(:input))) == true
@@ -51,27 +50,3 @@ simplifyeqs(eqs) = Equation.((x->x.lhs).(eqs), simplify.((x->x.rhs).(eqs)))
 @test getmetadata(y, Symbolics.option_to_metadata_type(Val(:output))) == true
 @test !hasmetadata(y, Symbolics.option_to_metadata_type(Val(:input)))
 @test_throws KeyError getmetadata(y, Symbolics.option_to_metadata_type(Val(:input)))
-
-@parameters t σ ρ β
-@variables x(t) y(t) z(t) a(t) u(t) F(t)
-D = Differential(t)
-
-eqs = [
-       D(x) ~ σ*(y-x)
-       D(y) ~ x*(ρ-z)-y + β
-       0 ~ z - x + y
-       0 ~ a + z
-       u ~ z + a
-      ]
-
-lorenz1 = ODESystem(eqs,t,name=:lorenz1)
-
-lorenz1_aliased = structural_simplify(lorenz1)
-
-reduced_eqs = [
-               D(x) ~ σ*(y - x)
-               D(y) ~ β + x*(ρ - (x - y)) - y
-              ]
-
-@info states(lorenz1)
-@info states(lorenz1_aliased)


### PR DESCRIPTION
This PR aims to prevent certain variables/states from being eliminated by declaring them as input/output at the time of their instantiation. 

For example, in the following system, `z` variable will be prevented from being eliminated structural_simplify.
```julia
@parameters t σ ρ β
@variables x(t) y(t) z(t) [output=true] a(t) u(t) F(t)
D = Differential(t)

eqs = [
       D(x) ~ σ*(y-x)
       D(y) ~ x*(ρ-z)-y + β
       0 ~ z - x + y
       0 ~ a + z
       u ~ z + a
      ]

lorenz1 = ODESystem(eqs,t,name=:lorenz1)
lorenz1_reduced = structural_simplify(lorenz1)


@assert any(isequal.(z, states(lorenz1_reduced)))
```
