### PR TITLE
Allow `find_eq_solvables!` to take extra unsed keyword arguments

### DIFF
--- a/src/structural_transformation/utils.jl
+++ b/src/structural_transformation/utils.jl
@@ -161,7 +161,7 @@ end
 ###
 
 function find_eq_solvables!(state::TearingState, ieq; may_be_zero = false,
-                            allow_symbolic = false, allow_parameter = true)
+                            allow_symbolic = false, allow_parameter = true, kwargs...)
     fullvars = state.fullvars
     @unpack graph, solvable_graph = state.structure
     eq = equations(state)[ieq]


### PR DESCRIPTION
following https://github.com/SciML/ModelingToolkit.jl/pull/1865

Without this PR, passing arbitrary keyword arguments to `ModelingToolkit.generate_control_function` gives the error:
```julia
ERROR: MethodError: no method matching find_eq_solvables!(::TearingState{ODESystem}, ::Int64; force_SA=false)
Closest candidates are:
  find_eq_solvables!(::TearingState, ::Any; may_be_zero, allow_symbolic, allow_parameter) at ~/Projects/ModelingToolkit.jl/src/structural_transformation/utils.jl:163 got unsupported keyword argument "force_SA"
Stacktrace:
 [1] kwerr(::NamedTuple{(:force_SA,), Tuple{Bool}}, ::Function, ::TearingState{ODESystem}, ::Int64)
   @ Base ./error.jl:165
 [2] find_solvables!(state::TearingState{ODESystem}; kwargs::Base.Pairs{Symbol, Bool, Tuple{Symbol}, NamedTuple{(:force_SA,), Tuple{Bool}}})
   @ ModelingToolkit.StructuralTransformations ~/Projects/ModelingToolkit.jl/src/structural_transformation/utils.jl:209
 [3] structural_simplify(sys::ODESystem, io::NamedTuple{(:inputs, :outputs), Tuple{Vector{Any}, Vector{Any}}}; simplify::Bool, kwargs::Base.Pairs{Symbol, Bool, Tuple{Symbol}, NamedTuple{(:force_SA,), Tuple{Bool}}})
   @ ModelingToolkit ~/Projects/ModelingToolkit.jl/src/systems/abstractsystem.jl:1023
 [4] io_preprocessing(sys::ODESystem, inputs::Vector{Any}, outputs::Vector{Any}; simplify::Bool, kwargs::Base.Pairs{Symbol, Bool, Tuple{Symbol}, NamedTuple{(:force_SA,), Tuple{Bool}}})
   @ ModelingToolkit ~/Projects/ModelingToolkit.jl/src/systems/abstractsystem.jl:1033
 [5] generate_control_function(sys::ODESystem, inputs::Vector{Any}, disturbance_inputs::Vector{Any}; implicit_dae::Bool, simplify::Bool, kwargs::Base.Pairs{Symbol, Bool, Tuple{Symbol}, NamedTuple{(:force_SA,), Tuple{Bool}}})
   @ ModelingToolkit ~/Projects/ModelingToolkit.jl/src/inputoutput.jl:205
 [6] top-level scope
   @ ~/Projects/ModelingToolkit.jl/test/input_output_handling.jl:138
```