### PR TITLE
eltype promotion in varmap_tp_vars

### DIFF
--- a/src/variables.jl
+++ b/src/variables.jl
@@ -72,20 +72,15 @@ function _varmap_to_vars(varmap::Dict, varlist; defaults=Dict(), check=false, to
     varmap = merge(defaults, varmap) # prefers the `varmap`
     varmap = Dict(toterm(value(k))=>value(varmap[k]) for k in keys(varmap))
     # resolve symbolic parameter expressions
-    example_val = nothing
     for (p, v) in pairs(varmap)
         val = varmap[p] = fixpoint_sub(v, varmap)
-        if example_val === nothing && unwrap(val) isa Number
-            example_val = val
-        end
     end
     vs = values(varmap)
     T′ = eltype(vs)
     if Base.isconcretetype(T′)
         T = T′
     else
-        example_val === nothing && throw_missingvars(varlist)
-        T = float(typeof(example_val))
+        T = foldl((t, elem)->promote_type(t, typeof(elem)), vs; init=typeof(first(vs)))
     end
     out = Vector{T}(undef, length(varlist))
     missingvars = setdiff(varlist, keys(varmap))

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -80,7 +80,7 @@ function _varmap_to_vars(varmap::Dict, varlist; defaults=Dict(), check=false, to
     if Base.isconcretetype(T′)
         T = T′
     else
-        T = foldl((t, elem)->promote_type(t, typeof(elem)), vs; init=typeof(first(vs)))
+        T = foldl((t, elem)->promote_type(t, eltype(elem)), vs; init=typeof(first(vs)))
     end
     out = Vector{T}(undef, length(varlist))
     missingvars = setdiff(varlist, keys(varmap))


### PR DESCRIPTION
The old approach took the first type it found (`example_val`), which is a brittle approach. This approach tries to promote all the element types to a common supertype. With this PR, one can simulate systems with uncertain coefficients etc., which previously failed if `example_val` by random happened to be `Float64` etc.

An alternative approach would perhaps be to allow the user to be explicit about the element type used in simulation. Currently, it's a bit inconvenient to simulating anything using, e.g., `Float32`, since all default values etc. would have to be provided in `Float32`.