### PR TITLE
Cleanup callbacks 

### DIFF
--- a/src/ModelingToolkit.jl
+++ b/src/ModelingToolkit.jl
@@ -121,6 +121,7 @@ include("domains.jl")
 
 include("systems/abstractsystem.jl")
 include("systems/connectors.jl")
+include("systems/callbacks.jl")
 
 include("systems/diffeqs/odesystem.jl")
 include("systems/diffeqs/sdesystem.jl")

--- a/src/systems/callbacks.jl
+++ b/src/systems/callbacks.jl
@@ -98,12 +98,14 @@ affect. The generated function has the signature `affect!(integrator)`.
 Notes
 - `expression = Val{true}`, causes the generated function to be returned as an expression.
   If  set to `Val{false}` a `RuntimeGeneratedFunction` will be returned.
-- `outputidxs`, a vector of indices of the output variables.
+- `outputidxs`, a vector of indices of the output variables which should correspond to
+  `states(sys)`. If provided checks that the LHS of affect equations are variables are
+  dropped, i.e. it is assumed these indices are correct and affect equations are
+  well-formed.
 - `kwargs` are passed through to `Symbolics.build_function`.
 """
 function compile_affect(eqs::Vector{Equation}, sys, dvs, ps; outputidxs = nothing,
-                        expression = Val{true},
-                        kwargs...)
+                        expression = Val{true}, kwargs...)
     if isempty(eqs)
         if expression == Val{true}
             return :((args...) -> ())
@@ -115,6 +117,8 @@ function compile_affect(eqs::Vector{Equation}, sys, dvs, ps; outputidxs = nothin
 
         if outputidxs === nothing
             lhss = map(x -> x.lhs, eqs)
+            all(isvariable, lhss) ||
+                error("Non-variable symbolic expression found on the left hand side of an affect equation. Such equations must be of the form variable ~ symbolic expression for the new value of the variable.")
             update_vars = collect(Iterators.flatten(map(ModelingToolkit.vars, lhss))) # these are the ones we're chaning
             length(update_vars) == length(unique(update_vars)) == length(eqs) ||
                 error("affected variables not unique, each state can only be affected by one equation for a single `root_eqs => affects` pair.")

--- a/src/systems/callbacks.jl
+++ b/src/systems/callbacks.jl
@@ -3,7 +3,6 @@ get_continuous_events(sys::AbstractSystem) = Equation[]
 get_continuous_events(sys::AbstractODESystem) = getfield(sys, :continuous_events)
 has_continuous_events(sys::AbstractSystem) = isdefined(sys, :continuous_events)
 
-
 #################################### continuous events #####################################
 
 const NULL_AFFECT = Equation[]
@@ -73,7 +72,6 @@ function continuous_events(sys::AbstractSystem)
     filter(!isempty, cbs)
 end
 
-
 ################################# compilation functions ####################################
 
 # handles ensuring that affect! functions work with integrator arguments
@@ -104,8 +102,8 @@ Notes
 - `kwargs` are passed through to `Symbolics.build_function`.
 """
 function compile_affect(eqs::Vector{Equation}, sys, dvs, ps; outputidxs = nothing,
-                                                             expression = Val{true},
-                                                             kwargs...)
+                        expression = Val{true},
+                        kwargs...)
     if isempty(eqs)
         if expression == Val{true}
             return :((args...) -> ())
@@ -130,13 +128,12 @@ function compile_affect(eqs::Vector{Equation}, sys, dvs, ps; outputidxs = nothin
         p = map(x -> time_varying_as_func(value(x), sys), ps)
         t = get_iv(sys)
         rf_oop, rf_ip = build_function(rhss, u, p, t; expression = expression,
-                                                      wrap_code = add_integrator_header(),
-                                                      outputidxs = update_inds,
-                                                      kwargs...)
+                                       wrap_code = add_integrator_header(),
+                                       outputidxs = update_inds,
+                                       kwargs...)
         rf_ip
     end
 end
-
 
 function generate_rootfinding_callback(sys::AbstractODESystem, dvs = states(sys),
                                        ps = parameters(sys); kwargs...)

