### PR TITLE
lowering ReactionSystem to CME ODEs

### DIFF
--- a/test/reactionsystem.jl
+++ b/test/reactionsystem.jl
@@ -286,3 +286,12 @@ prob = ODEProblem(cmesys, [], (0, 10.), [1., 2.])
 
 sol = solve(prob, Tsit5())
 @test all(sum(arr; dims=1) .≈ 1.) # sanity check that states sum to probability 1
+
+# birth death (infinte)
+rs = @reaction_network begin
+  (c1, c2), X <--> 2X
+end c1 c2
+u0 = [2]
+
+@test_throws ErrorException traverse_reactionsystem(rs, u0)
+@test length(traverse_reactionsystem(rs, u0; truncation=[10])) == 10


### PR DESCRIPTION
Should I add a kwarg to `convert(ODESystem, rs)` to specify which method is chosen? How should `ODESystem_cme` be integrated?

Note that the BFS method fails to terminate on ReactionSystems like Catalyst's [birth death](https://catalyst.sciml.ai/stable/tutorials/basic_examples/#Example:-Birth-Death-Process). I am wondering if I should try to detect cycles where you end up with more than you started (or am I just doing this all wrong).

This was copied over quite hastily but I'd like some comments/review, particularly someone to verify that I have generated the right equations (I think I have but haven't investigated enough).

addresses one of the todos in #405