### PR TITLE
Removed the definition of the unused variable RHS(t) from the copy-pastable example in the docs.

### DIFF
--- a/docs/src/tutorials/ode_modeling.md
+++ b/docs/src/tutorials/ode_modeling.md
@@ -13,11 +13,11 @@ But if you want to just see some code and run, here's an example:
 ```julia
 using ModelingToolkit
 
-@variables t x(t) RHS(t)  # independent and dependent variables
+@variables t x(t)   # independent and dependent variables
 @parameters τ       # parameters
 D = Differential(t) # define an operator for the differentiation w.r.t. time
 
-# your first ODE, consisting of a single equation, indicated by ~
+# your first ODE, consisting of a single equation, the equality indicated by ~
 @named fol = ODESystem([ D(x)  ~ (1 - x)/τ])
 
 using DifferentialEquations: solve


### PR DESCRIPTION
I found it confusing that in the very first (hello-world-like) example a variable is defined that is never used.  