### PR TITLE
Bypass unit checking if none of the variables/parameters have units.

### DIFF
--- a/src/systems/control/controlsystem.jl
+++ b/src/systems/control/controlsystem.jl
@@ -78,7 +78,7 @@ struct ControlSystem <: AbstractControlSystem
             check_parameters(ps, iv)
             check_equations(deqs, iv)
             check_equations(observed, iv)
-            check_units(deqs)
+            all_dimensionless([dvs;ps;controls;iv]) || check_units(deqs)
         end
         new(loss, deqs, iv, dvs, controls, ps, observed, name, systems, defaults)
     end

--- a/src/systems/diffeqs/odesystem.jl
+++ b/src/systems/diffeqs/odesystem.jl
@@ -93,7 +93,7 @@ struct ODESystem <: AbstractODESystem
             check_variables(dvs,iv)
             check_parameters(ps,iv)
             check_equations(deqs,iv)
-            check_units(deqs)
+            all_dimensionless([dvs;ps;iv]) ||check_units(deqs)
         end
         new(deqs, iv, dvs, ps, var_to_name, ctrls, observed, tgrad, jac, ctrl_jac, Wfact, Wfact_t, name, systems, defaults, structure, connection_type, preface)
     end

--- a/src/systems/diffeqs/sdesystem.jl
+++ b/src/systems/diffeqs/sdesystem.jl
@@ -91,7 +91,7 @@ struct SDESystem <: AbstractODESystem
             check_variables(dvs,iv)
             check_parameters(ps,iv)
             check_equations(deqs,iv)
-            check_units(deqs,neqs)
+            all_dimensionless([dvs;ps;iv]) || check_units(deqs,neqs)
         end
         new(deqs, neqs, iv, dvs, ps, var_to_name, ctrls, observed, tgrad, jac, ctrl_jac, Wfact, Wfact_t, name, systems, defaults, connection_type)
     end

--- a/src/systems/discrete_system/discrete_system.jl
+++ b/src/systems/discrete_system/discrete_system.jl
@@ -58,7 +58,7 @@ struct DiscreteSystem <: AbstractTimeDependentSystem
         if checks
             check_variables(dvs, iv)
             check_parameters(ps, iv)
-            check_units(discreteEqs)
+            all_dimensionless([dvs;ps;iv;ctrls]) ||check_units(discreteEqs)
         end
         new(discreteEqs, iv, dvs, ps, var_to_name, ctrls, observed, name, systems, default_u0, default_p)
     end

--- a/src/systems/jumps/jumpsystem.jl
+++ b/src/systems/jumps/jumpsystem.jl
@@ -57,7 +57,7 @@ struct JumpSystem{U <: ArrayPartition} <: AbstractTimeDependentSystem
         if checks
             check_variables(states, iv)
             check_parameters(ps, iv)
-            check_units(ap,iv)
+            all_dimensionless([states;ps;iv]) || check_units(ap,iv)
         end
         new{U}(ap, iv, states, ps, var_to_name, observed, name, systems, defaults, connection_type)
     end

--- a/src/systems/nonlinear/nonlinearsystem.jl
+++ b/src/systems/nonlinear/nonlinearsystem.jl
@@ -56,7 +56,7 @@ struct NonlinearSystem <: AbstractTimeIndependentSystem
     connection_type::Any
     function NonlinearSystem(eqs, states, ps, var_to_name, observed, jac, name, systems, defaults, structure, connection_type; checks::Bool = true)
         if checks
-            check_units(eqs)
+            all_dimensionless([states;ps]) ||check_units(eqs)
         end
         new(eqs, states, ps, var_to_name, observed, jac, name, systems, defaults, structure, connection_type)
     end

--- a/src/systems/optimization/optimizationsystem.jl
+++ b/src/systems/optimization/optimizationsystem.jl
@@ -46,7 +46,7 @@ struct OptimizationSystem <: AbstractTimeIndependentSystem
             check_units(op)
             check_units(observed)
             check_units(equality_constraints)
-            check_units(inequality_constraints)
+            all_dimensionless([states;ps]) || check_units(inequality_constraints)
         end
         new(op, states, ps, var_to_name, observed, equality_constraints, inequality_constraints, name, systems, defaults)
     end

--- a/src/systems/pde/pdesystem.jl
+++ b/src/systems/pde/pdesystem.jl
@@ -68,7 +68,7 @@ struct PDESystem <: ModelingToolkit.AbstractMultivariateSystem
                                    name
                                   )
         if checks
-            check_units(eqs)
+            all_dimensionless([dvs;ivs;ps]) ||check_units(eqs)
         end
         new(eqs, bcs, domain, ivs, dvs, ps, defaults, connection_type, name)
     end

--- a/src/systems/validation.jl
+++ b/src/systems/validation.jl
@@ -152,3 +152,4 @@ validate(term::Symbolics.SymbolicUtils.Symbolic) = safe_get_unit(term,"") !== no
 
 "Throws error if units of equations are invalid."
 check_units(eqs...) = validate(eqs...) || throw(ValidationError("Some equations had invalid units. See warnings for details."))
+all_dimensionless(states) = all(map(x->safe_get_unit(x,"") in (unitless,nothing),states))


### PR DESCRIPTION
As suggested by @ChrisRackauckas.