### PR TITLE
Update optimizationsystem.jl - Documentation

### DIFF
--- a/src/systems/optimization/optimizationsystem.jl
+++ b/src/systems/optimization/optimizationsystem.jl
@@ -191,6 +191,7 @@ function DiffEqBase.OptimizationProblem{iip}(sys::OptimizationSystem,u0map,
                                           parammap=DiffEqBase.NullParameters();
                                           grad = false,
                                           hess = false, sparse = false,
+                                          cons_j = false, cons_h = false,
                                           checkbounds = false,
                                           linenumbers = true, parallel=SerialForm(),
                                           kwargs...) where iip
@@ -198,6 +199,8 @@ function DiffEqBase.OptimizationProblem{iip}(sys::OptimizationSystem,u0map,
 
 Generates an OptimizationProblem from an OptimizationSystem and allows for automatically
 symbolically calculating numerical enhancements.
+                
+Certain solvers require setting `cons_j`, `cons_h` to `true` for constrained-optimization problems.
 """
 function DiffEqBase.OptimizationProblem(sys::OptimizationSystem, args...; kwargs...)
     DiffEqBase.OptimizationProblem{true}(sys::OptimizationSystem, args...; kwargs...)


### PR DESCRIPTION
Adds documentation following up from  #1943 , if `cons_j` and `cons_h` are set by default to `false`, it is necessary to document that the user may need to set them to `true`. Otherwise, certain solvers such as `IPNewton()` with `OptimizationOptimJL` fail with no documentation.