### PR TITLE
Reverse the order of the boolean check in the inner loop of `get_cset_sv`

### DIFF
--- a/src/systems/connectors.jl
+++ b/src/systems/connectors.jl
@@ -513,7 +513,7 @@ function get_cset_sv(namespace, ex, csets)
         crep = first(c.set)
         current = namespace == crep.sys.namespace
         for (idx_in_set, v) in enumerate(c.set)
-            if isequal(namespaced_var(v), full_name_sv) && (current || !v.isouter)
+            if (current || !v.isouter) && isequal(namespaced_var(v), full_name_sv)
                 return c.set, idx_in_set, v.v
             end
         end


### PR DESCRIPTION
Reverse the order of the boolean check, as `namespaced_var` is more costly than the precalculated `current` or v.isouter. This should yield a speedup in nested systems.

@visr