### PR TITLE
BipartiteGraph: Clean up Graphs.jl integration

### DIFF
--- a/src/structural_transformation/bipartite_tearing/modia_tearing.jl
+++ b/src/structural_transformation/bipartite_tearing/modia_tearing.jl
@@ -35,6 +35,7 @@ function tearEquations!(ict::IncrementalCycleTracker, Gsolvable, es::Vector{Int}
             if G.matching[vj] === unassigned && (vj in vActive)
                 r = add_edge_checked!(ict, Iterators.filter(!=(vj), 𝑠neighbors(G.graph, eq)), vj) do G
                     G.matching[vj] = eq
+                    G.ne += length(𝑠neighbors(G.graph, eq)) - 1
                 end
                 r && break
             end

--- a/src/systems/alias_elimination.jl
+++ b/src/systems/alias_elimination.jl
@@ -127,6 +127,8 @@ struct AliasGraph <: AbstractDict{Int, Pair{Int, Int}}
     end
 end
 
+Base.length(ag::AliasGraph) = length(ag.eliminated)
+
 function Base.getindex(ag::AliasGraph, i::Integer)
     r = ag.aliasto[i]
     r === nothing && throw(KeyError(i))
@@ -281,7 +283,7 @@ function alias_eliminate_graph!(graph, varassoc, mm_orig::SparseMatrixCLIL)
 
     # Step 3: Reflect our update decitions back into the graph
     for (ei, e) in enumerate(mm.nzrows)
-        graph.fadjlist[e] = mm.row_cols[ei]
+        set_neighbors!(graph, e, mm.row_cols[ei])
     end
 
     return ag, mm

--- a/test/structural_transformation/utils.jl
+++ b/test/structural_transformation/utils.jl
@@ -27,9 +27,7 @@ sss = structure(sys)
 @test nv(solvable_graph) == 9 + 5
 @test varassoc == [0, 0, 0, 0, 1, 2, 3, 4, 0]
 
-se = collect(StructuralTransformations.𝑠edges(graph))
+se = collect(StructuralTransformations.edges(graph))
 @test se == mapreduce(vcat, enumerate(graph.fadjlist)) do (s, d)
     StructuralTransformations.BipartiteEdge.(s, d)
 end
-@test_throws ArgumentError collect(StructuralTransformations.𝑑edges(graph))
-@test_throws ArgumentError collect(StructuralTransformations.edges(graph))


### PR DESCRIPTION
Removes the `ALL` option for BipartiteGraph edges iteration.
This option makes little sense. The fadjlist and badjlist represent
the same edges just with two different index structures. It is up
to the BipartiteGraph to keep them internally consistent, but there's
no reason to allow iteration over both from outside - they should never
be inconsistent.

Also add a few more Graphs.jl integration to allow more interesting
graph algorithms to be run on our graph as we explore.