### PR TITLE
Default allow_symbolic to true

### DIFF
--- a/src/structural_transformation/codegen.jl
+++ b/src/structural_transformation/codegen.jl
@@ -453,10 +453,10 @@ function build_observed_function(
         [],
         pre(Let(
             [
+             assignments[is_not_prepended_assignment]
              collect(Iterators.flatten(solves))
              map(eq -> eq.lhs←eq.rhs, obs[1:maxidx])
              subs
-             assignments[is_not_prepended_assignment]
             ],
             isscalar ? ts[1] : MakeArray(ts, output_type),
             false

--- a/src/structural_transformation/utils.jl
+++ b/src/structural_transformation/utils.jl
@@ -158,7 +158,7 @@ end
 ### Structural and symbolic utilities
 ###
 
-function find_eq_solvables!(state::TearingState, ieq; may_be_zero=false, allow_symbolic=false)
+function find_eq_solvables!(state::TearingState, ieq; may_be_zero=false, allow_symbolic=true)
     fullvars = state.fullvars
     @unpack graph, solvable_graph = state.structure
     eq = equations(state)[ieq]
@@ -191,7 +191,7 @@ function find_eq_solvables!(state::TearingState, ieq; may_be_zero=false, allow_s
     end
 end
 
-function find_solvables!(state::TearingState; allow_symbolic=false)
+function find_solvables!(state::TearingState; allow_symbolic=true)
     @assert state.structure.solvable_graph === nothing
     eqs = equations(state)
     graph = state.structure.graph


### PR DESCRIPTION
This allows more aggressive optimization.

```julia
julia> equations(m)
2-element Vector{Equation}:
 RHS(t) ~ (1 - x(t)) / τ
 Differential(t)(x(t)) ~ RHS(t)

julia> full_equations(structural_simplify(m))
1-element Vector{Equation}:
 Differential(t)(x(t)) ~ (1 - x(t)) / τ
```