### PR TITLE
Keep invview for var_matching valid in pss

### DIFF
--- a/src/bipartite_graph.jl
+++ b/src/bipartite_graph.jl
@@ -63,7 +63,10 @@ end
 function Base.setindex!(m::Matching{U}, v::Union{Integer, U}, i::Integer) where {U}
     if m.inv_match !== nothing
         oldv = m.match[i]
-        isa(oldv, Int) && (m.inv_match[oldv] = unassigned)
+        if isa(oldv, Int)
+            @assert m.inv_match[oldv] == i
+            m.inv_match[oldv] = unassigned
+        end
         isa(v, Int) && (m.inv_match[v] = i)
     end
     return m.match[i] = v

--- a/src/structural_transformation/partial_state_selection.jl
+++ b/src/structural_transformation/partial_state_selection.jl
@@ -87,6 +87,9 @@ function pss_graph_modia!(structure::SystemStructure, var_eq_matching, varlevel,
             tearEquations!(ict, solvable_graph.fadjlist, to_tear_eqs, BitSet(to_tear_vars),
                            nothing)
             for var in to_tear_vars
+                var_eq_matching[var] = unassigned
+            end
+            for var in to_tear_vars
                 var_eq_matching[var] = ict.graph.matching[var]
             end
             old_level_vars = to_tear_vars


### PR DESCRIPTION
Previously we could introduce inconsistent assignments, which caused the invview to be wrong after the return from pss.