### PR TITLE
Add nullspace computation

### DIFF
--- a/src/systems/alias_elimination.jl
+++ b/src/systems/alias_elimination.jl
@@ -250,7 +250,7 @@ function aag_bareiss!(graph, var_to_diff, mm_orig::SparseMatrixCLIL)
             swaprows!(M, i, j)
         end
         bareiss_ops = ((M,i,j)->nothing, myswaprows!, bareiss_update_virtual_colswap_mtk!, bareiss_zero!)
-        rank3 = bareiss!(M, bareiss_ops; find_pivot=find_and_record_pivot)
+        rank3, = bareiss!(M, bareiss_ops; find_pivot=find_and_record_pivot)
         rank1 = something(rank1, rank3)
         rank2 = something(rank2, rank3)
         (rank1, rank2, rank3, pivots)

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -1,0 +1,17 @@
+using ModelingToolkit
+using Test
+
+A = [
+     0  1   1   2   2  1  1   2  1   2
+     0  1  -1  -3  -2  2  1  -5  0  -5
+     0  1   2   2   1  1  2   1  1   2
+     0  1   1   1   2  1  1   2  2   1
+     0  2   1   2   2  2  2   1  1   1
+     0  1   1   1   2  2  1   1  2   1
+     0  2   1   2   2  1  2   1  1   2
+     0  1   7  17  14  2  1  19  4  23
+     0  1  -1  -3  -2  1  1  -4  0  -5
+     0  1   1   2   2  1  1   2  2   2
+    ]
+N = ModelingToolkit.nullspace(A)
+@test iszero(A * N)

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -1,4 +1,5 @@
 using ModelingToolkit
+using LinearAlgebra
 using Test
 
 A = [
@@ -14,4 +15,6 @@ A = [
      0  1   1   2   2  1  1   2  2   2
     ]
 N = ModelingToolkit.nullspace(A)
+@test size(N, 2) == 3
+@test rank(N) == 3
 @test iszero(A * N)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 using SafeTestsets, Test
 
+@safetestset "Linear Algebra Test" begin include("linalg.jl") end
 @safetestset "AbstractSystem Test" begin include("abstractsystem.jl") end
 @safetestset "Variable scope tests" begin include("variable_scope.jl") end
 @safetestset "Symbolic parameters test" begin include("symbolic_parameters.jl") end


### PR DESCRIPTION
Closes #1551 

For the BCR model:
```julia
julia> M = netstoichmat(prnbng.rn); size(M)
(1122, 24388)

julia> aaM = matrix(AbstractAlgebra.Integers{Int}(), M');

julia> @time aaN = AbstractAlgebra.nullspace(aaM);
164.074442 seconds (17 allocations: 209.207 MiB, 0.01% gc time)

julia> @time mmN = ModelingToolkit.nullspace(M');
 45.533511 seconds (9 allocations: 208.843 MiB)

julia> iszero(M'aaN[2].entries)
true

julia> iszero(M'mmN)
true
```