### PR TITLE
Symbolic indexing of vectors of pairs

### DIFF
--- a/docs/src/basics/FAQ.md
+++ b/docs/src/basics/FAQ.md
@@ -11,9 +11,11 @@ function will do the trick:
 indexof(sym,syms) = findfirst(isequal(sym),syms)
 indexof(σ,parameters(sys))
 ```
-Further, you can support symbolic lookup of parameter values using:
+Further, you can support symbolic lookup/update of parameter values using:
 ```julia
 Base.getindex(A::AbstractArray{Pair{S,T}},sym::S) where {T,S<:Union{Num,Symbol}} = A[findfirst(x->isequal(sym,x.first),A)].second
+Base.setindex!(A::AbstractArray{Pair{S,T}},v::T,sym::S) where {T,S<:Union{Num,Symbol}} = setindex!(A,(sym=>v),findfirst(x->isequal(sym,x.first),A))
+v
 ```
 
 ## Transforming value maps to arrays

--- a/docs/src/basics/FAQ.md
+++ b/docs/src/basics/FAQ.md
@@ -13,7 +13,7 @@ indexof(σ,parameters(sys))
 ```
 Further, you can support symbolic lookup of parameter values using:
 ```julia
-Base.getindex(A::AbstractArray{Pair{Num,T}},sym::Num) where {T} = vec[indexof(sym,map(x->x.first,vec))].second
+Base.getindex(A::AbstractArray{Pair{S,T}},sym::S) where {T,S<:Union{Num,Symbol}} = A[findfirst(x->isequal(sym,x.first),A)].second
 ```
 
 ## Transforming value maps to arrays

--- a/docs/src/basics/FAQ.md
+++ b/docs/src/basics/FAQ.md
@@ -11,6 +11,10 @@ function will do the trick:
 indexof(sym,syms) = findfirst(isequal(sym),syms)
 indexof(σ,parameters(sys))
 ```
+Further, you can support symbolic lookup of parameter values using:
+```julia
+Base.getindex(A::AbstractArray{Pair{Num,T}},sym::Num) where {T} = vec[indexof(sym,map(x->x.first,vec))].second
+```
 
 ## Transforming value maps to arrays
 


### PR DESCRIPTION
This is a hack that lets you do things like `ps[E]` where `E` is a parameter and `ps` is a vector of pairs mapping parameters to values.