### PR TITLE
avoid n^2 scaling in expand_instream

### DIFF
--- a/src/systems/connectors.jl
+++ b/src/systems/connectors.jl
@@ -395,11 +395,8 @@ function expand_instream(csets::AbstractVector{<:ConnectionSet}, sys::AbstractSy
     for ex in instream_exprs
         ns_sv = only(arguments(ex))
         full_name_sv = renamespace(namespace, ns_sv)
-        if haskey(expr_cset, full_name_sv)
-            cset = expr_cset[full_name_sv]
-        else
-            error("$ns_sv is not a variable inside stream connectors")
-        end
+        cset = get(expr_cset, full_name_sv, nothing)
+        cset === nothing && error("$ns_sv is not a variable inside stream connectors")
         idx_in_set, sv = get_cset_sv(full_name_sv, cset)
 
         n_inners = n_outers = 0


### PR DESCRIPTION
Before this patch, the connection set that belongs to an instream expression was found by looping over all of them. With n expressions and n connection sets, the time this took for large systems became very large (at least a day for me). This fixes that by creating a Dict that maps directly to the required connection set. This Dict is created by looping over all connection sets once.