### PR TITLE
allow bit flagging for system checks

### DIFF
--- a/src/systems/diffeqs/odesystem.jl
+++ b/src/systems/diffeqs/odesystem.jl
@@ -120,12 +120,14 @@ struct ODESystem <: AbstractODESystem
                        jac, ctrl_jac, Wfact, Wfact_t, name, systems, defaults,
                        torn_matching, connector_type, connections, preface, cevents,
                        devents, tearing_state = nothing, substitutions = nothing;
-                       checks::Bool = true)
-        if checks
+                       checks::Union{Bool, Int} = true)
+        if checks == true || (checks & CheckComponents) > 0
             check_variables(dvs, iv)
             check_parameters(ps, iv)
             check_equations(deqs, iv)
             check_equations(equations(cevents), iv)
+        end
+        if checks == true || (checks & CheckUnits) > 0
             all_dimensionless([dvs; ps; iv]) || check_units(deqs)
         end
         new(deqs, iv, dvs, ps, var_to_name, ctrls, observed, tgrad, jac,

--- a/src/systems/diffeqs/sdesystem.jl
+++ b/src/systems/diffeqs/sdesystem.jl
@@ -99,12 +99,14 @@ struct SDESystem <: AbstractODESystem
 
     function SDESystem(deqs, neqs, iv, dvs, ps, var_to_name, ctrls, observed, tgrad, jac,
                        ctrl_jac, Wfact, Wfact_t, name, systems, defaults, connector_type,
-                       cevents, devents; checks::Bool = true)
-        if checks
+                       cevents, devents; checks::Union{Bool, Int} = true)
+        if checks == true || (checks & CheckComponents) > 0
             check_variables(dvs, iv)
             check_parameters(ps, iv)
             check_equations(deqs, iv)
             check_equations(equations(cevents), iv)
+        end
+        if checks == true || (checks & CheckUnits) > 0
             all_dimensionless([dvs; ps; iv]) || check_units(deqs, neqs)
         end
         new(deqs, neqs, iv, dvs, ps, var_to_name, ctrls, observed, tgrad, jac, ctrl_jac,

--- a/src/systems/discrete_system/discrete_system.jl
+++ b/src/systems/discrete_system/discrete_system.jl
@@ -71,10 +71,12 @@ struct DiscreteSystem <: AbstractTimeDependentSystem
     function DiscreteSystem(discreteEqs, iv, dvs, ps, var_to_name, ctrls, observed, name,
                             systems, defaults, preface, connector_type,
                             tearing_state = nothing, substitutions = nothing;
-                            checks::Bool = true)
-        if checks
+                            checks::Union{Bool, Int} = true)
+        if checks == true || (checks & CheckComponents) > 0
             check_variables(dvs, iv)
             check_parameters(ps, iv)
+        end
+        if checks == true || (checks & CheckUnits) > 0
             all_dimensionless([dvs; ps; iv; ctrls]) || check_units(discreteEqs)
         end
         new(discreteEqs, iv, dvs, ps, var_to_name, ctrls, observed, name, systems, defaults,

--- a/src/systems/jumps/jumpsystem.jl
+++ b/src/systems/jumps/jumpsystem.jl
@@ -86,10 +86,12 @@ struct JumpSystem{U <: ArrayPartition} <: AbstractTimeDependentSystem
 
     function JumpSystem{U}(ap::U, iv, states, ps, var_to_name, observed, name, systems,
                            defaults, connector_type, devents;
-                           checks::Bool = true) where {U <: ArrayPartition}
-        if checks
+                           checks::Union{Bool, Int} = true) where {U <: ArrayPartition}
+        if checks == true || (checks & CheckComponents) > 0
             check_variables(states, iv)
             check_parameters(ps, iv)
