### PR TITLE
Add DelayParentScope scoping utility

### DIFF
--- a/src/ModelingToolkit.jl
+++ b/src/ModelingToolkit.jl
@@ -200,7 +200,7 @@ export PDESystem
 export Differential, expand_derivatives, @derivatives
 export Equation, ConstrainedEquation
 export Term, Sym
-export SymScope, LocalScope, ParentScope, GlobalScope
+export SymScope, LocalScope, ParentScope, DelayParentScope, GlobalScope
 export independent_variables, independent_variable, states, parameters, equations, controls,
        observed, structure, full_equations
 export structural_simplify, expand_connections, linearize, linearization_function

--- a/src/systems/abstractsystem.jl
+++ b/src/systems/abstractsystem.jl
@@ -363,15 +363,15 @@ function ParentScope(sym::Union{Num, Symbolic})
     setmetadata(sym, SymScope, ParentScope(getmetadata(value(sym), SymScope, LocalScope())))
 end
 
-struct DelayParentScope <: SymScope 
+struct DelayParentScope <: SymScope
     parent::SymScope
     N::Int
 end
 function DelayParentScope(sym::Union{Num, Symbolic}, N)
     setmetadata(sym, SymScope,
-        DelayParentScope(getmetadata(value(sym), SymScope, LocalScope()),N))
+                DelayParentScope(getmetadata(value(sym), SymScope, LocalScope()), N))
 end
-DelayParentScope(sym::Union{Num, Symbolic}) = DelayParentScope(sym,1)
+DelayParentScope(sym::Union{Num, Symbolic}) = DelayParentScope(sym, 1)
 
 struct GlobalScope <: SymScope end
 GlobalScope(sym::Union{Num, Symbolic}) = setmetadata(sym, SymScope, GlobalScope())
@@ -394,7 +394,7 @@ function renamespace(sys, x)
             elseif scope isa DelayParentScope
                 if scope.N > 0
                     x = setmetadata(x, SymScope,
-                        DelayParentScope(scope.parent, scope.N-1))
+                                    DelayParentScope(scope.parent, scope.N - 1))
                     rename(x, renamespace(getname(sys), getname(x)))
                 else
                     #rename(x, renamespace(getname(sys), getname(x)))

--- a/test/variable_scope.jl
+++ b/test/variable_scope.jl
@@ -58,9 +58,11 @@ level1 = ODESystem(Equation[], t, [], []; name = :level1) ∘ level0
 level2 = ODESystem(Equation[], t, [], []; name = :level2) ∘ level1
 level3 = ODESystem(Equation[], t, [], []; name = :level3) ∘ level2
 
-@test isequal(parameters(level3)[1], level2.level1.level0.a)
-@test isequal(parameters(level3)[2], level2.level1.b)
-@test isequal(parameters(level3)[3], level2.c)
-@test isequal(parameters(level3)[4], level2.level0.d)
-@test isequal(parameters(level3)[5], level1.level0.e)
-@test isequal(parameters(level3)[6], f)
+ps = ModelingToolkit.getname.(parameters(level3))
+
+@test isequal(ps[1], :level2₊level1₊level0₊a)
+@test isequal(ps[2], :level2₊level1₊b)
+@test isequal(ps[3], :level2₊c)
+@test isequal(ps[4], :level2₊level0₊d)
+@test isequal(ps[5], :level1₊level0₊e)
+@test isequal(ps[6], :f)

--- a/test/variable_scope.jl
+++ b/test/variable_scope.jl
@@ -44,25 +44,23 @@ end
 @test renamed([:foo :bar :baz], b) == Symbol("foo₊bar₊b")
 @test renamed([:foo :bar :baz], c) == Symbol("foo₊c")
 @test renamed([:foo :bar :baz], d) == :d
-       
+
 @parameters t a b c d e f
-p = [
-    a 
-    ParentScope(b)
-    ParentScope(ParentScope(c))
-    DelayParentScope(d)
-    DelayParentScope(e,2)
-    GlobalScope(f)
-]
+p = [a
+     ParentScope(b)
+     ParentScope(ParentScope(c))
+     DelayParentScope(d)
+     DelayParentScope(e, 2)
+     GlobalScope(f)]
 
-level0 = ODESystem(Equation[],t,[],p; name = :level0)
-level1 = ODESystem(Equation[],t,[],[];name = :level1) ∘ level0
-level2 = ODESystem(Equation[],t,[],[];name = :level2) ∘ level1
-level3 = ODESystem(Equation[],t,[],[];name = :level3) ∘ level2
+level0 = ODESystem(Equation[], t, [], p; name = :level0)
+level1 = ODESystem(Equation[], t, [], []; name = :level1) ∘ level0
+level2 = ODESystem(Equation[], t, [], []; name = :level2) ∘ level1
+level3 = ODESystem(Equation[], t, [], []; name = :level3) ∘ level2
 
-@test isequal(parameters(level3)[1],level2.level1.level0.a)
-@test isequal(parameters(level3)[2],level2.level1.b)
-@test isequal(parameters(level3)[3],level2.c)
-@test isequal(parameters(level3)[4],level2.level0.d)
-@test isequal(parameters(level3)[5],level1.level0.e)
-@test isequal(parameters(level3)[6],f)
+@test isequal(parameters(level3)[1], level2.level1.level0.a)
+@test isequal(parameters(level3)[2], level2.level1.b)
+@test isequal(parameters(level3)[3], level2.c)
+@test isequal(parameters(level3)[4], level2.level0.d)
+@test isequal(parameters(level3)[5], level1.level0.e)
+@test isequal(parameters(level3)[6], f)

--- a/test/variable_scope.jl
+++ b/test/variable_scope.jl
@@ -44,3 +44,25 @@ end
 @test renamed([:foo :bar :baz], b) == Symbol("foo₊bar₊b")
 @test renamed([:foo :bar :baz], c) == Symbol("foo₊c")
 @test renamed([:foo :bar :baz], d) == :d
+       
+@parameters t a b c d e f
+p = [
+    a 
+    ParentScope(b)
+    ParentScope(ParentScope(c))
+    DelayParentScope(d)
+    DelayParentScope(e,2)
+    GlobalScope(f)
+]
+
+level0 = ODESystem(Equation[],t,[],p; name = :level0)
+level1 = ODESystem(Equation[],t,[],[];name = :level1) ∘ level0
+level2 = ODESystem(Equation[],t,[],[];name = :level2) ∘ level1
+level3 = ODESystem(Equation[],t,[],[];name = :level3) ∘ level2
+
+@test isequal(parameters(level3)[1],level2.level1.level0.a)
+@test isequal(parameters(level3)[2],level2.level1.b)
+@test isequal(parameters(level3)[3],level2.c)
+@test isequal(parameters(level3)[4],level2.level0.d)
+@test isequal(parameters(level3)[5],level1.level0.e)
+@test isequal(parameters(level3)[6],f)


### PR DESCRIPTION
from slack: I made a scoping utility DelayParentScope for MTK and I am happy to document it and submit a PR if it would be a welcome addition. It was intended to solve the following use case:
I have this model structure: current < cell < cellgroup < network and I need the parameters that control equations at the current-level to be shared across all cells at the celltype level, but each current should have its own namepace within that the cellgroup namespace. This allows me to construct many instances of Identical Cells.

One could easily combine ParentScope and DelayParentScope, but I don't think it really matters.