### PR TITLE
Strengthen alias elimination

### DIFF
--- a/src/structural_transformation/bipartite_tearing/modia_tearing.jl
+++ b/src/structural_transformation/bipartite_tearing/modia_tearing.jl
@@ -37,9 +37,38 @@ end
 
 function tear_graph_modia(structure::SystemStructure; varfilter = v -> true,
                           eqfilter = eq -> true)
+    # It would be possible here to simply iterate over all variables and attempt to
+    # use tearEquations! to produce a matching that greedily selects the minimal
+    # number of torn variables. However, we can do this process faster if we first
+    # compute the strongly connected components. In the absence of cycles and
+    # non-solvability, a maximal matching on the original graph will give us an
+    # optimal assignment. However, even with cycles, we can use the maximal matching
+    # to give us a good starting point for a good matching and then proceed to
+    # reverse edges in each scc to improve the solution. Note that it is possible
+    # to have optimal solutions that cannot be found by this process. We will not
+    # find them here [TODO: It would be good to have an explicit example of this.]
+
     @unpack graph, solvable_graph = structure
     var_eq_matching = complete(maximal_matching(graph, eqfilter, varfilter))
     var_sccs::Vector{Union{Vector{Int}, Int}} = find_var_sccs(graph, var_eq_matching)
+
+    # Here, we're using a maximal matching on the post-pantelides system to find
+    # the strongly connected components of the system (of variables that depend
+    # on each other). The strongly connected components are unique, however, the
+    # maximal matching itself is not. Every maximal matching gives rise to the
+    # same set of strongly connected components, but the associated equations need
+    # not be the same. In the absence of solvability constraints, this may be a
+    # small issue, but here it is possible that an equation got assigned to an
+    # scc that cannot actually use it for solving a variable, but still precludes
+    # another scc from using it. To avoid this, we delete any assignments that
+    # are not in the solvable graph and extend the set of considered eqauations
+    # below.
+    for var in ndsts(solvable_graph)
+        var_eq_matching[var] === unassigned && continue
+        if !(BipartiteEdge(var, var_eq_matching[var]) in solvable_graph)
+            var_eq_matching[var] = unassigned
+        end
+    end
 
     for vars in var_sccs
         filtered_vars = filter(varfilter, vars)
@@ -47,6 +76,17 @@ function tear_graph_modia(structure::SystemStructure; varfilter = v -> true,
                    for v in filtered_vars if var_eq_matching[v] !== unassigned]
         for var in vars
             var_eq_matching[var] = unassigned
+        end
+        for var in filtered_vars
+            # Add any equations that we may not have been able to use earlier to see
+            # if a different matching may have been possible.
+            for eq′ in 𝑑neighbors(solvable_graph, var)
+                eqfilter(eq′) || continue
+                eq′ in ieqs && continue
+                if invview(var_eq_matching)[eq′] === unassigned
+                    push!(ieqs, eq′)
+                end
+            end
         end
         tear_graph_block_modia!(var_eq_matching, graph, solvable_graph, ieqs, filtered_vars)
     end

--- a/src/systems/alias_elimination.jl
+++ b/src/systems/alias_elimination.jl
@@ -217,10 +217,11 @@ function aag_bareiss!(graph, var_to_diff, mm_orig::SparseMatrixCLIL)
         is_linear_equations[e] = true
     end
 
-    # For now, onlt consider variables linear that are not differentiated.
+    # For now, only consider variables linear that are not differentiated.
     # We could potentially apply the same logic to variables whose derivative
     # is also linear, but that's a TODO.
-    is_linear_variables = isnothing.(var_to_diff)
+    diff_to_var = invview(var_to_diff)
+    is_linear_variables = .&(isnothing.(var_to_diff), isnothing.(diff_to_var))
     for i in 𝑠vertices(graph)
         is_linear_equations[i] && continue
         for j in 𝑠neighbors(graph, i)

--- a/src/systems/alias_elimination.jl
+++ b/src/systems/alias_elimination.jl
@@ -57,7 +57,13 @@ function alias_elimination(sys)
 
     newstates = []
     for j in eachindex(fullvars)
