### PR TITLE
Change icon_name to type

### DIFF
--- a/src/systems/abstractsystem.jl
+++ b/src/systems/abstractsystem.jl
@@ -5,7 +5,7 @@ struct GUIMetadata
     layout::Any
 end
 
-GUIMetadata(icon_name) = GUIMetadata(icon_name, nothing)
+GUIMetadata(type) = GUIMetadata(type, nothing)
 
 """
 ```julia

--- a/src/systems/abstractsystem.jl
+++ b/src/systems/abstractsystem.jl
@@ -1,7 +1,7 @@
 const SYSTEM_COUNT = Threads.Atomic{UInt}(0)
 
 struct GUIMetadata
-    icon_name::String
+    type::String
     layout::Any
 end
 


### PR DESCRIPTION
`icon_name` is the wrong variable name here. The GUI does not only change the icon name based on the type. There will be several other properties that change with the type. The more general name `type` fits better here.