### PR TITLE
Fix accidental aliasing between mm and structure.graph

### DIFF
--- a/src/bipartite_graph.jl
+++ b/src/bipartite_graph.jl
@@ -428,11 +428,6 @@ function set_neighbors!(g::BipartiteGraph, i::Integer, new_neighbors)
     old_neighbors = g.fadjlist[i]
     old_nneighbors = length(old_neighbors)
     new_nneighbors = length(new_neighbors)
-    if iszero(new_nneighbors) # this handles Tuple as well
-        empty!(g.fadjlist[i])
-    else
-        g.fadjlist[i] = copy(new_neighbors)
-    end
     g.ne += new_nneighbors - old_nneighbors
     if isa(g.badjlist, AbstractVector)
         for n in old_neighbors
@@ -445,6 +440,12 @@ function set_neighbors!(g::BipartiteGraph, i::Integer, new_neighbors)
             index = searchsortedfirst(list, i)
             insert!(list, index, i)
         end
+    end
+    if iszero(new_nneighbors) # this handles Tuple as well
+        # Warning: Aliases old_neighbors
+        empty!(g.fadjlist[i])
+    else
+        g.fadjlist[i] = copy(new_neighbors)
     end
 end
 

--- a/src/bipartite_graph.jl
+++ b/src/bipartite_graph.jl
@@ -431,7 +431,7 @@ function set_neighbors!(g::BipartiteGraph, i::Integer, new_neighbors)
     if iszero(new_nneighbors) # this handles Tuple as well
         empty!(g.fadjlist[i])
     else
-        g.fadjlist[i] = new_neighbors
+        g.fadjlist[i] = copy(new_neighbors)
     end
     g.ne += new_nneighbors - old_nneighbors
     if isa(g.badjlist, AbstractVector)


### PR DESCRIPTION
After the set_neighbors! call, future modifications to the graph
would silently corrupt the coefficient matrix. We didn't notice
because we're currently not doing that, but it's a big footgun
that I hit trying to do some fancier things, so fix this up
in the hope to prevent others from hitting it in the future.