### PR TITLE
Iterative callback and alteranive syntax for preset time and periodic callbacks

### DIFF
--- a/docs/src/basics/Events.md
+++ b/docs/src/basics/Events.md
@@ -151,9 +151,13 @@ of one or more equations, an affect is defined as a `tuple`:
 [x ~ 0] => (affect!, [v, x], [p, q], ctx)
 ```
 
-where, `affect!` is a Julia function with the signature: `affect!(integ, u, p, ctx)`; `[u,v]` and `[p,q]` are the symbolic states (variables) and parameters
-that are accessed by `affect!`, respectively; and `ctx` is any context that is
-passed to `affect!` as the `ctx` argument.
+where `affect!` is a Julia function with the signature: `affect!(integ, sts, pars, ctx)`; `stats` and `pars` are the symbolic states (variables) and parameters
+that are accessed by `affect!`, respectively — in this case,
+we make the states `[v, x]` and the parameters `[p, q]` available.
+Additionally, `ctx` is any context that is passed to `affect!` as the `ctx` argument. 
+As you can see below, in simple cases, we might wish to ignore
+contexts and simply use `nothing` in the tuple.
+Otherwise, it is useful to avoid global variables in the definition of the affect.
 
 `affect!` receives a [DifferentialEquations.jl
 integrator](https://docs.sciml.ai/DiffEqDocs/stable/basics/integrator/)
@@ -340,4 +344,31 @@ one must still use a vector
 
 ```julia
 discrete_events = [[2.0] => [v ~ -v]]
+```
+
+### Discrete generalized functional affects
+
+As with [continuous events](@ref func_affects), we can also define more complicated
+events with generalized functional affects by providing tuples
+like
+
+```julia
+condition => (affect!, [v, x], [p, q], ctx)
+```
+
+* If `condition` is a `Real`, then the affect is applied periodically.
+* If `condition` is a `Vector{<:Real}`, then the affect is applied at preset times.
+* If `condition` is some symbolic expression, then the affect is applied,  
+  if it evaluates to `true`. Care has to be taken by providing `tstops` to `solve`.
+
+There are also two special discrete Callback structures exploiting this more general
+mechanism behind the scenes. `ModelingToolkit.SymbolicPeriodicCallback` provides just an 
+alternative syntax for periodic events, while `ModelingToolkit.SymbolicIterativeCallback` 
+is similar to `DiffEqCallbacks.IterativeCallback`:
+A `time_choice` function can be provided to iteratively determine time steps for events 
+without having to deal with `tstops`.
+
+```@docs
+ModelingToolkit.SymbolicPeriodicCallback
+ModelingToolkit.SymbolicIterativeCallback
 ```

--- a/docs/src/basics/Events.md
+++ b/docs/src/basics/Events.md
@@ -371,5 +371,6 @@ without having to deal with `tstops`.
 
 ```@docs
 ModelingToolkit.SymbolicPeriodicCallback
+ModelingToolkit.SymbolicPresetTimeCallback
 ModelingToolkit.SymbolicIterativeCallback
 ```

--- a/docs/src/basics/Events.md
+++ b/docs/src/basics/Events.md
@@ -361,9 +361,10 @@ condition => (affect!, [v, x], [p, q], ctx)
 * If `condition` is some symbolic expression, then the affect is applied,  
   if it evaluates to `true`. Care has to be taken by providing `tstops` to `solve`.
 
-There are also two special discrete Callback structures exploiting this more general
-mechanism behind the scenes. `ModelingToolkit.SymbolicPeriodicCallback` provides just an 
-alternative syntax for periodic events, while `ModelingToolkit.SymbolicIterativeCallback` 
+There are also three special discrete Callback structures exploiting this more general
+mechanism behind the scenes. `ModelingToolkit.SymbolicPeriodicCallback` and 
+`ModelingToolkit.SymbolicPresetTimeCallback` just provide an alternative syntax for periodic 
+and timed events respectively, while `ModelingToolkit.SymbolicIterativeCallback` 
 is similar to `DiffEqCallbacks.IterativeCallback`:
 A `time_choice` function can be provided to iteratively determine time steps for events 
 without having to deal with `tstops`.

--- a/docs/src/basics/Events.md
+++ b/docs/src/basics/Events.md
@@ -154,7 +154,7 @@ of one or more equations, an affect is defined as a `tuple`:
 where `affect!` is a Julia function with the signature: `affect!(integ, sts, pars, ctx)`; `stats` and `pars` are the symbolic states (variables) and parameters
 that are accessed by `affect!`, respectively — in this case,
 we make the states `[v, x]` and the parameters `[p, q]` available.
-Additionally, `ctx` is any context that is passed to `affect!` as the `ctx` argument. 
+Additionally, `ctx` is any context that is passed to `affect!` as the `ctx` argument.
 As you can see below, in simple cases, we might wish to ignore
 contexts and simply use `nothing` in the tuple.
 Otherwise, it is useful to avoid global variables in the definition of the affect.
@@ -356,17 +356,17 @@ like
 condition => (affect!, [v, x], [p, q], ctx)
 ```
 
