### PR TITLE
[RFC] Get depvars and indvars in the right type for MOL

### DIFF
--- a/src/systems/pde/pdesystem.jl
+++ b/src/systems/pde/pdesystem.jl
@@ -77,7 +77,7 @@ struct PDESystem <: ModelingToolkit.AbstractMultivariateSystem
         # Get all dependent variables in the correct type
         alldepvars = get_all_depvars(pdesys, depvar_ops)
         dvs = filter(u -> !any(map(x -> x isa Number, arguments(u))), alldepvars)
-        # Get all independent variables in the correct type, removing time from the list
+        # Get all independent variables in the correct type
         ivs = collect(filter(x -> !(x isa Number), reduce(union, map(arguments, alldepvars))))
 
         new(eqs, bcs, domain, ivs, dvs, ps, defaults, connector_type, name)


### PR DESCRIPTION
This change reflects something that is done internally in MethodOfLines.jl, which may have more general applicability. 

Gets all dvs and ivs in their naked Symbolics.jl type, which is more useful for applying rules based on SymbolicUtils.jl.

What do you think of this @zoemcc @YingboMa?

I will add tests if this is decided to be a good change.