### PR TITLE
`ODAEProblem` doesn't pass `paramsyms`

### DIFF
--- a/src/structural_transformation/codegen.jl
+++ b/src/structural_transformation/codegen.jl
@@ -339,6 +339,8 @@ function build_torn_function(sys;
                                                                                                           states_idxs) :
                                                                nothing,
                                                     syms = syms,
+                                                    paramsyms = Symbol.(parameters(sys)),
+                                                    indepsym = Symbol(get_iv(sys)),
                                                     observed = observedfun,
                                                     mass_matrix = mass_matrix), states
     end

--- a/test/odesystem.jl
+++ b/test/odesystem.jl
@@ -861,7 +861,7 @@ let
     @variables y(t) = 1
     @parameters pp = -1
     der = Differential(t)
-    @named sys4 = ODESystem([der(x) ~ -y; der(y) ~ 1 - y + x], t)
+    @named sys4 = ODESystem([der(x) ~ -y; der(y) ~ 1 + pp * y + x], t)
     as = alias_elimination(sys4)
     @test length(equations(as)) == 1
     @test isequal(equations(as)[1].lhs, -der(der(x)))
@@ -869,6 +869,8 @@ let
     sys4s = structural_simplify(sys4)
     prob = ODAEProblem(sys4s, [x => 1.0, D(x) => 1.0], (0, 1.0))
     @test string.(prob.f.syms) == ["x(t)", "xˍt(t)"]
+    @test string.(prob.f.paramsyms) == ["pp"]
+    @test string(prob.f.indepsym) == "t"
 end
 
 let


### PR DESCRIPTION
`ODAEProblem` didn't pass `paramsyms` and `indepsym` to the underlying `ODEFunction` constructor, so symbolic parameter indexing didn't work.