### PR TITLE
add isvariable for Nums

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -225,6 +225,7 @@ isdiffeq(eq) = isdifferential(eq.lhs)
 isdifference(expr) = istree(expr) && operation(expr) isa Difference
 isdifferenceeq(eq) = isdifference(eq.lhs)
 
+isvariable(x::Num) = isvariable(value(x))
 function isvariable(x)
     x isa Symbolic || return false
     p = getparent(x, nothing)


### PR DESCRIPTION
`isparameter(x::Num)` is defined, and I've found myself reaching for `isvariable(x::Num)` at times too...