-        if !(j in keys(ag))
+        if j in keys(ag)
+            # Put back equations for alias eliminated dervars
+            if isdervar(state.structure, j) &&
+               !(invview(state.structure.var_to_diff)[j] in keys(ag))
+                push!(eqs, fullvars[j] ~ subs[fullvars[j]])
+            end
+        else
             isdervar(state.structure, j) || push!(newstates, fullvars[j])
         end
     end
@@ -192,6 +198,7 @@ struct AliasGraphKeySet <: AbstractSet{Int}
 end
 Base.keys(ag::AliasGraph) = AliasGraphKeySet(ag)
 Base.iterate(agk::AliasGraphKeySet, state...) = Base.iterate(agk.ag.eliminated, state...)
+Base.length(agk::AliasGraphKeySet) = Base.length(agk.ag.eliminated)
 function Base.in(i::Int, agk::AliasGraphKeySet)
     aliasto = agk.ag.aliasto
     1 <= i <= length(aliasto) && aliasto[i] !== nothing
@@ -210,9 +217,10 @@ function aag_bareiss!(graph, var_to_diff, mm_orig::SparseMatrixCLIL)
         is_linear_equations[e] = true
     end
 
-    # Variables that are highest order differentiated cannot be states of an ODE
-    is_not_potential_state = isnothing.(var_to_diff)
-    is_linear_variables = copy(is_not_potential_state)
+    # For now, onlt consider variables linear that are not differentiated.
+    # We could potentially apply the same logic to variables whose derivative
+    # is also linear, but that's a TODO.
+    is_linear_variables = isnothing.(var_to_diff)
     for i in 𝑠vertices(graph)
         is_linear_equations[i] && continue
         for j in 𝑠neighbors(graph, i)
@@ -230,11 +238,9 @@ function aag_bareiss!(graph, var_to_diff, mm_orig::SparseMatrixCLIL)
                 r !== nothing && return r
                 rank1 = k - 1
             end
-            if rank2 === nothing
-                r = find_masked_pivot(is_not_potential_state, M, k)
-                r !== nothing && return r
-                rank2 = k - 1
-            end
+            # TODO: It would be better to sort the variables by
+            # derivative order here to enable more elimination
+            # opportunities.
             return find_masked_pivot(nothing, M, k)
         end
         function find_and_record_pivot(M, k)
@@ -249,10 +255,9 @@ function aag_bareiss!(graph, var_to_diff, mm_orig::SparseMatrixCLIL)
         end
         bareiss_ops = ((M, i, j) -> nothing, myswaprows!,
                        bareiss_update_virtual_colswap_mtk!, bareiss_zero!)
-        rank3, = bareiss!(M, bareiss_ops; find_pivot = find_and_record_pivot)
-        rank1 = something(rank1, rank3)
-        rank2 = something(rank2, rank3)
-        (rank1, rank2, rank3, pivots)
+        rank2, = bareiss!(M, bareiss_ops; find_pivot = find_and_record_pivot)
+        rank1 = something(rank1, rank2)
+        (rank1, rank2, pivots)
     end
 
     return mm, solvable_variables, do_bareiss!(mm, mm_orig)
@@ -266,16 +271,27 @@ function alias_eliminate_graph!(graph, var_to_diff, mm_orig::SparseMatrixCLIL)
     # variables`.
     #
     # `do_bareiss` conceptually gives us this system:
-    # rank1 | [ M₁₁  M₁₂ | M₁₃  M₁₄ ]   [v₁] = [0]
-    # rank2 | [ 0    M₂₂ | M₂₃  M₂₄ ] P [v₂] = [0]
+    # rank1 | [ M₁₁  M₁₂ | M₁₃ ]   [v₁] = [0]
+    # rank2 | [ 0    M₂₂ | M₂₃ ] P [v₂] = [0]
     # -------------------|------------------------
