### PR TITLE
AbstractTrees v0.4 compat

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -44,7 +44,7 @@ UnPack = "3a884ed6-31ef-47d7-9d2a-63182c4928ed"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [compat]
-AbstractTrees = "0.3"
+AbstractTrees = "0.3, 0.4"
 ArrayInterfaceCore = "0.1.1"
 Combinatorics = "1"
 ConstructionBase = "1"

--- a/src/systems/abstractsystem.jl
+++ b/src/systems/abstractsystem.jl
@@ -1055,7 +1055,8 @@ end
 function AbstractTrees.printnode(io::IO, sys::ModelingToolkit.AbstractSystem)
     print(io, nameof(sys))
 end
-AbstractTrees.nodetype(::ModelingToolkit.AbstractSystem) = ModelingToolkit.AbstractSystem
+Base.IteratorEltype(::Type{<:TreeIterator{ModelingToolkit.AbstractSystem}}) = Base.HasEltype()
+Base.eltype(::Type{<:TreeIterator{ModelingToolkit.AbstractSystem}}) = ModelingToolkit.AbstractSystem
 
 function check_eqs_u0(eqs, dvs, u0; check_length = true, kwargs...)
     if u0 !== nothing

--- a/src/systems/abstractsystem.jl
+++ b/src/systems/abstractsystem.jl
@@ -1055,8 +1055,12 @@ end
 function AbstractTrees.printnode(io::IO, sys::ModelingToolkit.AbstractSystem)
     print(io, nameof(sys))
 end
-Base.IteratorEltype(::Type{<:TreeIterator{ModelingToolkit.AbstractSystem}}) = Base.HasEltype()
-Base.eltype(::Type{<:TreeIterator{ModelingToolkit.AbstractSystem}}) = ModelingToolkit.AbstractSystem
+function Base.IteratorEltype(::Type{<:TreeIterator{ModelingToolkit.AbstractSystem}})
+    Base.HasEltype()
+end
+function Base.eltype(::Type{<:TreeIterator{ModelingToolkit.AbstractSystem}})
+    ModelingToolkit.AbstractSystem
+end
 
 function check_eqs_u0(eqs, dvs, u0; check_length = true, kwargs...)
     if u0 !== nothing


### PR DESCRIPTION
This removes a function that no longer exists to allow for AbstractTrees 0.4 compat.