-* If `condition` is a `Real`, then the affect is applied periodically.
-* If `condition` is a `Vector{<:Real}`, then the affect is applied at preset times.
-* If `condition` is some symbolic expression, then the affect is applied,  
-  if it evaluates to `true`. Care has to be taken by providing `tstops` to `solve`.
+  - If `condition` is a `Real`, then the affect is applied periodically.
+  - If `condition` is a `Vector{<:Real}`, then the affect is applied at preset times.
+  - If `condition` is some symbolic expression, then the affect is applied,
+    if it evaluates to `true`. Care has to be taken by providing `tstops` to `solve`.
 
 There are also three special discrete Callback structures exploiting this more general
-mechanism behind the scenes. `ModelingToolkit.SymbolicPeriodicCallback` and 
-`ModelingToolkit.SymbolicPresetTimeCallback` just provide an alternative syntax for periodic 
-and timed events respectively, while `ModelingToolkit.SymbolicIterativeCallback` 
+mechanism behind the scenes. `ModelingToolkit.SymbolicPeriodicCallback` and
+`ModelingToolkit.SymbolicPresetTimeCallback` just provide an alternative syntax for periodic
+and timed events respectively, while `ModelingToolkit.SymbolicIterativeCallback`
 is similar to `DiffEqCallbacks.IterativeCallback`:
-A `time_choice` function can be provided to iteratively determine time steps for events 
+A `time_choice` function can be provided to iteratively determine time steps for events
 without having to deal with `tstops`.
 
 ```@docs

--- a/src/systems/callbacks.jl
+++ b/src/systems/callbacks.jl
@@ -556,7 +556,7 @@ Both functions are compiled to suit the requirements of their counterparts for
 
 # Example
 Below, we model the growth of some population with size ``N(t)``.
-If we start with ``N(0) = 0``, then the population will to approximate
+If we start with ``N(0) = 0``, then the population will approximate
 ``α`` in the limit, i.e., ``N(t) ↗ α`` for ``t → ∞``.
 With some calculus, we find that ``N(t) ≈ 50`` at ``t = \\ln(2)``.
 At this point in time, we decide to inject ``M = 60`` individuals
@@ -663,7 +663,7 @@ The affect is applied at times `tspan[1]`, `tspan[1] + Δt`, `tspan[1] + 2*Δt`,
 
 # Example
 Below, we model the growth of some population with size ``N(t)``.
-If we start with ``N(0) = 0``, then the population will to approximate
+If we start with ``N(0) = 0``, then the population will approximate
 ``α`` in the limit, i.e., ``N(t) ↗ α`` for ``t → ∞``.
 But we now imagine some periodic event afflicting our population.
 If at that point in time, the population is too big, it is reduced by 
@@ -750,7 +750,7 @@ Define a Callback with preset times based on the arguments `tstops::Vector{Real}
 
 # Example
 Below, we model the growth of some population with size ``N(t)``.
