### PR TITLE
add nicer discrete sys -> prob constructor

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -225,6 +225,14 @@ isdiffeq(eq) = isdifferential(eq.lhs)
 isdifference(expr) = istree(expr) && operation(expr) isa Difference
 isdifferenceeq(eq) = isdifference(eq.lhs)
 
+iv_from_nested_difference(x::Term) = operation(x) isa Difference ? iv_from_nested_difference(arguments(x)[1]) : arguments(x)[1]
+iv_from_nested_difference(x::Sym) = x
+iv_from_nested_difference(x) = missing
+
+var_from_nested_difference(x, i=0) = (missing, missing)
+var_from_nested_difference(x::Term,i=0) = operation(x) isa Difference ? var_from_nested_difference(arguments(x)[1], i + 1) : (x, i)
+var_from_nested_difference(x::Sym,i=0) = (x, i)
+
 function isvariable(x)
     x isa Symbolic || return false
     p = getparent(x, nothing)
@@ -297,6 +305,20 @@ function collect_vars!(states, parameters, expr, iv)
         for var in vars(expr)
             if istree(var) && operation(var) isa Differential
                 var, _ = var_from_nested_derivative(var)
+            end
+            collect_var!(states, parameters, var, iv)
+        end
+    end
+    return nothing
+end
+
+function collect_vars_difference!(states, parameters, expr, iv)
+    if expr isa Sym
+        collect_var!(states, parameters, expr, iv)
+    else
+        for var in vars(expr)
+            if istree(var) && operation(var) isa Difference
+                var, _ = var_from_nested_difference(var)
             end
             collect_var!(states, parameters, var, iv)
         end

--- a/test/discretesystem.jl
+++ b/test/discretesystem.jl
@@ -12,7 +12,7 @@ end;
 # Independent and dependent variables and parameters
 @parameters t c nsteps δt β γ
 D = Difference(t; dt=0.1)
-@variables S(t) I(t) R(t) next_S(t) next_I(t) next_R(t)
+@variables S(t) I(t) R(t)
 
 infection = rate_to_proportion(β*c*I/(S+I+R),δt)*S
 recovery = rate_to_proportion(γ,δt)*I
@@ -34,6 +34,19 @@ prob_map = DiscreteProblem(sys,u0,tspan,p)
 # Solution
 using OrdinaryDiffEq
 sol_map = solve(prob_map,FunctionMap());
+
+# Using defaults constructor
+@parameters t c=10.0 nsteps=400 δt=0.1 β=0.05 γ=0.25
+Diff = Difference(t; dt=0.1)
+@variables S(t)=990.0 I(t)=10.0 R(t)=0.0
+
+@named sys = DiscreteSystem(eqs; controls = [β, γ])
+@test ModelingToolkit.defaults(sys) != Dict()
+
+prob_map2 = DiscreteProblem(sys,[],tspan)
+sol_map2 = solve(prob_map,FunctionMap());
+
+@test sol_map == sol_map2
 
 # Direct Implementation
 

--- a/test/discretesystem.jl
+++ b/test/discretesystem.jl
@@ -40,13 +40,21 @@ sol_map = solve(prob_map,FunctionMap());
 Diff = Difference(t; dt=0.1)
 @variables S(t)=990.0 I(t)=10.0 R(t)=0.0
 
-@named sys = DiscreteSystem(eqs; controls = [β, γ])
+infection2 = rate_to_proportion(β*c*I/(S+I+R),δt)*S
+recovery2 = rate_to_proportion(γ,δt)*I
+
+eqs2 = [D(S) ~ S-infection2,
+       D(I) ~ I+infection2-recovery2,
+       D(R) ~ R+recovery2]
+
+@named sys = DiscreteSystem(eqs2; controls = [β, γ])
 @test ModelingToolkit.defaults(sys) != Dict()
 
 prob_map2 = DiscreteProblem(sys,[],tspan)
 sol_map2 = solve(prob_map,FunctionMap());
 
-@test sol_map == sol_map2
+@test sol_map.u == sol_map2.u
+@test sol_map.prob.p == sol_map2.prob.p
 
 # Direct Implementation
 


### PR DESCRIPTION
This makes it a bit easier to use DiscreteSystem/Problem, since you can now just do `DiscreteProblem(sys, [], tspan)` and it gets the defaults for you. 

A few things I was wondering about is how best to generalize the functions that internally hard-code `Differential`, such as 
`iv_from_nested_derivative`, `collect_vars!` and `var_from_nested_differential`. 

I was thinking maybe I should replace collect_vars! like so:

```julia 
function collect_vars!(states, parameters, expr, iv; T=Differential)
    if T == Differential
        f = var_from_nested_derivative 
    elseif T == Difference
        f = var_from_nested_difference
    end

    if expr isa Sym
        collect_var!(states, parameters, expr, iv)
    else
        for var in vars(expr)
            if istree(var) && operation(var) isa T
                var, _ = f(var)
            end
            collect_var!(states, parameters, var, iv)
        end
    end
    return nothing
end
```
which wouldn't be breaking and would avoid duplicated code.

I was hoping to do a loop + `@eval` for `iv_from_nested`, `var_from`, and a few others (`isdifferenceeq`, etc) like so:
```julia 
for T in [:Difference, :Differential]
    fname = lowercasefirst(string(T))
    f = Symbol(:iv_from_nested_, fname)
    f2 = Symbol(:var_from_nested_, fname)

    f3 = Symbol(:is, fname)
    f4 = Symbol(:is, fname, :eq)


    @eval begin 
        $f(x::Term) = operation(x) isa $T ? $f(arguments(x)[1]) : arguments(x)[1]
        $f(x::Sym) = x
        $f(x) = missing

        $f2(x::Term,i=0) = operation(x) isa $T ? $f2(arguments(x)[1], i + 1) : (x, i)
        $f2(x, i=0) = (missing, missing)
        $f2(x::Sym,i=0) = (x, i)

        $f3(expr) = istree(expr) && operation(expr) isa $T
        $f4(eq) = $f3(eq.lhs)
    end
end
```

I guess maybe this is worse than just having duplicate code, since actually doing the above would require a lot of annoying stuff
