### PR TITLE
fixed sparsity bug

### DIFF
--- a/src/systems/diffeqs/abstractodesystem.jl
+++ b/src/systems/diffeqs/abstractodesystem.jl
@@ -562,7 +562,7 @@ function ODEFunctionExpr{iip}(sys::AbstractODESystem, dvs = states(sys),
                           syms = $(Symbol.(states(sys))),
                           indepsym = $(QuoteNode(Symbol(get_iv(sys)))),
                           paramsyms = $(Symbol.(parameters(sys))),
-                          sparsity = $sparsity ? $(jacobian_sparsity(sys)) : $nothing)
+                          sparsity = $(sparsity ? jacobian_sparsity(sys) : nothing))
     end
     !linenumbers ? striplines(ex) : ex
 end

--- a/test/odesystem.jl
+++ b/test/odesystem.jl
@@ -82,6 +82,13 @@ f.f(du, u, p, 0.1)
 @test du == [4, 0, -16]
 @test_throws ArgumentError f.f(u, p, 0.1)
 
+#check sparsity
+f = eval(ODEFunctionExpr(de, [x, y, z], [σ, ρ, β], sparsity = true))
+@test f.sparsity == ModelingToolkit.jacobian_sparsity(de)
+
+f = eval(ODEFunctionExpr(de, [x, y, z], [σ, ρ, β], sparsity = false))
+@test isnothing(f.sparsity)
+
 eqs = [D(x) ~ σ * (y - x),
     D(y) ~ x * (ρ - z) - y * t,
     D(z) ~ x * y - β * z * κ]


### PR DESCRIPTION
Just a simple fix to the `ODEFunctionExpr` sparsity.  Previously generated code 

```julia
sparsity = if false 
   [.....] 
else 
   nothing
end
```

Now properly generates the code

```julia
sparsity = [.....]
```