### PR TITLE
WIP: introduce time-domain operators

### DIFF
--- a/src/ModelingToolkit.jl
+++ b/src/ModelingToolkit.jl
@@ -153,6 +153,9 @@ include("systems/alias_elimination.jl")
 include("structural_transformation/StructuralTransformations.jl")
 @reexport using .StructuralTransformations
 
+include("discretedomain.jl")
+include("timedomain.jl")
+
 for S in subtypes(ModelingToolkit.AbstractSystem)
     S = nameof(S)
     @eval convert_system(::Type{<:$S}, sys::$S) = sys
@@ -206,5 +209,10 @@ export build_function
 export modelingtoolkitize
 export @variables, @parameters
 export @named, @nonamespace, @namespace, extend, compose
+
+export Continuous, Discrete, sampletime, input_timedomain, output_timedomain
+export has_discrete_domain, has_continuous_domain, transitions_timedomain
+export is_discrete_domain, is_continuous_domain
+export Sample, Hold, Shift
 
 end # module

--- a/src/ModelingToolkit.jl
+++ b/src/ModelingToolkit.jl
@@ -211,8 +211,8 @@ export @variables, @parameters
 export @named, @nonamespace, @namespace, extend, compose
 
 export Continuous, Discrete, sampletime, input_timedomain, output_timedomain
-export has_discrete_domain, has_continuous_domain, transitions_timedomain
-export is_discrete_domain, is_continuous_domain
+export has_discrete_domain, has_continuous_domain
+export is_discrete_domain, is_continuous_domain, is_hybrid_domain
 export Sample, Hold, Shift
 
 end # module

--- a/src/discretedomain.jl
+++ b/src/discretedomain.jl
@@ -1,0 +1,169 @@
+using Symbolics: Operator, Num, Term, value
+
+# Shift
+
+"""
+$(TYPEDEF)
+
+Represents a shift operator.
+
+# Fields
+$(FIELDS)
+
+# Examples
+
+```jldoctest
+julia> using Symbolics
+
+julia> @variables t;
+
+julia> Δ = Shift(t; dt=0.01)
+(::Shift) (generic function with 2 methods)
+```
+"""
+struct Shift <: Operator
+    """Fixed Shift"""
+    t
+    dt
+    Shift(t; dt) = new(value(t), dt)
+end
+(D::Shift)(t) = Term{symtype(t)}(D, [t])
+(D::Shift)(t::Num) = Num(D(value(t)))
+SymbolicUtils.promote_symtype(::Shift, t) = t
+
+Base.show(io::IO, D::Shift) = print(io, "Shift(", D.t, "; dt=", D.dt, ")")
+
+Base.:(==)(D1::Shift, D2::Shift) = isequal(D1.t, D2.t) && isequal(D1.dt, D2.dt)
+Base.hash(D::Shift, u::UInt) = hash(D.dt, hash(D.t, xor(u, 0x055640d6d952f101)))
+
+Base.:^(D::Shift, n::Integer) = Symbolics._repeat_apply(D, n)
+
+hasshift(eq::Equation) = hasshift(eq.lhs) || hasshift(eq.rhs)
+
+
+"""
+    hasshift(O)
+
+Returns true if the expression or equation `O` contains [`Shift`](@ref) terms.
+"""
+function hasshift(O)
+    istree(O) || return false
+    if operation(O) isa Shift
+        return true
+    else
+        if O isa Union{Add, Mul}
+            any(hasshift, keys(O.dict))
+        elseif O isa Pow
+            hasshift(O.base) || hasshift(O.exp)
+        elseif O isa SymbolicUtils.Div
+            hasshift(O.num) || hasshift(O.den)
+        else
+            any(hasshift, arguments(O))
+        end
+    end
+end
+
+
+# Sample
+
+"""
+$(TYPEDEF)
+
+Represents a sample operator. A discrete-time signal is created by sampling a continuous-time signal.
+
+# Fields
+$(FIELDS)
+
+# Examples
+
+```jldoctest
+julia> using Symbolics
+
+julia> @variables t;
+
+julia> Δ = Sample(t; dt=0.01)
+(::Sample) (generic function with 2 methods)
+```
+"""
+struct Sample <: Operator
+    t
+    dt
+    Sample(t; dt) = new(value(t), dt)
+end
+(D::Sample)(t) = Term{symtype(t)}(D, [t])
+(D::Sample)(t::Num) = Num(D(value(t)))
+SymbolicUtils.promote_symtype(::Sample, t) = t
+
+Base.show(io::IO, D::Sample) = print(io, "Sample(", D.t, "; dt=", D.dt, ")")
+
+Base.:(==)(D1::Sample, D2::Sample) = isequal(D1.t, D2.t) && isequal(D1.dt, D2.dt)
+Base.hash(D::Sample, u::UInt) = hash(D.dt, hash(D.t, xor(u, 0x055640d6d952f101)))
+
+
+hassample(eq::Equation) = hassample(eq.lhs) || hassample(eq.rhs)
+hassample(h::Sample) = true
+
+"""
+    hassample(O)
+
+Returns true if the expression or equation `O` contains [`Sample`](@ref) terms.
+"""
+function hassample(O)
+    istree(O) || return false
+    if operation(O) isa Sample
+        return true
+    else
+        if O isa Union{Add, Mul}
+            any(hassample, keys(O.dict))
+        elseif O isa Pow
+            hassample(O.base) || hassample(O.exp)
+        elseif O isa SymbolicUtils.Div
+            hassample(O.num) || hassample(O.den)
+        else
+            any(hassample, arguments(O))
+        end
+    end
+end
+
+
+# Hold
+
+"""
+$(TYPEDEF)
+
+Represents a hold operator. A continuous-time signal is produced by holding a discrete-time signal `x` with zero-order hold.
+
+```
+cont_x = Hold()(disc_x)
+```
+"""
+struct Hold <: Operator
+end
+(D::Hold)(x) = Term{symtype(x)}(D, [x])
+(D::Hold)(x::Num) = Num(D(value(x)))
+SymbolicUtils.promote_symtype(::Hold, x) = x
+
+hashold(eq::Equation) = hashold(eq.lhs) || hashold(eq.rhs)
+hashold(h::Hold) = true
+
+"""
+    hashold(O)
+
+Returns true if the expression or equation `O` contains [`Hold`](@ref) terms.
+"""
+function hashold(O)
+    istree(O) || return false
+    if operation(O) isa Hold
+        return true
+    else
+        if O isa Union{Add, Mul}
+            any(hashold, keys(O.dict))
+        elseif O isa Pow
+            hashold(O.base) || hashold(O.exp)
+        elseif O isa SymbolicUtils.Div
+            hashold(O.num) || hashold(O.den)
+        else
+            any(hashold, arguments(O))
+        end
+    end
+end

