### PR TITLE
Show selected states in MatchedSystemStructure

### DIFF
--- a/src/bipartite_graph.jl
+++ b/src/bipartite_graph.jl
@@ -192,7 +192,7 @@ end
 struct BipartiteAdjacencyList
     u::Union{Vector{Int}, Nothing}
     highligh_u::Union{Set{Int}, Nothing}
-    match::Union{Int, Unassigned}
+    match::Union{Int, Bool, Unassigned}
 end
 function BipartiteAdjacencyList(u::Union{Vector{Int}, Nothing})
     BipartiteAdjacencyList(u, nothing, unassigned)
@@ -213,6 +213,9 @@ function Base.show(io::IO, hi::HighlightInt)
 end
 
 function Base.show(io::IO, l::BipartiteAdjacencyList)
+    if l.match === true
+        printstyled(io, "∫ ", color = :light_blue, bold = true)
+    end
     if l.u === nothing
         printstyled(io, '⋅', color = :light_black)
     elseif isempty(l.u)
@@ -220,9 +223,11 @@ function Base.show(io::IO, l::BipartiteAdjacencyList)
     elseif l.highligh_u === nothing
         print(io, l.u)
     else
+        match = l.match
+        isa(match, Bool) && (match = unassigned)
         function choose_color(i)
-            i in l.highligh_u ? (i == l.match ? :light_yellow : :green) :
-            (i == l.match ? :yellow : nothing)
+            i in l.highligh_u ? (i == match ? :light_yellow : :green) :
+            (i == match ? :yellow : nothing)
         end
         if !isempty(setdiff(l.highligh_u, l.u))
             # Only for debugging, shouldn't happen in practice

--- a/src/systems/systemstructure.jl
+++ b/src/systems/systemstructure.jl
@@ -441,15 +441,17 @@ function Base.getindex(bgpm::SystemStructurePrintMatrix, i::Integer, j::Integer)
                                       (i - 1 <= length(invview(bgpm.var_eq_matching))) ?
                                       invview(bgpm.var_eq_matching)[i - 1] : unassigned)
     elseif j == 5
+        match = unassigned
+        if bgpm.var_eq_matching !== nothing && i - 1 <= length(bgpm.var_eq_matching)
+            match = bgpm.var_eq_matching[i - 1]
+            isa(match, Union{Int, Unassigned}) || (match = true) # Selected State
+        end
         return BipartiteAdjacencyList(i - 1 <= ndsts(bgpm.bpg) ?
                                       𝑑neighbors(bgpm.bpg, i - 1) : nothing,
                                       bgpm.highlight_graph !== nothing &&
                                       i - 1 <= ndsts(bgpm.highlight_graph) ?
                                       Set(𝑑neighbors(bgpm.highlight_graph, i - 1)) :
-                                      nothing,
-                                      bgpm.var_eq_matching !== nothing &&
-                                      (i - 1 <= length(bgpm.var_eq_matching)) ?
-                                      bgpm.var_eq_matching[i - 1] : unassigned)
+                                      nothing, match)
     else
         @assert false
     end


### PR DESCRIPTION
In the printing for `MatchedSystemStructure`, add a little blue `∫` symbol to indicate variables that are set to `SelectedState`, thus making the printing suitable for matchings produced from state selection (not just pantelides).