### PR TITLE
Patch for #1659.

### DIFF
--- a/src/systems/validation.jl
+++ b/src/systems/validation.jl
@@ -130,7 +130,7 @@ function get_unit(x::Symbolic)
     end
 end
 
-get_unit(parameter::Pair{Num, T}) where {T} = get_unit(parameter[1]) #Handle parameter/value pairs
+get_unit(parameter::Pair) = get_unit(parameter[1]) #Handle parameter/value pairs
 
 "Get unit of term, returning nothing & showing warning instead of throwing errors."
 function safe_get_unit(term, info)

--- a/src/systems/validation.jl
+++ b/src/systems/validation.jl
@@ -130,7 +130,7 @@ function get_unit(x::Symbolic)
     end
 end
 
-get_unit(parameter::Pair{Num,T}) where T = get_unit(parameter[1]) #Handle parameter/value pairs
+get_unit(parameter::Pair{Num, T}) where {T} = get_unit(parameter[1]) #Handle parameter/value pairs
 
 "Get unit of term, returning nothing & showing warning instead of throwing errors."
 function safe_get_unit(term, info)

--- a/src/systems/validation.jl
+++ b/src/systems/validation.jl
@@ -130,6 +130,8 @@ function get_unit(x::Symbolic)
     end
 end
 
+get_unit(parameter::Pair{Num,T}) where T = get_unit(parameter[1]) #Handle parameter/value pairs
+
 "Get unit of term, returning nothing & showing warning instead of throwing errors."
 function safe_get_unit(term, info)
     side = nothing
@@ -228,4 +230,5 @@ function check_units(eqs...)
     validate(eqs...) ||
         throw(ValidationError("Some equations had invalid units. See warnings for details."))
 end
-all_dimensionless(states) = all(x -> safe_get_unit(x, "") in (unitless, nothing), states)
+
+all_dimensionless(states) = all(x -> get_unit(x) in (unitless, nothing), states)

--- a/test/units.jl
+++ b/test/units.jl
@@ -45,7 +45,7 @@ eqs = [D(E) ~ P - E / τ
 @named sys = ODESystem(eqs)
 
 # Issue 1659
-@test MT.get_unit(τ=>1) == u"ms"
+@test MT.get_unit(τ => 1) == u"ms"
 
 @test !MT.validate(D(D(E)) ~ P)
 @test !MT.validate(0 ~ P + E * τ)

--- a/test/units.jl
+++ b/test/units.jl
@@ -44,6 +44,9 @@ eqs = [D(E) ~ P - E / τ
 @test MT.validate(eqs)
 @named sys = ODESystem(eqs)
 
+# Issue 1659
+@test MT.get_unit(τ=>1) == u"ms"
+
 @test !MT.validate(D(D(E)) ~ P)
 @test !MT.validate(0 ~ P + E * τ)
 


### PR DESCRIPTION
Adding support for unit checking when the inputs to the system constructor are vectors of `Pairs` containing the variable/parameter and the default value. Also turns warning for inability to check the units into an error. Fixes #1659.