### PR TITLE
WIP: add algebraic equations to ReactionSystems

### DIFF
--- a/src/systems/reaction/reactionsystem.jl
+++ b/src/systems/reaction/reactionsystem.jl
@@ -155,7 +155,7 @@ struct ReactionSystem <: AbstractSystem
     """
     defaults::Dict
     """Algebraic equations that impose constraints on species."""
-    algebraic_eqs::Vector{Equation}
+    algebraic_eqs::Union{Nothing,Vector{Equation}}
 
     function ReactionSystem(eqs, iv, states, ps, observed, name, systems, defaults, algebraic_eqs)
         iv′ = value(iv)


### PR DESCRIPTION
@paulflang @anandijain is this what you wanted / does it cover your use cases?

There are a few limitations in this version. Right now all variables must be declared as states of the ReactionSystem (i.e. species), even variables that appear only within the algebraic equations, which in turn causes ODEs/SDEs to be generated for them. This can be disabled in `convert` with the `include_zero_odes=false` kwarg, see the test example, (but note the ODEs will still appear if they are non-zero even if you want them dropped). 

An alternative would be to also pass ReactionSystems a list of `algebraic_states`, which will not be considered species or have ODEs/SDEs generated. I'm thinking this could be a better approach, but I'd be interested to hear your thoughts.