### PR TITLE
fix matrix sizes and input order in linearize

### DIFF
--- a/src/inputoutput.jl
+++ b/src/inputoutput.jl
@@ -278,10 +278,12 @@ function inputs_to_parameters!(state::TransformationState, io)
 
     if io !== nothing
         # Change order of new parameters to correspond to user-provided order in argument `inputs`
-        param_permutation = map(io.inputs) do inp
-            findfirst(isequal(inp), new_parameters)
+        d = Dict{Any, Int}()
+        for (i, inp) in enumerate(new_parameters)
+            d[inp] = i
         end
-        new_parameters = new_parameters[param_permutation]
+        permutation = [d[i] for i in io.inputs]
+        new_parameters = new_parameters[permutation]
     end
 
     @set! sys.ps = [ps; new_parameters]

--- a/src/inputoutput.jl
+++ b/src/inputoutput.jl
@@ -218,7 +218,8 @@ function generate_control_function(sys::AbstractODESystem, inputs = unbound_inpu
     f, dvs, ps
 end
 
-function inputs_to_parameters!(state::TransformationState, check_bound = true)
+function inputs_to_parameters!(state::TransformationState, io)
+    check_bound = io === nothing
     @unpack structure, fullvars, sys = state
     @unpack var_to_diff, graph, solvable_graph = structure
     @assert solvable_graph === nothing
@@ -274,6 +275,15 @@ function inputs_to_parameters!(state::TransformationState, check_bound = true)
     @set! sys.eqs = map(Base.Fix2(substitute, input_to_parameters), equations(sys))
     @set! sys.states = setdiff(states(sys), keys(input_to_parameters))
     ps = parameters(sys)
+
+    if io !== nothing
+        # Change order of new parameters to correspond to user-provided order in argument `inputs`
+        param_permutation = map(io.inputs) do inp
+            findfirst(isequal(inp), new_parameters)
+        end
+        new_parameters = new_parameters[param_permutation]
+    end
+
     @set! sys.ps = [ps; new_parameters]
 
     @set! state.sys = sys

--- a/src/systems/abstractsystem.jl
+++ b/src/systems/abstractsystem.jl
@@ -1198,6 +1198,8 @@ function linearize(sys, lin_fun; t = 0.0, op = Dict(), allow_input_derivatives =
     nz = size(f_z, 2)
     ny = size(h_x, 1)
 
+    D = h_u
+
     if isempty(g_z)
         A = f_x
         B = f_u
@@ -1213,19 +1215,19 @@ function linearize(sys, lin_fun; t = 0.0, op = Dict(), allow_input_derivatives =
         A = [f_x f_z
              gzgx*f_x gzgx*f_z]
         B = [f_u
-             zeros(nz, nu)]
+             gzgx*f_u]
+
         C = [h_x h_z]
         Bs = -(gz \ g_u) # This equation differ from the cited paper, the paper is likely wrong since their equaiton leads to a dimension mismatch.
         if !iszero(Bs)
             if !allow_input_derivatives
                 der_inds = findall(vec(any(!=(0), Bs, dims = 1)))
-                error("Input derivatives appeared in expressions (-g_z\\g_u != 0), the following inputs appeared differentiated: $(inputs(sys)[der_inds]). Call `linear_staespace` with keyword argument `allow_input_derivatives = true` to allow this and have the returned `B` matrix be of double width ($(2nu)), where the last $nu inputs are the derivatives of the first $nu inputs.")
+                error("Input derivatives appeared in expressions (-g_z\\g_u != 0), the following inputs appeared differentiated: $(inputs(sys)[der_inds]). Call `linear_statespace` with keyword argument `allow_input_derivatives = true` to allow this and have the returned `B` matrix be of double width ($(2nu)), where the last $nu inputs are the derivatives of the first $nu inputs.")
             end
-            B = [B Bs]
+            B = [B [zeros(nx, nu); Bs]]
+            D = [D zeros(ny, nu)]
         end
     end
-
-    D = h_u
 
     (; A, B, C, D)
 end

--- a/src/systems/abstractsystem.jl
+++ b/src/systems/abstractsystem.jl
@@ -965,7 +965,7 @@ function structural_simplify(sys::AbstractSystem, io = nothing; simplify = false
     state = TearingState(sys)
     has_io = io !== nothing
     has_io && markio!(state, io...)
-    state, input_idxs = inputs_to_parameters!(state, !has_io)
+    state, input_idxs = inputs_to_parameters!(state, io)
     sys = alias_elimination!(state)
     # TODO: avoid construct `TearingState` again.
     state = TearingState(sys)
@@ -981,7 +981,7 @@ end
 
 function io_preprocessing(sys::AbstractSystem, inputs,
                           outputs; simplify = false, kwargs...)
-    sys, input_idxs = structural_simplify(sys, (inputs, outputs); simplify, kwargs...)
+    sys, input_idxs = structural_simplify(sys, (; inputs, outputs); simplify, kwargs...)
 
     eqs = equations(sys)
     alg_start_idx = findfirst(!isdiffeq, eqs)
@@ -1215,7 +1215,7 @@ function linearize(sys, lin_fun; t = 0.0, op = Dict(), allow_input_derivatives =
         A = [f_x f_z
              gzgx*f_x gzgx*f_z]
         B = [f_u
-             gzgx*f_u]
+             gzgx * f_u] # The cited paper has zeros in the bottom block, see derivation in https://github.com/SciML/ModelingToolkit.jl/pull/1691 for the correct formula
 
         C = [h_x h_z]
         Bs = -(gz \ g_u) # This equation differ from the cited paper, the paper is likely wrong since their equaiton leads to a dimension mismatch.


### PR DESCRIPTION
This PR
- Fixes the sizes of matrices when there are input derivatives present.
- Ensures that the input parameters are in the correct order as specified by the user, so that subsequent matrix operations make sense.
- The modelica paper used as reference contained multiple errors which this PR fixes, the code now links to a derivation in a previous PR. 

My attempt at testing this resulted in 
```
ERROR: Input p₊x(t) is differentiated!
```

I have a complicated model which is supposed to be proper (integrating), but currently still requires input differentiation, likely due to some non-optimality in a simplification pass. When explicitly creating a model that is supposed to require input differentiation (an inverse model), I get an error before `linearize`. I understand why this error appears, but I'm not sure how to think about the difference between this case and the case where [this matrix in linearize](https://github.com/SciML/ModelingToolkit.jl/blob/master/src/systems/abstractsystem.jl#L1215) is non-zero.
```julia
julia> lsys, ssys = linearize(cl, [p.x], [f.u])
ERROR: Input p₊x(t) is differentiated!
Stacktrace:
 [1] error(s::String)
   @ Base ./error.jl:35
 [2] inputs_to_parameters!(state::TearingState{ODESystem}, check_bound::Bool)
   @ ModelingToolkit ~/.julia/dev/ModelingToolkit/src/inputoutput.jl:234
 [3] structural_simplify(sys::ODESystem, io::Tuple{Vector{Num}, Vector{Num}}; simplify::Bool, kwargs::Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}})
   @ ModelingToolkit ~/.julia/dev/ModelingToolkit/src/systems/abstractsystem.jl:968
 [4] io_preprocessing(sys::ODESystem, inputs::Vector{Num}, outputs::Vector{Num}; simplify::Bool, kwargs::Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}})
   @ ModelingToolkit ~/.julia/dev/ModelingToolkit/src/systems/abstractsystem.jl:984
 [5] linearization_function(sys::ODESystem, inputs::Vector{Num}, outputs::Vector{Num}; simplify::Bool, kwargs::Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}})
   @ ModelingToolkit ~/.julia/dev/ModelingToolkit/src/systems/abstractsystem.jl:1024
 [6] linearization_function
   @ ~/.julia/dev/ModelingToolkit/src/systems/abstractsystem.jl:1021 [inlined]
 [7] linearize(sys::ODESystem, inputs::Vector{Num}, outputs::Vector{Num}; op::Dict{Any, Any}, t::Float64, allow_input_derivatives::Bool, kwargs::Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}})
   @ ModelingToolkit ~/.julia/dev/ModelingToolkit/src/systems/abstractsystem.jl:1236
 [8] linearize(sys::ODESystem, inputs::Vector{Num}, outputs::Vector{Num})
   @ ModelingToolkit ~/.julia/dev/ModelingToolkit/src/systems/abstractsystem.jl:1233
 [9] top-level scope
   @ REPL[92]:1
```