+        end
+        if checks == true || (checks & CheckUnits) > 0
             all_dimensionless([states; ps; iv]) || check_units(ap, iv)
         end
         new{U}(ap, iv, states, ps, var_to_name, observed, name, systems, defaults,

--- a/src/systems/nonlinear/nonlinearsystem.jl
+++ b/src/systems/nonlinear/nonlinearsystem.jl
@@ -65,8 +65,8 @@ struct NonlinearSystem <: AbstractTimeIndependentSystem
 
     function NonlinearSystem(eqs, states, ps, var_to_name, observed, jac, name, systems,
                              defaults, connector_type, connections, tearing_state = nothing,
-                             substitutions = nothing; checks::Bool = true)
-        if checks
+                             substitutions = nothing; checks::Union{Bool, Int} = true)
+        if checks == true || (checks & CheckUnits) > 0
             all_dimensionless([states; ps]) || check_units(eqs)
         end
         new(eqs, states, ps, var_to_name, observed, jac, name, systems, defaults,

--- a/src/systems/optimization/optimizationsystem.jl
+++ b/src/systems/optimization/optimizationsystem.jl
@@ -42,8 +42,8 @@ struct OptimizationSystem <: AbstractTimeIndependentSystem
     defaults::Dict
     function OptimizationSystem(op, states, ps, var_to_name, observed,
                                 constraints, name, systems, defaults;
-                                checks::Bool = true)
-        if checks
+                                checks::Union{Bool, Int} = true)
+        if checks == true || (checks & CheckUnits) > 0
             check_units(op)
             check_units(observed)
             all_dimensionless([states; ps]) || check_units(constraints)

--- a/src/systems/pde/pdesystem.jl
+++ b/src/systems/pde/pdesystem.jl
@@ -69,9 +69,9 @@ struct PDESystem <: ModelingToolkit.AbstractMultivariateSystem
                                    defaults = Dict(),
                                    systems = [],
                                    connector_type = nothing,
-                                   checks::Bool = true,
+                                   checks::Union{Bool, Int} = true,
                                    name)
-        if checks
+        if checks == true || (checks & CheckUnits) > 0
             all_dimensionless([dvs; ivs; ps]) || check_units(eqs)
         end
         eqs = eqs isa Vector ? eqs : [eqs]

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -122,6 +122,12 @@ function readable_code(expr)
     JuliaFormatter.format_text(string(expr), JuliaFormatter.SciMLStyle())
 end
 
+# System validation enums
+const CheckNone = 0
+const CheckAll = 1 << 0
+const CheckComponents = 1 << 1
+const CheckUnits = 1 << 2
+
 function check_parameters(ps, iv)
     for p in ps
         isequal(iv, p) &&

--- a/test/units.jl
+++ b/test/units.jl
@@ -47,6 +47,21 @@ eqs = [D(E) ~ P - E / τ
 @test !MT.validate(D(D(E)) ~ P)
 @test !MT.validate(0 ~ P + E * τ)
 
+# Disabling unit validation/checks selectively
+@test_throws MT.ArgumentError ODESystem(eqs, t, [E, P, t], [τ], name = :sys)
+ODESystem(eqs, t, [E, P, t], [τ], name = :sys, checks = MT.CheckUnits)
+eqs = [D(E) ~ P - E / τ
+       0 ~ P + E * τ]
+@test_throws MT.ValidationError ODESystem(eqs, name = :sys, checks = MT.CheckAll)
+@test_throws MT.ValidationError ODESystem(eqs, name = :sys, checks = true)
+ODESystem(eqs, name = :sys, checks = MT.CheckNone)
+ODESystem(eqs, name = :sys, checks = false)
+@test_throws MT.ValidationError ODESystem(eqs, name = :sys,
+                                          checks = MT.CheckComponents | MT.CheckUnits)
+@named sys = ODESystem(eqs, checks = MT.CheckComponents)
+@test_throws MT.ValidationError ODESystem(eqs, t, [E, P, t], [τ], name = :sys,
+                                          checks = MT.CheckUnits)
+
 # Array variables
 @variables t [unit = u"s"] x(t)[1:3] [unit = u"m"]
 @parameters v[1:3]=[1, 2, 3] [unit = u"m/s"]


### PR DESCRIPTION
alternative fix for #1763

Instead of altering unit validation itself I added support for bit flags to selectively disable unit checking. It's written such that the old defaults continue to work, or one can use the newly defined constants to turn checks on or off.

This would let me solve #1763 since I can then specialize the application of `check_units`/`validate` etc ad hoc, and disable further unit checks (but not system checks) when lowering to an `ODESystem`

CC: @lamorton and @YingboMa