### PR TITLE
Refactor to pull graph manipulation out of pantelides

### DIFF
--- a/src/bipartite_graph.jl
+++ b/src/bipartite_graph.jl
@@ -413,15 +413,17 @@ function Graphs.add_vertex!(g::BipartiteGraph{T}, type::VertType) where {T}
     if type === DST
         if g.badjlist isa AbstractVector
             push!(g.badjlist, T[])
+            return length(g.badjlist)
         else
             g.badjlist += 1
+            return g.badjlist
         end
     elseif type === SRC
         push!(g.fadjlist, T[])
+        return length(g.fadjlist)
     else
         error("type ($type) must be either `DST` or `SRC`")
     end
-    return true  # vertex successfully added
 end
 
 function set_neighbors!(g::BipartiteGraph, i::Integer, new_neighbors)

--- a/src/structural_transformation/pantelides.jl
+++ b/src/structural_transformation/pantelides.jl
@@ -75,7 +75,7 @@ end
 Perform Pantelides algorithm.
 """
 function pantelides!(state::TransformationState; maxiters = 8000)
-    @unpack graph, var_to_diff, eq_to_diff = state.structure
+    @unpack graph, solvable_graph, var_to_diff, eq_to_diff = state.structure
     neqs = nsrcs(graph)
     nvars = nv(var_to_diff)
     vcolor = falses(nvars)
@@ -105,22 +105,15 @@ function pantelides!(state::TransformationState; maxiters = 8000)
                 vcolor[var] || continue
                 # introduce a new variable
                 nvars += 1
-                add_vertex!(graph, DST)
-                # the new variable is the derivative of `var`
-
-                add_edge!(var_to_diff, var, add_vertex!(var_to_diff))
+                var_diff = var_derivative!(state, var)
                 push!(var_eq_matching, unassigned)
-                var_derivative!(state, var)
+                @assert length(var_eq_matching) == var_diff
             end
 
             for eq in eachindex(ecolor)
                 ecolor[eq] || continue
                 # introduce a new equation
                 neqs += 1
-                add_vertex!(graph, SRC)
-                # the new equation is created by differentiating `eq`
-                eq_diff = add_vertex!(eq_to_diff)
-                add_edge!(eq_to_diff, eq, eq_diff)
                 eq_derivative!(state, eq)
             end
 


### PR DESCRIPTION
It seemes a bit weird to update the graph itself in pantelides, but
update the solvable_graph in eq_derivative!, since it's not clear who
is in charge of the data structure. Refactor this to put eq_derivative!
in charge of updating both data structures, but pull out the graph
manipulation code into a separate helper function that can be used
by non-symbolic eq_derivative implementations to avoid repeating code.