### PR TITLE
Include root-finding equations in `ODESystem`

### DIFF
--- a/docs/src/basics/AbstractSystem.md
+++ b/docs/src/basics/AbstractSystem.md
@@ -56,6 +56,7 @@ Optionally, a system could have:
 
 - `observed(sys)`: All observed equations of the system and its subsystems.
 - `get_observed(sys)`: Observed equations of the current-level system.
+- `get_root_eqs(sys)`: Root-finding equations of the current-level system.
 - `get_defaults(sys)`: A `Dict` that maps variables into their default values.
 - `independent_variables(sys)`: The independent variables of a system.
 - `get_noiseeqs(sys)`: Noise equations of the current-level system.

--- a/docs/src/basics/AbstractSystem.md
+++ b/docs/src/basics/AbstractSystem.md
@@ -56,7 +56,7 @@ Optionally, a system could have:
 
 - `observed(sys)`: All observed equations of the system and its subsystems.
 - `get_observed(sys)`: Observed equations of the current-level system.
-- `get_root_eqs(sys)`: Root-finding equations of the current-level system.
+- `get_events(sys)`: `EqAffectPair`s of the current-level system.
 - `get_defaults(sys)`: A `Dict` that maps variables into their default values.
 - `independent_variables(sys)`: The independent variables of a system.
 - `get_noiseeqs(sys)`: Noise equations of the current-level system.

--- a/docs/src/basics/AbstractSystem.md
+++ b/docs/src/basics/AbstractSystem.md
@@ -56,7 +56,7 @@ Optionally, a system could have:
 
 - `observed(sys)`: All observed equations of the system and its subsystems.
 - `get_observed(sys)`: Observed equations of the current-level system.
-- `get_events(sys)`: `EqAffectPair`s of the current-level system.
+- `get_continuous_events(sys)`: `SymbolicContinuousCallback`s of the current-level system.
 - `get_defaults(sys)`: A `Dict` that maps variables into their default values.
 - `independent_variables(sys)`: The independent variables of a system.
 - `get_noiseeqs(sys)`: Noise equations of the current-level system.

--- a/docs/src/basics/Composition.md
+++ b/docs/src/basics/Composition.md
@@ -251,7 +251,7 @@ as the basis for building pre-simplified nonlinear systems in the implicit
 solving. In summary: these problems are structurally modified, but could be
 more efficient and more stable.
 
-## Components with discontinous dynamics
+## Components with discontinuous dynamics
 When modeling, e.g., impacts, saturations or Coulomb friction, the dynamic equations are discontinuous in either the state or one of its derivatives. This causes the solver to take very small steps around the discontinuity, and sometimes leads to early stopping due to `dt <= dt_min`. The correct way to handle such dynamics is to tell the solver about the discontinuity be means of a root-finding equation. [`ODEsystem`](@ref)s accept a keyword argument `root_eqs`
 ```
 ODESystem(eqs, ...; root_eqs::Vector{Equation})

--- a/docs/src/basics/Composition.md
+++ b/docs/src/basics/Composition.md
@@ -252,10 +252,10 @@ solving. In summary: these problems are structurally modified, but could be
 more efficient and more stable.
 
 ## Components with discontinuous dynamics
-When modeling, e.g., impacts, saturations or Coulomb friction, the dynamic equations are discontinuous in either the state or one of its derivatives. This causes the solver to take very small steps around the discontinuity, and sometimes leads to early stopping due to `dt <= dt_min`. The correct way to handle such dynamics is to tell the solver about the discontinuity be means of a root-finding equation. [`ODEsystem`](@ref)s accept a keyword argument `events`
+When modeling, e.g., impacts, saturations or Coulomb friction, the dynamic equations are discontinuous in either the state or one of its derivatives. This causes the solver to take very small steps around the discontinuity, and sometimes leads to early stopping due to `dt <= dt_min`. The correct way to handle such dynamics is to tell the solver about the discontinuity be means of a root-finding equation. [`ODEsystem`](@ref)s accept a keyword argument `continuous_events`
 ```