--- a/src/timedomain.jl
+++ b/src/timedomain.jl
@@ -59,11 +59,11 @@ has_continuous_domain(x) = hasderiv(x) || hasdiff(x) || hassample(x) || hashold(
 
 
 """
-    transitions_timedomain(x)
+    is_hybrid_domain(x)
 
 true if `x` contains both discrete and continuous-domain signals. `x` may be an expression or equation.
 """
-transitions_timedomain(x) = has_discrete_domain(x) && has_continuous_domain(x)
+is_hybrid_domain(x) = has_discrete_domain(x) && has_continuous_domain(x)
 
 """
     is_discrete_domain(x)

--- a/src/timedomain.jl
+++ b/src/timedomain.jl
@@ -1,0 +1,82 @@
+using Symbolics: Differential, Difference
+using Symbolics: hasderiv, hasdiff
+
+abstract type TimeDomain end
+
+struct Continuous <: TimeDomain end
+struct Discrete <: TimeDomain end
+
+
+for op in [Differential, Difference]
+    @eval input_timedomain(::$op) = Continuous()
+    @eval output_timedomain(::$op) = Continuous()
+end
+
+
+"""
+    input_timedomain(op::Operator)
+
+Return the time-domain type (`Continuous()` or `Discrete()`) that `op` operates on. 
+"""
+input_timedomain(::Shift) = Discrete()
+
+"""
+    output_timedomain(op::Operator)
+
+Return the time-domain type (`Continuous()` or `Discrete()`) that `op` results in. 
+"""
+output_timedomain(::Shift) = Discrete()
+
+input_timedomain(::Sample) = Continuous()
+output_timedomain(::Sample) = Discrete()
+
+input_timedomain(::Hold) = Discrete()
+output_timedomain(::Hold) = Continuous()
+
+
+"""
+    sampletime(op::Operator)
+
+Return the sample time for operators that are clocked. Returns `nothing` if the operator does not have a sample time.
+"""
+sampletime(op::Operator) = hasfield(typeof(op), :dt) ? op.dt : nothing
+
+"""
+    has_discrete_domain(x)
+
+true if `x` contains discrete signals (`x` may or may not contain continuous-domain signals). `x` may be an expression or equation.
+See also [`is_discrete_domain`](@ref)
+"""
+has_discrete_domain(x) = hasshift(x) || hassample(x) || hashold(x)
+
+"""
+    has_continuous_domain(x)
+
+true if `x` contains continuous signals (`x` may or may not contain discrete-domain signals). `x` may be an expression or equation.
+See also [`is_continuous_domain`](@ref)
+"""
+has_continuous_domain(x) = hasderiv(x) || hasdiff(x) || hassample(x) || hashold(x)
+
+
+"""
+    transitions_timedomain(x)
+
+true if `x` contains both discrete and continuous-domain signals. `x` may be an expression or equation.
+"""
+transitions_timedomain(x) = has_discrete_domain(x) && has_continuous_domain(x)
+
+"""
+    is_discrete_domain(x)
+
+true if `x` contains only discrete-domain signals.
+See also [`has_discrete_domain`](@ref)
+"""
+is_discrete_domain(x) = has_discrete_domain(x) && !has_continuous_domain(x)
+
+"""
+    is_continuous_domain(x)
+
+true if `x` contains only continuous-domain signals.
+See also [`has_continuous_domain`](@ref)
+"""
+is_continuous_domain(x) = !has_discrete_domain(x) && has_continuous_domain(x)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -40,3 +40,5 @@ println("Last test requires gcc available in the path!")
 @safetestset "print_tree" begin include("print_tree.jl") end
 @safetestset "error_handling" begin include("error_handling.jl") end
 @safetestset "root_equations" begin include("root_equations.jl") end
+@safetestset "Discrete domain" begin include("test_discrete_domain.jl") end
+@safetestset "Time domain" begin include("test_timedomain.jl") end

--- a/test/test_discrete_domain.jl
+++ b/test/test_discrete_domain.jl
@@ -22,6 +22,10 @@ D2 = Shift(t; dt=0.01)
 @test hasshift((D1^2)(x) ~ x)
 @test hasshift(D1(x) ~ D2(x))
 
+@test D1.steps == 1
+@test (D1^2).steps == 2
+@test (D1^(-2)).steps == -2
+
 
 ## Sample
 

--- a/test/test_discrete_domain.jl
+++ b/test/test_discrete_domain.jl
@@ -1,0 +1,53 @@
+using ModelingToolkit
+using ModelingToolkit: hashold, hassample, hasshift
+
+@variables t x
+
+## Shift
+
+D1 = Shift(t; dt=0.01)
+D2 = Shift(t; dt=0.01)
+
+@test D1 == D2
+@test Base.isequal(D1, D2)
+@test Base.hash(D1) == Base.hash(D2)
+
+@test D1(x) isa Num
+
+@test isequal((D1^2)(x), D1(D1(x)))
+
+@test hasshift(D1(x) ~ x)
+@test hasshift(x ~ D1(x))
+@test !hasshift(t ~ x)
+@test hasshift((D1^2)(x) ~ x)
+@test hasshift(D1(x) ~ D2(x))
+
+
+## Sample
+
+D1 = Sample(t; dt=0.01)
+D2 = Sample(t; dt=0.01)
+
+@test D1 == D2
+@test Base.isequal(D1, D2)
+@test Base.hash(D1) == Base.hash(D2)
+
+@test D1(x) isa Num
+
+@test hassample(D1(x) ~ x)
+@test hassample(x ~ D1(x))
+@test !hassample(t ~ x)
+@test hassample(D1(x) ~ D2(x))
+
+
+## Hold
+
+D1 = Hold()
+
+@test D1(x) isa Num
+
+@test hashold(D1(x) ~ x)
+@test hashold(x ~ D1(x))
+@test !hashold(t ~ x)
+@test hashold(D1(x) ~ D2(x))
+

--- a/test/test_timedomain.jl
+++ b/test/test_timedomain.jl
@@ -20,8 +20,8 @@ op = Difference(t; dt=0.01)
 @test !has_discrete_domain(t ~ x)
 @test !has_discrete_domain((op^2)(x) ~ x)
 
-@test !transitions_timedomain(op(x) ~ x)
-@test !transitions_timedomain(x ~ op(x))
+@test !is_hybrid_domain(op(x) ~ x)
+@test !is_hybrid_domain(x ~ op(x))
 
 
 @test is_continuous_domain(op(x) ~ x)
@@ -43,8 +43,8 @@ op = Shift(t; dt=0.01)
 @test has_discrete_domain(x ~ op(x))
 @test !has_discrete_domain(t ~ x)
 
-@test !transitions_timedomain(op(x) ~ x)
-@test !transitions_timedomain(x ~ op(x))
+@test !is_hybrid_domain(op(x) ~ x)
+@test !is_hybrid_domain(x ~ op(x))
 
 @test !is_continuous_domain(op(x) ~ x)
 @test is_discrete_domain(op(x) ~ x)
@@ -61,8 +61,8 @@ op = Sample(t; dt=0.01)
 @test has_discrete_domain(op(x) ~ x)
 @test has_discrete_domain(x ~ op(x))
 
-@test transitions_timedomain(op(x) ~ x)
-@test transitions_timedomain(x ~ op(x))
+@test is_hybrid_domain(op(x) ~ x)
+@test is_hybrid_domain(x ~ op(x))
 
 @test !is_continuous_domain(op(x) ~ x)
 @test !is_discrete_domain(op(x) ~ x)
@@ -79,8 +79,8 @@ op = Hold()
 @test has_discrete_domain(op(x) ~ x)
 @test has_discrete_domain(x ~ op(x))
 
-@test transitions_timedomain(op(x) ~ x)
-@test transitions_timedomain(x ~ op(x))
+@test is_hybrid_domain(op(x) ~ x)
+@test is_hybrid_domain(x ~ op(x))
 
 @test !is_continuous_domain(op(x) ~ x)
 @test !is_discrete_domain(op(x) ~ x)

--- a/test/test_timedomain.jl
+++ b/test/test_timedomain.jl
@@ -1,0 +1,86 @@
+using Symbolics, ModelingToolkit
+using Symbolics: hasderiv, hasdiff
+using ModelingToolkit: hashold, hassample, hasshift
+using Test
+
+@variables t x
+
+
+op = Difference(t; dt=0.01)
+@test sampletime(op) == 0.01
+
+
+@test has_continuous_domain(op(x) ~ x)
+@test has_continuous_domain(x ~ op(x))
+@test !has_continuous_domain(t ~ x)
+@test has_continuous_domain((op^2)(x) ~ x)
+
+@test !has_discrete_domain(op(x) ~ x)
+@test !has_discrete_domain(x ~ op(x))
+@test !has_discrete_domain(t ~ x)
+@test !has_discrete_domain((op^2)(x) ~ x)
+
+@test !transitions_timedomain(op(x) ~ x)
+@test !transitions_timedomain(x ~ op(x))
+
+
+@test is_continuous_domain(op(x) ~ x)
+@test !is_discrete_domain(op(x) ~ x)
+
+
+
+## Shift
+
+op = Shift(t; dt=0.01)
+@test sampletime(op) == 0.01
+
+
+@test !has_continuous_domain(op(x) ~ x)
+@test !has_continuous_domain(x ~ op(x))
+@test !has_continuous_domain(t ~ x)
+
+@test has_discrete_domain(op(x) ~ x)
+@test has_discrete_domain(x ~ op(x))
+@test !has_discrete_domain(t ~ x)
+
+@test !transitions_timedomain(op(x) ~ x)
+@test !transitions_timedomain(x ~ op(x))
+
+@test !is_continuous_domain(op(x) ~ x)
+@test is_discrete_domain(op(x) ~ x)
+
+
+## Sample
+
+op = Sample(t; dt=0.01)
+@test sampletime(op) == 0.01
+
+@test has_continuous_domain(op(x) ~ x)
+@test has_continuous_domain(x ~ op(x))
+
+@test has_discrete_domain(op(x) ~ x)
+@test has_discrete_domain(x ~ op(x))
+
+@test transitions_timedomain(op(x) ~ x)
+@test transitions_timedomain(x ~ op(x))
+
+@test !is_continuous_domain(op(x) ~ x)
+@test !is_discrete_domain(op(x) ~ x)
+
+
+## Hold
+
+op = Hold()
+@test sampletime(op) === nothing
+
+@test has_continuous_domain(op(x) ~ x)
+@test has_continuous_domain(x ~ op(x))
+
+@test has_discrete_domain(op(x) ~ x)
+@test has_discrete_domain(x ~ op(x))
+
+@test transitions_timedomain(op(x) ~ x)
+@test transitions_timedomain(x ~ op(x))
+
+@test !is_continuous_domain(op(x) ~ x)
+@test !is_discrete_domain(op(x) ~ x)


### PR DESCRIPTION
This PR introduces the operators
`Sample, Hold, Shift`
as well as functions to query their presence in expressions and equations. 

For background, see discussion in
- https://github.com/SciML/ModelingToolkit.jl/issues/1307

The intention is for this to serve as a foundation to improve the semantics of hybrid systems, systems with both continuous and discrete-time signals, similar to the Modelica Synchronous/Clocked module.

The `Sample` and `Hold` operators define the interface between the continuous domain and the discrete domain, while `Shift` is the time-shift operator that fills the same role for discrete systems as `Differential` does for continuous systems.


This PR depends on
- https://github.com/JuliaSymbolics/Symbolics.jl/pull/454

And supersedes
- https://github.com/SciML/ModelingToolkit.jl/pull/1381

Future work:
- Classify signals (states) as either continuous or discrete. 
- Check that time domains only mix through the interface `Sample/Hold`. Implicit sample and hold may be implemented at a later stage if the sample time can be inferred unambiguously. 