### PR TITLE
add functions to handle inputs and outputs

### DIFF
--- a/src/ModelingToolkit.jl
+++ b/src/ModelingToolkit.jl
@@ -112,6 +112,7 @@ using .BipartiteGraphs
 
 include("variables.jl")
 include("parameters.jl")
+include("inputoutput.jl")
 
 include("utils.jl")
 include("domains.jl")

--- a/src/inputoutput.jl
+++ b/src/inputoutput.jl
@@ -1,0 +1,160 @@
+using Symbolics: get_variables
+"""
+    inputs(sys)
+
+Return all variables that mare marked as inputs. See also [`unbound_inputs`](@ref)
+See also [`bound_inputs`](@ref), [`unbound_inputs`](@ref)
+"""
+inputs(sys) = filter(isinput, states(sys))
+
+"""
+    outputs(sys)
+
+Return all variables that mare marked as outputs. See also [`unbound_outputs`](@ref)
+See also [`bound_outputs`](@ref), [`unbound_outputs`](@ref)
+"""
+function outputs(sys)
+    o = observed(sys)
+    rhss = [eq.rhs for eq in o]
+    lhss = [eq.lhs for eq in o]
+    unique([
+        filter(isoutput, states(sys))
+        filter(x -> x isa Term && isoutput(x), rhss) # observed can return equations with complicated expressions, we are only looking for single Terms
+        filter(x -> x isa Term && isoutput(x), lhss)
+    ])
+end
+
+"""
+    bound_inputs(sys)
+
+Return inputs that are bound within the system, i.e., internal inputs
+See also [`bound_inputs`](@ref), [`unbound_inputs`](@ref), [`bound_outputs`](@ref), [`unbound_outputs`](@ref)
+"""
+bound_inputs(sys) = filter(x->is_bound(sys, x), inputs(sys))
+
+"""
+    unbound_inputs(sys)
+
+Return inputs that are not bound within the system, i.e., external inputs
+See also [`bound_inputs`](@ref), [`unbound_inputs`](@ref), [`bound_outputs`](@ref), [`unbound_outputs`](@ref)
+"""
+unbound_inputs(sys) = filter(x->!is_bound(sys, x), inputs(sys))
+
+"""
+    bound_outputs(sys)
+
+Return outputs that are bound within the system, i.e., internal outputs
+See also [`bound_inputs`](@ref), [`unbound_inputs`](@ref), [`bound_outputs`](@ref), [`unbound_outputs`](@ref)
+"""
+bound_outputs(sys) = filter(x->is_bound(sys, x), outputs(sys))
+
+"""
+    unbound_outputs(sys)
+
+Return outputs that are not bound within the system, i.e., external outputs
+See also [`bound_inputs`](@ref), [`unbound_inputs`](@ref), [`bound_outputs`](@ref), [`unbound_outputs`](@ref)
+"""
+unbound_outputs(sys) = filter(x->!is_bound(sys, x), outputs(sys))
+
+"""
+    is_bound(sys, u)
+
+Determine whether or not input/output variable `u` is "bound" within the system, i.e., if it's to be considered internal to `sys`.
+A variable/signal is considered bound if it appears in an equation together with variables from other subsystems.
+The typical usecase for this function is to determine whether the input to an IO component is connected to another component,
+or if it remains an external input that the user has to supply before simulating the system. 
+
+See also [`bound_inputs`](@ref), [`unbound_inputs`](@ref), [`bound_outputs`](@ref), [`unbound_outputs`](@ref)
+"""
+function is_bound(sys, u, stack=[])
+    #=
+    For observed quantities, we check if a variable is connected to something that is bound to something further out. 
+    In the following scenario
+    julia> observed(syss)
+        2-element Vector{Equation}:
+        sys₊y(tv) ~ sys₊x(tv)
+        y(tv) ~ sys₊x(tv)
+    sys₊y(t) is bound to the outer y(t) through the variable sys₊x(t) and should thus return is_bound(sys₊y(t)) = true.
+    When asking is_bound(sys₊y(t)), we know that we are looking through observed equations and can thus ask 
+    if var is bound, if it is, then sys₊y(t) is also bound. This can lead to an infinite recursion, so we maintain a stack of variables we have previously asked about to be able to break cycles
+    =#
+    u ∈ Set(stack) && return false # Cycle detected
+    eqs = equations(sys)
+    eqs = filter(eq->has_var(eq, u), eqs) # Only look at equations that contain u
+    # isout = isoutput(u)
+    for eq in eqs
+        vars = [get_variables(eq.rhs); get_variables(eq.lhs)]
+        for var in vars
+            var === u && continue
+            if !same_or_inner_namespace(u, var)
+                return true
+            end
+        end
+    end
+    # Look through observed equations as well
+    oeqs = observed(sys)
+    oeqs = filter(eq->has_var(eq, u), oeqs) # Only look at equations that contain u
+    for eq in oeqs
+        vars = [get_variables(eq.rhs); get_variables(eq.lhs)]
+        for var in vars
+            var === u && continue
+            if !same_or_inner_namespace(u, var)
+                return true
+            end
+            if is_bound(sys, var, [stack; u]) && !inner_namespace(u, var) # The variable we are comparing to can not come from an inner namespace, binding only counts outwards
+                return true
+            end
+        end
+    end
+    false
+end
+
+
+
+"""
+    same_or_inner_namespace(u, var)
+
+Determine whether or not `var` is in the same namespace as `u`, or a namespace internal to the namespace of `u`.
+Example: `sys.u ~ sys.inner.u` will bind `sys.inner.u`, but `sys.u` remains an unbound, external signal. The namepsaced signal `sys.inner.u` lives in a namspace internal to `sys`.
+"""
+function same_or_inner_namespace(u, var)
+    nu = get_namespace(u)
+    nv = get_namespace(var)
+    nu == nv ||           # namespaces are the same
+        startswith(nv, nu) || # or nv starts with nu, i.e., nv is an inner namepsace to nu
+        occursin('₊', var) && !occursin('₊', u) # or u is top level but var is internal
+end
+
+function inner_namespace(u, var)
+    nu = get_namespace(u)
+    nv = get_namespace(var)
+    nu == nv && return false
+    startswith(nv, nu) || # or nv starts with nu, i.e., nv is an inner namepsace to nu
+        occursin('₊', var) && !occursin('₊', u) # or u is top level but var is internal
+end
+
+"""
+    get_namespace(x)
+
+Return the namespace of a variable as a string. If the variable is not namespaced, the string is empty.
+"""
+function get_namespace(x)
+    sname = string(x)
+    parts = split(sname, '₊')
+    if length(parts) == 1
+        return ""
+    end
+    join(parts[1:end-1], '₊')
+end
+
+"""
+    has_var(eq, x)
+
+Determine whether or not an equation or expression contains variable `x`.
+"""
+function has_var(eq::Equation, x)
+    has_var(eq.rhs, x) || has_var(eq.lhs, x)
+end
+
+has_var(ex, x) = x ∈ Set(get_variables(ex))
+

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -16,6 +16,7 @@ struct Equality <: AbstractConnectType end # Equality connection
 struct Flow <: AbstractConnectType end     # sum to 0
 struct Stream <: AbstractConnectType end   # special stream connector
 