-    # rank3 | [ 0    0   | M₃₃  M₃₄ ]   [v₃] = [0]
-    #         [ 0    0   | 0    0   ]   [v₄] = [0]
-    mm, solvable_variables, (rank1, rank2, rank3, pivots) = aag_bareiss!(graph, var_to_diff,
-                                                                         mm_orig)
+    #         [ 0    0   | 0   ]   [v₃] = [0]
+    #
+    # Where `v₁` are the purely linear variables (i.e. those that only appear in linear equations),
+    # `v₂` are the variables that may be potentially solved by the linear system and v₃ are the variables
+    # that contribute to the equations, but are not solved by the linear system. Note
+    # that the complete system may be larger than the linear subsystem and include variables
+    # that do not appear here.
+    mm, solvable_variables, (rank1, rank2, pivots) = aag_bareiss!(graph, var_to_diff,
+                                                                  mm_orig)
 
     # Step 2: Simplify the system using the Bareiss factorization
+
     ag = AliasGraph(size(mm, 2))
+
+    # First, eliminate variables that only appear in linear equations and were removed
+    # completely from the coefficient matrix. These are technically singularities in
+    # the matrix, but assigning them to 0 is a feasible assignment and works well in
+    # practice.
     for v in setdiff(solvable_variables, @view pivots[1:rank1])
         ag[v] = 0
     end
@@ -287,11 +303,7 @@ function alias_eliminate_graph!(graph, var_to_diff, mm_orig::SparseMatrixCLIL)
     function lss!(ei::Integer)
         vi = pivots[ei]
         may_eliminate = true
-        for v in 𝑠neighbors(graph, mm.nzrows[ei])
-            # the differentiated variable cannot be eliminated
-            may_eliminate &= isnothing(diff_to_var[v]) && isnothing(var_to_diff[v])
-        end
-        locally_structure_simplify!((@view mm[ei, :]), vi, ag, may_eliminate)
+        locally_structure_simplify!((@view mm[ei, :]), vi, ag, var_to_diff)
     end
 
     # Step 2.1: Go backwards, collecting eliminated variables and substituting
@@ -333,7 +345,7 @@ function exactdiv(a::Integer, b)
     return d
 end
 
-function locally_structure_simplify!(adj_row, pivot_col, ag, may_eliminate)
+function locally_structure_simplify!(adj_row, pivot_col, ag, var_to_diff)
     pivot_val = adj_row[pivot_col]
     iszero(pivot_val) && return false
 
@@ -375,13 +387,21 @@ function locally_structure_simplify!(adj_row, pivot_col, ag, may_eliminate)
         end
     end
 
-    if may_eliminate && nirreducible <= 1
+    if nirreducible <= 1
         # There were only one or two terms left in the equation (including the
         # pivot variable). We can eliminate the pivot variable.
         #
         # Note that when `nirreducible <= 1`, `alias_candidate` is uniquely
         # determined.
         if alias_candidate !== 0
+            # Verify that the derivative depth of the variable is at least
+            # as deep as that of the alias, otherwise, we can't eliminate.
+            pivot_var = pivot_col
+            alias_var = alias_candidate[2]
+            while (pivot_var = var_to_diff[pivot_col]) !== nothing
+                alias_var = var_to_diff[alias_var]
+                alias_var === nothing && return false
+            end
             d, r = divrem(alias_candidate[1], pivot_val)
             if r == 0 && (d == 1 || d == -1)
                 alias_candidate = -d => alias_candidate[2]
@@ -389,7 +409,14 @@ function locally_structure_simplify!(adj_row, pivot_col, ag, may_eliminate)
                 return false
             end
         end
-        ag[pivot_col] = alias_candidate
+        diff_alias_candidate(ac) = ac === 0 ? 0 : ac[1] => var_to_diff[ac[2]]
+        while true
+            @assert !haskey(ag, pivot_col)
+            ag[pivot_col] = alias_candidate
+            pivot_col = var_to_diff[pivot_col]
+            pivot_col === nothing && break
+            alias_candidate = diff_alias_candidate(alias_candidate)
+        end
         zero!(adj_row)
         return true
     end

