### PR TITLE
Add the dummy derivative pass

### DIFF
--- a/docs/src/mtkitize_tutorials/modelingtoolkitize_index_reduction.md
+++ b/docs/src/mtkitize_tutorials/modelingtoolkitize_index_reduction.md
@@ -29,8 +29,8 @@ p = [9.8, 1]
 tspan = (0, 10.0)
 pendulum_prob = ODEProblem(pendulum_fun!, u0, tspan, p)
 traced_sys = modelingtoolkitize(pendulum_prob)
-pendulum_sys = structural_simplify(traced_sys)
-prob = ODAEProblem(pendulum_sys, Pair[], tspan)
+pendulum_sys = structural_simplify(dae_index_lowering(traced_sys))
+prob = ODAEProblem(pendulum_sys, [], tspan)
 sol = solve(prob, Tsit5(),abstol=1e-8,reltol=1e-8)
 plot(sol, vars=states(traced_sys))
 ```

--- a/src/ModelingToolkit.jl
+++ b/src/ModelingToolkit.jl
@@ -175,7 +175,7 @@ export ControlSystem
 export alias_elimination, flatten
 export connect, @connector, Connection, Flow, Stream, instream
 export isinput, isoutput, getbounds, hasbounds, isdisturbance, istunable, getdist, hasdist, tunable_parameters
-export ode_order_lowering, liouville_transform
+export ode_order_lowering, dae_order_lowering, liouville_transform
 export runge_kutta_discretize
 export PDESystem
 export Differential, expand_derivatives, @derivatives

--- a/src/bipartite_graph.jl
+++ b/src/bipartite_graph.jl
@@ -234,13 +234,13 @@ Base.in(edge::BipartiteEdge, g::BipartiteGraph) = Graphs.has_edge(g, edge)
 
 ### Maximal matching
 """
-    construct_augmenting_path!(m::Matching, g::BipartiteGraph, vsrc, dstfilter, vcolor=falses(ndsts(g)), ecolor=falses(nsrcs(g))) -> path_found::Bool
+    construct_augmenting_path!(m::Matching, g::BipartiteGraph, vsrc, dstfilter, vcolor=falses(ndsts(g)), ecolor=nothing) -> path_found::Bool
 
 Try to construct an augmenting path in matching and if such a path is found,
 update the matching accordingly.
 """
-function construct_augmenting_path!(matching::Matching, g::BipartiteGraph, vsrc, dstfilter, dcolor=falses(ndsts(g)), scolor=falses(nsrcs(g)))
-    scolor[vsrc] = true
+function construct_augmenting_path!(matching::Matching, g::BipartiteGraph, vsrc, dstfilter, dcolor=falses(ndsts(g)), scolor=nothing)
+    scolor === nothing || (scolor[vsrc] = true)
 
     # if a `vdst` is unassigned and the edge `vsrc <=> vdst` exists
     for vdst in 𝑠neighbors(g, vsrc)

--- a/src/inputoutput.jl
+++ b/src/inputoutput.jl
@@ -210,7 +210,7 @@ function generate_control_function(
     inputs = map(x->time_varying_as_func(value(x), sys), ctrls)
 
     eqs = [eq for eq in equations(sys) if !isdifferenceeq(eq)]
-    foreach(check_derivative_variables, eqs)
+    check_operator_variables(eqs, Differential)
     # substitute x(t) by just x
     rhss = implicit_dae ? [_iszero(eq.lhs) ? eq.rhs : eq.rhs - eq.lhs for eq in eqs] :
                         [eq.rhs for eq in eqs]
@@ -244,5 +244,5 @@ function toparam(sys, ctrls::AbstractVector)
     eqs = map(eqs) do eq
         substitute(eq.lhs, subs) ~ substitute(eq.rhs, subs)
     end
-    ODESystem(eqs, name=sys.name)
+    ODESystem(eqs, name=nameof(sys))
 end

--- a/src/structural_transformation/StructuralTransformations.jl
+++ b/src/structural_transformation/StructuralTransformations.jl
@@ -27,7 +27,7 @@ using ModelingToolkit.BipartiteGraphs
 import .BipartiteGraphs: invview
 using Graphs
 using ModelingToolkit.SystemStructures
-using ModelingToolkit.SystemStructures: algeqs
+using ModelingToolkit.SystemStructures: algeqs, EquationsView
 
 using ModelingToolkit.DiffEqBase
 using ModelingToolkit.StaticArrays
@@ -40,6 +40,7 @@ using SparseArrays
 using NonlinearSolve
 
 export tearing, partial_state_selection, dae_index_lowering, check_consistency
+export dummy_derivative
 export build_torn_function, build_observed_function, ODAEProblem
 export sorted_incidence_matrix, pantelides!, tearing_reassemble, find_solvables!
 export tearing_assignments, tearing_substitution

--- a/src/structural_transformation/bareiss.jl
+++ b/src/structural_transformation/bareiss.jl
@@ -222,7 +222,7 @@ function nullspace(A; col_order=nothing)
             @swap(col_order[i],col_order[cp])
         end
     end
-    
+
     N = ModelingToolkit.reduced_echelon_nullspace(rank, B)
     apply_inv_pivot_rows!(N, column_pivots)
 end

--- a/src/structural_transformation/bipartite_tearing/modia_tearing.jl
+++ b/src/structural_transformation/bipartite_tearing/modia_tearing.jl
@@ -1,17 +1,5 @@
-# This code is from the Modia project and is licensed as follows:
+# This code is derived from the Modia project and is licensed as follows:
 # https://github.com/ModiaSim/Modia.jl/blob/b61daad643ef7edd0c1ccce6bf462c6acfb4ad1a/LICENSE
-
-################################################
-#
-# Functions to tear systems of equations
-#
-# Author: Martin Otter, DLR-SR (first version: Jan. 14, 2017)
-#
-# Details are described in the paper:
-#   Otter, Elmqvist (2017): Transformation of Differential Algebraic Array Equations to
-#                           Index One Form. Modelica'2017 Conference.
-#
-################################################
 
 function try_assign_eq!(ict::IncrementalCycleTracker, vj::Integer, eq::Integer)
     G = ict.graph
@@ -21,19 +9,6 @@ function try_assign_eq!(ict::IncrementalCycleTracker, vj::Integer, eq::Integer)
     end
 end
 
-"""
-    (eSolved, vSolved, eResidue, vTear) = tearEquations!(td, Gsolvable, es, vs)
-
-Equations es shall be solved with respect to variables vs. The function returns
-the teared equation so that if vTear is given, vSolved can be computed from eSolved
-in a forward sequence (so solving eSolved[1] for vSolved[1], eSolved[2] for vSolved[2],
-and so on). vTear must be selected, so that the equations eResidues are fulfilled.
-Equations es are the union of eSolved and eResidue.
-Variables vs are the union of vSolved and vTear.
-
-Gsolvable defines the variables that can be explicitly solved in every equation without influencing the solution space
-(= rank preserving operation).
-"""
 function tearEquations!(ict::IncrementalCycleTracker, Gsolvable, es::Vector{Int}, vs::Vector{Int})
     G = ict.graph
     vActive = BitSet(vs)
@@ -59,13 +34,8 @@ function tear_graph_block_modia!(var_eq_matching, graph, solvable_graph, eqs, va
     return nothing
 end
 
-"""
-    tear_graph_modia(sys) -> sys
-
-Tear the bipartite graph in a system. End users are encouraged to call [`structural_simplify`](@ref)
-instead, which calls this function internally.
-"""
-function tear_graph_modia(graph::BipartiteGraph, solvable_graph::BipartiteGraph; varfilter=v->true, eqfilter=eq->true)
+function tear_graph_modia(structure::SystemStructure; varfilter=v->true, eqfilter=eq->true)
+    @unpack graph, solvable_graph = structure
     var_eq_matching = complete(maximal_matching(graph, eqfilter, varfilter))
     var_sccs::Vector{Union{Vector{Int}, Int}} = find_var_sccs(graph, var_eq_matching)
 

--- a/src/structural_transformation/codegen.jl
+++ b/src/structural_transformation/codegen.jl
@@ -524,8 +524,11 @@ function ODAEProblem{iip}(
                           parammap = DiffEqBase.NullParameters();
                           callback = nothing,
                           use_union = false,
+                          check = true,
                           kwargs...
                          ) where {iip}
+    eqs = equations(sys)
+    check && ModelingToolkit.check_operator_variables(eqs, Differential)
     fun, dvs = build_torn_function(sys; kwargs...)
     ps = parameters(sys)
     defs = defaults(sys)
@@ -535,7 +538,7 @@ function ODAEProblem{iip}(
     u0 = ModelingToolkit.varmap_to_vars(u0map, dvs; defaults=defs, tofloat=true)
     p = ModelingToolkit.varmap_to_vars(parammap, ps; defaults=defs, tofloat=!use_union, use_union)
 
-    has_difference = any(isdifferenceeq, equations(sys))
+    has_difference = any(isdifferenceeq, eqs)
     if has_continuous_events(sys)
         event_cb = generate_rootfinding_callback(sys; kwargs...)
     else

--- a/src/structural_transformation/partial_state_selection.jl
+++ b/src/structural_transformation/partial_state_selection.jl
@@ -143,11 +143,10 @@ end
 function dummy_derivative_graph!(state::TransformationState, jac=nothing)
     var_eq_matching = complete(pantelides!(state))
     complete!(state.structure)
-    # TODO: remove state when done
-    dummy_derivative_graph!(state.structure, var_eq_matching, jac, state)
+    dummy_derivative_graph!(state.structure, var_eq_matching, jac)
 end
 
-function dummy_derivative_graph!(structure::SystemStructure, var_eq_matching, jac, state)
+function dummy_derivative_graph!(structure::SystemStructure, var_eq_matching, jac)
     @unpack eq_to_diff, var_to_diff, graph = structure
     diff_to_eq = invview(eq_to_diff)
     diff_to_var = invview(var_to_diff)

--- a/src/structural_transformation/partial_state_selection.jl
+++ b/src/structural_transformation/partial_state_selection.jl
@@ -140,13 +140,14 @@ function partial_state_selection_graph!(structure::SystemStructure, var_eq_match
     var_eq_matching
 end
 
-function dummy_derivative_graph!(state::TransformationState)
+function dummy_derivative_graph!(state::TransformationState, jac=nothing)
     var_eq_matching = complete(pantelides!(state))
     complete!(state.structure)
-    dummy_derivative_graph!(state.structure, var_eq_matching)
+    # TODO: remove state when done
+    dummy_derivative_graph!(state.structure, var_eq_matching, jac, state)
 end
 
-function dummy_derivative_graph!(structure::SystemStructure, var_eq_matching)
+function dummy_derivative_graph!(structure::SystemStructure, var_eq_matching, jac, state)
     @unpack eq_to_diff, var_to_diff, graph = structure
     diff_to_eq = invview(eq_to_diff)
     diff_to_var = invview(var_to_diff)
@@ -182,6 +183,7 @@ function dummy_derivative_graph!(structure::SystemStructure, var_eq_matching)
     var_sccs = find_var_sccs(graph, var_eq_matching)
     eqcolor = falses(neqs)
     dummy_derivatives = Int[]
+    col_order = Int[]
     for vars in var_sccs
         eqs = [var_eq_matching[var] for var in vars if var_eq_matching[var] !== unassigned]
         isempty(eqs) && continue
@@ -195,18 +197,35 @@ function dummy_derivative_graph!(structure::SystemStructure, var_eq_matching)
             iszero(nrows) && break
             eqs_set = BitSet(eqs)
 
-            structural_rank = 0
-            for var in vars
-                pathfound = construct_augmenting_path!(rank_matching, invgraph, var, eq->eq in eqs_set, eqcolor)
-                pathfound || continue
-                push!(dummy_derivatives, var)
-                structural_rank += 1
-                structural_rank == nrows && break
+            # TODO: making the algorithm more robust
+            # 1. If the Jacobian is a integer matrix, use Bareiss to check
+            # linear independence. (done)
+            #
+            # 2. If the Jacobian is a single row, generate pivots. (Dynamic
+            # state selection.)
+            #
+            # 3. If the Jacobian is a polynomial matrix, use Gröbner basis (?)
+            if jac !== nothing && (_J = jac(eqs, vars); all(x->unwrap(x) isa Integer, _J))
+                J = Int.(unwrap.(_J))
+                N = ModelingToolkit.nullspace(J; col_order) # modifies col_order
+                rank = length(col_order)-size(N, 2)
+                for i in 1:rank
+                    push!(dummy_derivatives, vars[col_order[i]])
+                end
+            else
+                rank = 0
+                for var in vars
+                    pathfound = construct_augmenting_path!(rank_matching, invgraph, var, eq->eq in eqs_set, eqcolor)
+                    pathfound || continue
+                    push!(dummy_derivatives, var)
+                    rank += 1
+                    rank == nrows && break
+                end
+                fill!(rank_matching, unassigned)
             end
-            if structural_rank != nrows
+            if rank != nrows
                 @warn "The DAE system is structurally singular!"
             end
-            fill!(rank_matching, unassigned)
 
             # prepare the next iteration
             eqs = map(eq->diff_to_eq[eq], eqs)

--- a/src/structural_transformation/symbolics_tearing.jl
+++ b/src/structural_transformation/symbolics_tearing.jl
@@ -282,3 +282,15 @@ function partial_state_selection(sys; simplify=false)
 
     tearing_reassemble(state, var_eq_matching; simplify=simplify)
 end
+
+"""
+    dummy_derivative(sys)
+
+Perform index reduction and use the dummy derivative techinque to ensure that
+the system is balanced.
+"""
+function dummy_derivative(sys)
+    state = TearingState(sys)
+    dds = dummy_derivative_graph!(state)
+    EquationsView(state), state.fullvars[dds]
+end

--- a/src/structural_transformation/symbolics_tearing.jl
+++ b/src/structural_transformation/symbolics_tearing.jl
@@ -295,7 +295,6 @@ function dummy_derivative(sys, state=TearingState(sys))
         Symbolics.jacobian((x->x.rhs).(symeqs), state.fullvars[vars])
     end
     dds = dummy_derivative_graph!(state, jac)
-    length(dds) == length(state.extra_eqs) || error("Identified $(length(dds)) dummy derivatives, but Pantelides' algorithm generated $(length(state.extra_eqs)) more equations.")
     symdds = Symbolics.diff2term.(state.fullvars[dds])
     subs = Dict(state.fullvars[dd] => symdds[i] for (i, dd) in enumerate(dds))
     @set! sys.eqs = substitute.(EquationsView(state), (subs,))

--- a/src/structural_transformation/symbolics_tearing.jl
+++ b/src/structural_transformation/symbolics_tearing.jl
@@ -248,7 +248,7 @@ function tearing(state::TearingState; kwargs...)
     @unpack graph, solvable_graph = state.structure
     algvars = BitSet(findall(v->isalgvar(state.structure, v), 1:ndsts(graph)))
     aeqs = algeqs(state.structure)
-    var_eq_matching = Matching{Union{Unassigned, SelectedState}}(tear_graph_modia(graph, solvable_graph;
+    var_eq_matching = Matching{Union{Unassigned, SelectedState}}(tear_graph_modia(state.structure;
         varfilter=var->var in algvars, eqfilter=eq->eq in aeqs))
     for var in 1:ndsts(graph)
         if isdiffvar(state.structure, var)

--- a/src/structural_transformation/symbolics_tearing.jl
+++ b/src/structural_transformation/symbolics_tearing.jl
@@ -291,6 +291,10 @@ the system is balanced.
 """
 function dummy_derivative(sys)
     state = TearingState(sys)
-    dds = dummy_derivative_graph!(state)
+    function jac(eqs, vars)
+        symeqs = EquationsView(state)[eqs]
+        Symbolics.jacobian((x->x.rhs).(symeqs), state.fullvars[vars])
+    end
+    dds = dummy_derivative_graph!(state, jac)
     EquationsView(state), state.fullvars[dds]
 end

--- a/src/structural_transformation/symbolics_tearing.jl
+++ b/src/structural_transformation/symbolics_tearing.jl
@@ -296,5 +296,9 @@ function dummy_derivative(sys)
         Symbolics.jacobian((x->x.rhs).(symeqs), state.fullvars[vars])
     end
     dds = dummy_derivative_graph!(state, jac)
-    EquationsView(state), state.fullvars[dds]
+    length(dds) == length(state.extra_eqs) || error("Identified $(length(dds)) dummy derivatives, but Pantelides' algorithm generated $(length(state.extra_eqs)) more equations.")
+    symdds = Symbolics.diff2term.(state.fullvars[dds])
+    subs = Dict(state.fullvars[dd] => symdds[i] for (i, dd) in enumerate(dds))
+    @set! sys.eqs = substitute.(EquationsView(state), (subs,))
+    @set! sys.states = [states(sys); symdds]
 end

--- a/src/structural_transformation/symbolics_tearing.jl
+++ b/src/structural_transformation/symbolics_tearing.jl
@@ -289,8 +289,7 @@ end
 Perform index reduction and use the dummy derivative techinque to ensure that
 the system is balanced.
 """
-function dummy_derivative(sys)
-    state = TearingState(sys)
+function dummy_derivative(sys, state=TearingState(sys))
     function jac(eqs, vars)
         symeqs = EquationsView(state)[eqs]
         Symbolics.jacobian((x->x.rhs).(symeqs), state.fullvars[vars])

--- a/src/structural_transformation/utils.jl
+++ b/src/structural_transformation/utils.jl
@@ -109,20 +109,20 @@ function find_var_sccs(g::BipartiteGraph, assign=nothing)
     return sccs
 end
 
-function sorted_incidence_matrix(sys, val=true; only_algeqs=false, only_algvars=false)
-    var_eq_matching, var_scc = algebraic_variables_scc(sys)
-    s = structure(sys)
-    @unpack fullvars, graph = s
-    g = graph
+function sorted_incidence_matrix(ts::TransformationState, val=true; only_algeqs=false, only_algvars=false)
+    var_eq_matching, var_scc = algebraic_variables_scc(ts)
+    fullvars = ts.fullvars
+    s = ts.structure
+    graph = ts.structure.graph
     varsmap = zeros(Int, ndsts(graph))
     eqsmap = zeros(Int, nsrcs(graph))
     varidx = 0
     eqidx = 0
-    for vs in scc, v in vs
+    for vs in var_scc, v in vs
         eq = var_eq_matching[v]
         if eq !== unassigned
             eqsmap[eq] = (eqidx += 1)
-            varsmap[var] = (varidx += 1)
+            varsmap[v] = (varidx += 1)
         end
     end
     for i in diffvars_range(s)
@@ -139,9 +139,10 @@ function sorted_incidence_matrix(sys, val=true; only_algeqs=false, only_algvars=
 
     I = Int[]
     J = Int[]
-    for eq in 𝑠vertices(g)
-        only_algeqs && (isalgeq(s, eq) || continue)
-        for var in 𝑠neighbors(g, eq)
+    algeqs_set = algeqs(s)
+    for eq in 𝑠vertices(graph)
+        only_algeqs && (eq in algeqs_set || continue)
+        for var in 𝑠neighbors(graph, eq)
             only_algvars && (isalgvar(s, var) || continue)
             i = eqsmap[eq]
             j = varsmap[var]

--- a/src/systems/abstractsystem.jl
+++ b/src/systems/abstractsystem.jl
@@ -737,7 +737,7 @@ function n_extra_equations(sys::AbstractSystem)
     nextras = n_outer_stream_variables + length(ceqs)
 end
 
-function Base.show(io::IO, ::MIME"text/plain", sys::AbstractSystem)
+function Base.show(io::IO, mime::MIME"text/plain", sys::AbstractSystem)
     eqs = equations(sys)
     vars = states(sys); nvars = length(vars)
     if eqs isa AbstractArray
@@ -806,7 +806,7 @@ function Base.show(io::IO, ::MIME"text/plain", sys::AbstractSystem)
         state = get_tearing_state(sys)
         if state !== nothing
             Base.printstyled(io, "\nIncidence matrix:"; color=:magenta)
-            show(io, incidence_matrix(state.structure.graph, Num(Sym{Real}(:×))))
+            show(io, mime, incidence_matrix(state.structure.graph, Num(Sym{Real}(:×))))
         end
     end
     return nothing

--- a/src/systems/abstractsystem.jl
+++ b/src/systems/abstractsystem.jl
@@ -973,7 +973,7 @@ function structural_simplify(sys::AbstractSystem; simplify=false, kwargs...)
     state = TearingState(sys)
     check_consistency(state)
     if sys isa ODESystem
-        sys = dae_index_lowering(ode_order_lowering(sys))
+        sys = dae_order_lowering(dummy_derivative(sys, state))
     end
     state = TearingState(sys)
     find_solvables!(state; kwargs...)

--- a/src/systems/alias_elimination.jl
+++ b/src/systems/alias_elimination.jl
@@ -287,9 +287,12 @@ function alias_eliminate_graph!(graph, var_to_diff, mm_orig::SparseMatrixCLIL)
     diff_to_var = invview(var_to_diff)
     function lss!(ei::Integer)
         vi = pivots[ei]
-        # the differentiated variable cannot be eliminated
-        islowest = isnothing(diff_to_var[vi]) && isnothing(var_to_diff[vi])
-        locally_structure_simplify!((@view mm[ei, :]), vi, ag, islowest)
+        may_eliminate = true
+        for v in 𝑠neighbors(graph, mm.nzrows[ei])
+            # the differentiated variable cannot be eliminated
+            may_eliminate &= isnothing(diff_to_var[v]) && isnothing(var_to_diff[v])
+        end
+        locally_structure_simplify!((@view mm[ei, :]), vi, ag, may_eliminate)
     end
 
     # Step 2.1: Go backwards, collecting eliminated variables and substituting

--- a/src/systems/diffeqs/abstractodesystem.jl
+++ b/src/systems/diffeqs/abstractodesystem.jl
@@ -106,7 +106,9 @@ function generate_function(
     )
 
     eqs = [eq for eq in equations(sys) if !isdifferenceeq(eq)]
-    foreach(check_derivative_variables, eqs)
+    if !implicit_dae
+        foreach(check_derivative_variables, eqs)
+    end
     check_lhs(eqs, Differential, Set(dvs))
     # substitute x(t) by just x
     rhss = implicit_dae ? [_iszero(eq.lhs) ? eq.rhs : eq.rhs - eq.lhs for eq in eqs] :

--- a/src/systems/diffeqs/abstractodesystem.jl
+++ b/src/systems/diffeqs/abstractodesystem.jl
@@ -95,8 +95,6 @@ function generate_dae_jacobian(sys::AbstractODESystem, dvs = states(sys), ps = p
 
 end
 
-check_derivative_variables(eq) = check_operator_variables(eq, Differential)
-
 function generate_function(
         sys::AbstractODESystem, dvs = states(sys), ps = parameters(sys);
         implicit_dae=false,
@@ -107,7 +105,7 @@ function generate_function(
 
     eqs = [eq for eq in equations(sys) if !isdifferenceeq(eq)]
     if !implicit_dae
-        foreach(check_derivative_variables, eqs)
+        check_operator_variables(eqs, Differential)
     end
     check_lhs(eqs, Differential, Set(dvs))
     # substitute x(t) by just x
@@ -130,7 +128,7 @@ end
 
 function generate_difference_cb(sys::ODESystem, dvs = states(sys), ps = parameters(sys); kwargs...)
     eqs = equations(sys)
-    foreach(check_difference_variables, eqs)
+    check_operator_variables(eqs, Difference)
 
     var2eq = Dict(arguments(eq.lhs)[1] => eq for eq in eqs if isdifference(eq.lhs))
 

--- a/src/systems/diffeqs/abstractodesystem.jl
+++ b/src/systems/diffeqs/abstractodesystem.jl
@@ -106,8 +106,8 @@ function generate_function(
     eqs = [eq for eq in equations(sys) if !isdifferenceeq(eq)]
     if !implicit_dae
         check_operator_variables(eqs, Differential)
+        check_lhs(eqs, Differential, Set(dvs))
     end
-    check_lhs(eqs, Differential, Set(dvs))
     # substitute x(t) by just x
     rhss = implicit_dae ? [_iszero(eq.lhs) ? eq.rhs : eq.rhs - eq.lhs for eq in eqs] :
                           [eq.rhs for eq in eqs]

--- a/src/systems/discrete_system/discrete_system.jl
+++ b/src/systems/discrete_system/discrete_system.jl
@@ -243,14 +243,12 @@ function get_delay_val(iv, x)
     return -delay
 end
 
-check_difference_variables(eq) = check_operator_variables(eq, Difference)
-
 function generate_function(
         sys::DiscreteSystem, dvs = states(sys), ps = parameters(sys);
         kwargs...
     )
     eqs = equations(sys)
-    foreach(check_difference_variables, eqs)
+    check_operator_variables(eqs, Difference)
     rhss = [eq.rhs for eq in eqs]
 
     u = map(x->time_varying_as_func(value(x), sys), dvs)

--- a/src/systems/nonlinear/nonlinearsystem.jl
+++ b/src/systems/nonlinear/nonlinearsystem.jl
@@ -257,7 +257,7 @@ function NonlinearFunctionExpr{iip}(sys::NonlinearSystem, dvs = states(sys),
         _jac = :nothing
     end
 
-    jp_expr = sparse ? :(similar($(sys.jac[]),Float64)) : :nothing
+    jp_expr = sparse ? :(similar($(get_jac(sys)[]),Float64)) : :nothing
 
     ex = quote
         f = $f

--- a/src/systems/systemstructure.jl
+++ b/src/systems/systemstructure.jl
@@ -233,8 +233,9 @@ function TearingState(sys; quick_cancel=false, check=true)
         isalgeq = true
         statevars = []
         for var in vars
-            any(isequal(var), ivs) && continue
-            if isparameter(var) || (istree(var) && isparameter(operation(var)))
+            _var, _ = var_from_nested_derivative(var)
+            any(isequal(_var), ivs) && continue
+            if isparameter(_var) || (istree(_var) && isparameter(operation(_var)))
                 continue
             end
             varidx = addvar!(var)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -233,12 +233,39 @@ end
 end
 
 "Check if difference/derivative operation occurs in the R.H.S. of an equation"
-function check_operator_variables(eq, op::Type, expr=eq.rhs)
+function _check_operator_variables(eq, op::T, expr=eq.rhs) where T
     istree(expr) || return nothing
     if operation(expr) isa op
         throw_invalid_operator(expr, eq, op)
     end
-    foreach(expr -> check_operator_variables(eq, op, expr), SymbolicUtils.unsorted_arguments(expr))
+    foreach(expr -> _check_operator_variables(eq, op, expr), SymbolicUtils.unsorted_arguments(expr))
+end
+"Check if all the LHS are unique"
+function check_operator_variables(eqs, op::T) where T
+    ops = Set()
+    tmp = Set()
+    for eq in eqs
+        _check_operator_variables(eq, op)
+        vars!(tmp, eq.lhs)
+        if length(tmp) == 1
+            x = only(tmp)
+            if op === Differential
+                # Having a differece is fine for ODEs
+                is_tmp_fine = isdifferential(x) || isdifference(x)
+            else
+                is_tmp_fine = istree(x) && !(operation(x) isa op)
+            end
+        else
+            nd = count(x->istree(x) && !(operation(x) isa op), tmp)
+            is_tmp_fine = iszero(nd)
+        end
+        empty!(tmp)
+        is_tmp_fine || error("The LHS cannot contain nondifferentiated variables. Please run `structural_simplify` or use the DAE form.\nGot $eq")
+        for v in tmp
+            v in ops && error("The LHS operator must be unique. Please run `structural_simplify` or use the DAE form. $v appears in LHS more than once.")
+            push!(ops, v)
+        end
+    end
 end
 
 isoperator(expr, op) = istree(expr) && operation(expr) isa op

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -228,7 +228,7 @@ end
         optext="derivative"
     end
     msg = "The $optext variable must be isolated to the left-hand " *
-    "side of the equation like `$opvar ~ ...`.\n Got $eq."
+    "side of the equation like `$opvar ~ ...`. You may want to use `structural_simplify` or the DAE form.\nGot $eq."
     throw(InvalidSystemException(msg))
 end
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -259,12 +259,12 @@ function check_operator_variables(eqs, op::T) where T
             nd = count(x->istree(x) && !(operation(x) isa op), tmp)
             is_tmp_fine = iszero(nd)
         end
-        empty!(tmp)
         is_tmp_fine || error("The LHS cannot contain nondifferentiated variables. Please run `structural_simplify` or use the DAE form.\nGot $eq")
         for v in tmp
             v in ops && error("The LHS operator must be unique. Please run `structural_simplify` or use the DAE form. $v appears in LHS more than once.")
             push!(ops, v)
         end
+        empty!(tmp)
     end
 end
 

--- a/test/components.jl
+++ b/test/components.jl
@@ -130,11 +130,10 @@ u0 = [
       inductor2.i => 0.0
       inductor2.v => 0.0
      ]
-prob = ODEProblem(sys, u0, (0, 10.0))
-sol = solve(prob, Rodas4())
-
-prob = ODAEProblem(sys, u0, (0, 10.0))
-sol = solve(prob, Tsit5())
+@test_throws Any ODEProblem(sys, u0, (0, 10.0))
+@test_throws Any ODAEProblem(sys, u0, (0, 10.0))
+prob = DAEProblem(sys, Differential(t).(states(sys)) .=> 0, u0, (0, 0.5))
+@test_nowarn sol = solve(prob, DFBDF())
 
 @variables t x1(t) x2(t) x3(t) x4(t)
 D = Differential(t)

--- a/test/state_selection.jl
+++ b/test/state_selection.jl
@@ -12,6 +12,17 @@ eqs = [
 ]
 @named sys = ODESystem(eqs, t)
 
+let dd = dummy_derivative(sys)
+    has_dx1 = has_dx2 = false
+    for eq in equations(dd)
+        vars = ModelingToolkit.vars(eq)
+        has_dx1 |= D(x1) in vars || D(D(x1)) in vars
+        has_dx2 |= D(x2) in vars || D(D(x2)) in vars
+    end
+    @test has_dx1 ⊻ has_dx2 # only one of x1 and x2 can be a dummy derivative
+    @test length(states(dd)) == length(equations(dd)) == 10
+end
+
 let pss = partial_state_selection(sys)
     @test length(equations(pss)) == 1
     @test length(states(pss)) == 2

--- a/test/state_selection.jl
+++ b/test/state_selection.jl
@@ -1,4 +1,4 @@
-using ModelingToolkit, OrdinaryDiffEq
+using ModelingToolkit, OrdinaryDiffEq, Test
 
 @variables t
 sts = @variables x1(t) x2(t) x3(t) x4(t)
@@ -21,7 +21,7 @@ let dd = dummy_derivative(sys)
     end
     @test has_dx1 ⊻ has_dx2 # only one of x1 and x2 can be a dummy derivative
     @test length(states(dd)) == length(equations(dd)) == 9
-    @test length(states(structural_simplify(dd))) <= 6
+    @test length(states(structural_simplify(dd))) < 9
 end
 
 let pss = partial_state_selection(sys)

--- a/test/state_selection.jl
+++ b/test/state_selection.jl
@@ -1,4 +1,4 @@
-using ModelingToolkit
+using ModelingToolkit, OrdinaryDiffEq
 
 @variables t
 sts = @variables x1(t) x2(t) x3(t) x4(t)
@@ -47,4 +47,167 @@ let al1 = alias_elimination(lorenz1)
     let lss = partial_state_selection(al1)
         @test length(equations(lss)) == 2
     end
+end
+
+# 1516
+let
+    @variables t
+    D = Differential(t)
+
+    @connector function Fluid_port(;name, p=101325.0, m=0.0, T=293.15)
+        sts = @variables p(t)=p m(t)=m [connect=Flow] T(t)=T [connect=Stream]
+        ODESystem(Equation[], t, sts, []; name=name)
+    end
+
+    #this one is for latter
+    @connector function Heat_port(;name, Q=0.0, T=293.15)
+        sts = @variables T(t)=T Q(t)=Q [connect=Flow]
+        ODESystem(Equation[], t, sts, []; name=name)
+    end
+
+    # like ground but for fluid systems (fluid_port.m is expected to be zero in closed loop)
+    function Compensator(;name, p=101325.0, T_back=273.15)
+        @named fluid_port = Fluid_port()
+        ps = @parameters p=p T_back=T_back
+        eqs = [
+               fluid_port.p ~ p
+               fluid_port.T ~ T_back
+              ]
+        compose(ODESystem(eqs, t, [], ps; name=name), fluid_port)
+    end
+
+    function Source(;name, delta_p=100, T_feed=293.15)
+        @named supply_port = Fluid_port() # expected to feed connected pipe -> m<0
+        @named return_port = Fluid_port() # expected to receive from connected pipe -> m>0
+        ps = @parameters delta_p=delta_p T_feed=T_feed
+        eqs = [
+               supply_port.m ~ -return_port.m
+               supply_port.p ~ return_port.p + delta_p
+               supply_port.T ~ instream(supply_port.T)
+               return_port.T ~ T_feed
+              ]
+        compose(ODESystem(eqs, t, [], ps; name=name), [supply_port, return_port])
+    end
+
+    function Substation(;name, T_return=343.15)
+        @named supply_port = Fluid_port() # expected to receive from connected pipe -> m>0
+        @named return_port = Fluid_port() # expected to feed connected pipe -> m<0
+        ps = @parameters T_return=T_return
+        eqs = [
+               supply_port.m ~ -return_port.m
+               supply_port.p  ~ return_port.p # zero pressure loss for now
+               supply_port.T ~ instream(supply_port.T)
+               return_port.T ~ T_return
+              ]
+        compose(ODESystem(eqs, t, [], ps; name=name), [supply_port, return_port])
+    end
+
+    function Pipe(;name, L=1000, d=0.1, N=100, rho=1000, f=1)
+        @named fluid_port_a = Fluid_port()
+        @named fluid_port_b = Fluid_port()
+        ps = @parameters L=L d=d rho=rho f=f N=N
+        sts = @variables v(t)=0.0 dp_z(t)=0.0
+        eqs = [
+               fluid_port_a.m ~ -fluid_port_b.m
+               fluid_port_a.T ~ instream(fluid_port_a.T)
+               fluid_port_b.T ~ fluid_port_a.T
+               v*pi*d^2/4*rho ~ fluid_port_a.m
+               dp_z ~ abs(v)*v*0.5*rho*L/d*f  # pressure loss
+               D(v)*rho*L ~ (fluid_port_a.p - fluid_port_b.p - dp_z) # acceleration of fluid m*a=sum(F)
+              ]
+        compose(ODESystem(eqs, t, sts, ps; name=name), [fluid_port_a, fluid_port_b])
+    end
+    function System(;name, L=10.0)
+        @named compensator = Compensator()
+        @named source = Source()
+        @named substation = Substation()
+        @named supply_pipe = Pipe(L=L)
+        @named return_pipe = Pipe(L=L)
+        subs = [compensator, source, substation, supply_pipe, return_pipe]
+        ps = @parameters L=L
+        eqs = [
+               connect(compensator.fluid_port, source.supply_port)
+               connect(source.supply_port, supply_pipe.fluid_port_a)
+               connect(supply_pipe.fluid_port_b, substation.supply_port)
+               connect(substation.return_port, return_pipe.fluid_port_b)
+               connect(return_pipe.fluid_port_a, source.return_port)
+              ]
+        compose(ODESystem(eqs, t, [], ps; name=name), subs)
+    end
+
+    @named system = System(L=10)
+    @unpack supply_pipe = system
+    sys = structural_simplify(system)
+    u0 = [system.supply_pipe.v => 0.1, system.return_pipe.v => 0.1, D(supply_pipe.v) => 0.0]
+    # This is actually an implicit DAE system
+    @test_throws Any ODEProblem(sys, u0, (0.0, 10.0), [])
+    @test_throws Any ODAEProblem(sys, u0, (0.0, 10.0), [])
+    prob = DAEProblem(sys, D.(states(sys)) .=> 0.0, u0, (0.0, 10.0), [])
+    @test solve(prob, DFBDF()).retcode == :Success
+end
+
+# 1537
+let
+    @variables t
+    @variables begin
+        p_1(t)
+        p_2(t)
+        rho_1(t)
+        rho_2(t)
+        rho_3(t)
+        u_1(t)
+        u_2(t)
+        u_3(t)
+        mo_1(t)
+        mo_2(t)
+        mo_3(t)
+        Ek_1(t)
+        Ek_2(t)
+        Ek_3(t)
+    end
+
+    @parameters dx = 100 f = 0.3 pipe_D = 0.4
+
+    D = Differential(t)
+
+    eqs = [
+           p_1 ~ 1.2e5
+           p_2 ~ 1e5
+           u_1 ~ 10
+           mo_1 ~ u_1 * rho_1
+           mo_2 ~ u_2 * rho_2
+           mo_3 ~ u_3 * rho_3
+           Ek_1 ~ rho_1 * u_1 * u_1
+           Ek_2 ~ rho_2 * u_2 * u_2
+           Ek_3 ~ rho_3 * u_3 * u_3
+           rho_1 ~ p_1 / 273.11 / 300
+           rho_2 ~ (p_1 + p_2) * 0.5 / 273.11 / 300
+           rho_3 ~ p_2 / 273.11 / 300
+           D(rho_2) ~ (mo_1 - mo_3) / dx
+           D(mo_2) ~ (Ek_1 - Ek_3 + p_1 - p_2) / dx - f / 2 / pipe_D * u_2 * u_2
+          ]
+
+    @named trans = ODESystem(eqs, t)
+
+    sys = structural_simplify(trans)
+
+    n = 3
+    u = 0 * ones(n)
+    rho = 1.2 * ones(n)
+
+    u0 = [
+          p_1 => 1.2e5
+          p_2 => 1e5
+          u_1 => 0
+          u_2 => 0.1
+          u_3 => 0.2
+          rho_1 => 1.1
+          rho_2 => 1.2
+          rho_3 => 1.3
+          mo_1 => 0
+          mo_2 => 1
+          mo_3 => 2
+         ]
+    prob = ODAEProblem(sys, u0, (0.0, 0.1))
+    @test solve(prob, FBDF()).retcode == :Success
 end

--- a/test/state_selection.jl
+++ b/test/state_selection.jl
@@ -20,7 +20,8 @@ let dd = dummy_derivative(sys)
         has_dx2 |= D(x2) in vars || D(D(x2)) in vars
     end
     @test has_dx1 ⊻ has_dx2 # only one of x1 and x2 can be a dummy derivative
-    @test length(states(dd)) == length(equations(dd)) == 10
+    @test length(states(dd)) == length(equations(dd)) == 9
+    @test length(states(structural_simplify(dd))) <= 6
 end
 
 let pss = partial_state_selection(sys)

--- a/test/structural_transformation/index_reduction.jl
+++ b/test/structural_transformation/index_reduction.jl
@@ -131,3 +131,22 @@ let pss_pendulum = partial_state_selection(pendulum)
     # This currently selects `T` rather than `x` at top level. Needs tearing priorities to fix.
     @test_broken length(equations(pss_pendulum)) == 3
 end
+
+sys = structural_simplify(pendulum2)
+@test length(equations(sys)) == 5
+@test length(states(sys)) == 5
+
+u0 = [
+  D(x)    => 0.0,
+  D(y)    => 0.0,
+  x       => sqrt(2)/2,
+  y       => sqrt(2)/2,
+  T       => 0.0
+]
+p = [
+    L => 1.0,
+    g => 9.8
+]
+
+prob_auto = DAEProblem(sys,zeros(length(u0)),u0,(0.0,10.0),p)
+@test_nowarn solve(prob_auto, DFBDF())

--- a/test/structural_transformation/index_reduction.jl
+++ b/test/structural_transformation/index_reduction.jl
@@ -148,5 +148,6 @@ p = [
     g => 9.8
 ]
 
-prob_auto = DAEProblem(sys,zeros(length(u0)),u0,(0.0,10.0),p)
-@test_nowarn solve(prob_auto, DFBDF())
+prob_auto = DAEProblem(sys,zeros(length(u0)),u0,(0.0,0.2),p)
+sol = solve(prob_auto, DFBDF())
+@test norm(sol[x].^2 + sol[y].^2 .- 1) < 1e-2


### PR DESCRIPTION
```julia
julia> u0 = [
         D(x)    => 0.0,
         D(y)    => 0.0,
         x       => sqrt(2)/2,
         y       => sqrt(2)/2,
         T       => 0.0
       ];

julia> p = [
           L => 1.0,
           g => 9.8
       ];

julia> equations(pendulum2)
3-element Vector{Equation}:
 Differential(t)(Differential(t)(x(t))) ~ T(t)*x(t)
 Differential(t)(Differential(t)(y(t))) ~ T(t)*y(t) - g
 0 ~ x(t)^2 + y(t)^2 - (L^2)

julia> prob_auto = DAEProblem(structural_simplify(pendulum2),zeros(length(u0)),u0,(0.0,10.0),p);

julia> sol = solve(prob_auto, DFBDF());
```

![pendulum_dd_mtk](https://user-images.githubusercontent.com/17304743/168402835-2aba1745-1c78-4a7e-87f3-861d2e01b08a.png)

The solver would error out if I integrate it for longer. Since `x''(t) == d/dt x'(t)` may not hold if `x''` is a dummy derivative, we might have to implement manifold projection for DAE solvers to ensure that the dummy derivatives don't drift too much.


This PR fixes https://github.com/SciML/ModelingToolkit.jl/issues/1537 and https://github.com/SciML/ModelingToolkit.jl/issues/1516