+isvarkind(m, x::Num) = isvarkind(m, value(x))
 function isvarkind(m, x)
     p = getparent(x, nothing)
     p === nothing || (x = p)

--- a/test/input_output_handling.jl
+++ b/test/input_output_handling.jl
@@ -83,3 +83,90 @@ syss = structural_simplify(sys2)
 
 @test isequal(unbound_outputs(syss), [y])
 @test isequal(bound_outputs(syss), [sys.y])
+
+
+## Code generation with unbound inputs
+
+@variables t x(t)=0 u(t)=0 [input=true]
+D = Differential(t)
+eqs = [
+    D(x) ~ -x + u
+]
+
+@named sys = ODESystem(eqs)
+f, dvs, ps = ModelingToolkit.generate_control_function(sys, expression=Val{false}, simplify=true)
+
+@test isequal(dvs[], x)
+@test isempty(ps)
+
+p = []
+x = [rand()]
+u = [rand()]
+@test f[1](x,u,p,1) == -x + u
+
+
+# more complicated system
+
+@variables u(t) [input=true] 
+
+function Mass(; name, m = 1.0, p = 0, v = 0)
+    @variables y(t) [output=true]
+    ps = @parameters m=m
+    sts = @variables pos(t)=p vel(t)=v
+    eqs = [
+        D(pos) ~ vel
+        y ~ pos
+    ]
+    ODESystem(eqs, t, [pos, vel], ps; name)
+end
+
+function Spring(; name, k = 1e4)
+    ps = @parameters k=k
+    @variables x(t)=0 # Spring deflection
+    ODESystem(Equation[], t, [x], ps; name)
+end
+
+function Damper(; name, c = 10)
+    ps = @parameters c=c
+    @variables vel(t)=0
+    ODESystem(Equation[], t, [vel], ps; name)
+end
+
+function SpringDamper(; name, k=false, c=false)
+    spring = Spring(; name=:spring, k)
+    damper = Damper(; name=:damper, c)
+    compose(
+        ODESystem(Equation[], t; name),
+        spring, damper)
+end
+
+
+connect_sd(sd, m1, m2) = [sd.spring.x ~ m1.pos - m2.pos, sd.damper.vel ~ m1.vel - m2.vel]
+sd_force(sd) = -sd.spring.k * sd.spring.x - sd.damper.c * sd.damper.vel
+
+# Parameters
+m1 = 1
+m2 = 1
+k = 1000
+c = 10
+
+@named mass1 = Mass(; m=m1)
+@named mass2 = Mass(; m=m2)
+@named sd = SpringDamper(; k, c)
+
+eqs = [
+    connect_sd(sd, mass1, mass2)
+    D(mass1.vel) ~ ( sd_force(sd) + u) / mass1.m
+    D(mass2.vel) ~ (-sd_force(sd)) / mass2.m
+]
+@named _model = ODESystem(eqs, t)
+@named model = compose(_model, mass1, mass2, sd);
+
+
+f, dvs, ps = ModelingToolkit.generate_control_function(model, expression=Val{false}, simplify=true)
+@test length(dvs) == 4
+@test length(ps) == length(parameters(model))
+p = ModelingToolkit.varmap_to_vars(ModelingToolkit.defaults(model), ps)
+x = ModelingToolkit.varmap_to_vars(ModelingToolkit.defaults(model), dvs)
+u = [rand()]
+@test f[1](x,u,p,1) == [u;0;0;0]

