### PR TITLE
return the lhs instead of observable equation from `getvar`

### DIFF
--- a/src/systems/abstractsystem.jl
+++ b/src/systems/abstractsystem.jl
@@ -309,7 +309,7 @@ function getvar(sys::AbstractSystem, name::Symbol; namespace = false)
         obs = get_observed(sys)
         i = findfirst(x -> getname(x.lhs) == name, obs)
         if i !== nothing
-            return namespace ? renamespace(sys, obs[i]) : obs[i]
+            return namespace ? renamespace(sys, obs[i].lhs) : obs[i].lhs
         end
     end
 


### PR DESCRIPTION
Fixes #1743 