### PR TITLE
Document `io` argument to `structural_simplify`

### DIFF
--- a/src/systems/abstractsystem.jl
+++ b/src/systems/abstractsystem.jl
@@ -955,6 +955,10 @@ topological sort of the observed equations. When `simplify=true`, the `simplify`
 function will be applied during the tearing process. It also takes kwargs
 `allow_symbolic=false` and `allow_parameter=true` which limits the coefficient
 types during tearing.
+
+The optional argument `io` may take a tuple `(inputs, outputs)`.
+This will convert all `inputs` to parameters and allow them to be unconnected, i.e.,
+simplification will allow models where `n_states = n_equations - n_inputs`.
 """
 function structural_simplify(sys::AbstractSystem, io = nothing; simplify = false, kwargs...)
     sys = expand_connections(sys)


### PR DESCRIPTION
In order to
- Make it easier to understand
- Mark as public interface to avoid functionality being broken. This is motivated by external packages that may implement functionality making use of this.