### PR TITLE
Add `namespace_expr` for `Connection`

### DIFF
--- a/src/systems/connectors.jl
+++ b/src/systems/connectors.jl
@@ -66,6 +66,12 @@ SymbolicUtils.promote_symtype(::typeof(instream), _) = Real
 
 isconnector(s::AbstractSystem) = has_connector_type(s) && get_connector_type(s) !== nothing
 
+function namespace_expr(c::Connection, sys, n = nameof(sys))
+    c.systems === nothing && return c
+    systems = renamespace.(Ref(sys), c.systems)
+    Connection(systems)
+end
+
 function flowvar(sys::AbstractSystem)
     sts = get_states(sys)
     for s in sts


### PR DESCRIPTION
An attempt at fixing #1826
This change makes namespacing in
- https://github.com/SciML/ModelingToolkitStandardLibrary.jl/pull/110

work quite easily. If the change in this PR is okay, I'll add some tests.