### PR TITLE
Add verbose REPL printing for SystemStructure

### DIFF
--- a/src/bipartite_graph.jl
+++ b/src/bipartite_graph.jl
@@ -191,14 +191,49 @@ end
 # Matrix whose only purpose is to pretty-print the bipartite graph
 struct BipartiteAdjacencyList
     u::Union{Vector{Int}, Nothing}
+    highligh_u::Union{Set{Int}, Nothing}
+    match::Union{Int, Unassigned}
 end
+function BipartiteAdjacencyList(u::Union{Vector{Int}, Nothing})
+    BipartiteAdjacencyList(u, nothing, unassigned)
+end
+
+struct HighlightInt
+    i::Int
+    highlight::Union{Symbol, Nothing}
+end
+Base.typeinfo_implicit(::Type{HighlightInt}) = true
+
+function Base.show(io::IO, hi::HighlightInt)
+    if hi.highlight !== nothing
+        printstyled(io, hi.i, color = hi.highlight)
+    else
+        print(io, hi.i)
+    end
+end
+
 function Base.show(io::IO, l::BipartiteAdjacencyList)
     if l.u === nothing
         printstyled(io, '⋅', color = :light_black)
     elseif isempty(l.u)
         printstyled(io, '∅', color = :light_black)
-    else
+    elseif l.highligh_u === nothing
         print(io, l.u)
+    else
+        function choose_color(i)
+            i in l.highligh_u ? (i == l.match ? :light_yellow : :green) :
+            (i == l.match ? :yellow : nothing)
+        end
+        if !isempty(setdiff(l.highligh_u, l.u))
+            # Only for debugging, shouldn't happen in practice
+            print(io, map(union(l.u, l.highligh_u)) do i
+                      HighlightInt(i, !(i in l.u) ? :light_red : choose_color(i))
+                  end)
+        else
+            print(io, map(l.u) do i
+                      HighlightInt(i, choose_color(i))
+                  end)
+        end
     end
 end
 

--- a/src/systems/systemstructure.jl
+++ b/src/systems/systemstructure.jl
@@ -403,11 +403,93 @@ function linear_subsys_adjmat(state::TransformationState)
                             linear_equations, eadj, cadj)
 end
 
+using .BipartiteGraphs: Label, BipartiteAdjacencyList
+struct SystemStructurePrintMatrix <:
+       AbstractMatrix{Union{Label, Int, BipartiteAdjacencyList}}
+    bpg::BipartiteGraph
+    highlight_graph::BipartiteGraph
+    var_to_diff::DiffGraph
+    eq_to_diff::DiffGraph
+    var_eq_matching::Union{Matching, Nothing}
+end
+Base.size(bgpm::SystemStructurePrintMatrix) = (max(nsrcs(bgpm.bpg), ndsts(bgpm.bpg)) + 1, 5)
+function compute_diff_label(diff_graph, i)
+    di = i - 1 <= length(diff_graph) ? diff_graph[i - 1] : nothing
+    ii = i - 1 <= length(invview(diff_graph)) ? invview(diff_graph)[i - 1] : nothing
+    return Label(string(di === nothing ? "" : string(di, '↓'),
+                        di !== nothing && ii !== nothing ? " " : "",
+                        ii === nothing ? "" : string(ii, '↑')))
+end
+function Base.getindex(bgpm::SystemStructurePrintMatrix, i::Integer, j::Integer)
+    checkbounds(bgpm, i, j)
+    if i <= 1
+        return (Label.(("#", "∂ₜ", "eq", "∂ₜ", "v")))[j]
+    elseif j == 2
+        return compute_diff_label(bgpm.eq_to_diff, i)
+    elseif j == 4
+        return compute_diff_label(bgpm.var_to_diff, i)
+    elseif j == 1
+        return i - 1
+    elseif j == 3
+        return BipartiteAdjacencyList(i - 1 <= nsrcs(bgpm.bpg) ?
+                                      𝑠neighbors(bgpm.bpg, i - 1) : nothing,
+                                      bgpm.highlight_graph !== nothing &&
+                                      i - 1 <= nsrcs(bgpm.highlight_graph) ?
+                                      Set(𝑠neighbors(bgpm.highlight_graph, i - 1)) :
+                                      nothing,
+                                      bgpm.var_eq_matching !== nothing &&
+                                      (i - 1 <= length(invview(bgpm.var_eq_matching))) ?
+                                      invview(bgpm.var_eq_matching)[i - 1] : unassigned)
+    elseif j == 5
+        return BipartiteAdjacencyList(i - 1 <= ndsts(bgpm.bpg) ?
+                                      𝑑neighbors(bgpm.bpg, i - 1) : nothing,
+                                      bgpm.highlight_graph !== nothing &&
+                                      i - 1 <= ndsts(bgpm.highlight_graph) ?
+                                      Set(𝑑neighbors(bgpm.highlight_graph, i - 1)) :
+                                      nothing,
+                                      bgpm.var_eq_matching !== nothing &&
+                                      (i - 1 <= length(bgpm.var_eq_matching)) ?
+                                      bgpm.var_eq_matching[i - 1] : unassigned)
+    else
+        @assert false
+    end
+end
+
 function Base.show(io::IO, mime::MIME"text/plain", s::SystemStructure)
