### PR TITLE
Refactor use of the Bareiss algorithm

### DIFF
--- a/src/systems/alias_elimination.jl
+++ b/src/systems/alias_elimination.jl
@@ -2,6 +2,8 @@ using SymbolicUtils: Rewriters
 
 const KEEP = typemin(Int)
 
+include("compat/bareiss.jl")
+
 function alias_elimination(sys)
     sys = initialize_system_structure(sys; quick_cancel=true)
     s = structure(sys)
@@ -62,6 +64,216 @@ function alias_elimination(sys)
     return sys
 end
 
+"""
+    SparseMatrixCLIL{T, Ti}
+
+The SparseMatrixCLIL represents a sparse matrix in two distinct ways:
+
+1. As a sparse (in both row and column) n x m matrix
+2. As a row-dense, column-sparse k x m matrix
+
+The data structure keeps a permutation between the row order of the two representations.
+Swapping the rows in one does not affect the other.
+
+On construction, the second representation is equivalent to the first with fully-sparse
+rows removed, though this may cease being true as row permutations are being applied
+to the matrix.
+
+The default structure of the `SparseMatrixCLIL` type is the second structure, while
+the first is available via the thin `AsSubMatrix` wrapper.
+"""
+struct SparseMatrixCLIL{T, Ti<:Integer} <: AbstractSparseMatrix{T, Ti}
+    nparentrows::Int
+    ncols::Int
+    nzrows::Vector{Ti}
+    row_cols::Vector{Vector{Ti}}
+    row_vals::Vector{Vector{T}}
+end
+Base.size(S::SparseMatrixCLIL) = (length(S.nzrows), S.ncols)
+Base.copy(S::SparseMatrixCLIL{T, Ti}) where {T, Ti} =
+    SparseMatrixCLIL(S.nparentrows, S.ncols, copy(S.nzrows), copy(S.row_cols), copy(S.row_vals))
+function swaprows!(S::SparseMatrixCLIL, i, j)
+    swap!(S.nzrows, i, j)
+    swap!(S.row_cols, i, j)
+    swap!(S.row_vals, i, j)
+end
+
+function bareiss_update_virtual_colswap_mtk!(zero!, M::SparseMatrixCLIL, k, swapto, pivot, last_pivot; pivot_equal_optimization=true)
+    # for ei in nzrows(>= k)
+    eadj = M.row_cols
+    old_cadj = M.row_vals
+    vpivot = swapto[2]
+
+    ## N.B.: Micro-optimization
+    #
+    # For rows that do not have an entry in the eliminated column, all this
+    # update does is multiply the row in question by `pivot/last_pivot` (the
+    # result of which is guaranteed to be integer by general properties of the
+    # bareiss algorithm, even if `pivot/last_pivot` is not).
+    #
+    # Thus, when `pivot == last pivot`, we can skip the update for any rows that
+    # do not have an entry in the eliminated column (because we'd simply be
+    # multiplying by 1).
+    #
+    # As an additional MTK-specific enhancement, we further allow the case
+    # when the absolute values are equal, i.e. effectively multiplying the row
+    # by `-1`. To ensure this is legal, we need to show two things.
+    # 1. The multiplication does not change the answer and
+    # 2. The multiplication does not affect the fraction-freeness of the Bareiss
+    #    algorithm.
+    #
+    # For point 1, remember that we're working on a system of linear equations,
+    # so it is always legal for us to multiply any row by a sclar without changing
+    # the underlying system of equations.
+    #
+    # For point 2, note that the factorization we're now computing is the same
+    # as if we had multiplied the corresponding row (accounting for row swaps)
+    # in the original matrix by `last_pivot/pivot`, ensuring that the matrix
+    # itself has integral entries when `last_pivot/pivot` is integral (here we
+    # have -1, which counts). We could use the more general integrality
+    # condition, but that would in turn disturb the growth bounds on the
+    # factorization matrix entries that the bareiss algorithm guarantees. To be
+    # conservative, we leave it at this, as this captures the most important
+    # case for MTK (where most pivots are `1` or `-1`).
+    pivot_equal = pivot_equal_optimization && abs(pivot) == abs(last_pivot)
+
+    for ei in k+1:size(M, 1)
+        # elimate `v`
+        coeff = 0
+        ivars = eadj[ei]
+        vj = findfirst(isequal(vpivot), ivars)
+        if vj !== nothing
+            coeff = old_cadj[ei][vj]
+            deleteat!(old_cadj[ei], vj)
+            deleteat!(eadj[ei], vj)
+        elseif pivot_equal
+            continue
+        end
+
+        # the pivot row
+        kvars = eadj[k]
+        kcoeffs = old_cadj[k]
+        # the elimination target
+        ivars = eadj[ei]
+        icoeffs = old_cadj[ei]
+
+        tmp_incidence = similar(eadj[ei], 0)
+        tmp_coeffs = similar(old_cadj[ei], 0)
+        vars = union(ivars, kvars)
+
+        for v in vars
+            v == vpivot && continue
+            ck = getcoeff(kvars, kcoeffs, v)
+            ci = getcoeff(ivars, icoeffs, v)
+            ci = (pivot*ci - coeff*ck) ÷ last_pivot
+            if ci !== 0
+                push!(tmp_incidence, v)
+                push!(tmp_coeffs, ci)
+            end
+        end
+
+        eadj[ei] = tmp_incidence
+        old_cadj[ei] = tmp_coeffs
+    end
+
+    # Swap pivots to the front of the coefficient list
+    # TODO: This prevents the coefficient list from being sorted, making
+    # the rest of the algorithm much more expensive
+    pivot_idx = findfirst(==(vpivot), eadj[k])
+    deleteat!(eadj[k], pivot_idx)
+    deleteat!(old_cadj[k], pivot_idx)
+    pushfirst!(eadj[k], vpivot)
+    pushfirst!(old_cadj[k], pivot)
+end
+
+function bareiss_update_virtual_colswap_mtk!(zero!, M::AbstractMatrix, k, swapto, pivot, last_pivot; pivot_equal_optimization=true)
+    if pivot_equal_optimization
+        error("MTK pivot micro-optimization not implemented for `$(typeof(M))`.
+            Turn off the optimization for debugging or use a different matrix type.")
+    end
+    bareiss_update_virtual_colswap!(zero!, M, k, swapto, pivot, last_pivot)
+end
+
+struct AsSubMatrix{T, Ti<:Integer} <: AbstractSparseMatrix{T, Ti}
+    M::SparseMatrixCLIL{T, Ti}
+end
+Base.size(S::AsSubMatrix) = (S.M.nparentrows, S.M.ncols)
+
+function Base.getindex(S::SparseMatrixCLIL{T}, i1, i2) where {T}
+    checkbounds(S, i1, i2)
+
+    nncol = findfirst(==(i2), S.row_cols[i1])
+    isnothing(nncol) && return zero(T)
+
+    return S.row_vals[i1][nncol]
+end
+
+function Base.getindex(S::AsSubMatrix{T}, i1, i2) where {T}
+    checkbounds(S, i1, i2)
+    S = S.M
+
+    nnrow = findfirst(==(i1), S.nzrows)
+    isnothing(nnrow) && return zero(T)
+
+    nncol = findfirst(==(i2), S.row_cols[nnrow])
+    isnothing(nncol) && return zero(T)
+
+    return S.row_vals[nnrow][nncol]
+end
+
+"""
+$(SIGNATURES)
+
+Find the first linear variable such that `𝑠neighbors(adj, i)[j]` is true given
+the `constraint`.
+"""
+@inline function find_first_linear_variable(
+        M::SparseMatrixCLIL,
+        range,
+        mask,
+        constraint,
+    )
+    eadj = M.row_cols
+    for i in range
+        vertices = eadj[i]
+        if constraint(length(vertices))
+            for (j, v) in enumerate(vertices)
+                (mask === nothing || mask[v]) && return (CartesianIndex(i, v), M.row_vals[i][j])
+            end
+        end
+    end
+    return nothing
+end
+
+@inline function find_first_linear_variable(
+        M::AbstractMatrix,
+        range,
+        mask,
+        constraint,
+    )
+    for i in range
+        row = @view M[i, :]
+        if constraint(count(!iszero, row))
+            for (v, val) in enumerate(row)
+                iszero(val) && continue
+                if mask === nothing || mask[v]
+                    return CartesianIndex(i, v), val
+                end
+            end
+        end
+    end
+    return nothing
+end
+
+function find_masked_pivot(variables, M, k)
+    r = find_first_linear_variable(M, k:size(M,1), variables, isequal(1))
+    r !== nothing && return r
+    r = find_first_linear_variable(M, k:size(M,1), variables, isequal(2))
+    r !== nothing && return r
+    r = find_first_linear_variable(M, k:size(M,1), variables, _->true)
+    return r
+end
+
 function alias_eliminate_graph(s::SystemStructure, is_linear_equations, eadj, cadj)
     @unpack graph, varassoc = s
     invvarassoc = inverse_mapping(varassoc)
@@ -79,10 +291,41 @@ function alias_eliminate_graph(s::SystemStructure, is_linear_equations, eadj, ca
 
     linear_equations = findall(is_linear_equations)
 
-    rank1 = bareiss!(
-        (eadj, cadj),
-        old_cadj, linear_equations, is_linear_variables, 1
-       )
+    mm = SparseMatrixCLIL(nsrcs(graph),
+                          ndsts(graph),
+                          linear_equations, eadj, old_cadj)
+
+    function do_bareiss!(M, cadj=nothing)
+        rank1 = rank2 = nothing
+        function find_pivot(M, k)
+            if rank1 === nothing
+                r = find_masked_pivot(is_linear_variables, M, k)
+                r !== nothing && return r
+                rank1 = k - 1
+            end
+            if rank2 === nothing
+                r = find_masked_pivot(is_not_potential_state, M, k)
+                r !== nothing && return r
+                rank2 = k - 1
+            end
+            return find_masked_pivot(nothing, M, k)
+        end
+        function myswaprows!(M, i, j)
+            cadj !== nothing && swap!(cadj, i, j)
+            swaprows!(M, i, j)
+        end
+        bareiss_ops = ((M,i,j)->nothing, myswaprows!, bareiss_update_virtual_colswap_mtk!, bareiss_zero!)
+        rank3 = bareiss!(M, bareiss_ops; find_pivot)
+        rank1 = something(rank1, rank3)
+        rank2 = something(rank2, rank3)
+        (rank1, rank2, rank3)
+    end
+
+    # mm2 = Array(copy(mm))
+    # @show do_bareiss!(mm2)
+    # display(mm2)
+
+    (rank1, rank2, rank3) = do_bareiss!(mm, cadj)
 
     v_solved = [eadj[i][1] for i in 1:rank1]
     v_eliminated = setdiff(solvable_variables, v_solved)
@@ -92,16 +335,6 @@ function alias_eliminate_graph(s::SystemStructure, is_linear_equations, eadj, ca
     for v in v_eliminated
         v_types[v] = 0
     end
-
-    rank2 = bareiss!(
-        (eadj, cadj),
-        old_cadj, linear_equations, is_not_potential_state, rank1+1
-       )
-
-    rank3 = bareiss!(
-        (eadj, cadj),
-        old_cadj, linear_equations, nothing, rank2+1
-       )
 
     # kind of like the backward substitution
     for ei in reverse(1:rank2)
@@ -205,116 +438,29 @@ function locally_structure_simplify!(
     end # while
 
     v = first(vars)
-    if invvarassoc[v] == 0
-        if length(vars) == 1
+
+    # Do not attempt to eliminate derivatives
+    invvarassoc[v] != 0 && return false
+
+    if length(vars) == 1
+        push!(v_eliminated, v)
+        v_types[v] = 0
+        empty!(vars); empty!(coeffs)
+        return true
+    elseif length(vars) == 2 && abs(coeffs[1]) == abs(coeffs[2])
+        if (coeffs[1] > 0 && coeffs[2] < 0) || (coeffs[1] < 0 && coeffs[2] > 0)
+            # positive alias
             push!(v_eliminated, v)
-            v_types[v] = 0
-            empty!(vars); empty!(coeffs)
-            return true
-        elseif length(vars) == 2 && abs(coeffs[1]) == abs(coeffs[2])
-            if (coeffs[1] > 0 && coeffs[2] < 0) || (coeffs[1] < 0 && coeffs[2] > 0)
-                # positive alias
-                push!(v_eliminated, v)
-                v_types[v] = vars[2]
-            else
-                # negative alias
-                push!(v_eliminated, v)
-                v_types[v] = -vars[2]
-            end
-            empty!(vars); empty!(coeffs)
-            return true
+            v_types[v] = vars[2]
+        else
+            # negative alias
+            push!(v_eliminated, v)
+            v_types[v] = -vars[2]
         end
+        empty!(vars); empty!(coeffs)
+        return true
     end
     return false
-end
-
-"""
-$(SIGNATURES)
-
-Use Bareiss algorithm to compute the nullspace of an integer matrix exactly.
-"""
-function bareiss!(
-        (eadj, cadj),
-        old_cadj, linear_equations, is_linear_variables, offset
-       )
-    m = length(eadj)
-    # v = eadj[ei][vj]
-    v = ei = vj = 0
-    pivot = last_pivot = 1
-    tmp_incidence = Int[]
-    tmp_coeffs = Int[]
-
-    for k in offset:m
-        ###
-        ### Pivoting:
-        ###
-        ei, vj = find_first_linear_variable(eadj, k:m, is_linear_variables, isequal(1))
-        if vj == 0
-            ei, vj = find_first_linear_variable(eadj, k:m, is_linear_variables, isequal(2))
-        end
-        if vj == 0
-            ei, vj = find_first_linear_variable(eadj, k:m, is_linear_variables, _->true)
-        end
-
-        if vj > 0 # has a pivot
-            pivot = old_cadj[ei][vj]
-            deleteat!(old_cadj[ei] , vj)
-            v = eadj[ei][vj]
-            deleteat!(eadj[ei], vj)
-            if ei != k
-                swap!(cadj, ei, k)
-                swap!(old_cadj, ei, k)
-                swap!(eadj, ei, k)
-                swap!(linear_equations, ei, k)
-            end
-        else # rank deficient
-            return k-1
-        end
-
-        for ei in k+1:m
-            # elimate `v`
-            coeff = 0
-            ivars = eadj[ei]
-            vj = findfirst(isequal(v), ivars)
-            if vj === nothing # `v` is not in in `e`
-                continue
-            else # remove `v`
-                coeff = old_cadj[ei][vj]
-                deleteat!(old_cadj[ei], vj)
-                deleteat!(eadj[ei], vj)
-            end
-
-            # the pivot row
-            kvars = eadj[k]
-            kcoeffs = old_cadj[k]
-            # the elimination target
-            ivars = eadj[ei]
-            icoeffs = old_cadj[ei]
-
-            empty!(tmp_incidence)
-            empty!(tmp_coeffs)
-            vars = union(ivars, kvars)
-
-            for v in vars
-                ck = getcoeff(kvars, kcoeffs, v)
-                ci = getcoeff(ivars, icoeffs, v)
-                ci = (pivot*ci - coeff*ck) ÷ last_pivot
-                if ci !== 0
-                    push!(tmp_incidence, v)
-                    push!(tmp_coeffs, ci)
-                end
-            end
-
-            eadj[ei], tmp_incidence = tmp_incidence, eadj[ei]
-            old_cadj[ei], tmp_coeffs = tmp_coeffs, old_cadj[ei]
-        end
-        last_pivot = pivot
-        # add `v` in the front of the `k`-th equation
-        pushfirst!(eadj[k], v)
-        pushfirst!(old_cadj[k], pivot)
-    end
-
-    return m # fully ranked
 end
 
 swap!(v, i, j) = v[i], v[j] = v[j], v[i]
@@ -324,29 +470,6 @@ function getcoeff(vars, coeffs, var)
         v == var && return coeffs[vj]
     end
     return 0
-end
-
-"""
-$(SIGNATURES)
-
-Find the first linear variable such that `𝑠neighbors(adj, i)[j]` is true given
-the `constraint`.
-"""
-@inline function find_first_linear_variable(
-        eadj,
-        range,
-        mask,
-        constraint,
-    )
-    for i in range
-        vertices = eadj[i]
-        if constraint(length(vertices))
-            for (j, v) in enumerate(vertices)
-                (mask === nothing || mask[v]) && return i, j
-            end
-        end
-    end
-    return 0, 0
 end
 
 function inverse_mapping(assoc)

--- a/src/systems/compat/bareiss.jl
+++ b/src/systems/compat/bareiss.jl
@@ -1,0 +1,181 @@
+# Keeps compatibility with bariess code movoed to Base/stdlib on older releases
+
+using LinearAlgebra
+using SparseArrays
+using SparseArrays: AbstractSparseMatrixCSC
+
+macro swap(a, b)
+    esc(:(($a, $b) = ($b, $a)))
+end
+
+if isdefined(Base, :swaprows!)
+    import Base: swaprows!
+else
+    function swaprows!(a::AbstractMatrix, i, j)
+        i == j && return
+        rows = axes(a,1)
+        @boundscheck i in rows || throw(BoundsError(a, (:,i)))
+        @boundscheck j in rows || throw(BoundsError(a, (:,j)))
+        for k in axes(a,2)
+            @inbounds a[i,k],a[j,k] = a[j,k],a[i,k]
+        end
+    end
+    function Base.circshift!(a::AbstractVector, shift::Integer)
+        n = length(a)
+        n == 0 && return
+        shift = mod(shift, n)
+        shift == 0 && return
+        reverse!(a, 1, shift)
+        reverse!(a, shift+1, length(a))
+        reverse!(a)
+        return a
+    end
+    function Base.swapcols!(A::AbstractSparseMatrixCSC, i, j)
+        i == j && return
+
+        # For simplicitly, let i denote the smaller of the two columns
+        j < i && @swap(i, j)
+
+        colptr = getcolptr(A)
+        irow = colptr[i]:(colptr[i+1]-1)
+        jrow = colptr[j]:(colptr[j+1]-1)
+
+        function rangeexchange!(arr, irow, jrow)
+            if length(irow) == length(jrow)
+                for (a, b) in zip(irow, jrow)
+                    @inbounds @swap(arr[i], arr[j])
+                end
+                return
+            end
+            # This is similar to the triple-reverse tricks for
+            # circshift!, except that we have three ranges here,
+            # so it ends up being 4 reverse calls (but still
+            # 2 overall reversals for the memory range). Like
+            # circshift!, there's also a cycle chasing algorithm
+            # with optimal memory complexity, but the performance
+            # tradeoffs against this implementation are non-trivial,
+            # so let's just do this simple thing for now.
+            # See https://github.com/JuliaLang/julia/pull/42676 for
+            # discussion of circshift!-like algorithms.
+            reverse!(@view arr[irow])
+            reverse!(@view arr[jrow])
+            reverse!(@view arr[(last(irow)+1):(first(jrow)-1)])
+            reverse!(@view arr[first(irow):last(jrow)])
+        end
+        rangeexchange!(rowvals(A), irow, jrow)
+        rangeexchange!(nonzeros(A), irow, jrow)
+
+        if length(irow) != length(jrow)
+            @inbounds colptr[i+1:j] .+= length(jrow) - length(irow)
+        end
+        return nothing
+    end
+    function swaprows!(A::AbstractSparseMatrixCSC, i, j)
+        # For simplicitly, let i denote the smaller of the two rows
+        j < i && @swap(i, j)
+
+        rows = rowvals(A)
+        vals = nonzeros(A)
+        for col = 1:size(A, 2)
+            rr = nzrange(A, col)
+            iidx = searchsortedfirst(@view(rows[rr]), i)
+            has_i = iidx <= length(rr) && rows[rr[iidx]] == i
+
+            jrange = has_i ? (iidx:last(rr)) : rr
+            jidx = searchsortedlast(@view(rows[jrange]), j)
+            has_j = jidx != 0 && rows[jrange[jidx]] == j
+
+            if !has_j && !has_i
+                # Has neither row - nothing to do
+                continue
+            elseif has_i && has_j
+                # This column had both i and j rows - swap them
+                @swap(vals[rr[iidx]], vals[jrange[jidx]])
+            elseif has_i
+                # Update the rowval and then rotate both nonzeros
+                # and the remaining rowvals into the correct place
+                rows[rr[iidx]] = j
+                jidx == 0 && continue
+                rotate_range = rr[iidx]:jrange[jidx]
+                circshift!(@view(vals[rotate_range]), -1)
+                circshift!(@view(rows[rotate_range]), -1)
+            else
+                # Same as i, but in the opposite direction
+                @assert has_j
+                rows[jrange[jidx]] = i
+                iidx > length(rr) && continue
+                rotate_range = rr[iidx]:jrange[jidx]
+                circshift!(@view(vals[rotate_range]), 1)
+                circshift!(@view(rows[rotate_range]), 1)
+            end
+        end
+        return nothing
+    end
+end
+
+if isdefined(LinearAlgebra, :bareiss!)
+    import LinearAlgebra: bareiss!, bareiss_update_virtual_colswap!, bareiss_zero!
+else
+    function bareiss_update!(zero!, M::Matrix, k, swapto, pivot, prev_pivot)
+        for i in k+1:size(M, 2), j in k+1:size(M, 1)
+            M[j,i] = exactdiv(M[j,i]*pivot - M[j,k]*M[k,i], prev_pivot)
+        end
+        zero!(M, k+1:size(M, 1), k)
+    end
+
+    function bareiss_update!(zero!, M::AbstractMatrix, k, swapto, pivot, prev_pivot)
+        V = @view M[k+1:end, k+1:end]
+        V .= exactdiv.(V * pivot - M[k+1:end, k] * M[k, k+1:end]', prev_pivot)
+        zero!(M, k+1:size(M, 1), k)
+    end
+
+    function bareiss_update_virtual_colswap!(zero!, M::AbstractMatrix, k, swapto, pivot, prev_pivot)
+        V = @view M[k+1:end, :]
+        V .= exactdiv.(V * pivot - M[k+1:end, swapto[2]] * M[k, :]', prev_pivot)
+        zero!(M, k+1:size(M, 1), swapto[2])
+    end
+
+    bareiss_zero!(M, i, j) = M[i,j] .= zero(eltype(M))
+
+    function find_pivot_col(M, i)
+        p = findfirst(!iszero, @view M[i,i:end])
+        p === nothing && return nothing
+        idx = CartesianIndex(i, p + i - 1)
+        (idx, M[idx])
+    end
+
+    function find_pivot_any(M, i)
+        p = findfirst(!iszero, @view M[i:end,i:end])
+        p === nothing && return nothing
+        idx = p + CartesianIndex(i - 1, i - 1)
+        (idx, M[idx])
+    end
+
+    const bareiss_colswap = (Base.swapcols!, swaprows!, bareiss_update!, bareiss_zero!)
+    const bareiss_virtcolswap = ((M,i,j)->nothing, swaprows!, bareiss_update_virtual_colswap!, bareiss_zero!)
+
+    """
+        bareiss!(M)
+
+    Perform Bareiss's fraction-free row-reduction algorithm on the matrix `M`.
+    Optionally, a specific pivoting method may be specified.
+    """
+    function bareiss!(M::AbstractMatrix,
+                         (swapcols!, swaprows!, update!, zero!) = bareiss_colswap;
+                      find_pivot=find_pivot_any)
+        prev = one(eltype(M))
+        n = size(M, 1)
+        for k in 1:n
+            r = find_pivot(M, k)
+            r === nothing && return k - 1
+            (swapto, pivot) = r
+            if CartesianIndex(k, k) != swapto
+                swapcols!(M, k, swapto[2])
+                swaprows!(M, k, swapto[1])
+            end
+            update!(zero!, M, k, swapto, pivot, prev)
+            prev = pivot
+        end
+        return n
+    end
+end

--- a/src/systems/systemstructure.jl
+++ b/src/systems/systemstructure.jl
@@ -72,6 +72,8 @@ end
 Base.@kwdef struct SystemStructure
     fullvars::Vector
     vartype::Vector{VariableType}
+    # Maps the (index of) a variable to the (index of) the variable describing
+    # its derivative.
     varassoc::Vector{Int}
     inv_varassoc::Vector{Int}
     varmask::BitVector # `true` if the variable has the highest order derivative


### PR DESCRIPTION
This PR goes with https://github.com/JuliaLang/julia/pull/42683.

When I was originally reading this code, I was having trouble
figuring out exactly what the `bareiss!` function was actually
doing. In order to hopfully make that easier to follow, this
attempts to separate the original bareiss! function into three
separate concerns:

1. The core bareiss algorithm (in LinearAlgebra)
2. The compressed eadj/cadj sparse matrix representation of the
   adjancency matrix
3. MTK's pivoting heuristics

At first glance not much is gained by this refactoring, but there
are notable advantages:

1. The new sparse matrix datastructure is interconvertable with regular
   sparse or dense matrices as well as displaying as a matrix.
   This makes it much easier to swap in and out matrix types to
   validate correctness and understand the algorithm.
2. It's much easier to gain confidence in optimizing the data structure
   further. For example, currently, the inner loop has O(N^4) behavior,
   rather than the expected O(N^3). This can be fixed by making the
   data structure maintain coefficients in sorted order, but it's hard
   to see that if everything is interleaved.
3. It's compatible with future extensions to take advantage of hierarchical
   system structure.

I'm planning a number of further refactorings here, but this is the
first self-contained piece. I've kept most behavioral changes and
optimizations out of this PR, except for two:
1. I removed the early-out at https://github.com/SciML/ModelingToolkit.jl/blob/9bf38dd2b8d8c2fb0412d223ca95e713c666d81f/src/systems/alias_elimination.jl#L280
   The base implementation of bareiss doesn't have it and I couldn't come
   up with a reason why it be ok to have it here. There may be an MTK-specific
   reason it is ok. If so, we can put it back.

2. I'm not doing a bariess-restart. As written, the bareiss restart
   basically resets the prev_pivot to `1`. This isn't terrible for what
   we need it for (it merely multiplies the rank minors by a scalar factor),
   but it does technically break the coefficient-growth guarantees of the
   bareiss algorithm. Instead, I simply merged the three pivot stages into
   one function that simply records the boundries between the stages.
   For the same reason that it shouldn't affect MTK's ultimate output to
   do the restarts, removing it shouldn't either, but I felt it worth pointing out.