### PR TITLE
WIP: Automatic sample rate  inference for DiscreteProblems

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -127,15 +127,19 @@ function check_variables(dvs, iv)
     end
 end
 
-"Get all the independent variables with respect to which differentials are taken."
-function collect_differentials(eqs)
+"Get all the independent variables with respect to which differentials are taken"
+function collect_ivs(eqs)
     vars = Set()
     ivs = Set()
     for eq in eqs
         vars!(vars, eq)
+        difference_vars!(vars, eq)
         for v in vars
-            isdifferential(v) || continue
-            collect_ivs_from_nested_differential!(ivs, v)
+            if isdifferential(v)
+                collect_ivs_from_nested_operator!(ivs, v, Differential)
+            elseif isdifference(v)
+                collect_ivs_from_nested_operator!(ivs, v, Difference)
+            end
         end
         empty!(vars)
     end
@@ -148,7 +152,7 @@ end
 Assert that equations are well-formed when building ODE, i.e., only containing a single independent variable.
 """
 function check_equations(eqs, iv)
-    ivs = collect_differentials(eqs)
+    ivs = collect_ivs(eqs)
     display = collect(ivs)
     length(ivs) <= 1 || throw(ArgumentError("Differential w.r.t. multiple variables $display are not allowed."))
     if length(ivs) == 1
@@ -156,18 +160,18 @@ function check_equations(eqs, iv)
         isequal(single_iv, iv) || throw(ArgumentError("Differential w.r.t. variable ($single_iv) other than the independent variable ($iv) are not allowed."))
     end
 end
-"Get all the independent variables with respect to which differentials are taken."
-function collect_ivs_from_nested_differential!(ivs, x::Term)
+"Get all the independent variables with respect to which differentials/differences are taken."
+function collect_ivs_from_nested_operator!(ivs, x::Term, target_op)
     op = operation(x)
-    if op isa Differential
-        push!(ivs, op.x)
-        collect_ivs_from_nested_differential!(ivs, arguments(x)[1])
+    if op isa target_op
+        push!(ivs, Symbolics.get_iv(op))
+        collect_ivs_from_nested_operator!(ivs, arguments(x)[1], target_op)
     end
 end
 
-iv_from_nested_derivative(x::Term) = operation(x) isa Differential ? iv_from_nested_derivative(arguments(x)[1]) : arguments(x)[1]
-iv_from_nested_derivative(x::Sym) = x
-iv_from_nested_derivative(x) = missing
+iv_from_nested_derivative(x::Term, op=Differential) = operation(x) isa op ? iv_from_nested_derivative(arguments(x)[1], op) : arguments(x)[1]
+iv_from_nested_derivative(x::Sym, op=Differential) = x
+iv_from_nested_derivative(x, op=Differential) = missing
 
 hasdefault(v) = hasmetadata(v, Symbolics.VariableDefaultValue)
 getdefault(v) = value(getmetadata(v, Symbolics.VariableDefaultValue))
@@ -246,9 +250,24 @@ function isvariable(x)
     hasmetadata(x, VariableSource)
 end
 
+"""
+    vars(x; op=Differential)
+Return a `Set` containing all variables in `x` that appear in
+- differential equations if `op = Differential`
+- difference equations if `op = Differential`
+
+Example:
+```
+@variables t u(t) y(t)
+D  = Differential(t)
+v  = ModelingToolkit.vars(D(y) ~ u)
+v == Set([D(y), u])
+```
+"""
 vars(x::Sym; op=Differential) = Set([x])
 vars(exprs::Symbolic; op=Differential) = vars([exprs]; op=op)
 vars(exprs; op=Differential) = foldl((x, y) -> vars!(x, y; op=op), exprs; init = Set())
+vars(eq::Equation; op=Differential) = vars!(Set(), eq; op=op)
 vars!(vars, eq::Equation; op=Differential) = (vars!(vars, eq.lhs; op=op); vars!(vars, eq.rhs; op=op); vars)
 function vars!(vars, O; op=Differential)
     if isvariable(O)
@@ -271,14 +290,13 @@ function vars!(vars, O; op=Differential)
 
     return vars
 end
-difference_vars(x::Sym) = vars(x; op=Difference)
-difference_vars(exprs::Symbolic) = vars(exprs; op=Difference)
-difference_vars(exprs) = vars(exprs; op=Difference)
-difference_vars!(vars, eq::Equation) = vars!(vars, eq; op=Difference)
+
+difference_vars(x) = vars(x; op=Difference)
 difference_vars!(vars, O) = vars!(vars, O; op=Difference)
 
-function collect_operator_variables(sys, isop::Function)
-    eqs = equations(sys)
+collect_operator_variables(sys::AbstractSystem, args...) = collect_operator_variables(equations(sys), args...)
+collect_operator_variables(eq::Equation, args...) = collect_operator_variables([eq], args...)
+function collect_operator_variables(eqs::AbstractVector{Equation}, isop::Function)
     vars = Set()
     diffvars = Set()
     for eq in eqs
@@ -293,6 +311,27 @@ function collect_operator_variables(sys, isop::Function)
 end
 collect_differential_variables(sys) = collect_operator_variables(sys, isdifferential)
 collect_difference_variables(sys) = collect_operator_variables(sys, isdifference)
+
+"""
+    collect_applied_operators(x, op)
+
+Return  a `Set` with all applied operators in `x`, example:
+```
+@variables t u(t) y(t)
+D = Differential(t)
+eq = D(y) ~ u
+ModelingToolkit.collect_applied_operators(eq, Differential) == Set([D(y)])
+```
+The difference compared to `collect_operator_variables` is that `collect_operator_variables` returns the variable without the operator applied.
+"""
+function collect_applied_operators(x, op)
+    v = vars(x, op=op)
+    filter(v) do x
+        x isa Sym && return false
+        x isa Term && return operation(x) isa op
+        false
+    end
+end
 
 find_derivatives!(vars, expr::Equation, f=identity) = (find_derivatives!(vars, expr.lhs, f); find_derivatives!(vars, expr.rhs, f); vars)
 function find_derivatives!(vars, expr, f)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -282,7 +282,7 @@ function collect_operator_variables(sys, isop::Function)
     vars = Set()
     diffvars = Set()
     for eq in eqs
-        vars!(vars, eq)
+        isop === isdifferential ? vars!(vars, eq) : difference_vars!(vars, eq)
         for v in vars
             isop(v) || continue
             push!(diffvars, arguments(v)[1])

--- a/test/discretesystem.jl
+++ b/test/discretesystem.jl
@@ -32,11 +32,13 @@ u0 = [S => 990.0, I => 10.0, R => 0.0]
 p = [β => 0.05, c => 10.0, γ => 0.25, δt => 0.1, nsteps => 400]
 tspan = (0.0,ModelingToolkit.value(substitute(nsteps,p))) # value function (from Symbolics) is used to convert a Num to Float64
 prob_map = DiscreteProblem(sys,u0,tspan,p)
+@test prob_map.kwargs[:dt] == D.dt
 
 # Solution
 using OrdinaryDiffEq
 sol_map = solve(prob_map,FunctionMap());
 @test sol_map[S] isa Vector
+@test sol_map.t ≈ tspan[1]:D.dt:tspan[end]
 
 # Using defaults constructor
 @parameters t c=10.0 nsteps=400 δt=0.1 β=0.05 γ=0.25

--- a/test/variable_utils.jl
+++ b/test/variable_utils.jl
@@ -16,16 +16,54 @@ new = (((1 / β - 1) + δ) / γ) ^ (1 / (γ - 1))
 @test iszero(sol - new)
 
 
+
+# Continuous
+using ModelingToolkit: isdifferential, isdifference, vars, difference_vars, collect_difference_variables, collect_differential_variables, collect_ivs
+@variables t u(t) y(t)
+D = Differential(t)
+eq = D(y) ~ u
+v = vars(eq)
+@test v == Set([D(y), u])
+
+ov = collect_differential_variables(eq)
+@test ov == Set(Any[y])
+
+aov = ModelingToolkit.collect_applied_operators(eq, Differential)
+@test aov == Set(Any[D(y)])
+
+ts = collect_ivs([eq])
+@test ts == Set([t])
+
+
+
+
+# Discrete
+z = Difference(t; dt=1, update=true)
+eq = z(y) ~ u
+v = difference_vars(eq)
+@test v == Set([z(y), u])
+
+ov = collect_difference_variables(eq)
+@test ov == Set(Any[y])
+
+aov = ModelingToolkit.collect_applied_operators(eq, Difference)
+@test aov == Set(Any[z(y)])
+
+
+ts = collect_ivs([eq])
+@test ts == Set([t])
+
+
 @variables t
 function UnitDelay(dt; name)
     @variables u(t)=0.0 [input=true] y(t)=0.0 [output=true]
-    Dₜ = Difference(t; dt=dt, update=true)
+    z = Difference(t; dt=dt, update=true)
     eqs = [
-        Dₜ(y) ~ u
+        z(y) ~ u
     ]
     DiscreteSystem(eqs, t, name=name)
 end
 
 dt = 0.1
 @named int = UnitDelay(dt)
-ModelingToolkit.collect_difference_variables(int) == Set(Any[@nonamespace(int.y)])
+collect_difference_variables(int) == Set(Any[@nonamespace(int.y)])

--- a/test/variable_utils.jl
+++ b/test/variable_utils.jl
@@ -14,3 +14,18 @@ expr = (((1 / β - 1) + δ) / α) ^ (1 / (α - 1))
 sol = ModelingToolkit.substitute(expr, s)
 new = (((1 / β - 1) + δ) / γ) ^ (1 / (γ - 1))
 @test iszero(sol - new)
+
+
+@variables t
+function UnitDelay(dt; name)
+    @variables u(t)=0.0 [input=true] y(t)=0.0 [output=true]
+    Dₜ = Difference(t; dt=dt, update=true)
+    eqs = [
+        Dₜ(y) ~ u
+    ]
+    DiscreteSystem(eqs, t, name=name)
+end
+
+dt = 0.1
+@named int = UnitDelay(dt)
+ModelingToolkit.collect_difference_variables(int) == Set(Any[@nonamespace(int.y)])


### PR DESCRIPTION
The PR builds on #1375 

Checks are added to the constructor for a `DiscreteProblem` to see that al difference operators in the system have the same time step. If not, an error is thrown. If they are all the same, this sample rate is provided to the `DiscreteProblem`.

Also adds tests that the simulation indeed does step at all the requested time steps.

To accomplish this
- some utilities for `Difference` operators are added and tested.
- An internal function was renamed from `collect_differentials` to `collect_ivs` 
- A function `collect_applied_operators` was added