### PR TITLE
Throw a more concrete error on unsupported modelingtoolkitize parameters

### DIFF
--- a/src/systems/diffeqs/modelingtoolkitize.jl
+++ b/src/systems/diffeqs/modelingtoolkitize.jl
@@ -91,7 +91,7 @@ function define_vars(u::Union{SLArray, LArray}, t)
     [_defvar(x)(t) for x in LabelledArrays.symnames(typeof(u))]
 end
 
-function define_vars(u::Tuple, t)
+function define_vars(u::NTuple{<:Number}, t)
     tuple((_defvaridx(:x, i)(ModelingToolkit.value(t)) for i in eachindex(u))...)
 end
 
@@ -99,7 +99,33 @@ function define_vars(u::NamedTuple, t)
     NamedTuple(x => _defvar(x)(ModelingToolkit.value(t)) for x in keys(u))
 end
 
+const PARAMETERS_NOT_SUPPORTED_MESSAGE = 
+"""
+The chosen parameter type is currently not supported by `modelingtoolkitize`. The
+current supported types are:
+
+- AbstractArrays
+- AbstractDicts
+- LabelledArrays (SLArray, LArray)
+- Flat tuples (tuples of numbers)
+- Flat named tuples (namedtuples of numbers)
+"""
+
+struct ModelingtoolkitizeParametersNotSupportedError <: Exception 
+    type::Any
+end
+
+function Base.showerror(io::IO, e::ModelingtoolkitizeParametersNotSupportedError)
+    println(io, PARAMETERS_NOT_SUPPORTED_MESSAGE)
+    print(io, "Parameter type: ")
+    println(io,e.type)
+end
+
 function define_params(p)
+    throw(ModelingtoolkitizeParametersNotSupportedError(typeof(p)))
+end
+
+function define_params(p::AbstractArray)
     [toparam(variable(:α, i)) for i in eachindex(p)]
 end
 


### PR DESCRIPTION
This is at least an intermediate solution to help give more interpretable error messages for https://github.com/SciML/ModelingToolkit.jl/issues/1678 . It's not a full solution since the real problem there is that while tuples are supported, it assumes `::NTuple{<:Number}`

The "real" answer of course is to make this handling recursive, but I'll leave that as a separate PR.