### PR TITLE
fix unbound arg

### DIFF
--- a/src/bipartite_graph.jl
+++ b/src/bipartite_graph.jl
@@ -45,7 +45,8 @@ Matching{U}(v::V) where {U, V <: AbstractVector} = Matching{U, V}(v, nothing)
 function Matching{U}(v::V, iv::Union{V, Nothing}) where {U, V <: AbstractVector}
     Matching{U, V}(v, iv)
 end
-function Matching(v::V) where {U, V <: AbstractVector{Union{U, Int}}}
+function Matching(v::V) where {V <: AbstractVector{Union{<:Any, Int}}}
+    U = eltype(V).a # try to avoid unbounding the arg here
     Matching{@isdefined(U) ? U : Unassigned, V}(v, nothing)
 end
 function Matching(m::Int)


### PR DESCRIPTION
I am not sure why this original syntax works.
This bounds the argument, which should avoid
some excess precompile/inference time.