### PR TITLE
Drop extraneous line in varmap_to_vars

### DIFF
--- a/src/variables.jl
+++ b/src/variables.jl
@@ -48,7 +48,6 @@ function varmap_to_vars(varmap, varlist; defaults=Dict(), check=true, toterm=Sym
 
     if eltype(varmap) <: Pair # `varmap` is a dict or an array of pairs
         varmap = todict(varmap)
-        rules = Dict(varmap)
         vals = _varmap_to_vars(varmap, varlist; defaults=defaults, check=check, toterm=toterm)
     else # plain array-like initialization
         vals = varmap


### PR DESCRIPTION
This seems to completely allocate a copy of the `Dict` for the mapping that is never used...