--- a/src/systems/systemstructure.jl
+++ b/src/systems/systemstructure.jl
@@ -348,7 +348,6 @@ function linear_subsys_adjmat(state::TransformationState)
     cadj = Vector{Int}[]
     coeffs = Int[]
     for (i, eq) in enumerate(eqs)
-        isdiffeq(eq) && continue
         empty!(coeffs)
         linear_term = 0
         all_int_vars = true

--- a/test/odesystem.jl
+++ b/test/odesystem.jl
@@ -608,9 +608,10 @@ let
     @test sol[y] ≈ 0.9 * sol[x[1]] + sol[x[2]]
     @test isapprox(sol[x[1]][end], 1, atol = 1e-3)
 
-    prob = DAEProblem(sys, [D(y) => 0, D(x[1]) => 0, D(x[2]) => 0], Pair[x[1] => 0.5],
+    prob = DAEProblem(sys, [D(y) => 0, D(x[1]) => 0, D(x[2]) => 0], [x[1] => 0.5],
                       (0, 50))
-    @test prob.u0 ≈ [0.5, 0]
+    u0_dict = Dict(x[1] => 0.5, x[2] => 0.0)
+    @test prob.u0 ≈ [u0_dict[x] for x in states(sys)]
     @test prob.du0 ≈ [0, 0]
     @test prob.p ≈ [1]
     sol = solve(prob, IDA())
@@ -618,7 +619,7 @@ let
 
     prob = DAEProblem(sys, [D(y) => 0, D(x[1]) => 0, D(x[2]) => 0], Pair[x[1] => 0.5],
                       (0, 50), [k => 2])
-    @test prob.u0 ≈ [0.5, 0]
+    @test prob.u0 ≈ [u0_dict[x] for x in states(sys)]
     @test prob.du0 ≈ [0, 0]
     @test prob.p ≈ [2]
     sol = solve(prob, IDA())

--- a/test/reduction.jl
+++ b/test/reduction.jl
@@ -267,5 +267,5 @@ eqs = [D(x) ~ 0]
 trivialconst = ODESystem(eqs, t, name = :trivial0)
 let trivialconst = alias_elimination(trivialconst)
     # Test that alias elimination doesn't eliminate a D(x) that is needed.
-    @test length(equations(trivial0)) == length(states(trivial0)) == 1
+    @test length(equations(trivialconst)) == length(states(trivialconst)) == 1
 end

--- a/test/reduction.jl
+++ b/test/reduction.jl
@@ -246,3 +246,26 @@ eqs = [D(x) ~ σ * (y - x)
 lorenz1 = ODESystem(eqs, t, name = :lorenz1)
 lorenz1_reduced = structural_simplify(lorenz1)
 @test z in Set(parameters(lorenz1_reduced))
+
+# Test that alias elimination can propagate `x ~ 0` to derivatives
+@parameters t
+@variables x(t) y(t)
+
+eqs = [x ~ 0
+       D(x) ~ x + y]
+trivial0 = ODESystem(eqs, t, name = :trivial0)
+let trivial0 = alias_elimination(trivial0)
+    # For symbolic systems, we currently don't let
+    # alias elimination touch differential eqs, so
+    # this leaves one equation left over. In theory,
+    # the whole system would get eliminated.
+    @test length(equations(trivial0)) <= 1
+    @test length(states(trivial0)) <= 1
+end
+
+eqs = [D(x) ~ 0]
+trivialconst = ODESystem(eqs, t, name = :trivial0)
+let trivialconst = alias_elimination(trivialconst)
+    # Test that alias elimination doesn't eliminate a D(x) that is needed.
+    @test length(equations(trivial0)) == length(states(trivial0)) == 1
+end


### PR DESCRIPTION
Previously, we would only alias eliminate variables that do not occur
differentiated. This was unnecessarily restricted for systems such as
```
x ~ 0
D(x) ~ x - y
```
where alias elimination is now able to determine that `x` and `y` are
aliases.

While this is the main point of the PR, this does improve alias elimination
in some of the tests, causing tearing order to change. Previously we had
a suboptimality in tearing where an equation assigned to an scc in which it
is not able to solve a variable would not be reconsidered in another scc.
Fix that also, to make sure the tests keep working.