--- a/test/input_output_handling.jl
+++ b/test/input_output_handling.jl
@@ -1,0 +1,85 @@
+using ModelingToolkit, Symbolics, Test
+using ModelingToolkit: get_namespace, has_var, inputs, outputs, is_bound, bound_inputs, unbound_inputs, bound_outputs, unbound_outputs, isinput, isoutput
+
+
+# Test input handling
+@parameters tv
+D = Differential(tv)
+@variables x(tv) u(tv) [input=true]
+@test isinput(u)
+
+@named sys = ODESystem([D(x) ~ -x + u], tv) # both u and x are unbound
+@named sys2 = ODESystem([D(x) ~ -sys.x], tv, systems=[sys]) # this binds sys.x in the context of sys2, sys2.x is still unbound
+@named sys3 = ODESystem([D(x) ~ -sys.x + sys.u], tv, systems=[sys]) # This binds both sys.x and sys.u
+
+@named sys4 = ODESystem([D(x) ~ -sys.x, u~sys.u], tv, systems=[sys]) # This binds both sys.x and sys3.u, this system is one layer deeper than the previous. u is directly forwarded to sys.u, and in this case sys.u is bound while u is not
+
+@test has_var(x ~ 1, x)
+@test has_var(1 ~ x, x)
+@test has_var(x + x, x)
+@test !has_var(2 ~ 1, x)
+
+@test get_namespace(x) == ""
+@test get_namespace(sys.x) == "sys"
+@test get_namespace(sys2.x) == "sys2"
+@test get_namespace(sys2.sys.x) == "sys2₊sys"
+
+@test !is_bound(sys, u)
+@test !is_bound(sys, x)
+@test !is_bound(sys, sys.u)
+@test  is_bound(sys2, sys.x)
+@test !is_bound(sys2, sys.u)
+@test !is_bound(sys2, sys2.sys.u)
+
+@test is_bound(sys3, sys.u) # I would like to write sys3.sys.u here but that's not how the variable is stored in the equations
+@test is_bound(sys3, sys.x)
+
+@test  is_bound(sys4, sys.u)
+@test !is_bound(sys4, u)
+
+@test isequal(inputs(sys), [u])
+@test isequal(inputs(sys2), [sys.u])
+
+@test isempty(bound_inputs(sys))
+@test isequal(unbound_inputs(sys), [u])
+
+@test isempty(bound_inputs(sys2))
+@test isequal(unbound_inputs(sys2), [sys.u])
+
+@test isequal(bound_inputs(sys3), [sys.u])
+@test isempty(unbound_inputs(sys3))
+
+
+
+# Test output handling
+@parameters tv
+D = Differential(tv)
+@variables x(tv) y(tv) [output=true]
+@test isoutput(y)
+@named sys = ODESystem([D(x) ~ -x, y ~ x], tv) # both y and x are unbound
+syss = structural_simplify(sys) # This makes y an observed variable
+
+@named sys2 = ODESystem([D(x) ~ -sys.x, y~sys.y], tv, systems=[sys])
+
+@test !is_bound(sys, y)
+@test !is_bound(sys, x)
+@test !is_bound(sys, sys.y)
+
+@test !is_bound(syss, y)
+@test !is_bound(syss, x)
+@test !is_bound(syss, sys.y)
+
+@test isequal(unbound_outputs(sys), [y])
+@test isequal(unbound_outputs(syss), [y])
+
+@test isequal(unbound_outputs(sys2), [y])
+@test isequal(bound_outputs(sys2), [sys.y])
+
+syss = structural_simplify(sys2)
+
+@test !is_bound(syss, y)
+@test !is_bound(syss, x)
+@test is_bound(syss, sys.y)
+
+@test isequal(unbound_outputs(syss), [y])
+@test isequal(bound_outputs(syss), [sys.y])

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,6 +7,7 @@ using SafeTestsets, Test
 @safetestset "Simplify Test" begin include("simplify.jl") end
 @safetestset "Direct Usage Test" begin include("direct.jl") end
 @safetestset "System Linearity Test" begin include("linearity.jl") end