-    @unpack graph = s
-    S = incidence_matrix(graph, Num(Sym{Real}(:×)))
-    print(io, "Incidence matrix:")
-    show(io, mime, S)
+    @unpack graph, solvable_graph, var_to_diff, eq_to_diff = s
+    if !get(io, :limit, true) || !get(io, :mtk_limit, true)
+        print(io, "SystemStructure with ", length(graph.fadjlist), " equations and ",
+              isa(graph.badjlist, Int) ? graph.badjlist : length(graph.badjlist),
+              " variables\n")
+        Base.print_matrix(io,
+                          SystemStructurePrintMatrix(complete(graph),
+                                                     complete(solvable_graph),
+                                                     complete(var_to_diff),
+                                                     complete(eq_to_diff), nothing))
+    else
+        S = incidence_matrix(graph, Num(Sym{Real}(:×)))
+        print(io, "Incidence matrix:")
+        show(io, mime, S)
+    end
+end
+
+struct MatchedSystemStructure
+    structure::SystemStructure
+    var_eq_matching::Matching
+end
+
+function Base.show(io::IO, mime::MIME"text/plain", ms::MatchedSystemStructure)
+    s = ms.structure
+    @unpack graph, solvable_graph, var_to_diff, eq_to_diff = s
+    print(io, "Matched SystemStructure with ", length(graph.fadjlist), " equations and ",
+          isa(graph.badjlist, Int) ? graph.badjlist : length(graph.badjlist),
+          " variables\n")
+    Base.print_matrix(io,
+                      SystemStructurePrintMatrix(complete(graph),
+                                                 complete(solvable_graph),
+                                                 complete(var_to_diff),
+                                                 complete(eq_to_diff),
+                                                 complete(ms.var_eq_matching, nsrcs(graph))))
 end
 
 end # module

--- a/test/structural_transformation/tearing.jl
+++ b/test/structural_transformation/tearing.jl
@@ -31,10 +31,10 @@ if VERSION >= v"1.6"
     @test occursin("×", prt)
     @test occursin("⋅", prt)
 
-    io = IOContext(IOBuffer(), :mtk_limit => false)
+    buff = IOBuffer()
+    io = IOContext(buff, :mtk_limit => false)
     show(io, MIME"text/plain"(), state.structure)
-    prt = String(take!(io))
-    prt = String(take!(io))
+    prt = String(take!(buff))
     @test occursin("SystemStructure", prt)
 end
 

--- a/test/structural_transformation/tearing.jl
+++ b/test/structural_transformation/tearing.jl
@@ -30,6 +30,12 @@ if VERSION >= v"1.6"
     @test occursin("Incidence matrix:", prt)
     @test occursin("×", prt)
     @test occursin("⋅", prt)
+
+    io = IOContext(IOBuffer(), :mtk_limit => false)
+    show(io, MIME"text/plain"(), state.structure)
+    prt = String(take!(io))
+    prt = String(take!(io))
+    @test occursin("SystemStructure", prt)
 end
 
 # u1 = f1(u5)


### PR DESCRIPTION
This adds REPL printing for SystemStructure that prints out the details of graph, solvable_graph, var_to_diff and eq_to_diff in a compact, but comprehensive dump. Because this is a lot of information, it is not provided by default. Instead, the user may opt into it by setting `:limit` or `:mtk_limit` to false in the IOContext. E.g. to enable the verbose printing for all structures shown in the REPL, use

```
Base.active_repl.options.iocontext[:mtk_limit] = false
```
![Screenshot from 2022-09-22 02-41-03](https://user-images.githubusercontent.com/1291671/191679056-fa35f180-dad5-4570-b364-671c59a29cf9.png)


