### PR TITLE
fix bounds check for `build_torn_function`

### DIFF
--- a/src/structural_transformation/codegen.jl
+++ b/src/structural_transformation/codegen.jl
@@ -166,7 +166,7 @@ function gen_nlsolve(sys, eqs, vars; checkbounds=true)
     ]
 end
 
-function get_torn_eqs_vars(sys)
+function get_torn_eqs_vars(sys; checkbounds=true)
     s = structure(sys)
     partitions = s.partitions
     vars = s.fullvars
@@ -175,7 +175,7 @@ function get_torn_eqs_vars(sys)
     torn_eqs  = map(idxs-> eqs[idxs], map(x->x.e_residual, partitions))
     torn_vars = map(idxs->vars[idxs], map(x->x.v_residual, partitions))
 
-    gen_nlsolve.((sys,), torn_eqs, torn_vars)
+    gen_nlsolve.((sys,), torn_eqs, torn_vars, checkbounds=checkbounds)
 end
 
 function build_torn_function(
@@ -212,7 +212,7 @@ function build_torn_function(
              ],
              [],
              Let(
-                 collect(Iterators.flatten(get_torn_eqs_vars(sys))),
+                 collect(Iterators.flatten(get_torn_eqs_vars(sys, checkbounds=checkbounds))),
                  odefunbody
                 )
             )

--- a/src/structural_transformation/codegen.jl
+++ b/src/structural_transformation/codegen.jl
@@ -193,7 +193,7 @@ function build_torn_function(
 
     out = Sym{Any}(gensym("out"))
     odefunbody = SetArray(
-        checkbounds,
+        !checkbounds,
         out,
         rhss
     )


### PR DESCRIPTION
fixes #1174 

For demo before and after, [this gist](https://gist.github.com/wsphillips/e68c8c95cfd256f6f76ddf874f7b679b) uses a MWE to show a readable version of the generated expression.

Before:
```julia
function out_fun!(du, u, p, t)
    let x = @inbounds(u[1]), p = @inbounds(p[1])
        let bird = @RuntimeGeneratedFunction(
                :((
                    (turtle, coati) ->
                        let z = turtle[1], p = coati[1], x = coati[2], t = coati[3]
                            x + sin(z) + -1 * p * t
                        end
                ))
            ),
            salmon = numerical_nlsolve(bird, 0.001, (p, x, t)),
            z = salmon[1]

            du[1] = z
            nothing
        end
    end
end
```

After:
```julia
function out_fun!(du, u, p, t)
    let x = @inbounds(u[1]), p = @inbounds(p[1])
        let cattle = @RuntimeGeneratedFunction(
                :((
                    (dunlin, gazelle) ->
                        let z = dunlin[1], p = gazelle[1], x = gazelle[2], t = gazelle[3]
                            x + sin(z) + -1 * p * t
                        end
                ))
            ),
            flamingo = numerical_nlsolve(cattle, 0.001, (p, x, t)),
            z = flamingo[1]

            @inbounds begin
                du[1] = z
                nothing
            end
        end
    end
end
```
Note that while the function body is wrapped in a call to `@inbounds`, the assignments at the head of the innermost `let` block are not. However, that's an upstream issue I guess.

Hope this helps!

