### PR TITLE
Don't overparametrize BipartiteGraph

### DIFF
--- a/src/bipartite_graph.jl
+++ b/src/bipartite_graph.jl
@@ -71,10 +71,10 @@ badjlist = [[1,2,5,6],[3,4,6]]
 bg = BipartiteGraph(7, fadjlist, badjlist)
 ```
 """
-mutable struct BipartiteGraph{I<:Integer,F<:Vector{Vector{I}},B<:Union{Vector{Vector{I}},I},M} <: Graphs.AbstractGraph{I}
+mutable struct BipartiteGraph{I<:Integer, M} <: LightGraphs.AbstractGraph{I}
     ne::Int
-    fadjlist::F # `fadjlist[src] => dsts`
-    badjlist::B # `badjlist[dst] => srcs` or `ndsts`
+    fadjlist::Vector{Vector{I}} # `fadjlist[src] => dsts`
+    badjlist::Union{Vector{Vector{I}},I} # `badjlist[dst] => srcs` or `ndsts`
     metadata::M
 end
 BipartiteGraph(ne::Integer, fadj::AbstractVector, badj::Union{AbstractVector,Integer}=maximum(maximum, fadj); metadata=nothing) = BipartiteGraph(ne, fadj, badj, metadata)

--- a/src/bipartite_graph.jl
+++ b/src/bipartite_graph.jl
@@ -71,7 +71,7 @@ badjlist = [[1,2,5,6],[3,4,6]]
 bg = BipartiteGraph(7, fadjlist, badjlist)
 ```
 """
-mutable struct BipartiteGraph{I<:Integer, M} <: LightGraphs.AbstractGraph{I}
+mutable struct BipartiteGraph{I<:Integer, M} <: Graphs.AbstractGraph{I}
     ne::Int
     fadjlist::Vector{Vector{I}} # `fadjlist[src] => dsts`
     badjlist::Union{Vector{Vector{I}},I} # `badjlist[dst] => srcs` or `ndsts`

--- a/src/systems/systemstructure.jl
+++ b/src/systems/systemstructure.jl
@@ -78,8 +78,8 @@ Base.@kwdef struct SystemStructure
     inv_varassoc::Vector{Int}
     varmask::BitVector # `true` if the variable has the highest order derivative
     algeqs::BitVector
-    graph::BipartiteGraph{Int,Vector{Vector{Int}},Int,Nothing}
-    solvable_graph::BipartiteGraph{Int,Vector{Vector{Int}},Int,Nothing}
+    graph::BipartiteGraph{Int,Nothing}
+    solvable_graph::BipartiteGraph{Int,Nothing}
     assign::Vector{Union{Int, Unassigned}}
     inv_assign::Vector{Int}
     scc::Vector{Vector{Int}}


### PR DESCRIPTION
Avoids a base julia type intersection issue: https://github.com/JuliaLang/julia/issues/43082.
The overparameterization is not particularly required - Julia is fast
at union splitting and this access is not particularly hot anyway.