### PR TITLE
implement coerce_units

### DIFF
--- a/src/systems/validation.jl
+++ b/src/systems/validation.jl
@@ -152,9 +152,8 @@ end
 
 "Coerce the units of an equation to match, overriding the right-hand side."
 function coerce_units(eq::Equation)
-    (; lhs, rhs) = eq
-    rhs = setmetadata(rhs, VariableUnit, safe_get_unit(lhs, "left"))
-    return lhs ~ rhs
+    new_rhs = setmetadata(eq.rhs, VariableUnit, safe_get_unit(eq.lhs, "left"))
+    return eq.lhs ~ new_rhs
 end
 
 function _validate(terms::Vector, labels::Vector{String}; info::String = "")

--- a/src/systems/validation.jl
+++ b/src/systems/validation.jl
@@ -132,6 +132,7 @@ end
 
 "Get unit of term, returning nothing & showing warning instead of throwing errors."
 function safe_get_unit(term, info)
+    hasmetadata(term, VariableUnit) && return getmetadata(term, VariableUnit)
     side = nothing
     try
         side = get_unit(term)
@@ -147,6 +148,13 @@ function safe_get_unit(term, info)
         end
     end
     side
+end
+
+"Coerce the units of an equation to match, overriding the right-hand side."
+function coerce_units(eq::Equation)
+    (; lhs, rhs) = eq
+    rhs = setmetadata(rhs, VariableUnit, safe_get_unit(lhs, "left"))
+    return lhs ~ rhs
 end
 
 function _validate(terms::Vector, labels::Vector{String}; info::String = "")

--- a/src/systems/validation.jl
+++ b/src/systems/validation.jl
@@ -132,7 +132,7 @@ end
 
 "Get unit of term, returning nothing & showing warning instead of throwing errors."
 function safe_get_unit(term, info)
-    if term isa Union{Num,Complex{Num},Symbolic} && hasmetadata(term, VariableUnit)
+    if term isa Union{Num, Complex{Num}, Symbolic} && hasmetadata(term, VariableUnit)
         return getmetadata(term, VariableUnit)
     end
     side = nothing

--- a/src/systems/validation.jl
+++ b/src/systems/validation.jl
@@ -132,7 +132,9 @@ end
 
 "Get unit of term, returning nothing & showing warning instead of throwing errors."
 function safe_get_unit(term, info)
-    hasmetadata(term, VariableUnit) && return getmetadata(term, VariableUnit)
+    if term isa Union{Num,Complex{Num},Symbolic} && hasmetadata(term, VariableUnit)
+        return getmetadata(term, VariableUnit)
+    end
     side = nothing
     try
         side = get_unit(term)

--- a/test/units.jl
+++ b/test/units.jl
@@ -47,6 +47,12 @@ eqs = [D(E) ~ P - E / τ
 @test !MT.validate(D(D(E)) ~ P)
 @test !MT.validate(0 ~ P + E * τ)
 
+# Equation unit coercion
+@variables X
+eq1 = D(X) ~ 3P - 5
+eq2 = MT.coerce_units(eq1)
+@test !MT.validate(eq1) && MT.validate(eq2)
+
 # Array variables
 @variables t [unit = u"s"] x(t)[1:3] [unit = u"m"]
 @parameters v[1:3]=[1, 2, 3] [unit = u"m/s"]


### PR DESCRIPTION
fixes #1763

Introduces a non-exported utility called `coerce_units` that allows applying LHS units of an equation _directly_ onto the RHS term. This allows short circuiting `safe_get_unit` if unit metadata is detected prior to checking units through the whole operation.

@isaacsas assuming this passes tests, what do you think?