-If we start with ``N(0) = 0``, then the population will to approximate
+If we start with ``N(0) = 0``, then the population will approximate
 ``α`` in the limit, i.e., ``N(t) ↗ α`` for ``t → ∞``.
 At preset times we want to check if ``N(t) > 70`.
 If that is the case, we substract ``m=20``:

--- a/src/systems/callbacks.jl
+++ b/src/systems/callbacks.jl
@@ -146,6 +146,8 @@ function continuous_events(sys::AbstractSystem)
 end
 
 #################################### discrete events #####################################
+
+"Abstract super type to conveniently inject custom symbolic callbacks."
 abstract type AbstractSpecialCallback end
 
 struct SymbolicDiscreteCallback{T<:Union{Nothing, AbstractSpecialCallback}}
@@ -537,8 +539,8 @@ end
 Define an iterative Callback based on the arguments `time_choice_tuple` and `user_affect!_tuple`.
 
 # Arguments
-- `time_choice_tuple` is a tuple of the form `(time_choice, vec_of_states, vec_of_params, ctx)`
-- `user_affect!_tuple` is a tuple of the form `(user_affect!, vec_of_states, vec_of_params, ctx)`
+- `time_choice_tuple` is a (optionally named) tuple of the form `(time_choice, sts, pars, ctx)`
+- `user_affect!_tuple` is a tuple of the form `(user_affect!, sts, pars, ctx)`
 - `initial_affact::Bool=false` indicates whether or not to apply the affect at `t0`.
 
 Both `time_choice` and `user_affect!` should have signatures `(integrator, sys_states, sys_params, ctx)`.
@@ -581,10 +583,10 @@ function generate_discrete_callback(
 end
 
 struct SymbolicPeriodicCallback <: AbstractSpecialCallback
-    affect::Any
     del_t::Real
-
-    function SymbolicPeriodicCallback(affect, del_t)
+    affect::Any
+    
+    function SymbolicPeriodicCallback(del_t, affect)
         _affect = scalarize_affects(affect)
         return new(_affect, del_t)
     end

--- a/test/funcaffect.jl
+++ b/test/funcaffect.jl
@@ -286,3 +286,160 @@ bb_sol = solve(bb_prob, Tsit5())
 
 @test bb_sol[y] ≈ map(u -> u[1], sol_.u)
 @test bb_sol[v] ≈ map(u -> u[2], sol_.u)
+
+@testset "SymbolicIterativeCallback" begin
+    # This is loosely based on the Population example from the docs
+    # `t` is the time
+    # `N` is the population size
+    # `m` is an additive quantity to add to the population size `N`
+    # `M` is an additive quantity to add to the population size `N`
+    # `α` is the limit value of `N` for large `t`
+    @parameters m=-10 M=50 α=100.0
+    @variables t N(t)
+
+    Dt = Differential(t)
+    eqs = [Dt(N) ~ α - N]
+    #=
+    NOTE
+    The differential equation is 
+    d/dt N(t) = α - N
+    Suppose that N(0) >= α, then the solution is 
+    N(t) = (N0 - α) * exp(-t) + α
+    Otherwise, the solution is 
+    N(t) = α - (α - N0) * exp(-t)
+    =#
+
+    u0 = [N => 0.0]
+    tspan = (0.0, 20.0)
+
+    # Until the first call to `user_affect!` hits, the population develops according to
+    # N(t) = 100 - 100 * exp(-t)
+    # At ``t₁ ≈ ln(2)`` the population will be ``N(t₁) ≈ 50``.
+    t1 = 1.1 * log(2)
+    N1 = 100 - 100 * exp(-t1)
+
+    # From t1 onwards, the solution is 
+    # N(t) = (N1+M-α) * exp(t1 - t) + α
+    # N(t) = (N1+M-α) * exp(t1) * exp(-t) + α
+    # At ``t₂ = t₁ + ln(2) = 2 ln(2)`` the population will roughly be
+    # N(t) = 0.5 (N1+M-α) * exp(t1) * exp(-t) + α
+    t2 = 2 * t1
+    N2 = (N1+50-100) * exp(t1) * exp(-t2) + 100
+
+    time_choice_history = Float64[]
+    solution_history = Float64[]
+
+    function time_choice(integ, sts, pars, ctx)
+        local N = integ.u[sts.N]
+        local t = integ.t
+
+        tnext = if N <= 50
+            t1
+        elseif t < t2
+            t2 
+        elseif t <= 15
+            t + 1
+        else
+            nothing
+        end
+        if !isnothing(tnext)
+            push!(time_choice_history, tnext)
+        end
+        return tnext
+    end
+
+    function user_affect!(integ, sts, pars, ctx)
+        local N = integ.u[sts.N]
+        local α = integ.p[pars.α]
+        local m = integ.p[pars.m]
+        local M = integ.p[pars.M]
+        local t = integ.t
+
+        push!(solution_history, N)
+
+        if t == t1
+            @test abs(N - N1) <= 1e-3
+            integ.u[sts.N] += M # now the population is > 100 and begins to exponentially shrink
+        elseif t == t2
+            @test abs(N - N2) <= 1e-3
+            integ.u[sts.N] += m
+        else
+            if N > α - m 
+                integ.u[sts.N] += m
+            else
+                integ.u[sts.N] += M
+            end
+        end
+    end
+
+    cb = ModelingToolkit.SymbolicIterativeCallback(
+        (time_choice, [N], [], nothing),
+        (user_affect!, [N], [α, m, M], nothing),
+        false
+    )
+   
+    @named osys = ODESystem(eqs, t, [N], [α, m, M]; discrete_events=[cb])
+    oprob = ODEProblem(osys, u0, tspan)
+    sol = solve(oprob, Tsit5())
+
+    @test all( abs( first(sol(t))-_N ) <= 1e-3 for (t,_N)=zip(time_choice_history, solution_history) )
+
+    # Now: `initial_affect = true`
+    function time_choice2(integ, sts, pars, ctx)
+        return nothing
+    end
+
+    function user_affect!2(integ, sts, pars, ctx)
+        integ.u[ sts.N ] += integ.p[ pars.M ]
+    end
+
+    @show N, M
+    cb2 = ModelingToolkit.SymbolicIterativeCallback(
+        (time_choice2, [], [], nothing),
+        (user_affect!2, [N], [M], nothing),
+        true
+    )
+   
+    @named osys2 = ODESystem(eqs, t, [N], [α, m, M]; discrete_events=[cb2])
+    oprob2 = ODEProblem(osys2, u0, tspan)
+    sol2 = solve(oprob2, Tsit5())
+
+    @test first(sol2(1e-3)) >= 50
+end
+
+@testset "SymbolicPeriodicCallback" begin
+    @parameters α=100 m=20
+    @variables t N(t)
+    Dt = Differential(t)
+    eqs = [Dt(N) ~ α - N]
+
+    del_t = log(2)/2
+
+    T = Float64[]
+
+    function user_affect!(integ, sts, pars, ctx)
+        push!(T, integ.t)
+        N = integ.u[ sts.N ]
+        if N > 70
+            integ.u[ sts.N ] -= integ.p[ pars.m ]
+        end
+    end
+
+    # define discrete symbolic callback
+    cb = ModelingToolkit.SymbolicPeriodicCallback(
+        del_t, (user_affect!, [N], [m], nothing)
+    )
+
+    # setup system, problem, and solve:
+    @named osys = ODESystem(
+        eqs, t, [N], [α, m]; discrete_events=[cb]
+    )
+    oprob = ODEProblem(osys, u0, tspan)
+    sol = solve(oprob, Tsit5())
+
+    for _t in T
+        if first(sol(_t)) > 70
+            @test first(sol(_t + 1e-5)) < 70
+        end
+    end
+end


### PR DESCRIPTION
This pull request is a follow up to https://github.com/SciML/ModelingToolkit.jl/pull/1673 and one of the ToDo's that was not yet implemented: iterative callbacks.

In DiffEqCallbacks, iterative callbacks define a functional condition, which is not supported (yet) for `SymbolicDiscreteCallback`. This would require something like `FunctionalAffect` for conditions and changing the compilation methods.

What is done with this pull request instead is the addition of the field `wrapped` to `SymbolicDiscreteCallback`, which now also has a type parameter.
It is then very easy to implement custom symbolic callback types (ideally subtyping `AbstractSpecialDiscreteCallback`). It suffices to specialize `generate_discrete_callback` by dispatching on the type parameter.

I have included 3 example types: `SymbolicIterativeCallback`, `SymbolicPeriodicCallback` and `SymbolicPresetTimeCallback`. They closely mimick their counterparts from DiffEqCallbacks and 
allow for a similar syntax. These types can be passed to the `discrete_events` keyword argument of system constructors.

Everything has doc-strings, I am just going to copy one example to better illustrate the syntax:

## Example

Below, we model the growth of some population with size ``N(t)``. If we start with ``N(0) = 0``, then the population will approximate ``α`` in the limit, i.e., ``N(t) ↗ α`` for ``t → ∞``.
With some calculus, we find that ``N(t) ≈ 50`` at ``t = \\ln(2)``. At this point in time, we decide to inject ``M = 60`` individuals to the population. A short while later, we can check if that was 
successful:
```julia
using ModelingToolkit, OrdinaryDiffEq
@parameters α=100 M=60
@variables t N(t)
Dt = Differential(t)
eqs = [Dt(N) ~ α - N]
t_inject = log(2)
t_check = t_inject + 1e-6
t_ref = Base.RefValue{Union{Nothing, Float64}}(-1.0)
function time_choice(integ, sts, pars, ctx)
    if t_ref[] < 0
        t_ref[] = t_inject
    elseif t_ref[] == t_inject
        t_ref[] = t_check
    else
        t_ref[] = nothing
    end
    return t_ref[]
end
function user_affect!(integ, sts, pars, ctx)
    if integ.t == t_inject
        integ.u[ sts.N ] += integ.p[ pars.M ]
    elseif integ.t == t_check
        @assert integ.u[ sts.N ] > integ.p[ pars.α ]
    end
end
# define discrete symbolic callback
cb = ModelingToolkit.SymbolicIterativeCallback(
    (time_choice, [], [], nothing),
    (user_affect!, [N], [α, M], nothing)
)
# setup system, problem, and solve:
@named osys = ODESystem(
    eqs, t, [N], [α, M]; discrete_events=[cb]
)
u0 = [N => 0.0]
tspan = (0.0, 20.0)
oprob = ODEProblem(osys, u0, tspan)
sol = solve(oprob, Tsit5())
```