### PR TITLE
remove call to nonexisting function `polynormalize`

### DIFF
--- a/src/structural_transformation/symbolics_tearing.jl
+++ b/src/structural_transformation/symbolics_tearing.jl
@@ -18,9 +18,6 @@ function tearing_reassemble(sys, var_eq_matching; simplify=false)
         if var in vars(rhs)
             # Usually we should be done here, but if we don't simplify we can get in
             # trouble, so try our best to still solve for rhs
-            if !simplify
-                rhs = SymbolicUtils.polynormalize(rhs)
-            end
 
             # Since we know `eq` is linear wrt `var`, so the round off must be a
             # linear term. We can correct the round off error by a linear


### PR DESCRIPTION
There appears to be no function `polynormalize` in the registered package ecosystem?
https://juliahub.com/ui/Search?q=polynormalize&type=symbols