### PR TITLE
Periodic Callbacks with general affect function (PoC)

### DIFF
--- a/src/inputoutput.jl
+++ b/src/inputoutput.jl
@@ -141,7 +141,7 @@ function common_namespace(vs, include_trailing=true)
         push!(common, s[1])
     end
     ns = join(common, "₊")
-    return include_trailing ? (ns * "₊") : ns
+    return include_trailing && length(ns) > 0 ? (ns * "₊") : ns
 end
 
 """

--- a/src/inputoutput.jl
+++ b/src/inputoutput.jl
@@ -129,6 +129,21 @@ function inner_namespace(u, var)
         occursin('₊', var) && !occursin('₊', u) # or u is top level but var is internal
 end
 
+
+function common_namespace(vs, include_trailing=true)
+    common = []
+    nss = split.(get_namespace.(vs), "₊")
+    min_len = minimum(length.(nss))
+
+    for i in 1:min_len
+        s = unique([p[i] for p in nss])
+        length(s) == 1 || break
+        push!(common, s[1])
+    end
+    ns = join(common, "₊")
+    return include_trailing ? (ns * "₊") : ns
+end
+
 """
     get_namespace(x)
 

--- a/src/structural_transformation/codegen.jl
+++ b/src/structural_transformation/codegen.jl
@@ -1,7 +1,7 @@
 using LinearAlgebra
 
 using ModelingToolkit: isdifferenceeq, has_continuous_events, generate_rootfinding_callback,
-                       generate_difference_cb, merge_cb
+                       generate_difference_cb, merge_cb, has_periodic_events, generate_periodic_callbacks
 
 const MAX_INLINE_NLSOLVE_SIZE = 8
 
