### PR TITLE
Also treat selected states as unassigned edges in matching graph

### DIFF
--- a/src/bipartite_graph.jl
+++ b/src/bipartite_graph.jl
@@ -546,7 +546,7 @@ function Base.iterate(c::CMONeighbors{false}, (l, state...))
         # directed graph. Otherwise, if there is no matching for this destination
         # edge, also skip it, since it got delted in the contraction.
         vsrc = c.g.matching[r[1]]
-        if vsrc === c.v || vsrc === unassigned
+        if vsrc === c.v || !isa(vsrc, Int)
             state = (r[2],)
             continue
         end


### PR DESCRIPTION
I think this is a more useful interpretation, since this way,
DiCMOBiGraph{true}(graph, var_eq_matching) can be used to
topsort equation dependencies.