### PR TITLE
Corrected the `name` vs `@named` problem in the tutorial

### DIFF
--- a/docs/src/tutorials/ode_modeling.md
+++ b/docs/src/tutorials/ode_modeling.md
@@ -211,7 +211,7 @@ again are just algebraic relations:
 connections = [ fol_1.f ~ 1.5,
                 fol_2.f ~ fol_1.x ]
 
-@named connected = compose(ODESystem(connections), fol_1, fol_2)
+connected = compose(ODESystem(connections,name=:connected), fol_1, fol_2)
       # Model connected with 5 equations
       # States (5):
       #   fol_1₊f(t)


### PR DESCRIPTION
The [Building component-based, hierarchical models](https://mtk.sciml.ai/dev/tutorials/ode_modeling/#Building-component-based,-hierarchical-models) tutorial did not work (see the issue #1326). The culprit was apparently that the `@named` macro doesn't work (well) with the `compose`.