--- a/src/systems/callbacks.jl
+++ b/src/systems/callbacks.jl
@@ -105,7 +105,7 @@ Notes
 - `kwargs` are passed through to `Symbolics.build_function`.
 """
 function compile_affect(eqs::Vector{Equation}, sys, dvs, ps; outputidxs = nothing,
-                        expression = Val{true}, kwargs...)
+                        expression = Val{true}, checkvars = true, kwargs...)
     if isempty(eqs)
         if expression == Val{true}
             return :((args...) -> ())
@@ -128,8 +128,13 @@ function compile_affect(eqs::Vector{Equation}, sys, dvs, ps; outputidxs = nothin
             update_inds = outputidxs
         end
 
-        u = map(x -> time_varying_as_func(value(x), sys), dvs)
-        p = map(x -> time_varying_as_func(value(x), sys), ps)
+        if checkvars
+            u = map(x -> time_varying_as_func(value(x), sys), dvs)
+            p = map(x -> time_varying_as_func(value(x), sys), ps)
+        else
+            u = dvs
+            p = ps
+        end
         t = get_iv(sys)
         rf_oop, rf_ip = build_function(rhss, u, p, t; expression = expression,
                                        wrap_code = add_integrator_header(),

--- a/src/systems/callbacks.jl
+++ b/src/systems/callbacks.jl
@@ -138,14 +138,14 @@ function compile_affect(eqs::Vector{Equation}, sys, dvs, ps; outputidxs = nothin
 end
 
 
-function generate_rootfinding_callback(sys::ODESystem, dvs = states(sys),
+function generate_rootfinding_callback(sys::AbstractODESystem, dvs = states(sys),
                                        ps = parameters(sys); kwargs...)
     cbs = continuous_events(sys)
     isempty(cbs) && return nothing
     generate_rootfinding_callback(cbs, sys, dvs, ps; kwargs...)
 end
 
-function generate_rootfinding_callback(cbs, sys::ODESystem, dvs = states(sys),
+function generate_rootfinding_callback(cbs, sys::AbstractODESystem, dvs = states(sys),
                                        ps = parameters(sys); kwargs...)
     eqs = map(cb -> cb.eqs, cbs)
     num_eqs = length.(eqs)

--- a/src/systems/callbacks.jl
+++ b/src/systems/callbacks.jl
@@ -99,7 +99,7 @@ Notes
 - `expression = Val{true}`, causes the generated function to be returned as an expression.
   If  set to `Val{false}` a `RuntimeGeneratedFunction` will be returned.
 - `outputidxs`, a vector of indices of the output variables which should correspond to
-  `states(sys)`. If provided checks that the LHS of affect equations are variables are
+  `states(sys)`. If provided, checks that the LHS of affect equations are variables are
   dropped, i.e. it is assumed these indices are correct and affect equations are
   well-formed.
 - `kwargs` are passed through to `Symbolics.build_function`.

--- a/src/systems/callbacks.jl
+++ b/src/systems/callbacks.jl
@@ -1,0 +1,186 @@
+#################################### system operations #####################################
+get_continuous_events(sys::AbstractSystem) = Equation[]
+get_continuous_events(sys::AbstractODESystem) = getfield(sys, :continuous_events)
+has_continuous_events(sys::AbstractSystem) = isdefined(sys, :continuous_events)
+
+
+#################################### continuous events #####################################
+
+const NULL_AFFECT = Equation[]
+struct SymbolicContinuousCallback
+    eqs::Vector{Equation}
+    affect::Vector{Equation}
+    function SymbolicContinuousCallback(eqs::Vector{Equation}, affect = NULL_AFFECT)
+        new(eqs, affect)
+    end # Default affect to nothing
+end
+
+function Base.:(==)(e1::SymbolicContinuousCallback, e2::SymbolicContinuousCallback)
+    isequal(e1.eqs, e2.eqs) && isequal(e1.affect, e2.affect)
+end
+Base.isempty(cb::SymbolicContinuousCallback) = isempty(cb.eqs)
+function Base.hash(cb::SymbolicContinuousCallback, s::UInt)
+    s = foldr(hash, cb.eqs, init = s)
+    foldr(hash, cb.affect, init = s)
+end
+
+to_equation_vector(eq::Equation) = [eq]
+to_equation_vector(eqs::Vector{Equation}) = eqs
+function to_equation_vector(eqs::Vector{Any})
+    isempty(eqs) || error("This should never happen")
+    Equation[]
+end
+
+function SymbolicContinuousCallback(args...)
+    SymbolicContinuousCallback(to_equation_vector.(args)...)
+end # wrap eq in vector
+SymbolicContinuousCallback(p::Pair) = SymbolicContinuousCallback(p[1], p[2])
+SymbolicContinuousCallback(cb::SymbolicContinuousCallback) = cb # passthrough
+
+SymbolicContinuousCallbacks(cb::SymbolicContinuousCallback) = [cb]
+SymbolicContinuousCallbacks(cbs::Vector{<:SymbolicContinuousCallback}) = cbs
+SymbolicContinuousCallbacks(cbs::Vector) = SymbolicContinuousCallback.(cbs)
+function SymbolicContinuousCallbacks(ve::Vector{Equation})
+    SymbolicContinuousCallbacks(SymbolicContinuousCallback(ve))
+end
+function SymbolicContinuousCallbacks(others)
+    SymbolicContinuousCallbacks(SymbolicContinuousCallback(others))
+end
+SymbolicContinuousCallbacks(::Nothing) = SymbolicContinuousCallbacks(Equation[])
+
+equations(cb::SymbolicContinuousCallback) = cb.eqs
+function equations(cbs::Vector{<:SymbolicContinuousCallback})
+    reduce(vcat, [equations(cb) for cb in cbs])
+end
+affect_equations(cb::SymbolicContinuousCallback) = cb.affect
+function affect_equations(cbs::Vector{SymbolicContinuousCallback})
+    reduce(vcat, [affect_equations(cb) for cb in cbs])
+end
+namespace_equation(cb::SymbolicContinuousCallback, s)::SymbolicContinuousCallback = SymbolicContinuousCallback(namespace_equation.(equations(cb),
+                                                                                                                                   (s,)),
+                                                                                                               namespace_equation.(affect_equations(cb),
+                                                                                                                                   (s,)))
+
+function continuous_events(sys::AbstractSystem)
+    obs = get_continuous_events(sys)
+    filter(!isempty, obs)
+    systems = get_systems(sys)
+    cbs = [obs;
+           reduce(vcat,
+                  (map(o -> namespace_equation(o, s), continuous_events(s))
+                   for s in systems),
+                  init = SymbolicContinuousCallback[])]
+    filter(!isempty, cbs)
+end
+
+
+################################# compilation functions ####################################
+
+function compile_affect(cb::SymbolicContinuousCallback, args...; kwargs...)
+    compile_affect(affect_equations(cb), args...; kwargs...)
+end
+
+"""
+    compile_affect(eqs::Vector{Equation}, sys, dvs, ps; kwargs...)
+    compile_affect(cb::SymbolicContinuousCallback, args...; kwargs...)
+
+Returns a function that takes an integrator as argument and modifies the state with the affect.
+"""
+function compile_affect(eqs::Vector{Equation}, sys, dvs, ps; expression = Val{false}, kwargs...)
+    if isempty(eqs)
+        return (args...) -> () # We don't do anything in the callback, we're just after the event
+    else
+        rhss = map(x -> x.rhs, eqs)
+        lhss = map(x -> x.lhs, eqs)
+        update_vars = collect(Iterators.flatten(map(ModelingToolkit.vars, lhss))) # these are the ones we're chaning
+        length(update_vars) == length(unique(update_vars)) == length(eqs) ||
+            error("affected variables not unique, each state can only be affected by one equation for a single `root_eqs => affects` pair.")
+        vars = states(sys)
+
+        u = map(x -> time_varying_as_func(value(x), sys), vars)
+        p = map(x -> time_varying_as_func(value(x), sys), ps)
+        t = get_iv(sys)
+        # stateind(sym) = findfirst(isequal(sym), vars)
+        # update_inds = stateind.(update_vars)
+        # rf_oop, rf_ip = build_function(rhss, u, p, t; expression = expression, wrap_code=add_integrator_header(), outputidxs = update_inds, kwargs...)
+        # rf_ip
+
+        rf_oop, rf_ip = build_function(rhss, u, p, t; expression = expression, kwargs...)
+
+        stateind(sym) = findfirst(isequal(sym), vars)
+
+        update_inds = stateind.(update_vars)
+        let update_inds = update_inds
+            function (integ)
+                lhs = @views integ.u[update_inds]
+                rf_ip(lhs, integ.u, integ.p, integ.t)
+            end
+        end
+    end
+end
+
+
+function generate_rootfinding_callback(sys::ODESystem, dvs = states(sys),
+                                       ps = parameters(sys); kwargs...)
+    cbs = continuous_events(sys)
+    isempty(cbs) && return nothing
+    generate_rootfinding_callback(cbs, sys, dvs, ps; kwargs...)
+end
+
+function generate_rootfinding_callback(cbs, sys::ODESystem, dvs = states(sys),
+                                       ps = parameters(sys); kwargs...)
+    eqs = map(cb -> cb.eqs, cbs)
+    num_eqs = length.(eqs)
+    (isempty(eqs) || sum(num_eqs) == 0) && return nothing
+    # fuse equations to create VectorContinuousCallback
+    eqs = reduce(vcat, eqs)
+    # rewrite all equations as 0 ~ interesting stuff
+    eqs = map(eqs) do eq
+        isequal(eq.lhs, 0) && return eq
+        0 ~ eq.lhs - eq.rhs
+    end
+
+    rhss = map(x -> x.rhs, eqs)
+    root_eq_vars = unique(collect(Iterators.flatten(map(ModelingToolkit.vars, rhss))))
+
+    u = map(x -> time_varying_as_func(value(x), sys), dvs)
+    p = map(x -> time_varying_as_func(value(x), sys), ps)
+    t = get_iv(sys)
+    rf_oop, rf_ip = build_function(rhss, u, p, t; expression = Val{false}, kwargs...)
+
+    affect_functions = map(cbs) do cb # Keep affect function separate
+        eq_aff = affect_equations(cb)
+        affect = compile_affect(eq_aff, sys, dvs, ps; kwargs...)
+    end
+
+    if length(eqs) == 1
+        cond = function (u, t, integ)
+            if DiffEqBase.isinplace(integ.sol.prob)
+                tmp, = DiffEqBase.get_tmp_cache(integ)
+                rf_ip(tmp, u, integ.p, t)
+                tmp[1]
+            else
+                rf_oop(u, integ.p, t)
+            end
+        end
+        ContinuousCallback(cond, affect_functions[])
+    else
+        cond = function (out, u, t, integ)
+            rf_ip(out, u, integ.p, t)
+        end
+
+        # since there may be different number of conditions and affects,
+        # we build a map that translates the condition eq. number to the affect number
+        eq_ind2affect = reduce(vcat,
+                               [fill(i, num_eqs[i]) for i in eachindex(affect_functions)])
+        @assert length(eq_ind2affect) == length(eqs)
+        @assert maximum(eq_ind2affect) == length(affect_functions)
+
+        affect = let affect_functions = affect_functions, eq_ind2affect = eq_ind2affect
+            function (integ, eq_ind) # eq_ind refers to the equation index that triggered the event, each event has num_eqs[i] equations
+                affect_functions[eq_ind2affect[eq_ind]](integ)
+            end
+        end
+        VectorContinuousCallback(cond, affect, length(eqs))
+    end
+end

--- a/src/systems/diffeqs/abstractodesystem.jl
+++ b/src/systems/diffeqs/abstractodesystem.jl
@@ -188,123 +188,6 @@ function generate_difference_cb(sys::ODESystem, dvs = states(sys), ps = paramete
     PeriodicCallback(cb_affect!, first(dt))
 end
 
-function generate_rootfinding_callback(sys::ODESystem, dvs = states(sys),
-                                       ps = parameters(sys); kwargs...)
-    cbs = continuous_events(sys)
-    isempty(cbs) && return nothing
-    generate_rootfinding_callback(cbs, sys, dvs, ps; kwargs...)
-end
-
-function generate_rootfinding_callback(cbs, sys::ODESystem, dvs = states(sys),
-                                       ps = parameters(sys); kwargs...)
-    eqs = map(cb -> cb.eqs, cbs)
-    num_eqs = length.(eqs)
-    (isempty(eqs) || sum(num_eqs) == 0) && return nothing
-    # fuse equations to create VectorContinuousCallback
-    eqs = reduce(vcat, eqs)
-    # rewrite all equations as 0 ~ interesting stuff
-    eqs = map(eqs) do eq
-        isequal(eq.lhs, 0) && return eq
-        0 ~ eq.lhs - eq.rhs
-    end
-
-    rhss = map(x -> x.rhs, eqs)
-    root_eq_vars = unique(collect(Iterators.flatten(map(ModelingToolkit.vars, rhss))))
-
-    u = map(x -> time_varying_as_func(value(x), sys), dvs)
-    p = map(x -> time_varying_as_func(value(x), sys), ps)
-    t = get_iv(sys)
-    rf_oop, rf_ip = build_function(rhss, u, p, t; expression = Val{false}, kwargs...)
-
-    affect_functions = map(cbs) do cb # Keep affect function separate
-        eq_aff = affect_equations(cb)
-        affect = compile_affect(eq_aff, sys, dvs, ps; kwargs...)
-    end
-
-    if length(eqs) == 1
-        cond = function (u, t, integ)
-            if DiffEqBase.isinplace(integ.sol.prob)
-                tmp, = DiffEqBase.get_tmp_cache(integ)
-                rf_ip(tmp, u, integ.p, t)
-                tmp[1]
-            else
-                rf_oop(u, integ.p, t)
-            end
-        end
-        ContinuousCallback(cond, affect_functions[])
-    else
-        cond = function (out, u, t, integ)
-            rf_ip(out, u, integ.p, t)
-        end
-
-        # since there may be different number of conditions and affects,
-        # we build a map that translates the condition eq. number to the affect number
-        eq_ind2affect = reduce(vcat,
-                               [fill(i, num_eqs[i]) for i in eachindex(affect_functions)])
-        @assert length(eq_ind2affect) == length(eqs)
-        @assert maximum(eq_ind2affect) == length(affect_functions)
-
-        affect = let affect_functions = affect_functions, eq_ind2affect = eq_ind2affect
-            function (integ, eq_ind) # eq_ind refers to the equation index that triggered the event, each event has num_eqs[i] equations
-                affect_functions[eq_ind2affect[eq_ind]](integ)
-            end
-        end
-        VectorContinuousCallback(cond, affect, length(eqs))
-    end
-end
-
-function compile_affect(cb::SymbolicContinuousCallback, args...; kwargs...)
-    compile_affect(affect_equations(cb), args...; kwargs...)
-end
-
-"""
-    compile_affect(eqs::Vector{Equation}, sys, dvs, ps; kwargs...)
-    compile_affect(cb::SymbolicContinuousCallback, args...; kwargs...)
-
-Returns a function that takes an integrator as argument and modifies the state with the affect.
-"""
-function compile_affect(eqs::Vector{Equation}, sys, dvs, ps; kwargs...)
-    if isempty(eqs)
-        return (args...) -> () # We don't do anything in the callback, we're just after the event
-    else
-        rhss = map(x -> x.rhs, eqs)
-        lhss = map(x -> x.lhs, eqs)
-        update_vars = collect(Iterators.flatten(map(ModelingToolkit.vars, lhss))) # these are the ones we're chaning
-        length(update_vars) == length(unique(update_vars)) == length(eqs) ||
-            error("affected variables not unique, each state can only be affected by one equation for a single `root_eqs => affects` pair.")
-        vars = states(sys)
-
-        u = map(x -> time_varying_as_func(value(x), sys), vars)
-        p = map(x -> time_varying_as_func(value(x), sys), ps)
-        t = get_iv(sys)
-        rf_oop, rf_ip = build_function(rhss, u, p, t; expression = Val{false}, kwargs...)
-
-        stateind(sym) = findfirst(isequal(sym), vars)
-
-        update_inds = stateind.(update_vars)
-        let update_inds = update_inds
-            function (integ)
-                lhs = @views integ.u[update_inds]
-                rf_ip(lhs, integ.u, integ.p, integ.t)
-            end
-        end
-    end
-end
-
-function time_varying_as_func(x, sys::AbstractTimeDependentSystem)
-    # if something is not x(t) (the current state)
-    # but is `x(t-1)` or something like that, pass in `x` as a callable function rather
-    # than pass in a value in place of x(t).
-    #
-    # This is done by just making `x` the argument of the function.
-    if istree(x) &&
-       operation(x) isa Sym &&
-       !(length(arguments(x)) == 1 && isequal(arguments(x)[1], get_iv(sys)))
-        return operation(x)
-    end
-    return x
-end
-
 function calculate_massmatrix(sys::AbstractODESystem; simplify = false)
     eqs = [eq for eq in full_equations(sys) if !isdifferenceeq(eq)]
     dvs = states(sys)
@@ -772,6 +655,8 @@ merge_cb(::Nothing, ::Nothing) = nothing
 merge_cb(::Nothing, x) = merge_cb(x, nothing)
 merge_cb(x, ::Nothing) = x
 merge_cb(x, y) = CallbackSet(x, y)
+get_callback(prob::ODEProblem) = prob.kwargs[:callback]
+
 
 """
 ```julia

--- a/src/systems/diffeqs/abstractodesystem.jl
+++ b/src/systems/diffeqs/abstractodesystem.jl
@@ -657,7 +657,6 @@ merge_cb(x, ::Nothing) = x
 merge_cb(x, y) = CallbackSet(x, y)
 get_callback(prob::ODEProblem) = prob.kwargs[:callback]
 
-
 """
 ```julia
 function DiffEqBase.DAEProblem{iip}(sys::AbstractODESystem,du0map,u0map,tspan,

--- a/src/systems/diffeqs/odesystem.jl
+++ b/src/systems/diffeqs/odesystem.jl
@@ -252,11 +252,6 @@ end
 
 ODESystem(eq::Equation, args...; kwargs...) = ODESystem([eq], args...; kwargs...)
 
-get_continuous_events(sys::AbstractSystem) = Equation[]
-get_continuous_events(sys::AbstractODESystem) = getfield(sys, :continuous_events)
-has_continuous_events(sys::AbstractSystem) = isdefined(sys, :continuous_events)
-get_callback(prob::ODEProblem) = prob.kwargs[:callback]
-
 """
 $(SIGNATURES)
 

--- a/src/systems/jumps/jumpsystem.jl
+++ b/src/systems/jumps/jumpsystem.jl
@@ -121,7 +121,7 @@ end
 
 function generate_affect_function(js::JumpSystem, affect, outputidxs)
     compile_affect(affect, js, states(js), parameters(js); outputidxs = outputidxs,
-                                                           expression = Val{true})
+                   expression = Val{true})
 end
 
 function assemble_vrj(js, vrj, statetoid)

--- a/src/systems/jumps/jumpsystem.jl
+++ b/src/systems/jumps/jumpsystem.jl
@@ -128,12 +128,13 @@ function add_integrator_header()
 end
 
 function generate_affect_function(js::JumpSystem, affect, outputidxs)
-    bf = build_function(map(x -> x isa Equation ? x.rhs : x, affect), states(js),
-                        parameters(js),
-                        get_iv(js),
-                        expression = Val{true},
-                        wrap_code = add_integrator_header(),
-                        outputidxs = outputidxs)[2]
+    compile_affect(affect, js, states(js), parameters(js); expression = Val{true})
+    # bf = build_function(map(x -> x isa Equation ? x.rhs : x, affect), states(js),
+    #                     parameters(js),
+    #                     get_iv(js),
+    #                     expression = Val{true},
+    #                     wrap_code = add_integrator_header(),
+    #                     outputidxs = outputidxs)[2]
 end
 
 function assemble_vrj(js, vrj, statetoid)

--- a/src/systems/jumps/jumpsystem.jl
+++ b/src/systems/jumps/jumpsystem.jl
@@ -118,23 +118,10 @@ function generate_rate_function(js::JumpSystem, rate)
                         conv = states_to_sym(states(js)),
                         expression = Val{true})
 end
-function add_integrator_header()
-    integrator = gensym(:MTKIntegrator)
-
-    expr -> Func([DestructuredArgs(expr.args, integrator, inds = [:u, :p, :t])], [],
-                 expr.body),
-    expr -> Func([DestructuredArgs(expr.args, integrator, inds = [:u, :u, :p, :t])], [],
-                 expr.body)
-end
 
 function generate_affect_function(js::JumpSystem, affect, outputidxs)
-    compile_affect(affect, js, states(js), parameters(js); expression = Val{true})
-    # bf = build_function(map(x -> x isa Equation ? x.rhs : x, affect), states(js),
-    #                     parameters(js),
-    #                     get_iv(js),
-    #                     expression = Val{true},
-    #                     wrap_code = add_integrator_header(),
-    #                     outputidxs = outputidxs)[2]
+    compile_affect(affect, js, states(js), parameters(js); outputidxs = outputidxs,
+                                                           expression = Val{true})
 end
 
 function assemble_vrj(js, vrj, statetoid)

--- a/src/systems/jumps/jumpsystem.jl
+++ b/src/systems/jumps/jumpsystem.jl
@@ -121,7 +121,7 @@ end
 
 function generate_affect_function(js::JumpSystem, affect, outputidxs)
     compile_affect(affect, js, states(js), parameters(js); outputidxs = outputidxs,
-                   expression = Val{true})
+                   expression = Val{true}, checkvars = false)
 end
 
 function assemble_vrj(js, vrj, statetoid)


### PR DESCRIPTION
The callback routines were kind of defined in a bunch of different places, so I factored them out to their own file. I also updated `compile_affect` to avoid having it generate a function that simply creates a view and then wraps another function, instead reusing how we generate affects for JumpSystems (which have the same affect function signature and was how @shashi originally built them to work with integrators). That allowed me to reuse `compile_affect` for jumps too now.

This should be non-breaking with respect to continuous callbacks -- all I actually changed was `compile_affect` and calls to `compile_affect` (adding one in JumpSystems).

I'll add `DiscreteCallbacks` in a followup PR.