@@ -529,8 +529,15 @@ function ODAEProblem{iip}(sys,
     else
         event_cb = nothing
     end
+    if has_periodic_events(sys)
+        periodic_event_cb = generate_periodic_callbacks(sys; kwargs...)
+    else
+        periodic_event_cb = nothing
+    end
+
     difference_cb = has_difference ? generate_difference_cb(sys; kwargs...) : nothing
     cb = merge_cb(event_cb, difference_cb)
+    cb = reduce(merge_cb, periodic_event_cb; init=cb)
     cb = merge_cb(cb, callback)
 
     if cb === nothing

--- a/src/systems/abstractsystem.jl
+++ b/src/systems/abstractsystem.jl
@@ -587,8 +587,8 @@ end
 function updated_periodic_event(sys::AbstractSystem, cb::PeriodicEventCallback)
     !isnothing(cb.states) && !isnothing(cb.ps) && return cb
 
-    st = isnothing(cb.states) ? states(sys) : cb.states
-    ps = isnothing(cb.ps) ? parameters(sys) : cb.ps
+    st = isnothing(cb.states) ? get_states(sys) : cb.states
+    ps = isnothing(cb.ps) ? get_ps(sys) : cb.ps
     return PeriodicEventCallback(cb.Δt, cb.affect, cb.state, st, ps)
 end
 

--- a/src/systems/diffeqs/abstractodesystem.jl
+++ b/src/systems/diffeqs/abstractodesystem.jl
@@ -275,15 +275,16 @@ function compile_affect(sys::ODESystem, cb::Function, cb_state, dvs, ps, args...
 
     prefix = common_namespace(vcat(dvs, ps))
 
-    # find indexes
-    ind(sym, v) = findfirst(isequal(sym), v)
-    inds(syms, v) = filter(!isnothing,map(sym -> ind(sym, v), syms)) # filter out eliminated symbols
+    inds(subsyms, allsyms) = [en[1] for en in enumerate(allsyms) 
+                                            if getname(en[2]) in Set(getname(s) 
+                                                for s in subsyms)]
+
     tr_name(v) = Symbol(unnamespace(prefix, getname(v)))
 
     v_inds = inds(dvs, all_dvs)
     p_inds = inds(ps, all_ps)
-    v_sym = Tuple([tr_name(all_dvs[i]) for i in v_inds])
-    p_sym = Tuple([tr_name(all_ps[i]) for i in p_inds])
+    v_sym = Tuple(map(tr_name, all_dvs[v_inds]))
+    p_sym = Tuple(map(tr_name, all_ps[p_inds]))
 
     let v_inds=v_inds, p_inds=p_inds, v_sym=v_sym, p_sym=p_sym
         function (integ)

--- a/src/systems/diffeqs/abstractodesystem.jl
+++ b/src/systems/diffeqs/abstractodesystem.jl
@@ -837,7 +837,7 @@ function DiffEqBase.ODEProblem{iip}(sys::AbstractODESystem, u0map, tspan,
     if has_periodic_events(sys)
         periodic_event_cb = generate_periodic_callbacks(sys; kwargs...)
     else
-        periodic_event_cb = nothing
+        periodic_event_cb = []
     end
 
     difference_cb = has_difference ? generate_difference_cb(sys; kwargs...) : nothing

--- a/test/periodiccb.jl
+++ b/test/periodiccb.jl
@@ -87,14 +87,21 @@ rc_eqs = [
           connect(capacitor.n, ground.g)
          ]
 
-@named _rc_model = ODESystem(rc_eqs, t)
+st2 = Float64[]
+
+function affect2!(u,p, t, state)
+    #@show(u, p, t, state)
+end
+
+
+@named _rc_model = ODESystem(rc_eqs, t, periodic_events=(5, affect2!))
 @named rc_model = compose(_rc_model,
                           [resistor, capacitor, source, ground])
 
-@test length(ModelingToolkit.periodic_events(rc_model)) == 1
+@test length(ModelingToolkit.periodic_events(rc_model)) == 2
 
 sys = structural_simplify(rc_model)
-@test length(ModelingToolkit.periodic_events(sys)) == 1
+@test length(ModelingToolkit.periodic_events(sys)) == 2
 u0 = [
       capacitor.v => 0.0
      ]

--- a/test/periodiccb.jl
+++ b/test/periodiccb.jl
@@ -1,112 +1,45 @@
 using ModelingToolkit, OrdinaryDiffEq, Test
-using ModelingToolkit: PR_NULL_AFFECT, PeriodicEventCallback, PeriodicEventCallbacks, periodic_events
+using Random
 
+struct MyController
+    rng
+    h
+    MyController() = new(MersenneTwister(1234), Float32[])
+end
 
-@variables t x(t)=1 v(t)=0 k(t)=0
-D = Differential(t)
+function newdirection!(c::MyController, pars, t)
+    # random update
+    pars.a, = Random.rand(c.rng, 1)
 
+    # use history for update
+    pars[:b] = t + sum(c.h)
+end
 
-function affect!(u,p, t, state)
-    p.R *= 2
-    append!(state, p.R)
+function updatehist!(c::MyController, sts)
+    push!(c.h, sts.x)
+end
+
+function affect!(u, p, t, ctrl::MyController)
+    updatehist!(ctrl, u)
+    newdirection!(ctrl, p, t)
 end
 
 period = 1.0
 
-@variables t
-@connector function Pin(;name)
-    sts = @variables v(t)=1.0 i(t)=1.0 [connect = Flow]
-    ODESystem(Equation[], t, sts, []; name=name)
-end
+@variables t, x(t)
+@parameters a, b
+D = Differential(t)
 
-function Ground(;name)
-    @named g = Pin()
-    eqs = [g.v ~ 0]
-    compose(ODESystem(eqs, t, [], []; name=name), g)
-end
+eqs = [ D(x) ~ a * x + b]
 
-function OnePort(;name)
-    @named p = Pin()
-    @named n = Pin()
-    sts = @variables v(t)=1.0 i(t)=1.0
-    eqs = [
-           v ~ p.v - n.v
-           0 ~ p.i + n.i
-           i ~ p.i
-          ]
-    compose(ODESystem(eqs, t, sts, []; name=name), p, n)
-end
+controller = MyController()
 
-function Resistor(;name, R = 1.0, state=nothing)
-    @named oneport = OnePort()
-    @unpack v, i = oneport
-    ps = @parameters R=R
-    eqs = [
-           v ~ i * R
-          ]
-    extend(ODESystem(eqs, t, [], ps; name=name, periodic_events=(period, affect!, state)), oneport)
-end
+@named model = ODESystem(eqs, t, [x], [a, b], periodic_events=(1.0, affect!, controller))
 
-function Capacitor(;name, C = 1.0)
-    @named oneport = OnePort()
-    @unpack v, i = oneport
-    ps = @parameters C=C
-    D = Differential(t)
-    eqs = [
-           D(v) ~ i / C
-          ]
-    extend(ODESystem(eqs, t, [], ps; name=name), oneport)
-end
+sys = structural_simplify(model)
 
-function ConstantVoltage(;name, V = 1.0)
-    @named oneport = OnePort()
-    @unpack v = oneport
-    ps = @parameters V=V
-    eqs = [
-           V ~ v
-          ]
-    extend(ODESystem(eqs, t, [], ps; name=name), oneport)
-end
-
-R = 1.0
-C = 1.0
-V = 1.0
-mystate = Float64[]
-@named resistor = Resistor(R=R; state=mystate)
-
-@test length(ModelingToolkit.periodic_events(resistor)) == 1
-
-@named capacitor = Capacitor(C=C)
-@named source = ConstantVoltage(V=V)
-@named ground = Ground()
-
-rc_eqs = [
-          connect(source.p, resistor.p)
-          connect(resistor.n, capacitor.p)
-          connect(capacitor.n, source.n)
-          connect(capacitor.n, ground.g)
-         ]
-
-st2 = Float64[]
-
-function affect2!(u,p, t, state)
-    #@show(u, p, t, state)
-end
-
-
-@named _rc_model = ODESystem(rc_eqs, t, periodic_events=(5, affect2!))
-@named rc_model = compose(_rc_model,
-                          [resistor, capacitor, source, ground])
-
-@test length(ModelingToolkit.periodic_events(rc_model)) == 2
-
-sys = structural_simplify(rc_model)
-@test length(ModelingToolkit.periodic_events(sys)) == 2
-u0 = [
-      capacitor.v => 0.0
-     ]
-prob = ODAEProblem(sys, u0, (0, 10.0))
+prob = ODAEProblem(sys, [x => 1.0], (0, 2.0), [a => 1.0, b => 3.0])
 sol = solve(prob, Tsit5())
-@test mystate == [2.0, 4.0, 8.0, 16.0, 32.0, 64.0, 128.0, 256.0, 512.0]
-# plot(sol)
 
+@test length(controller.h) == 1
+@test controller.h[1] ≈ 7.873127

--- a/test/periodiccb.jl
+++ b/test/periodiccb.jl
@@ -1,0 +1,105 @@
+using ModelingToolkit, OrdinaryDiffEq, Test
+using ModelingToolkit: PR_NULL_AFFECT, PeriodicEventCallback, PeriodicEventCallbacks, periodic_events
+
+
+@variables t x(t)=1 v(t)=0 k(t)=0
+D = Differential(t)
+
+
+function affect!(u,p, t, state)
+    p.R *= 2
+    append!(state, p.R)
+end
+
+period = 1.0
+
+@variables t
+@connector function Pin(;name)
+    sts = @variables v(t)=1.0 i(t)=1.0 [connect = Flow]
+    ODESystem(Equation[], t, sts, []; name=name)
+end
+
+function Ground(;name)
+    @named g = Pin()
+    eqs = [g.v ~ 0]
+    compose(ODESystem(eqs, t, [], []; name=name), g)
+end
+
+function OnePort(;name)
+    @named p = Pin()
+    @named n = Pin()
+    sts = @variables v(t)=1.0 i(t)=1.0
+    eqs = [
+           v ~ p.v - n.v
+           0 ~ p.i + n.i
+           i ~ p.i
+          ]
+    compose(ODESystem(eqs, t, sts, []; name=name), p, n)
+end
+
+function Resistor(;name, R = 1.0, state=nothing)
+    @named oneport = OnePort()
+    @unpack v, i = oneport
+    ps = @parameters R=R
+    eqs = [
+           v ~ i * R
+          ]
+    extend(ODESystem(eqs, t, [], ps; name=name, periodic_events=(period, affect!, state)), oneport)
+end
+
+function Capacitor(;name, C = 1.0)
+    @named oneport = OnePort()
+    @unpack v, i = oneport
+    ps = @parameters C=C
+    D = Differential(t)
+    eqs = [
+           D(v) ~ i / C
+          ]
+    extend(ODESystem(eqs, t, [], ps; name=name), oneport)
+end
+
+function ConstantVoltage(;name, V = 1.0)
+    @named oneport = OnePort()
+    @unpack v = oneport
+    ps = @parameters V=V
+    eqs = [
+           V ~ v
+          ]
+    extend(ODESystem(eqs, t, [], ps; name=name), oneport)
+end
+
+R = 1.0
+C = 1.0
+V = 1.0
+mystate = Float64[]
+@named resistor = Resistor(R=R; state=mystate)
+
+@test length(ModelingToolkit.periodic_events(resistor)) == 1
+
+@named capacitor = Capacitor(C=C)
+@named source = ConstantVoltage(V=V)
+@named ground = Ground()
+
+rc_eqs = [
+          connect(source.p, resistor.p)
+          connect(resistor.n, capacitor.p)
+          connect(capacitor.n, source.n)
+          connect(capacitor.n, ground.g)
+         ]
+
+@named _rc_model = ODESystem(rc_eqs, t)
+@named rc_model = compose(_rc_model,
+                          [resistor, capacitor, source, ground])
+
+@test length(ModelingToolkit.periodic_events(rc_model)) == 1
+
+sys = structural_simplify(rc_model)
+@test length(ModelingToolkit.periodic_events(sys)) == 1
+u0 = [
+      capacitor.v => 0.0
+     ]
+prob = ODAEProblem(sys, u0, (0, 10.0))
+sol = solve(prob, Tsit5())
+@test mystate == [2.0, 4.0, 8.0, 16.0, 32.0, 64.0, 128.0, 256.0, 512.0]
+# plot(sol)
+


### PR DESCRIPTION
This is a proof-of-concept of running general Julia code in event callbacks (in this case, periodic callbacks which are now supported alongside continuous callbacks).

Using equations to define an `affect!` is great when it works, but it can be limiting.

Defining a new event
```julia

function affect!(u,p, t, c)
    update!(c, p.R, p.T)
    p.R = some_complex_logic(p.R, t)
end

ctrl = MyControl()
ps = @parameters R, T
ODESystem(eqs, t, [], ps; name=name, periodic_events=(period, affect!, ctrl))

# ctrl was modified
```

