### PR TITLE
Patch concrete init

### DIFF
--- a/src/systems/diffeqs/abstractodesystem.jl
+++ b/src/systems/diffeqs/abstractodesystem.jl
@@ -563,12 +563,12 @@ function process_DEProblem(constructor, sys::AbstractODESystem,u0map,parammap;
     defs = mergedefaults(defs,parammap,ps)
     defs = mergedefaults(defs,u0map,dvs)
     
-    u0 = promote_to_concrete(varmap_to_vars(u0map,dvs; defaults=defs))
+    u0 = varmap_to_vars(u0map,dvs; defaults=defs, promotetoconcrete=true)
     p = varmap_to_vars(parammap,ps; defaults=defs)
     if implicit_dae && du0map !== nothing
         ddvs = map(Differential(iv), dvs)
         defs = mergedefaults(defs,du0map, ddvs)
-        du0 = promote_to_concrete(varmap_to_vars(du0map,ddvs; defaults=defs, toterm=identity))
+        du0 = varmap_to_vars(du0map,ddvs; defaults=defs, toterm=identity, promotetoconcrete=true)
     else
         du0 = nothing
         ddvs = nothing

--- a/src/systems/diffeqs/abstractodesystem.jl
+++ b/src/systems/diffeqs/abstractodesystem.jl
@@ -563,12 +563,12 @@ function process_DEProblem(constructor, sys::AbstractODESystem,u0map,parammap;
     defs = mergedefaults(defs,parammap,ps)
     defs = mergedefaults(defs,u0map,dvs)
     
-    u0 = varmap_to_vars(u0map,dvs; defaults=defs)
+    u0 = promote_to_concrete(varmap_to_vars(u0map,dvs; defaults=defs))
     p = varmap_to_vars(parammap,ps; defaults=defs)
     if implicit_dae && du0map !== nothing
         ddvs = map(Differential(iv), dvs)
         defs = mergedefaults(defs,du0map, ddvs)
-        du0 = varmap_to_vars(du0map,ddvs; defaults=defs, toterm=identity)
+        du0 = promote_to_concrete(varmap_to_vars(du0map,ddvs; defaults=defs, toterm=identity))
     else
         du0 = nothing
         ddvs = nothing

--- a/src/systems/discrete_system/discrete_system.jl
+++ b/src/systems/discrete_system/discrete_system.jl
@@ -180,7 +180,7 @@ function DiffEqBase.DiscreteProblem(sys::DiscreteSystem,u0map,tspan,
     defs = mergedefaults(defs,parammap,ps)
     defs = mergedefaults(defs,u0map,dvs)
     
-    u0 = varmap_to_vars(u0map,dvs; defaults=defs)
+    u0 = promote_to_concrete(varmap_to_vars(u0map,dvs; defaults=defs))
     p = varmap_to_vars(parammap,ps; defaults=defs)
 
     rhss = [eq.rhs for eq in eqs]

--- a/src/systems/discrete_system/discrete_system.jl
+++ b/src/systems/discrete_system/discrete_system.jl
@@ -180,7 +180,7 @@ function DiffEqBase.DiscreteProblem(sys::DiscreteSystem,u0map,tspan,
     defs = mergedefaults(defs,parammap,ps)
     defs = mergedefaults(defs,u0map,dvs)
     
-    u0 = promote_to_concrete(varmap_to_vars(u0map,dvs; defaults=defs))
+    u0 = varmap_to_vars(u0map,dvs; defaults=defs, promotetoconcrete=true)
     p = varmap_to_vars(parammap,ps; defaults=defs)
 
     rhss = [eq.rhs for eq in eqs]

--- a/src/systems/jumps/jumpsystem.jl
+++ b/src/systems/jumps/jumpsystem.jl
@@ -228,7 +228,7 @@ function DiffEqBase.DiscreteProblem(sys::JumpSystem, u0map, tspan::Union{Tuple,N
     defs = mergedefaults(defs,parammap,ps)
     defs = mergedefaults(defs,u0map,dvs) 
     
-    u0 = varmap_to_vars(u0map,dvs; defaults=defs)
+    u0 = promote_to_concrete(varmap_to_vars(u0map,dvs; defaults=defs))
     p = varmap_to_vars(parammap,ps; defaults=defs)
         
     f  = DiffEqBase.DISCRETE_INPLACE_DEFAULT

--- a/src/systems/jumps/jumpsystem.jl
+++ b/src/systems/jumps/jumpsystem.jl
@@ -228,7 +228,7 @@ function DiffEqBase.DiscreteProblem(sys::JumpSystem, u0map, tspan::Union{Tuple,N
     defs = mergedefaults(defs,parammap,ps)
     defs = mergedefaults(defs,u0map,dvs) 
     
-    u0 = promote_to_concrete(varmap_to_vars(u0map,dvs; defaults=defs))
+    u0 = varmap_to_vars(u0map,dvs; defaults=defs, promotetoconcrete=true)
     p = varmap_to_vars(parammap,ps; defaults=defs)
         
     f  = DiffEqBase.DISCRETE_INPLACE_DEFAULT

--- a/src/systems/nonlinear/nonlinearsystem.jl
+++ b/src/systems/nonlinear/nonlinearsystem.jl
@@ -269,7 +269,7 @@ function process_NonlinearProblem(constructor, sys::NonlinearSystem,u0map,paramm
     defs = mergedefaults(defs,parammap,ps)
     defs = mergedefaults(defs,u0map,dvs)
     
-    u0 = promote_to_concrete(varmap_to_vars(u0map,dvs; defaults=defs))
+    u0 = varmap_to_vars(u0map,dvs; defaults=defs, promotetoconcrete=true)
     p = varmap_to_vars(parammap,ps; defaults=defs)
 
     check_eqs_u0(eqs, dvs, u0; kwargs...)

--- a/src/systems/nonlinear/nonlinearsystem.jl
+++ b/src/systems/nonlinear/nonlinearsystem.jl
@@ -269,7 +269,7 @@ function process_NonlinearProblem(constructor, sys::NonlinearSystem,u0map,paramm
     defs = mergedefaults(defs,parammap,ps)
     defs = mergedefaults(defs,u0map,dvs)
     
-    u0 = varmap_to_vars(u0map,dvs; defaults=defs)
+    u0 = promote_to_concrete(varmap_to_vars(u0map,dvs; defaults=defs))
     p = varmap_to_vars(parammap,ps; defaults=defs)
 
     check_eqs_u0(eqs, dvs, u0; kwargs...)

--- a/src/systems/optimization/optimizationsystem.jl
+++ b/src/systems/optimization/optimizationsystem.jl
@@ -239,7 +239,7 @@ function OptimizationProblemExpr{iip}(sys::OptimizationSystem, u0,
     defs = mergedefaults(defs,parammap,ps)
     defs = mergedefaults(defs,u0map,dvs)
 
-    u0 = varmap_to_vars(u0map,dvs; defaults=defs)
+    u0 = promote_to_concrete(varmap_to_vars(u0map,dvs; defaults=defs))
     p = varmap_to_vars(parammap,ps; defaults=defs)
     lb = varmap_to_vars(lb,dvs)
     ub = varmap_to_vars(ub,dvs)

--- a/src/systems/optimization/optimizationsystem.jl
+++ b/src/systems/optimization/optimizationsystem.jl
@@ -239,7 +239,7 @@ function OptimizationProblemExpr{iip}(sys::OptimizationSystem, u0,
     defs = mergedefaults(defs,parammap,ps)
     defs = mergedefaults(defs,u0map,dvs)
 
-    u0 = promote_to_concrete(varmap_to_vars(u0map,dvs; defaults=defs))
+    u0 = varmap_to_vars(u0map,dvs; defaults=defs, promotetoconcrete=true)
     p = varmap_to_vars(parammap,ps; defaults=defs)
     lb = varmap_to_vars(lb,dvs)
     ub = varmap_to_vars(ub,dvs)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -473,6 +473,7 @@ function mergedefaults(defaults, varmap, vars)
 end
 
 function promote_to_concrete(vs)
+    isemtpy(vs) && return vs
     T = eltype(vs)
     if Base.isconcretetype(T) # nothing to do
         vs

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -473,7 +473,9 @@ function mergedefaults(defaults, varmap, vars)
 end
 
 function promote_to_concrete(vs)
-    isemtpy(vs) && return vs
+    if isempty(vs) 
+        return vs
+    end
     T = eltype(vs)
     if Base.isconcretetype(T) # nothing to do
         vs

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -471,3 +471,12 @@ function mergedefaults(defaults, varmap, vars)
         defaults
     end
 end
+
+function promote_to_concrete(vs::Vector{T}) where {T}
+    if Base.isconcretetype(T) # nothing to do
+        vs
+    else
+        C = foldl((t, elem)->promote_type(t, eltype(elem)), vs; init=typeof(first(vs)))
+        convert(Vector{C}, vs)
+    end
+end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -472,11 +472,12 @@ function mergedefaults(defaults, varmap, vars)
     end
 end
 
-function promote_to_concrete(vs::Vector{T}) where {T}
+function promote_to_concrete(vs)
+    T = eltype(vs)
     if Base.isconcretetype(T) # nothing to do
         vs
     else
         C = foldl((t, elem)->promote_type(t, eltype(elem)), vs; init=typeof(first(vs)))
-        convert(Vector{C}, vs)
+        convert.(C, vs)
     end
 end

--- a/test/odesystem.jl
+++ b/test/odesystem.jl
@@ -631,10 +631,14 @@ let
     @test isapprox(sol[x[1]][end], 2, atol=1e-3)
 
     # no initial conditions for D(x[1]) and D(x[2]) provided
-    @test_throws ArgumentError prob = DAEProblem(sys, Pair[], Pair[], (0, 50))    
+    @test_throws ArgumentError prob = DAEProblem(sys, Pair[], Pair[], (0, 50))   
+    
+    prob = ODEProblem(sys, Pair[x[1] => 0], (0, 50))
+    sol = solve(prob, Rosenbrock23())
+    @test isapprox(sol[x[1]][end], 1, atol=1e-3)
 end
 
-#issue 1475 (mixed numeric type)
+#issue 1475 (mixed numeric type for parameters)
 let
     @parameters k1 k2
     @variables t, A(t)


### PR DESCRIPTION
Re-adds concrete type promotion for `u0`, otherwise solvers like `Rosenbrock23` throw an exception. This was present in `v8.5.2`. Parameters can have mixed types, though.