### PR TITLE
Drive by: Fix haystack/needle ordering

### DIFF
--- a/src/structural_transformation/symbolics_tearing.jl
+++ b/src/structural_transformation/symbolics_tearing.jl
@@ -29,7 +29,7 @@ function tearing_reassemble(sys; simplify=false)
             var = fullvars[iv]
             rhs = value(solve_for(eq, var; simplify=simplify, check=false))
             # if we don't simplify the rhs and the `eq` is not solved properly
-            (!simplify && occursin(rhs, var)) && (rhs = SymbolicUtils.polynormalize(rhs))
+            (!simplify && occursin(var, rhs)) && (rhs = SymbolicUtils.polynormalize(rhs))
             # Since we know `eq` is linear wrt `var`, so the round off must be a
             # linear term. We can correct the round off error by a linear
             # correction.


### PR DESCRIPTION
Just a drive by I noticed while working on larger changes. I'm guessing we don't have a fallback for this
since it only happens when solve_for fails, but regardless, I'm pretty sure the other order was meant.