### PR TITLE
fix flow over >2 connectors with arrays

### DIFF
--- a/test/stream_connectors.jl
+++ b/test/stream_connectors.jl
@@ -224,12 +224,15 @@ end
 
 @named vp1 = VecPin()
 @named vp2 = VecPin()
+@named vp3 = VecPin()
 
-@named simple = ODESystem([connect(vp1, vp2)], t)
-sys = expand_connections(compose(simple, [vp1, vp2]))
+@named simple = ODESystem([connect(vp1, vp2, vp3)], t)
+sys = expand_connections(compose(simple, [vp1, vp2, vp3]))
 @test equations(sys) == [
                          vp1.v[1] ~ vp2.v[1]
                          vp1.v[2] ~ vp2.v[2]
-                         0 ~ -vp1.i[1] - vp2.i[1]
-                         0 ~ -vp1.i[2] - vp2.i[2]
+                         vp1.v[1] ~ vp3.v[1]
+                         vp1.v[2] ~ vp3.v[2]
+                         0 ~ -vp1.i[1] - vp2.i[1] - vp3.i[1]
+                         0 ~ -vp1.i[2] - vp2.i[2] - vp3.i[2]
                         ]


### PR DESCRIPTION
This test would otherwise throw a DimensionMismatch error because the number of connectors and number of elements in the array got mixed up.

Specifically, if I modify the existing test with size 2 variables from 2 pins to 3 pins:

```julia
using ModelingToolkit

@variables t
@connector function VecPin(;name)
    sts = @variables v[1:2](t)=[1.0,0.0] i[1:2](t)=1.0 [connect = Flow]
    ODESystem(Equation[], t, [sts...;], []; name=name)
end

@named vp1 = VecPin()
@named vp2 = VecPin()
@named vp3 = VecPin()

@named simple = ODESystem([connect(vp1, vp2, vp3)], t)
sys = expand_connections(compose(simple, [vp1, vp2, vp3]))
```

I get
```
julia> sys = expand_connections(compose(simple, [vp1, vp2, vp3]))
ERROR: DimensionMismatch: dimensions must match: a has dims (Base.OneTo(3),), b has dims (Base.OneTo(2),), mismatch at 1
Stacktrace:
 [1] promote_shape
   @ .\indices.jl:178 [inlined]
 [2] promote_shape
   @ .\indices.jl:169 [inlined]
 [3] +(A::Vector{Int64}, Bs::Vector{Num})
   @ Base .\arraymath.jl:14
 [4] connect(c::Connection; check::Bool)
   @ ModelingToolkit C:\Users\visser_mn\.julia\packages\ModelingToolkit\Uaky4\src\systems\connectors.jl:122
 [5] connect
   @ C:\Users\visser_mn\.julia\packages\ModelingToolkit\Uaky4\src\systems\connectors.jl:87 [inlined]
 [6] expand_connections(sys::ODESystem; debug::Bool, tol::Float64)
   @ ModelingToolkit C:\Users\visser_mn\.julia\packages\ModelingToolkit\Uaky4\src\systems\connectors.jl:288
 [7] expand_connections(sys::ODESystem)
   @ ModelingToolkit C:\Users\visser_mn\.julia\packages\ModelingToolkit\Uaky4\src\systems\connectors.jl:195
 [8] top-level scope
   @ REPL[16]:1
```
On the current MTK release, julia 1.8-beta.

Since we can iterate over both scalars and arrays, we don't need separate code paths for those cases here. For consistency I also applied this on the Equality case, though I can remove it if desired.