### PR TITLE
fix `getvar` access of state

### DIFF
--- a/src/systems/abstractsystem.jl
+++ b/src/systems/abstractsystem.jl
@@ -304,6 +304,9 @@ function getvar(sys::AbstractSystem, name::Symbol; namespace = false)
 
     sts = get_states(sys)
     i = findfirst(x -> getname(x) == name, sts)
+    if i !== nothing
+        return namespace ? renamespace(sys, sts[i]) : sts[i]
+    end
 
     if has_observed(sys)
         obs = get_observed(sys)


### PR DESCRIPTION
The result of 
```julia
i = findfirst(x -> getname(x) == name, sts)
```
right above the added code was never used, causing some states not to be found. I'm no sure if the added code is correct, but something is at least missing here