+@safetestset "Input Output Test" begin include("input_output_handling.jl") end
 @safetestset "DiscreteSystem Test" begin include("discretesystem.jl") end
 @safetestset "ODESystem Test" begin include("odesystem.jl") end
 @safetestset "Unitful Quantities Test" begin include("units.jl") end


### PR DESCRIPTION
This PR adds a number of functions to retrieve inputs and outputs, filtered on whether or not they are internally connected within a composite system.

In the language used , `r,d,n` below are `unbound_inputs` while `e, P.u` are `bound_inputs`.
`y` is an `unbound_output` while `z, controller.u` are `bound_output`. 
```
                          d│                 n│
                           │                  │
             ┌────────┐    │   ┌────────┐     │
    r      e │        │ u  ▼   │        │ z   ▼  y
  ───────+───►  PID   ├────+───►   P    ├─────+─┬───
        -▲   │        │        │        │       │
         │   └────────┘        └────────┘       │
         │                                      │
         └──────────────────────────────────────┘
```
A connection between two variables in different namespaces, where one namespace is internal to the other, only binds the inner variable and not the outer, e.g., `sys.u ~ sys.inner.u` will bind `sys.inner.u`, but `sys.u` remains an unbound, external signal. This reflects how components are typically connected in a block diagram.

The main thing to consider for a reviewer is if the strategy of determining the bound status of a signal based on connections to outer subsystems is sound.

This PR is the first in a series addressing
- #1311 
- #1111 
- #1088 
- #1216 