### PR TITLE
Replace open coded tarjan algorithm by Graphs.jl version

### DIFF
--- a/src/structural_transformation/StructuralTransformations.jl
+++ b/src/structural_transformation/StructuralTransformations.jl
@@ -1,8 +1,5 @@
 module StructuralTransformations
 
-const UNVISITED = typemin(Int)
-const UNASSIGNED = typemin(Int)
-
 using Setfield: @set!, @set
 using UnPack: @unpack
 

--- a/src/structural_transformation/pantelides.jl
+++ b/src/structural_transformation/pantelides.jl
@@ -62,7 +62,7 @@ function pantelides_reassemble(sys::ODESystem, eqassoc, assign)
     end
 
     final_vars = unique(filter(x->!(operation(x) isa Differential), fullvars))
-    final_eqs = map(identity, filter(x->value(x.lhs) !== nothing, out_eqs[sort(filter(x->x != UNASSIGNED, assign))]))
+    final_eqs = map(identity, filter(x->value(x.lhs) !== nothing, out_eqs[sort(filter(x->x !== unassigned, assign))]))
 
     @set! sys.eqs = final_eqs
     @set! sys.states = final_vars
@@ -84,7 +84,7 @@ function pantelides!(sys::ODESystem; maxiters = 8000)
     nvars = length(varassoc)
     vcolor = falses(nvars)
     ecolor = falses(neqs)
-    assign = fill(UNASSIGNED, nvars)
+    assign = Union{Unassigned, Int}[unassigned for _ = 1:nvars]
     eqassoc = fill(0, neqs)
     neqs′ = neqs
     D = Differential(iv)
@@ -112,7 +112,7 @@ function pantelides!(sys::ODESystem; maxiters = 8000)
                 # the new variable is the derivative of `var`
                 varassoc[var] = nvars
                 push!(varassoc, 0)
-                push!(assign, UNASSIGNED)
+                push!(assign, unassigned)
             end
 
             for eq in eachindex(ecolor); ecolor[eq] || continue

--- a/src/systems/systemstructure.jl
+++ b/src/systems/systemstructure.jl
@@ -80,7 +80,7 @@ Base.@kwdef struct SystemStructure
     algeqs::BitVector
     graph::BipartiteGraph{Int,Vector{Vector{Int}},Int,Nothing}
     solvable_graph::BipartiteGraph{Int,Vector{Vector{Int}},Int,Nothing}
-    assign::Vector{Int}
+    assign::Vector{Union{Int, Unassigned}}
     inv_assign::Vector{Int}
     scc::Vector{Vector{Int}}
     partitions::Vector{SystemPartition}

--- a/test/structural_transformation/index_reduction.jl
+++ b/test/structural_transformation/index_reduction.jl
@@ -34,7 +34,7 @@ pendulum = ODESystem(eqs, t, [x, y, w, z, T], [L, g], name=:pendulum)
 pendulum = initialize_system_structure(pendulum)
 sss = structure(pendulum)
 @unpack graph, fullvars, varassoc = sss
-@test StructuralTransformations.matching(sss, varassoc .== 0) == map(x -> x == 0 ? StructuralTransformations.UNASSIGNED : x, [1, 2, 3, 4, 0, 0, 0, 0, 0])
+@test StructuralTransformations.matching(sss, varassoc .== 0) == map(x -> x == 0 ? StructuralTransformations.unassigned : x, [1, 2, 3, 4, 0, 0, 0, 0, 0])
 
 sys, assign, eqassoc = StructuralTransformations.pantelides!(pendulum)
 sss = structure(sys)


### PR DESCRIPTION
Besides avoiding redundancy and making used of the more optimized
version in Graphs.jl, I think the extra abstraction also gives an
insight into what exactly the induced orientation of the graph is
that we're using to find strongly connected components.

While we're at it also replace the hardcoded integer sentintel by
a singleton type to align more with how we're doing this elsewhere
in Julia.