### PR TITLE
Fix dimension mismatch and wrong equation in linearize

### DIFF
--- a/src/systems/abstractsystem.jl
+++ b/src/systems/abstractsystem.jl
@@ -1210,11 +1210,11 @@ function linearize(sys, lin_fun; t = 0.0, op = Dict(), allow_input_derivatives =
         C = [
         h_x h_z
 ]
-        Bs = -(gz \ (f_x * f_u + g_u))
+        Bs = -(gz \ g_u) # This equation differ from the cited paper, the paper is likely wrong since their equaiton leads to a dimension mismatch.
         if !iszero(Bs)
             if !allow_input_derivatives
                 der_inds = findall(vec(any(!=(0), Bs, dims = 1)))
-                error("Input derivatives appeared in expressions (-g_z\\(f_x*f_u + g_u) != 0), the following inputs appeared differentiated: $(inputs(sys)[der_inds]). Call `linear_staespace` with keyword argument `allow_input_derivatives = true` to allow this and have the returned `B` matrix be of double width ($(2nu)), where the last $nu inputs are the derivatives of the first $nu inputs.")
+                error("Input derivatives appeared in expressions (-g_z\\g_u != 0), the following inputs appeared differentiated: $(inputs(sys)[der_inds]). Call `linear_staespace` with keyword argument `allow_input_derivatives = true` to allow this and have the returned `B` matrix be of double width ($(2nu)), where the last $nu inputs are the derivatives of the first $nu inputs.")
             end
             B = [B Bs]
         end


### PR DESCRIPTION
The referenced paper is likely wrong in this case, derivation below

![IMG_20220713_172453](https://user-images.githubusercontent.com/3797491/178772257-cdcdd695-9203-4599-a50a-dea93bd132bf.jpg)

our tests currently don't catch this bug since it happens in the DAE branch, which is currently not supported