### PR TITLE
Fix `OptimizationProblemExpr`

### DIFF
--- a/src/systems/optimization/optimizationsystem.jl
+++ b/src/systems/optimization/optimizationsystem.jl
@@ -391,7 +391,7 @@ function OptimizationProblemExpr(sys::OptimizationSystem, args...; kwargs...)
     OptimizationProblemExpr{true}(sys::OptimizationSystem, args...; kwargs...)
 end
 
-function OptimizationProblemExpr{iip}(sys::OptimizationSystem, u0,
+function OptimizationProblemExpr{iip}(sys::OptimizationSystem, u0map,
                                       parammap = DiffEqBase.NullParameters();
                                       lb = nothing, ub = nothing,
                                       grad = false,


### PR DESCRIPTION
Change argument `u0` to `u0map`. This was originally fixed in #1903 but looks like accidentally reverted in https://github.com/SciML/ModelingToolkit.jl/commit/d991beafdc0696d168517a97b34f866626150577