### PR TITLE
state_selection: Correct is_not_present condition

### DIFF
--- a/src/structural_transformation/partial_state_selection.jl
+++ b/src/structural_transformation/partial_state_selection.jl
@@ -277,6 +277,7 @@ function dummy_derivative_graph!(structure::SystemStructure, var_eq_matching, ja
                 end
                 x = diff_to_var[x]
                 x === nothing && break
+                isempty(𝑑neighbors(graph, x)) && continue
                 if !haskey(ag, x)
                     isred = false
                 end
@@ -284,15 +285,17 @@ function dummy_derivative_graph!(structure::SystemStructure, var_eq_matching, ja
             isred
         end
         irreducible_set = BitSet()
-        for (k, (_, v)) in ag
+        for (k, (c, v)) in ag
             isreducible(k) || push!(irreducible_set, k)
             isreducible(k) || push!(irreducible_set, k)
+            iszero(c) && continue
             push!(irreducible_set, v)
         end
     end
 
     is_not_present = v -> isempty(𝑑neighbors(graph, v)) &&
-        (ag === nothing || (haskey(ag, v) && !(v in irreducible_set)))
+        (ag === nothing || !haskey(ag, v) || !(v in irreducible_set))
+
     # Derivatives that are either in the dummy derivatives set or ended up not
     # participating in the system at all are not considered differential
     is_some_diff = let dummy_derivatives_set = dummy_derivatives_set

--- a/src/structural_transformation/partial_state_selection.jl
+++ b/src/structural_transformation/partial_state_selection.jl
@@ -278,7 +278,10 @@ function dummy_derivative_graph!(structure::SystemStructure, var_eq_matching, ja
                 end
                 x = diff_to_var[x]
                 x === nothing && break
-                isempty(𝑑neighbors(graph, x)) && continue
+                # We deliberately do not check `isempty(𝑑neighbors(graph, x))`
+                # because when `D(x)` appears in the alias graph, and `x`
+                # doesn't appear in any equations nor in the alias graph, `D(x)`
+                # is not reducible. Consider the system `D(x) ~ 0`.
                 if !haskey(ag, x)
                     isred = false
                 end

--- a/src/structural_transformation/partial_state_selection.jl
+++ b/src/structural_transformation/partial_state_selection.jl
@@ -296,11 +296,9 @@ function dummy_derivative_graph!(structure::SystemStructure, var_eq_matching, ja
     is_not_present_non_rec = let graph = graph, irreducible_set = irreducible_set
         v -> begin
             not_in_eqs = isempty(𝑑neighbors(graph, v))
-            isirreducible = false
-            if ag !== nothing
-                isirreducible = haskey(ag, v) && (v in irreducible_set)
-            end
-            not_in_eqs && !isirreducible
+            ag === nothing && return not_in_eqs
+            isirreducible = v in irreducible_set
+            return not_in_eqs && !isirreducible
         end
     end
 

--- a/test/structural_transformation/tearing.jl
+++ b/test/structural_transformation/tearing.jl
@@ -218,8 +218,8 @@ u0 = [mass.s => 0.0
       mass.v => 1.0]
 
 sys = structural_simplify(ms_model)
-@test sys.jac[] === ModelingToolkit.EMPTY_JAC
-@test sys.tgrad[] === ModelingToolkit.EMPTY_TGRAD
+@test ModelingToolkit.get_jac(sys)[] === ModelingToolkit.EMPTY_JAC
+@test ModelingToolkit.get_tgrad(sys)[] === ModelingToolkit.EMPTY_TGRAD
 prob_complex = ODAEProblem(sys, u0, (0, 1.0))
 sol = solve(prob_complex, Tsit5())
 @test all(sol[mass.v] .== 1)


### PR DESCRIPTION
The is_present condition is supposed to be equivalent to the variable not appearing in the system at all (for example, it could appear as `a*D(v)`, where `a` ends up aliased to `0`, meaning that we don't notice that it does not appear in the system until we've performed alias analysis. In these kinds of situations, a variable is present in the system if, either:

1. It appears in the graph (i.e. it's used in the equations), or
2. It is irreducible (and was in the alias graph).

The condition was trying to check this, but didn't quite get the negations correct, resulting in sub-optimal state selection.