### PR TITLE
Fix bug in bareiss algorithm

### DIFF
--- a/test/structural_transformation/tearing.jl
+++ b/test/structural_transformation/tearing.jl
@@ -139,6 +139,14 @@ eqs = [
        0 ~ x + z,
       ]
 @named nlsys = NonlinearSystem(eqs, [x, y, z], [])
+let (mm, _, _) = ModelingToolkit.aag_bareiss(nlsys)
+    @test mm == [
+        -1  1  0;
+         0 -1 -1;
+         0  0  0
+    ]
+end
+
 newsys = tearing(nlsys)
 @test length(equations(newsys)) == 1
 


### PR DESCRIPTION
We need to maintain the invariant that the rows of the sparse
matrix are sorted, otherwise the bareiss algorithm will be incorrect.
Without this, for appropriate choice of pivots, our bareiss
implementation turned

```
[1 1 0
 1 0 1
 0 1 1]
```

into

```
[1 1 0
 0 0 -1
 0 0 0]
```

rather than the correct

```
[1 1 0
 0 1 -1
 0 0 0]
```

Fix that and refactor a bit to make this testable.