### PR TITLE
dummy_derivatives: Reset eqcolor every loop

### DIFF
--- a/src/structural_transformation/partial_state_selection.jl
+++ b/src/structural_transformation/partial_state_selection.jl
@@ -227,6 +227,7 @@ function dummy_derivative_graph!(structure::SystemStructure, var_eq_matching, ja
             else
                 rank = 0
                 for var in vars
+                    eqcolor .= false
                     # We need `invgraph` here because we are matching from
                     # variables to equations.
                     pathfound = construct_augmenting_path!(rank_matching, invgraph, var,


### PR DESCRIPTION
We're using augmenting path construction here to try to find a maximal matching of the variables at the given differentiation level. However the construct_augmenting_path! function assumes as a pre-condition that eq-color is reset to zero in order for it to actually produce an augmenting path. Failing to do this can cause it to falsely declare a system singular.