-ODESystem(eqs, ...; events::Vector{Equation})
-ODESystem(eqs, ...; events::Pair{Vector{Equation}, Vector{Equation}})
+ODESystem(eqs, ...; continuous_events::Vector{Equation})
+ODESystem(eqs, ...; continuous_events::Pair{Vector{Equation}, Vector{Equation}})
 ```
 where equations can be added that evaluate to 0 at discontinuities.
 
@@ -275,7 +275,7 @@ function UnitMassWithFriction(k; name)
     D(x) ~ v
     D(v) ~ sin(t) - k*sign(v) # f = ma, sinusoidal force acting on the mass, and Coulomb friction opposing the movement
   ]
-  ODESystem(eqs, t, events=[v ~ 0], name=name) # when v = 0 there is a discontinuity
+  ODESystem(eqs, t, continuous_events=[v ~ 0], name=name) # when v = 0 there is a discontinuity
 end
 @named m = UnitMassWithFriction(0.7)
 prob = ODEProblem(m, Pair[], (0, 10pi))
@@ -296,7 +296,7 @@ affect   = [v ~ -v] # the effect is that the velocity changes sign
 @named ball = ODESystem([
     D(x) ~ v
     D(v) ~ -9.8
-], t, events = root_eqs => affect) # equation => affect
+], t, continuous_events = root_eqs => affect) # equation => affect
 
 ball = structural_simplify(ball)
 
@@ -313,7 +313,7 @@ Multiple events? No problem! This example models a bouncing ball in 2D that is e
 @variables t x(t)=1 y(t)=0 vx(t)=0 vy(t)=2
 D = Differential(t)
 
-events = [ # This time we have a vector of pairs
+continuous_events = [ # This time we have a vector of pairs
     [x ~ 0] => [vx ~ -vx]
     [y ~ -1.5, y ~ 1.5] => [vy ~ -vy]
 ]
@@ -323,7 +323,7 @@ events = [ # This time we have a vector of pairs
     D(y)  ~ vy,
     D(vx) ~ -9.8-0.1vx, # gravity + some small air resistance
     D(vy) ~ -0.1vy,
-], t, events = events)
+], t, continuous_events = continuous_events)
 
 
 ball = structural_simplify(ball)

--- a/src/systems/abstractsystem.jl
+++ b/src/systems/abstractsystem.jl
@@ -187,7 +187,6 @@ for prop in [
              :dvs
              :connection_type
              :preface
-             :root_eqs
             ]
     fname1 = Symbol(:get_, prop)
     fname2 = Symbol(:has_, prop)
@@ -979,7 +978,7 @@ function extend(sys::AbstractSystem, basesys::AbstractSystem; name::Symbol=nameo
     sts = union(get_states(basesys), get_states(sys))
     ps = union(get_ps(basesys), get_ps(sys))
     obs = union(get_observed(basesys), get_observed(sys))
-    roots = union(get_rooteqs(basesys), get_rooteqs(sys))
+    roots = union(get_root_eqs(basesys), get_root_eqs(sys))
     defs = merge(get_defaults(basesys), get_defaults(sys)) # prefer `sys`
     syss = union(get_systems(basesys), get_systems(sys))
 

--- a/src/systems/abstractsystem.jl
+++ b/src/systems/abstractsystem.jl
@@ -950,7 +950,7 @@ function Base.hash(sys::AbstractSystem, s::UInt)
         s = foldr(hash, get_eqs(sys), init=s)
     end
     s = foldr(hash, get_observed(sys), init=s)
-    s = foldr(hash, get_rooteqs(sys), init=s)
+    s = foldr(hash, get_root_eqs(sys), init=s)
     s = hash(independent_variables(sys), s)
     return s
 end

--- a/src/systems/abstractsystem.jl
+++ b/src/systems/abstractsystem.jl
@@ -187,6 +187,7 @@ for prop in [
              :dvs
              :connection_type
              :preface
+             :root_eqs
             ]
     fname1 = Symbol(:get_, prop)
     fname2 = Symbol(:has_, prop)
@@ -412,6 +413,15 @@ function observed(sys::AbstractSystem)
     [obs;
      reduce(vcat,
             (map(o->namespace_equation(o, s), observed(s)) for s in systems),
+            init=Equation[])]
+end
+
+function root_eqs(sys::AbstractSystem)
+    obs = get_root_eqs(sys)
+    systems = get_systems(sys)
+    [obs;
+     reduce(vcat,
+            (map(o->namespace_equation(o, s), root_eqs(s)) for s in systems),
             init=Equation[])]
 end
 
@@ -941,6 +951,7 @@ function Base.hash(sys::AbstractSystem, s::UInt)
         s = foldr(hash, get_eqs(sys), init=s)
     end
     s = foldr(hash, get_observed(sys), init=s)
+    s = foldr(hash, get_rooteqs(sys), init=s)
     s = hash(independent_variables(sys), s)
     return s
 end
@@ -968,13 +979,14 @@ function extend(sys::AbstractSystem, basesys::AbstractSystem; name::Symbol=nameo
     sts = union(get_states(basesys), get_states(sys))
     ps = union(get_ps(basesys), get_ps(sys))
     obs = union(get_observed(basesys), get_observed(sys))
+    roots = union(get_rooteqs(basesys), get_rooteqs(sys))
     defs = merge(get_defaults(basesys), get_defaults(sys)) # prefer `sys`
     syss = union(get_systems(basesys), get_systems(sys))
 
     if length(ivs) == 0
-        T(eqs, sts, ps, observed = obs, defaults = defs, name=name, systems = syss)
+        T(eqs, sts, ps, observed = obs, defaults = defs, name=name, systems = syss, root_eqs=roots)
     elseif length(ivs) == 1
-        T(eqs, ivs[1], sts, ps, observed = obs, defaults = defs, name = name, systems = syss)
+        T(eqs, ivs[1], sts, ps, observed = obs, defaults = defs, name = name, systems = syss, root_eqs=roots)
     end
 end
 

--- a/src/systems/diffeqs/abstractodesystem.jl
+++ b/src/systems/diffeqs/abstractodesystem.jl
@@ -186,7 +186,7 @@ function generate_rootfinding_callback(sys::ODESystem, dvs = states(sys), ps = p
         ContinuousCallback(condition, cb_affect!)
     else
         condition = (out, u, t, integ) -> rf_ip(out, u, integ.p, t)
-        VectorContinuousCallback(condition, cb_affect!, length(vars))
+        VectorContinuousCallback(condition, cb_affect!, length(eqs))
     end
 end
 

--- a/src/systems/diffeqs/abstractodesystem.jl
+++ b/src/systems/diffeqs/abstractodesystem.jl
@@ -648,6 +648,11 @@ function DiffEqBase.ODEProblem{iip}(sys::AbstractODESystem,u0map,tspan,
     difference_cb = has_difference ? generate_difference_cb(sys; kwargs...) : nothing
     cb = merge_cb(event_cb, difference_cb)
 
+    if haskey(kwargs, :callback)
+        cb = merge_cb(cb, kwargs[:callback])
+        kwargs = Base.structdiff((; kwargs...), NamedTuple{(:callback,)}) # remove the :callback key
+    end
+
     if cb === nothing
         ODEProblem{iip}(f, u0, tspan, p; kwargs...)
     else

--- a/src/systems/diffeqs/abstractodesystem.jl
+++ b/src/systems/diffeqs/abstractodesystem.jl
@@ -216,7 +216,8 @@ function compile_affect(eqs::Vector{Equation}, sys, dvs, ps; kwargs...)
         rhss = map(x->x.rhs, eqs)
         lhss = map(x->x.lhs, eqs)
         update_vars = collect(Iterators.flatten(map(ModelingToolkit.vars, lhss))) # these are the ones we're chaning
-        length(update_vars) == length(update_vars) || error("affected variables not unique, each state can only be affected by one equation for a single `root_eqs => affects` pair.")
+        length(update_vars) == length(unique(update_vars)) == length(eqs) ||
+            error("affected variables not unique, each state can only be affected by one equation for a single `root_eqs => affects` pair.")
         vars = states(sys)
     
         u        = map(x->time_varying_as_func(value(x), sys), vars)

--- a/src/systems/diffeqs/abstractodesystem.jl
+++ b/src/systems/diffeqs/abstractodesystem.jl
@@ -162,7 +162,7 @@ end
 function generate_rootfinding_callback(cbs, sys::ODESystem, dvs = states(sys), ps = parameters(sys); kwargs...)
     eqs = map(cb->cb.eqs, cbs)
     num_eqs = length.(eqs)
-    isempty(eqs) && return nothing
+    (isempty(eqs) || sum(num_eqs) == 0) && return nothing
     # fuse equations to create VectorContinuousCallback
     eqs = reduce(vcat, eqs)
     # rewrite all equations as 0 ~ interesting stuff

--- a/src/systems/diffeqs/abstractodesystem.jl
+++ b/src/systems/diffeqs/abstractodesystem.jl
@@ -637,7 +637,7 @@ Generates an ODEProblem from an ODESystem and allows for automatically
 symbolically calculating numerical enhancements.
 """
 function DiffEqBase.ODEProblem{iip}(sys::AbstractODESystem,u0map,tspan,
-                                    parammap=DiffEqBase.NullParameters();kwargs...) where iip
+                                    parammap=DiffEqBase.NullParameters(); callback=nothing, kwargs...) where iip
     has_difference = any(isdifferenceeq, equations(sys))
     f, u0, p = process_DEProblem(ODEFunction{iip}, sys, u0map, parammap; has_difference=has_difference, kwargs...)
     if has_continuous_events(sys)
@@ -647,11 +647,7 @@ function DiffEqBase.ODEProblem{iip}(sys::AbstractODESystem,u0map,tspan,
     end
     difference_cb = has_difference ? generate_difference_cb(sys; kwargs...) : nothing
     cb = merge_cb(event_cb, difference_cb)
-
-    if haskey(kwargs, :callback)
-        cb = merge_cb(cb, kwargs[:callback])
-        kwargs = Base.structdiff((; kwargs...), NamedTuple{(:callback,)}) # remove the :callback key
-    end
+    cb = merge_cb(cb, callback)
 
     if cb === nothing
         ODEProblem{iip}(f, u0, tspan, p; kwargs...)

--- a/src/systems/diffeqs/abstractodesystem.jl
+++ b/src/systems/diffeqs/abstractodesystem.jl
@@ -155,6 +155,8 @@ end
 
 function generate_rootfinding_callback(sys::ODESystem, dvs = states(sys), ps = parameters(sys); kwargs...)
     eqs = root_eqs(sys)
+
+    # rewrite all equations as 0 ~ interesting stuff
     eqs = map(eqs) do eq
         isequal(eq.lhs, 0) && return eq
         0 ~ eq.lhs - eq.rhs
@@ -170,7 +172,7 @@ function generate_rootfinding_callback(sys::ODESystem, dvs = states(sys), ps = p
 
     # Strategy 2
     x = filter(x->!isinput(x) && !isoutput(x), dvs)
-    rhss = [map(x->x.rhs, eqs); map(x->x.lhs, eqs)]
+    rhss = map(x->x.rhs, eqs)
     root_eq_vars = unique(collect(Iterators.flatten(map(ModelingToolkit.vars, rhss))))
     vars = x ∩ root_eq_vars # we look for the roots w.r.t. the states of the root equations
     u0map = defaults(sys)

--- a/src/systems/diffeqs/odesystem.jl
+++ b/src/systems/diffeqs/odesystem.jl
@@ -226,6 +226,10 @@ end
 
 ODESystem(eq::Equation, args...; kwargs...) = ODESystem([eq], args...; kwargs...)
 
+get_root_eqs(sys::AbstractSystem) = Equation[]
+get_root_eqs(sys::AbstractODESystem) = getfield(sys, :root_eqs)
+has_root_eqs(sys::AbstractSystem) = isdefined(sys, :root_eqs)
+
 """
 $(SIGNATURES)
 

--- a/src/systems/diffeqs/odesystem.jl
+++ b/src/systems/diffeqs/odesystem.jl
@@ -88,20 +88,20 @@ struct ODESystem <: AbstractODESystem
     """
     preface::Any
     """
-    root_eqs: A `Vector{EqAffectPair}` that evaluate to 0 at events.
+    events: A `Vector{EqAffectPair}` that model events.
     The integrator will use root finding to guarantee that it steps at each zero crossing.
     """
-    root_eqs::Vector{EqAffectPair}
+    events::Vector{EqAffectPair}
 
-    function ODESystem(deqs, iv, dvs, ps, var_to_name, ctrls, observed, tgrad, jac, ctrl_jac, Wfact, Wfact_t, name, systems, defaults, structure, connection_type, preface, root_eqs; checks::Bool = true)
+    function ODESystem(deqs, iv, dvs, ps, var_to_name, ctrls, observed, tgrad, jac, ctrl_jac, Wfact, Wfact_t, name, systems, defaults, structure, connection_type, preface, events; checks::Bool = true)
         if checks
             check_variables(dvs,iv)
             check_parameters(ps,iv)
             check_equations(deqs,iv)
-            check_equations(equations(root_eqs),iv)
+            check_equations(equations(events),iv)
             all_dimensionless([dvs;ps;iv]) || check_units(deqs)
         end
-        new(deqs, iv, dvs, ps, var_to_name, ctrls, observed, tgrad, jac, ctrl_jac, Wfact, Wfact_t, name, systems, defaults, structure, connection_type, preface, root_eqs)
+        new(deqs, iv, dvs, ps, var_to_name, ctrls, observed, tgrad, jac, ctrl_jac, Wfact, Wfact_t, name, systems, defaults, structure, connection_type, preface, events)
     end
 end
 
@@ -116,7 +116,7 @@ function ODESystem(
                    defaults=_merge(Dict(default_u0), Dict(default_p)),
                    connection_type=nothing,
                    preface=nothing,
-                   root_eqs=Equation[],
+                   events=nothing,
                    checks = true,
                   )
     name === nothing && throw(ArgumentError("The `name` keyword must be provided. Please consider using the `@named` macro"))
@@ -151,7 +151,7 @@ function ODESystem(
     if length(unique(sysnames)) != length(sysnames)
         throw(ArgumentError("System names must be unique."))
     end
-    eq_affect_pairs = EqAffectPairs(root_eqs)
+    eq_affect_pairs = EqAffectPairs(events)
     ODESystem(deqs, iv′, dvs′, ps′, var_to_name, ctrl′, observed, tgrad, jac, ctrl_jac, Wfact, Wfact_t, name, systems, defaults, nothing, connection_type, preface, eq_affect_pairs, checks = checks)
 end
 
@@ -217,7 +217,7 @@ function flatten(sys::ODESystem)
                          states(sys),
                          parameters(sys),
                          observed=observed(sys),
-                         root_eqs=root_eqs(sys),
+                         events=events(sys),
                          defaults=defaults(sys),
                          name=nameof(sys),
                          checks = false,
@@ -227,9 +227,9 @@ end
 
 ODESystem(eq::Equation, args...; kwargs...) = ODESystem([eq], args...; kwargs...)
 
-get_root_eqs(sys::AbstractSystem) = Equation[]
-get_root_eqs(sys::AbstractODESystem) = getfield(sys, :root_eqs)
-has_root_eqs(sys::AbstractSystem) = isdefined(sys, :root_eqs)
+get_events(sys::AbstractSystem) = Equation[]
+get_events(sys::AbstractODESystem) = getfield(sys, :events)
+has_events(sys::AbstractSystem) = isdefined(sys, :events)
 
 """
 $(SIGNATURES)

--- a/src/systems/diffeqs/odesystem.jl
+++ b/src/systems/diffeqs/odesystem.jl
@@ -88,10 +88,10 @@ struct ODESystem <: AbstractODESystem
     """
     preface::Any
     """
-    events: A `Vector{EqAffectPair}` that model events.
+    events: A `Vector{SymbolicContinuousCallback}` that model events.
     The integrator will use root finding to guarantee that it steps at each zero crossing.
     """
-    events::Vector{EqAffectPair}
+    continuous_events::Vector{SymbolicContinuousCallback}
 
     function ODESystem(deqs, iv, dvs, ps, var_to_name, ctrls, observed, tgrad, jac, ctrl_jac, Wfact, Wfact_t, name, systems, defaults, structure, connection_type, preface, events; checks::Bool = true)
         if checks
@@ -116,7 +116,7 @@ function ODESystem(
                    defaults=_merge(Dict(default_u0), Dict(default_p)),
                    connection_type=nothing,
                    preface=nothing,
-                   events=nothing,
+                   continuous_events=nothing,
                    checks = true,
                   )
     name === nothing && throw(ArgumentError("The `name` keyword must be provided. Please consider using the `@named` macro"))
@@ -151,8 +151,8 @@ function ODESystem(
     if length(unique(sysnames)) != length(sysnames)
         throw(ArgumentError("System names must be unique."))
     end
-    eq_affect_pairs = EqAffectPairs(events)
-    ODESystem(deqs, iv′, dvs′, ps′, var_to_name, ctrl′, observed, tgrad, jac, ctrl_jac, Wfact, Wfact_t, name, systems, defaults, nothing, connection_type, preface, eq_affect_pairs, checks = checks)
+    cont_callbacks = SymbolicContinuousCallbacks(continuous_events)
+    ODESystem(deqs, iv′, dvs′, ps′, var_to_name, ctrl′, observed, tgrad, jac, ctrl_jac, Wfact, Wfact_t, name, systems, defaults, nothing, connection_type, preface, cont_callbacks, checks = checks)
 end
 
 function ODESystem(eqs, iv=nothing; kwargs...)
@@ -217,7 +217,7 @@ function flatten(sys::ODESystem)
                          states(sys),
                          parameters(sys),
                          observed=observed(sys),
-                         events=events(sys),
+                         continuous_events=continuous_events(sys),
                          defaults=defaults(sys),
                          name=nameof(sys),
                          checks = false,
@@ -227,9 +227,9 @@ end
 
 ODESystem(eq::Equation, args...; kwargs...) = ODESystem([eq], args...; kwargs...)
 
-get_events(sys::AbstractSystem) = Equation[]
-get_events(sys::AbstractODESystem) = getfield(sys, :events)
-has_events(sys::AbstractSystem) = isdefined(sys, :events)
+get_continuous_events(sys::AbstractSystem) = Equation[]
+get_continuous_events(sys::AbstractODESystem) = getfield(sys, :continuous_events)
+has_continuous_events(sys::AbstractSystem) = isdefined(sys, :continuous_events)
 
 """
 $(SIGNATURES)

--- a/src/systems/diffeqs/odesystem.jl
+++ b/src/systems/diffeqs/odesystem.jl
@@ -230,6 +230,7 @@ ODESystem(eq::Equation, args...; kwargs...) = ODESystem([eq], args...; kwargs...
 get_continuous_events(sys::AbstractSystem) = Equation[]
 get_continuous_events(sys::AbstractODESystem) = getfield(sys, :continuous_events)
 has_continuous_events(sys::AbstractSystem) = isdefined(sys, :continuous_events)
+get_callback(prob::ODEProblem) = prob.kwargs[:callback]
 
 """
 $(SIGNATURES)

--- a/src/systems/diffeqs/odesystem.jl
+++ b/src/systems/diffeqs/odesystem.jl
@@ -88,17 +88,17 @@ struct ODESystem <: AbstractODESystem
     """
     preface::Any
     """
-    root_eqs: A `Vector{Equation}` that evaluate to 0 at events.
+    root_eqs: A `Vector{EqAffectPair}` that evaluate to 0 at events.
     The integrator will use root finding to guarantee that it steps at each zero crossing.
     """
-    root_eqs::Vector{Equation}
+    root_eqs::Vector{EqAffectPair}
 
     function ODESystem(deqs, iv, dvs, ps, var_to_name, ctrls, observed, tgrad, jac, ctrl_jac, Wfact, Wfact_t, name, systems, defaults, structure, connection_type, preface, root_eqs; checks::Bool = true)
         if checks
             check_variables(dvs,iv)
             check_parameters(ps,iv)
             check_equations(deqs,iv)
-            check_equations(root_eqs,iv)
+            check_equations(equations(root_eqs),iv)
             all_dimensionless([dvs;ps;iv]) || check_units(deqs)
         end
         new(deqs, iv, dvs, ps, var_to_name, ctrls, observed, tgrad, jac, ctrl_jac, Wfact, Wfact_t, name, systems, defaults, structure, connection_type, preface, root_eqs)
@@ -151,7 +151,8 @@ function ODESystem(
     if length(unique(sysnames)) != length(sysnames)
         throw(ArgumentError("System names must be unique."))
     end
-    ODESystem(deqs, iv′, dvs′, ps′, var_to_name, ctrl′, observed, tgrad, jac, ctrl_jac, Wfact, Wfact_t, name, systems, defaults, nothing, connection_type, preface, root_eqs, checks = checks)
+    eq_affect_pairs = EqAffectPairs(root_eqs)
+    ODESystem(deqs, iv′, dvs′, ps′, var_to_name, ctrl′, observed, tgrad, jac, ctrl_jac, Wfact, Wfact_t, name, systems, defaults, nothing, connection_type, preface, eq_affect_pairs, checks = checks)
 end
 
 function ODESystem(eqs, iv=nothing; kwargs...)

--- a/src/systems/nonlinear/nonlinearsystem.jl
+++ b/src/systems/nonlinear/nonlinearsystem.jl
@@ -70,10 +70,10 @@ function NonlinearSystem(eqs, states, ps;
                          defaults=_merge(Dict(default_u0), Dict(default_p)),
                          systems=NonlinearSystem[],
                          connection_type=nothing,
-                         root_eqs=nothing, # this argument is only required for ODESystems, but is added here for the constructor to accept it without error
+                         events=nothing, # this argument is only required for ODESystems, but is added here for the constructor to accept it without error
                          checks = true,
                          )
-    root_eqs === nothing || isempty(root_eqs) || throw(ArgumentError("NonlinearSystem does not accept `root_eqs`, you provided $root_eqs"))
+    events === nothing || isempty(events) || throw(ArgumentError("NonlinearSystem does not accept `events`, you provided $events"))
     name === nothing && throw(ArgumentError("The `name` keyword must be provided. Please consider using the `@named` macro"))
     # Move things over, but do not touch array expressions
     eqs = [0 ~ x.rhs - x.lhs for x in collect(eqs)]

--- a/src/systems/nonlinear/nonlinearsystem.jl
+++ b/src/systems/nonlinear/nonlinearsystem.jl
@@ -70,8 +70,10 @@ function NonlinearSystem(eqs, states, ps;
                          defaults=_merge(Dict(default_u0), Dict(default_p)),
                          systems=NonlinearSystem[],
                          connection_type=nothing,
+                         root_eqs=nothing, # this argument is only required for ODESystems, but is added here for the constructor to accept it without error
                          checks = true,
                          )
+    root_eqs === nothing || isempty(root_eqs) || throw(ArgumentError("NonlinearSystem does not accept `root_eqs`, you provided $root_eqs"))
     name === nothing && throw(ArgumentError("The `name` keyword must be provided. Please consider using the `@named` macro"))
     # Move things over, but do not touch array expressions
     eqs = [0 ~ x.rhs - x.lhs for x in collect(eqs)]

--- a/src/systems/nonlinear/nonlinearsystem.jl
+++ b/src/systems/nonlinear/nonlinearsystem.jl
@@ -70,10 +70,11 @@ function NonlinearSystem(eqs, states, ps;
                          defaults=_merge(Dict(default_u0), Dict(default_p)),
                          systems=NonlinearSystem[],
                          connection_type=nothing,
-                         events=nothing, # this argument is only required for ODESystems, but is added here for the constructor to accept it without error
+                         continuous_events=nothing, # this argument is only required for ODESystems, but is added here for the constructor to accept it without error
                          checks = true,
                          )
-    events === nothing || isempty(events) || throw(ArgumentError("NonlinearSystem does not accept `events`, you provided $events"))
+    continuous_events === nothing || isempty(continuous_events) ||
+        throw(ArgumentError("NonlinearSystem does not accept `continuous_events`, you provided $continuous_events"))
     name === nothing && throw(ArgumentError("The `name` keyword must be provided. Please consider using the `@named` macro"))
     # Move things over, but do not touch array expressions
     eqs = [0 ~ x.rhs - x.lhs for x in collect(eqs)]

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -142,7 +142,11 @@ function collect_differentials(eqs)
     return ivs
 end
 
-"Assert that equations are well-formed when building ODE."
+"""
+    check_equations(eqs, iv)
+
+Assert that equations are well-formed when building ODE, i.e., only containing a single independent variable.
+"""
 function check_equations(eqs, iv)
     ivs = collect_differentials(eqs)
     display = collect(ivs)

--- a/test/odesystem.jl
+++ b/test/odesystem.jl
@@ -427,9 +427,9 @@ eqs = [
 # prob = ODEProblem(ODEFunction{false}(de),[1.0,1.0],(0.0,1.0),[1.5,1.0,3.0,1.0])
 
 prob = ODEProblem(de,[1.0,1.0],(0.0,1.0),[1.5,1.0,3.0,1.0], check_length=false)
-@test prob.kwargs[:difference_cb] isa ModelingToolkit.DiffEqCallbacks.DiscreteCallback
+@test prob.kwargs[:callback] isa ModelingToolkit.DiffEqCallbacks.DiscreteCallback
 
-sol = solve(prob, Tsit5(); callback=prob.kwargs[:difference_cb], tstops=prob.tspan[1]:0.1:prob.tspan[2])
+sol = solve(prob, Tsit5(); callback=prob.kwargs[:callback], tstops=prob.tspan[1]:0.1:prob.tspan[2])
 
 # Direct implementation
 function lotka(du,u,p,t)

--- a/test/root_equations.jl
+++ b/test/root_equations.jl
@@ -1,0 +1,19 @@
+using ModelingToolkit, OrdinaryDiffEq, Test
+
+@parameters t
+@variables x(t)=0 
+D = Differential(t)
+
+eqs = [D(x) ~ 1]
+
+@named sys = ODESystem(eqs, root_eqs = [x ~ 1])
+@test isequal(sys.root_eqs[], x ~ 1)
+fsys = flatten(sys)
+@test isequal(fsys.root_eqs[], x ~ 1)
+prob = ODEProblem(sys, Pair[], (0.0, 2.0))
+
+@named sys2 = ODESystem([D(x) ~ sys.x], root_eqs = [x ~ 2], systems=[sys])
+@test isequal(sys2.root_eqs[], x ~ 2)
+@test length(ModelingToolkit.root_eqs(sys2)) == 2
+@test isequal(ModelingToolkit.root_eqs(sys2)[1], x ~ 2)
+@test isequal(ModelingToolkit.root_eqs(sys2)[2], sys.x ~ 1)

--- a/test/root_equations.jl
+++ b/test/root_equations.jl
@@ -1,5 +1,5 @@
 using ModelingToolkit, OrdinaryDiffEq, Test
-using ModelingToolkit: EqAffectPair, EqAffectPairs, NULL_AFFECT
+using ModelingToolkit: SymbolicContinuousCallback, SymbolicContinuousCallbacks, NULL_AFFECT
 
 @parameters t
 @variables x(t)=0 
@@ -8,67 +8,67 @@ D = Differential(t)
 eqs = [D(x) ~ 1]
 affect = [x ~ 0]
 
-## Test EqAffectPair
-@testset "EqAffectPair constructors" begin
-    e = EqAffectPair(eqs[]) 
-    @test e isa EqAffectPair
+## Test SymbolicContinuousCallback
+@testset "SymbolicContinuousCallback constructors" begin
+    e = SymbolicContinuousCallback(eqs[]) 
+    @test e isa SymbolicContinuousCallback
     @test isequal(e.eqs, eqs)
     @test e.affect == NULL_AFFECT
 
-    e = EqAffectPair(eqs) 
-    @test e isa EqAffectPair
+    e = SymbolicContinuousCallback(eqs) 
+    @test e isa SymbolicContinuousCallback
     @test isequal(e.eqs, eqs)
     @test e.affect == NULL_AFFECT
 
-    e = EqAffectPair(eqs, NULL_AFFECT) 
-    @test e isa EqAffectPair
+    e = SymbolicContinuousCallback(eqs, NULL_AFFECT) 
+    @test e isa SymbolicContinuousCallback
     @test isequal(e.eqs, eqs)
     @test e.affect == NULL_AFFECT
 
-    e = EqAffectPair(eqs[], NULL_AFFECT) 
-    @test e isa EqAffectPair
+    e = SymbolicContinuousCallback(eqs[], NULL_AFFECT) 
+    @test e isa SymbolicContinuousCallback
     @test isequal(e.eqs, eqs)
     @test e.affect == NULL_AFFECT
 
-    e = EqAffectPair(eqs => NULL_AFFECT) 
-    @test e isa EqAffectPair
+    e = SymbolicContinuousCallback(eqs => NULL_AFFECT) 
+    @test e isa SymbolicContinuousCallback
     @test isequal(e.eqs, eqs)
     @test e.affect == NULL_AFFECT
 
-    e = EqAffectPair(eqs[] => NULL_AFFECT) 
-    @test e isa EqAffectPair
+    e = SymbolicContinuousCallback(eqs[] => NULL_AFFECT) 
+    @test e isa SymbolicContinuousCallback
     @test isequal(e.eqs, eqs)
     @test e.affect == NULL_AFFECT
 
     ## With affect
 
-    e = EqAffectPair(eqs[], affect) 
-    @test e isa EqAffectPair
+    e = SymbolicContinuousCallback(eqs[], affect) 
+    @test e isa SymbolicContinuousCallback
     @test isequal(e.eqs, eqs)
     @test e.affect == affect
 
-    e = EqAffectPair(eqs, affect) 
-    @test e isa EqAffectPair
+    e = SymbolicContinuousCallback(eqs, affect) 
+    @test e isa SymbolicContinuousCallback
     @test isequal(e.eqs, eqs)
     @test e.affect == affect
 
-    e = EqAffectPair(eqs, affect) 
-    @test e isa EqAffectPair
+    e = SymbolicContinuousCallback(eqs, affect) 
+    @test e isa SymbolicContinuousCallback
     @test isequal(e.eqs, eqs)
     @test e.affect == affect
 
-    e = EqAffectPair(eqs[], affect) 
-    @test e isa EqAffectPair
+    e = SymbolicContinuousCallback(eqs[], affect) 
+    @test e isa SymbolicContinuousCallback
     @test isequal(e.eqs, eqs)
     @test e.affect == affect
 
-    e = EqAffectPair(eqs => affect) 
-    @test e isa EqAffectPair
+    e = SymbolicContinuousCallback(eqs => affect) 
+    @test e isa SymbolicContinuousCallback
     @test isequal(e.eqs, eqs)
     @test e.affect == affect
 
-    e = EqAffectPair(eqs[] => affect) 
-    @test e isa EqAffectPair
+    e = SymbolicContinuousCallback(eqs[] => affect) 
+    @test e isa SymbolicContinuousCallback
     @test isequal(e.eqs, eqs)
     @test e.affect == affect
 
@@ -77,38 +77,38 @@ affect = [x ~ 0]
 
     # test plural constructor
 
-    e = EqAffectPairs(eqs[]) 
-    @test e isa Vector{EqAffectPair}
+    e = SymbolicContinuousCallbacks(eqs[]) 
+    @test e isa Vector{SymbolicContinuousCallback}
     @test isequal(e[].eqs, eqs)
     @test e[].affect == NULL_AFFECT
 
-    e = EqAffectPairs(eqs) 
-    @test e isa Vector{EqAffectPair}
+    e = SymbolicContinuousCallbacks(eqs) 
+    @test e isa Vector{SymbolicContinuousCallback}
     @test isequal(e[].eqs, eqs)
     @test e[].affect == NULL_AFFECT
 
-    e = EqAffectPairs(eqs[] => affect) 
-    @test e isa Vector{EqAffectPair}
+    e = SymbolicContinuousCallbacks(eqs[] => affect) 
+    @test e isa Vector{SymbolicContinuousCallback}
     @test isequal(e[].eqs, eqs)
     @test e[].affect == affect
 
-    e = EqAffectPairs(eqs => affect) 
-    @test e isa Vector{EqAffectPair}
+    e = SymbolicContinuousCallbacks(eqs => affect) 
+    @test e isa Vector{SymbolicContinuousCallback}
     @test isequal(e[].eqs, eqs)
     @test e[].affect == affect
 
-    e = EqAffectPairs([eqs[] => affect]) 
-    @test e isa Vector{EqAffectPair}
+    e = SymbolicContinuousCallbacks([eqs[] => affect]) 
+    @test e isa Vector{SymbolicContinuousCallback}
     @test isequal(e[].eqs, eqs)
     @test e[].affect == affect
 
-    e = EqAffectPairs([eqs => affect]) 
-    @test e isa Vector{EqAffectPair}
+    e = SymbolicContinuousCallbacks([eqs => affect]) 
+    @test e isa Vector{SymbolicContinuousCallback}
     @test isequal(e[].eqs, eqs)
     @test e[].affect == affect
 
-    e = EqAffectPairs(EqAffectPairs([eqs => affect]))
-    @test e isa Vector{EqAffectPair}
+    e = SymbolicContinuousCallbacks(SymbolicContinuousCallbacks([eqs => affect]))
+    @test e isa Vector{SymbolicContinuousCallback}
     @test isequal(e[].eqs, eqs)
     @test e[].affect == affect
 
@@ -117,20 +117,20 @@ end
 
 ##
 
-@named sys = ODESystem(eqs, events = [x ~ 1])
-@test getfield(sys, :events)[] == EqAffectPair(Equation[x ~ 1], NULL_AFFECT)
-@test isequal(equations(getfield(sys, :events))[], x ~ 1)
+@named sys = ODESystem(eqs, continuous_events = [x ~ 1])
+@test getfield(sys, :continuous_events)[] == SymbolicContinuousCallback(Equation[x ~ 1], NULL_AFFECT)
+@test isequal(equations(getfield(sys, :continuous_events))[], x ~ 1)
 fsys = flatten(sys)
-@test isequal(equations(getfield(fsys, :events))[], x ~ 1)
+@test isequal(equations(getfield(fsys, :continuous_events))[], x ~ 1)
 
-@named sys2 = ODESystem([D(x) ~ 1], events = [x ~ 2], systems=[sys])
-@test getfield(sys2, :events)[] == EqAffectPair(Equation[x ~ 2], NULL_AFFECT)
-@test all(ModelingToolkit.events(sys2) .== [EqAffectPair(Equation[x ~ 2], NULL_AFFECT), EqAffectPair(Equation[sys.x ~ 1], NULL_AFFECT)])
+@named sys2 = ODESystem([D(x) ~ 1], continuous_events = [x ~ 2], systems=[sys])
+@test getfield(sys2, :continuous_events)[] == SymbolicContinuousCallback(Equation[x ~ 2], NULL_AFFECT)
+@test all(ModelingToolkit.continuous_events(sys2) .== [SymbolicContinuousCallback(Equation[x ~ 2], NULL_AFFECT), SymbolicContinuousCallback(Equation[sys.x ~ 1], NULL_AFFECT)])
 
-@test isequal(equations(getfield(sys2, :events))[1], x ~ 2)
-@test length(ModelingToolkit.events(sys2)) == 2
-@test isequal(ModelingToolkit.events(sys2)[1].eqs[], x ~ 2)
-@test isequal(ModelingToolkit.events(sys2)[2].eqs[], sys.x ~ 1)
+@test isequal(equations(getfield(sys2, :continuous_events))[1], x ~ 2)
+@test length(ModelingToolkit.continuous_events(sys2)) == 2
+@test isequal(ModelingToolkit.continuous_events(sys2)[1].eqs[], x ~ 2)
+@test isequal(ModelingToolkit.continuous_events(sys2)[2].eqs[], sys.x ~ 1)
 
 # Functions should be generated for root-finding equations
 prob = ODEProblem(sys, Pair[], (0.0, 2.0))
@@ -183,7 +183,7 @@ sol = solve(prob, Tsit5())
 @test minimum(t->abs(t-1), sol.t) < 1e-10 # test that the solver stepped at the first root
 @test minimum(t->abs(t-2), sol.t) < 1e-10 # test that the solver stepped at the second root
 
-@named sys = ODESystem(eqs, events = [x ~ 1, x ~ 2]) # two root eqs using the same state
+@named sys = ODESystem(eqs, continuous_events = [x ~ 1, x ~ 2]) # two root eqs using the same state
 prob = ODEProblem(sys, Pair[], (0.0, 3.0))
 @test prob.kwargs[:callback] isa ModelingToolkit.DiffEqCallbacks.VectorContinuousCallback
 sol = solve(prob, Tsit5())
@@ -201,9 +201,9 @@ affect   = [v ~ -v]
 @named ball = ODESystem([
     D(x) ~ v
     D(v) ~ -9.8
-], t, events = root_eqs => affect)
+], t, continuous_events = root_eqs => affect)
 
-@test getfield(ball, :events)[] == EqAffectPair(Equation[x ~ 0], Equation[v ~ -v])
+@test getfield(ball, :continuous_events)[] == SymbolicContinuousCallback(Equation[x ~ 0], Equation[v ~ -v])
 ball = structural_simplify(ball)
 
 tspan = (0.0,5.0)
@@ -217,7 +217,7 @@ sol = solve(prob,Tsit5())
 @variables t x(t)=1 y(t)=0 vx(t)=0 vy(t)=1
 D = Differential(t)
 
-events = [
+continuous_events = [
     [x ~ 0] => [vx ~ -vx]
     [y ~ -1.5, y ~ 1.5] => [vy ~ -vy]
 ]
@@ -227,7 +227,7 @@ events = [
     D(y) ~ vy
     D(vx) ~ -9.8
     D(vy) ~ -0.01vy # there is some small air resistance
-], t, events = events)
+], t, continuous_events = continuous_events)
 
 
 
@@ -239,8 +239,8 @@ prob = ODEProblem(ball, Pair[], tspan)
 
 cbs = prob.kwargs[:callback]
 @test cbs isa ModelingToolkit.DiffEqCallbacks.CallbackSet
-@test getfield(ball, :events)[1] == EqAffectPair(Equation[x ~ 0], Equation[vx ~ -vx])
-@test getfield(ball, :events)[2] == EqAffectPair(Equation[y ~ -1.5, y ~ 1.5], Equation[vy ~ -vy])
+@test getfield(ball, :continuous_events)[1] == SymbolicContinuousCallback(Equation[x ~ 0], Equation[vx ~ -vx])
+@test getfield(ball, :continuous_events)[2] == SymbolicContinuousCallback(Equation[y ~ -1.5, y ~ 1.5], Equation[vy ~ -vy])
 cb = cbs.continuous_callbacks[2]
 @test cb isa VectorContinuousCallback
 cond = cb.condition
@@ -255,6 +255,6 @@ sol = solve(prob,Tsit5())
 @test maximum(sol[y]) ≈ 1.5  # check wall conditions
 
 tv = sort([LinRange(0, 5, 200); sol.t])
-plot(sol(tv)[y], sol(tv)[x], line_z=tv)
-vline!([-1.5, 1.5], l=(:black, 5), primary=false)
-hline!([0], l=(:black, 5), primary=false)
+# plot(sol(tv)[y], sol(tv)[x], line_z=tv)
+# vline!([-1.5, 1.5], l=(:black, 5), primary=false)
+# hline!([0], l=(:black, 5), primary=false)

--- a/test/root_equations.jl
+++ b/test/root_equations.jl
@@ -36,8 +36,14 @@ sol = solve(prob, Tsit5())
 @test minimum(t->abs(t-1), sol.t) < 1e-10 # test that the solver stepped at the root
 
 
-# TODO: the problem is that the ContinuousCallback only handles scalar conditions. NEed to adjust the condition function to always be multivariate and use VectorContinuousCallback
-prob = ODEProblem(sys2, Pair[], (0.0, 2.0))
+prob = ODEProblem(sys2, Pair[], (0.0, 3.0))
+@test prob.kwargs[:callback] isa ModelingToolkit.DiffEqCallbacks.VectorContinuousCallback
+sol = solve(prob, Tsit5())
+@test minimum(t->abs(t-1), sol.t) < 1e-10 # test that the solver stepped at the first root
+@test minimum(t->abs(t-2), sol.t) < 1e-10 # test that the solver stepped at the second root
+
+@named sys = ODESystem(eqs, root_eqs = [x ~ 1, x ~ 2]) # two root eqs using the same state
+prob = ODEProblem(sys, Pair[], (0.0, 3.0))
 @test prob.kwargs[:callback] isa ModelingToolkit.DiffEqCallbacks.VectorContinuousCallback
 sol = solve(prob, Tsit5())
 @test minimum(t->abs(t-1), sol.t) < 1e-10 # test that the solver stepped at the first root

--- a/test/root_equations.jl
+++ b/test/root_equations.jl
@@ -1,4 +1,5 @@
 using ModelingToolkit, OrdinaryDiffEq, Test
+using ModelingToolkit: EqAffectPair, NULL_AFFECT
 
 @parameters t
 @variables x(t)=0 
@@ -6,28 +7,67 @@ D = Differential(t)
 
 eqs = [D(x) ~ 1]
 
+
+## Test EqAffectPair
+@testset "EqAffectPair constructors" begin
+    e = EqAffectPair(eqs[]) 
+    @test e isa EqAffectPair
+    @test isequal(e.eqs, eqs)
+    @test e.affect == NULL_AFFECT
+
+    e = EqAffectPair(eqs) 
+    @test e isa EqAffectPair
+    @test isequal(e.eqs, eqs)
+    @test e.affect == NULL_AFFECT
+
+    e = EqAffectPair(eqs, NULL_AFFECT) 
+    @test e isa EqAffectPair
+    @test isequal(e.eqs, eqs)
+    @test e.affect == NULL_AFFECT
+
+    e = EqAffectPair(eqs[], NULL_AFFECT) 
+    @test e isa EqAffectPair
+    @test isequal(e.eqs, eqs)
+    @test e.affect == NULL_AFFECT
+
+    e = EqAffectPair(eqs => NULL_AFFECT) 
+    @test e isa EqAffectPair
+    @test isequal(e.eqs, eqs)
+    @test e.affect == NULL_AFFECT
+
+    e = EqAffectPair(eqs[] => NULL_AFFECT) 
+    @test e isa EqAffectPair
+    @test isequal(e.eqs, eqs)
+    @test e.affect == NULL_AFFECT
+end
+
+
+##
+
 @named sys = ODESystem(eqs, root_eqs = [x ~ 1])
-@test isequal(sys.root_eqs[], x ~ 1)
+@test isequal(equations(getfield(sys, :root_eqs))[], x ~ 1)
 fsys = flatten(sys)
-@test isequal(fsys.root_eqs[], x ~ 1)
+@test isequal(equations(getfield(fsys, :root_eqs))[], x ~ 1)
 prob = ODEProblem(sys, Pair[], (0.0, 2.0))
 
-@named sys2 = ODESystem([D(x) ~ sys.x], root_eqs = [x ~ 2], systems=[sys])
-@test isequal(sys2.root_eqs[], x ~ 2)
+@named sys2 = ODESystem([D(x) ~ 1], root_eqs = [x ~ 2], systems=[sys])
+@test isequal(equations(getfield(sys2, :root_eqs))[1], x ~ 2)
 @test length(ModelingToolkit.root_eqs(sys2)) == 2
-@test isequal(ModelingToolkit.root_eqs(sys2)[1], x ~ 2)
-@test isequal(ModelingToolkit.root_eqs(sys2)[2], sys.x ~ 1)
+@test isequal(ModelingToolkit.root_eqs(sys2)[1].eqs[], x ~ 2)
+@test isequal(ModelingToolkit.root_eqs(sys2)[2].eqs[], sys.x ~ 1)
 
 # Functions should be generated for root-finding equations
+p0 = 0
+t0 = 0
 @test prob.kwargs[:callback] isa ModelingToolkit.DiffEqCallbacks.ContinuousCallback
 cb = ModelingToolkit.generate_rootfinding_callback(sys)
 cond = cb.condition
 out = [0.0]
-cond.rf_ip(out, [0], 1.2, 1)
+cond.rf_ip(out, [0], p0, t0)
 @test out[] ≈ -1 # signature is u,p,t
-cond.rf_ip(out, [1], 1.2, 1)
+cond.rf_ip(out, [1], p0, t0)
 @test out[] ≈ 0  # signature is u,p,t
-cond.rf_ip(out, [2], 1.2, 1)
+cond.rf_ip(out, [2], p0, t0)
 @test out[] ≈ 1  # signature is u,p,t
 
 
@@ -37,7 +77,31 @@ sol = solve(prob, Tsit5())
 
 
 prob = ODEProblem(sys2, Pair[], (0.0, 3.0))
-@test prob.kwargs[:callback] isa ModelingToolkit.DiffEqCallbacks.VectorContinuousCallback
+cbs = prob.kwargs[:callback]
+@test cbs isa ModelingToolkit.DiffEqCallbacks.CallbackSet
+
+cb = cbs.continuous_callbacks[1]
+cond = cb.condition
+out = [0.0]
+# the root to find is 2
+cond.rf_ip(out, [0], p0, t0)
+@test out[] ≈ -2 # signature is u,p,t
+cond.rf_ip(out, [1], p0, t0)
+@test out[] ≈ -1  # signature is u,p,t
+cond.rf_ip(out, [2], p0, t0) # this should return 0
+@test out[] ≈ 0  # signature is u,p,t
+
+# the root to find is 1
+cb = cbs.continuous_callbacks[2]
+cond = cb.condition
+out = [0.0]
+cond.rf_ip(out, [0], p0, t0)
+@test out[] ≈ -1 # signature is u,p,t
+cond.rf_ip(out, [1], p0, t0) # this should return 0
+@test out[] ≈ 0  # signature is u,p,t
+cond.rf_ip(out, [2], p0, t0)
+@test out[] ≈ 1  # signature is u,p,t
+
 sol = solve(prob, Tsit5())
 @test minimum(t->abs(t-1), sol.t) < 1e-10 # test that the solver stepped at the first root
 @test minimum(t->abs(t-2), sol.t) < 1e-10 # test that the solver stepped at the second root
@@ -48,3 +112,30 @@ prob = ODEProblem(sys, Pair[], (0.0, 3.0))
 sol = solve(prob, Tsit5())
 @test minimum(t->abs(t-1), sol.t) < 1e-10 # test that the solver stepped at the first root
 @test minimum(t->abs(t-2), sol.t) < 1e-10 # test that the solver stepped at the second root
+
+
+## Test affects
+secret_stash = []
+function affect(integ, _=0)
+    global secret_stash
+    println(integ.t)
+    push!(secret_stash, integ.t)
+end
+@named sys = ODESystem(eqs, root_eqs = [x ~ 1] => affect)
+@named sys2 = ODESystem([D(x) ~ 1], root_eqs = [x ~ 2] => affect, systems=[sys])
+
+
+# Functions should be generated for root-finding equations
+p0 = 0
+t0 = 0
+prob = ODEProblem(sys, Pair[], (0.0, 2.0))
+sol = solve(prob, Tsit5())
+@test minimum(t->abs(t-1), sol.t) < 1e-10 # test that the solver stepped at the root
+@test secret_stash[] ≈ 1 # test taht the affect was called
+empty!(secret_stash)
+
+
+prob = ODEProblem(sys2, Pair[], (0.0, 3.0))
+sol = solve(prob, Tsit5())
+@test secret_stash ≈ [1, 2]
+empty!(secret_stash)

--- a/test/root_equations.jl
+++ b/test/root_equations.jl
@@ -153,6 +153,14 @@ sol = solve(prob, Tsit5())
 @test minimum(t->abs(t-1), sol.t) < 1e-10 # test that the solver stepped at the root
 
 
+# Test that a user provided callback is respected
+test_callback = DiscreteCallback(x->x, x->x)
+prob = ODEProblem(sys, Pair[], (0.0, 2.0), callback = test_callback)
+cbs = get_callback(prob)
+@test cbs isa CallbackSet
+@test cbs.discrete_callbacks[1] == test_callback
+
+
 prob = ODEProblem(sys2, Pair[], (0.0, 3.0))
 cbs = get_callback(prob)
 @test cbs isa ModelingToolkit.DiffEqCallbacks.CallbackSet

--- a/test/root_equations.jl
+++ b/test/root_equations.jl
@@ -258,3 +258,30 @@ tv = sort([LinRange(0, 5, 200); sol.t])
 # plot(sol(tv)[y], sol(tv)[x], line_z=tv)
 # vline!([-1.5, 1.5], l=(:black, 5), primary=false)
 # hline!([0], l=(:black, 5), primary=false)
+
+
+## Test multi-variable affect
+# in this test, there are two variables affected by a single event.
+continuous_events = [
+    [x ~ 0] => [vx ~ -vx, vy ~ -vy]
+]
+
+@named ball = ODESystem([
+    D(x) ~ vx
+    D(y) ~ vy
+    D(vx) ~ -1
+    D(vy) ~ 0
+], t, continuous_events = continuous_events)
+
+ball = structural_simplify(ball)
+
+tspan = (0.0,5.0)
+prob = ODEProblem(ball, Pair[], tspan)
+sol = solve(prob,Tsit5())
+@test 0 <= minimum(sol[x]) <= 1e-10 # the ball never went through the floor but got very close
+@test -minimum(sol[y]) ≈ maximum(sol[y]) ≈ sqrt(2)  # the ball will never go further than √2 in either direction (gravity was changed to 1 to get this particular number)
+
+# tv = sort([LinRange(0, 5, 200); sol.t])
+# plot(sol(tv)[y], sol(tv)[x], line_z=tv)
+# vline!([-1.5, 1.5], l=(:black, 5), primary=false)
+# hline!([0], l=(:black, 5), primary=false)

--- a/test/root_equations.jl
+++ b/test/root_equations.jl
@@ -17,3 +17,22 @@ prob = ODEProblem(sys, Pair[], (0.0, 2.0))
 @test length(ModelingToolkit.root_eqs(sys2)) == 2
 @test isequal(ModelingToolkit.root_eqs(sys2)[1], x ~ 2)
 @test isequal(ModelingToolkit.root_eqs(sys2)[2], sys.x ~ 1)
+
+# Functions should be generated for root-finding equations
+cb = ModelingToolkit.generate_rootfinding_callback(sys)
+cond = cb.condition
+@test cond.rf([0], 1.2, 1.3) ≈ -1
+@test cond.rf([1], 1.2, 1.3) ≈ 0
+@test cond.rf([2], 1.2, 1.3) ≈ 1
+
+
+prob = ODEProblem(sys, Pair[], (0.0, 2.0))
+sol = solve(prob, Tsit5())
+@test minimum(t->abs(t-1), sol.t) < 1e-10 # test that the solver stepped at the root
+
+
+# TODO: the problem is that the ContinuousCallback only handles scalar conditions. NEed to adjust the condition function to always be multivariate and use VectorContinuousCallback
+prob = ODEProblem(sys2, Pair[], (0.0, 2.0))
+sol = solve(prob, Tsit5())
+@test minimum(t->abs(t-1), sol.t) < 1e-10 # test that the solver stepped at the first root
+@test minimum(t->abs(t-2), sol.t) < 1e-10 # test that the solver stepped at the second root

--- a/test/root_equations.jl
+++ b/test/root_equations.jl
@@ -162,30 +162,27 @@ cbs = get_callback(prob)
 
 
 prob = ODEProblem(sys2, Pair[], (0.0, 3.0))
-cbs = get_callback(prob)
-@test cbs isa ModelingToolkit.DiffEqCallbacks.CallbackSet
+cb = get_callback(prob)
+@test cb isa ModelingToolkit.DiffEqCallbacks.VectorContinuousCallback
 
-cb = cbs.continuous_callbacks[1]
 cond = cb.condition
-out = [0.0]
+out = [0.0, 0.0]
 # the root to find is 2
 cond.rf_ip(out, [0,0], p0, t0)
-@test out[] ≈ -2 # signature is u,p,t
+@test out[1] ≈ -2 # signature is u,p,t
 cond.rf_ip(out, [1,0], p0, t0)
-@test out[] ≈ -1  # signature is u,p,t
+@test out[1] ≈ -1  # signature is u,p,t
 cond.rf_ip(out, [2,0], p0, t0) # this should return 0
-@test out[] ≈ 0  # signature is u,p,t
+@test out[1] ≈ 0  # signature is u,p,t
 
 # the root to find is 1
-cb = cbs.continuous_callbacks[2]
-cond = cb.condition
-out = [0.0]
+out = [0.0, 0.0]
 cond.rf_ip(out, [0,0], p0, t0)
-@test out[] ≈ -1 # signature is u,p,t
+@test out[2] ≈ -1 # signature is u,p,t
 cond.rf_ip(out, [0,1], p0, t0) # this should return 0
-@test out[] ≈ 0  # signature is u,p,t
+@test out[2] ≈ 0  # signature is u,p,t
 cond.rf_ip(out, [0,2], p0, t0)
-@test out[] ≈ 1  # signature is u,p,t
+@test out[2] ≈ 1  # signature is u,p,t
 
 sol = solve(prob, Tsit5())
 @test minimum(t->abs(t-1), sol.t) < 1e-10 # test that the solver stepped at the first root
@@ -245,16 +242,14 @@ tspan = (0.0,5.0)
 prob = ODEProblem(ball, Pair[], tspan)
 
 
-cbs = get_callback(prob)
-@test cbs isa ModelingToolkit.DiffEqCallbacks.CallbackSet
+cb = get_callback(prob)
+@test cb isa ModelingToolkit.DiffEqCallbacks.VectorContinuousCallback
 @test getfield(ball, :continuous_events)[1] == SymbolicContinuousCallback(Equation[x ~ 0], Equation[vx ~ -vx])
 @test getfield(ball, :continuous_events)[2] == SymbolicContinuousCallback(Equation[y ~ -1.5, y ~ 1.5], Equation[vy ~ -vy])
-cb = cbs.continuous_callbacks[2]
-@test cb isa VectorContinuousCallback
 cond = cb.condition
-out = [0.0, 0.0]
+out = [0.0, 0.0, 0.0]
 cond.rf_ip(out, [0,0,0,0], p0, t0)
-@test out ≈ [1.5, -1.5] # signature is u,p,t
+@test out ≈ [0, 1.5, -1.5] 
 
 
 sol = solve(prob,Tsit5())
@@ -262,7 +257,7 @@ sol = solve(prob,Tsit5())
 @test minimum(sol[y]) ≈ -1.5 # check wall conditions
 @test maximum(sol[y]) ≈ 1.5  # check wall conditions
 
-tv = sort([LinRange(0, 5, 200); sol.t])
+# tv = sort([LinRange(0, 5, 200); sol.t])
 # plot(sol(tv)[y], sol(tv)[x], line_z=tv)
 # vline!([-1.5, 1.5], l=(:black, 5), primary=false)
 # hline!([0], l=(:black, 5), primary=false)

--- a/test/root_equations.jl
+++ b/test/root_equations.jl
@@ -19,6 +19,7 @@ prob = ODEProblem(sys, Pair[], (0.0, 2.0))
 @test isequal(ModelingToolkit.root_eqs(sys2)[2], sys.x ~ 1)
 
 # Functions should be generated for root-finding equations
+@test prob.kwargs[:callback] isa ModelingToolkit.DiffEqCallbacks.ContinuousCallback
 cb = ModelingToolkit.generate_rootfinding_callback(sys)
 cond = cb.condition
 @test cond.rf([0], 1.2, 1.3) ≈ -1
@@ -33,6 +34,7 @@ sol = solve(prob, Tsit5())
 
 # TODO: the problem is that the ContinuousCallback only handles scalar conditions. NEed to adjust the condition function to always be multivariate and use VectorContinuousCallback
 prob = ODEProblem(sys2, Pair[], (0.0, 2.0))
+@test prob.kwargs[:callback] isa ModelingToolkit.DiffEqCallbacks.VectorContinuousCallback
 sol = solve(prob, Tsit5())
 @test minimum(t->abs(t-1), sol.t) < 1e-10 # test that the solver stepped at the first root
 @test minimum(t->abs(t-2), sol.t) < 1e-10 # test that the solver stepped at the second root

--- a/test/root_equations.jl
+++ b/test/root_equations.jl
@@ -139,3 +139,26 @@ prob = ODEProblem(sys2, Pair[], (0.0, 3.0))
 sol = solve(prob, Tsit5())
 @test secret_stash ≈ [1, 2]
 empty!(secret_stash)
+
+
+
+## Test bouncing ball
+@variables t x(t)=1 v(t)=0
+D = Differential(t)
+
+function affect!(integrator)
+    integrator.u[2] = -integrator.u[2]
+end
+
+@named ball = ODESystem([
+    D(x) ~ v
+    D(v) ~ -9.8
+], t, root_eqs = [x ~ 0] => affect!)
+
+ball = structural_simplify(ball)
+
+tspan = (0.0,15.0)
+prob = ODEProblem(ball, Pair[], tspan)
+sol = solve(prob,Tsit5())
+@test all(sol[x] .>= 0)
+# plot(sol)

--- a/test/root_equations.jl
+++ b/test/root_equations.jl
@@ -1,5 +1,5 @@
 using ModelingToolkit, OrdinaryDiffEq, Test
-using ModelingToolkit: SymbolicContinuousCallback, SymbolicContinuousCallbacks, NULL_AFFECT
+using ModelingToolkit: SymbolicContinuousCallback, SymbolicContinuousCallbacks, NULL_AFFECT, get_callback
 
 @parameters t
 @variables x(t)=0 
@@ -136,7 +136,7 @@ fsys = flatten(sys)
 prob = ODEProblem(sys, Pair[], (0.0, 2.0))
 p0 = 0
 t0 = 0
-@test prob.kwargs[:callback] isa ModelingToolkit.DiffEqCallbacks.ContinuousCallback
+@test get_callback(prob) isa ModelingToolkit.DiffEqCallbacks.ContinuousCallback
 cb = ModelingToolkit.generate_rootfinding_callback(sys)
 cond = cb.condition
 out = [0.0]
@@ -154,7 +154,7 @@ sol = solve(prob, Tsit5())
 
 
 prob = ODEProblem(sys2, Pair[], (0.0, 3.0))
-cbs = prob.kwargs[:callback]
+cbs = get_callback(prob)
 @test cbs isa ModelingToolkit.DiffEqCallbacks.CallbackSet
 
 cb = cbs.continuous_callbacks[1]
@@ -185,7 +185,7 @@ sol = solve(prob, Tsit5())
 
 @named sys = ODESystem(eqs, continuous_events = [x ~ 1, x ~ 2]) # two root eqs using the same state
 prob = ODEProblem(sys, Pair[], (0.0, 3.0))
-@test prob.kwargs[:callback] isa ModelingToolkit.DiffEqCallbacks.VectorContinuousCallback
+@test get_callback(prob) isa ModelingToolkit.DiffEqCallbacks.VectorContinuousCallback
 sol = solve(prob, Tsit5())
 @test minimum(t->abs(t-1), sol.t) < 1e-10 # test that the solver stepped at the first root
 @test minimum(t->abs(t-2), sol.t) < 1e-10 # test that the solver stepped at the second root
@@ -237,7 +237,7 @@ tspan = (0.0,5.0)
 prob = ODEProblem(ball, Pair[], tspan)
 
 
-cbs = prob.kwargs[:callback]
+cbs = get_callback(prob)
 @test cbs isa ModelingToolkit.DiffEqCallbacks.CallbackSet
 @test getfield(ball, :continuous_events)[1] == SymbolicContinuousCallback(Equation[x ~ 0], Equation[vx ~ -vx])
 @test getfield(ball, :continuous_events)[2] == SymbolicContinuousCallback(Equation[y ~ -1.5, y ~ 1.5], Equation[vy ~ -vy])

--- a/test/root_equations.jl
+++ b/test/root_equations.jl
@@ -22,9 +22,13 @@ prob = ODEProblem(sys, Pair[], (0.0, 2.0))
 @test prob.kwargs[:callback] isa ModelingToolkit.DiffEqCallbacks.ContinuousCallback
 cb = ModelingToolkit.generate_rootfinding_callback(sys)
 cond = cb.condition
-@test cond.rf([0], 1.2, 1.3) ≈ -1
-@test cond.rf([1], 1.2, 1.3) ≈ 0
-@test cond.rf([2], 1.2, 1.3) ≈ 1
+out = [0.0]
+cond.rf_ip(out, [0], 1.2, 1)
+@test out[] ≈ -1 # signature is u,p,t
+cond.rf_ip(out, [1], 1.2, 1)
+@test out[] ≈ 0  # signature is u,p,t
+cond.rf_ip(out, [2], 1.2, 1)
+@test out[] ≈ 1  # signature is u,p,t
 
 
 prob = ODEProblem(sys, Pair[], (0.0, 2.0))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -39,3 +39,4 @@ println("Last test requires gcc available in the path!")
 @safetestset "print_tree" begin include("print_tree.jl") end
 @safetestset "connectors" begin include("connectors.jl") end
 @safetestset "error_handling" begin include("error_handling.jl") end
+@safetestset "root_equations" begin include("root_equations.jl") end


### PR DESCRIPTION
This PR adds a vector of equations to an `ODESystem` that can be used for root-finding when solving an `ODEProblem`.
The intended usage is to specify such equations when an ODESystem is created rather than when the `ODEProblem` is created, for example, when a component in a component library contains discountinous dynamics etc.

The provided tests pass locally, but there are a number of points I would like to get feedback on
1. The `root_eqs` field was added to `ODESystem` only, how should all other `AbstractSystems` be treated?
2. I wasn't able to use the inplace update for `VectorContinuousCallback` [here](https://github.com/SciML/ModelingToolkit.jl/compare/master...baggepinnen:rootfuns?expand=1#diff-7195a73d9d71f7a993fe71086614d700629ebc22306be7b602f60fbc054bcdb7R184), can the `RuntimeGeneratedFunction` somehow be generated in an inplace form as well?

Fixes https://github.com/SciML/ModelingToolkit.jl/issues/38