### PR TITLE
Make sure that the alias candidate is an integer

### DIFF
--- a/src/systems/alias_elimination.jl
+++ b/src/systems/alias_elimination.jl
@@ -375,6 +375,8 @@ function locally_structure_simplify!(adj_row, pivot_col, ag, may_eliminate)
             d, r = divrem(alias_candidate[1], pivot_val)
             if r == 0 && (d == 1 || d == -1)
                 alias_candidate = -d => alias_candidate[2]
+            else
+                return false
             end
         end
         ag[pivot_col] = alias_candidate

--- a/src/systems/alias_elimination.jl
+++ b/src/systems/alias_elimination.jl
@@ -372,7 +372,10 @@ function locally_structure_simplify!(adj_row, pivot_col, ag, may_eliminate)
         # Note that when `nirreducible <= 1`, `alias_candidate` is uniquely
         # determined.
         if alias_candidate !== 0
-            alias_candidate = -exactdiv(alias_candidate[1], pivot_val) => alias_candidate[2]
+            d, r = divrem(alias_candidate[1], pivot_val)
+            if r == 0 && (d == 1 || d == -1)
+                alias_candidate = -d => alias_candidate[2]
+            end
         end
         ag[pivot_col] = alias_candidate
         zero!(adj_row)

--- a/test/nonlinearsystem.jl
+++ b/test/nonlinearsystem.jl
@@ -159,9 +159,21 @@ end
 
 # observed variable handling
 @variables t x(t) RHS(t)
-@parameters τ   
+@parameters τ
 @named fol = NonlinearSystem([0  ~ (1 - x)/τ], [x], [τ]; observed=[RHS ~ (1 - x)/τ])
 @test isequal(RHS, @nonamespace fol.RHS)
 RHS2 = RHS
 @unpack RHS = fol
 @test isequal(RHS, RHS2)
+
+# issue #1358
+@variables t
+@variables v1(t) v2(t) i1(t) i2(t)
+eq = [
+    v1 ~ sin(2pi*t)
+    v1 - v2 ~ i1
+    v2 ~ i2
+    i1 ~ i2
+]
+@named sys = ODESystem(eq)
+@test length(equations(structural_simplify(sys))) == 0


### PR DESCRIPTION
Note that even when the linear system of equations only consists of
integer coefficients, there may be fractions during backsubstation.

Fix #1358