### PR TITLE
start trying to precompile ModelingToolkit better

### DIFF
--- a/src/ModelingToolkit.jl
+++ b/src/ModelingToolkit.jl
@@ -151,6 +151,9 @@ using .SystemStructures
 
 include("systems/alias_elimination.jl")
 include("structural_transformation/StructuralTransformations.jl")
+
+include("precompile.jl")
+
 @reexport using .StructuralTransformations
 
 for S in subtypes(ModelingToolkit.AbstractSystem)

--- a/src/ModelingToolkit.jl
+++ b/src/ModelingToolkit.jl
@@ -152,8 +152,6 @@ using .SystemStructures
 include("systems/alias_elimination.jl")
 include("structural_transformation/StructuralTransformations.jl")
 
-include("precompile.jl")
-
 @reexport using .StructuralTransformations
 
 for S in subtypes(ModelingToolkit.AbstractSystem)
@@ -209,5 +207,7 @@ export build_function
 export modelingtoolkitize
 export @variables, @parameters
 export @named, @nonamespace, @namespace, extend, compose
+
+include("precompile.jl")
 
 end # module

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -1,0 +1,28 @@
+let
+    while true
+        @parameters t σ ρ β
+        @variables x(t) y(t) z(t)
+        D = Differential(t)
+
+        eqs = [D(D(x)) ~ σ*(y-x) + 0.000000000000135,
+               D(y) ~ x*(ρ-z)-y,
+               D(z) ~ x*y - β*z]
+
+        @named sys = ODESystem(eqs)
+        sys = ode_order_lowering(sys)
+
+        u0 = [D(x) => 2.0,
+              x => 1.0,
+              y => 0.0,
+              z => 0.0]
+
+        p  = [σ => 28.0,
+              ρ => 10.0,
+              β => 8/3]
+
+        tspan = (0.0,100.0)
+        prob = ODEProblem(sys,u0,tspan,p,jac=true)
+
+        break
+    end
+end

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -4,7 +4,7 @@ let
         @variables x(t) y(t) z(t)
         D = Differential(t)
 
-        eqs = [D(D(x)) ~ σ*(y-x) + 0.000000000000135,
+        eqs = [D(D(x)) ~ σ*(y-x) + x^0.000000000000135,
                D(y) ~ x*(ρ-z)-y,
                D(z) ~ x*y - β*z]
 

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -9,7 +9,7 @@ let
                D(z) ~ x*y - β*z]
 
         @named sys = ODESystem(eqs)
-        sys = ode_order_lowering(sys)
+        sys = structural_simplify(sys)
 
         u0 = [D(x) => 2.0,
               x => 1.0,


### PR DESCRIPTION
```julia
using ModelingToolkit, OrdinaryDiffEq

function f()
      @parameters t σ ρ β
      @variables x(t) y(t) z(t)
      D = Differential(t)

      eqs = [D(D(x)) ~ σ*(y-x),
             D(y) ~ x*(ρ-z)-y,
             D(z) ~ x*y - β*z]

      @named sys = ODESystem(eqs)
      sys = structural_simplify(sys)

      u0 = [D(x) => 2.0,
            x => 1.0,
            y => 0.0,
            z => 0.0]

      p  = [σ => 28.0,
            ρ => 10.0,
            β => 8/3]

      tspan = (0.0,100.0)
      prob = ODEProblem(sys,u0,tspan,p,jac=true)
end

using SnoopCompile

tinf = @snoopi_deep f()
```

```julia
Before:
InferenceTimingNode: 8.138765/20.550152 on Core.Compiler.Timings.ROOT() with 821 direct children
InferenceTimingNode: 8.152606/20.643050 on Core.Compiler.Timings.ROOT() with 821 direct children

After:
InferenceTimingNode: 8.216759/17.715817 on Core.Compiler.Timings.ROOT() with 839 direct children
InferenceTimingNode: 8.272943/17.854555 on Core.Compiler.Timings.ROOT() with 840 direct children
```

only 2 seconds for now, but it's a start.