### PR TITLE
expose tofloat for ODEProblem

### DIFF
--- a/src/systems/diffeqs/abstractodesystem.jl
+++ b/src/systems/diffeqs/abstractodesystem.jl
@@ -550,6 +550,7 @@ function process_DEProblem(constructor, sys::AbstractODESystem, u0map, parammap;
                            linenumbers = true, parallel = nothing,
                            eval_expression = true,
                            use_union = false,
+                           tofloat = !use_union,
                            kwargs...)
     eqs = equations(sys)
     dvs = states(sys)
@@ -560,8 +561,8 @@ function process_DEProblem(constructor, sys::AbstractODESystem, u0map, parammap;
     defs = mergedefaults(defs, parammap, ps)
     defs = mergedefaults(defs, u0map, dvs)
 
-    u0 = varmap_to_vars(u0map, dvs; defaults = defs, tofloat = true)
-    p = varmap_to_vars(parammap, ps; defaults = defs, tofloat = !use_union, use_union)
+    u0 = varmap_to_vars(u0map, dvs; defaults = defs, tofloat)
+    p = varmap_to_vars(parammap, ps; defaults = defs, tofloat, use_union)
     p = p === nothing ? SciMLBase.NullParameters() : p
 
     if implicit_dae && du0map !== nothing

--- a/src/systems/diffeqs/abstractodesystem.jl
+++ b/src/systems/diffeqs/abstractodesystem.jl
@@ -561,7 +561,7 @@ function process_DEProblem(constructor, sys::AbstractODESystem, u0map, parammap;
     defs = mergedefaults(defs, parammap, ps)
     defs = mergedefaults(defs, u0map, dvs)
 
-    u0 = varmap_to_vars(u0map, dvs; defaults = defs, tofloat)
+    u0 = varmap_to_vars(u0map, dvs; defaults = defs, tofloat = true)
     p = varmap_to_vars(parammap, ps; defaults = defs, tofloat, use_union)
     p = p === nothing ? SciMLBase.NullParameters() : p
 

--- a/test/symbolic_events.jl
+++ b/test/symbolic_events.jl
@@ -227,7 +227,7 @@ continuous_events = [[x ~ 0] => [vx ~ -vx]
 @named ball = ODESystem([D(x) ~ vx
                          D(y) ~ vy
                          D(vx) ~ -9.8
-                         D(vy) ~ -0.01vy], t; continuous_events)
+                         D(vy) ~ -0.01vy;], t; continuous_events)
 
 ball = structural_simplify(ball)
 
@@ -264,7 +264,7 @@ continuous_events = [
 @named ball = ODESystem([D(x) ~ vx
                          D(y) ~ vy
                          D(vx) ~ -1
-                         D(vy) ~ 0], t; continuous_events)
+                         D(vy) ~ 0;], t; continuous_events)
 
 ball = structural_simplify(ball)
 

--- a/test/symbolic_events.jl
+++ b/test/symbolic_events.jl
@@ -227,7 +227,7 @@ continuous_events = [[x ~ 0] => [vx ~ -vx]
 @named ball = ODESystem([D(x) ~ vx
                          D(y) ~ vy
                          D(vx) ~ -9.8
-                         D(vy) ~ -0.01vy;], t; continuous_events)
+                         D(vy) ~ -0.01vy], t; continuous_events)
 
 ball = structural_simplify(ball)
 
@@ -264,7 +264,7 @@ continuous_events = [
 @named ball = ODESystem([D(x) ~ vx
                          D(y) ~ vy
                          D(vx) ~ -1
-                         D(vy) ~ 0;], t; continuous_events)
+                         D(vy) ~ 0], t; continuous_events)
 
 ball = structural_simplify(ball)
 


### PR DESCRIPTION
Attempting to construct an ODEProblem with a parameter type of `Vector{Vector{Float64}}` will cause an error because `tofloat` defaults to true and `Vector{Float64}` cannot be converted to `Float64`, therefore now with this change one can set `tofloat=false`