### PR TITLE
Fix Barreiss algorithm

### DIFF
--- a/src/structural_transformation/bareiss.jl
+++ b/src/structural_transformation/bareiss.jl
@@ -124,8 +124,8 @@ function bareiss_update!(zero!, M::StridedMatrix, k, swapto, pivot,
             M[j, i], r = divrem(M[j, i] * pivot - M[j, k] * Mki, prev_pivot)
             flag = flag | r
         end
-        iszero(flag) || error("Overflow occurred")
     end
+    iszero(flag) || error("Overflow occurred")
     zero!(M, (k + 1):size(M, 1), k)
 end
 

--- a/src/structural_transformation/bareiss.jl
+++ b/src/structural_transformation/bareiss.jl
@@ -124,8 +124,8 @@ function bareiss_update!(zero!, M::StridedMatrix, k, swapto, pivot,
             M[j, i], r = divrem(M[j, i] * pivot - M[j, k] * Mki, prev_pivot)
             flag = flag | r
         end
+        iszero(flag) || error("Overflow occurred")
     end
-    iszero(flag) || error("Overflow occurred")
     zero!(M, (k + 1):size(M, 1), k)
 end
 

--- a/src/systems/alias_elimination.jl
+++ b/src/systems/alias_elimination.jl
@@ -557,7 +557,8 @@ function aag_bareiss!(graph, var_to_diff, mm_orig::SparseMatrixCLIL)
     local bar
     try
         bar = do_bareiss!(mm, mm_orig, is_linear_variables)
-    catch
+    catch e
+        e isa OverflowError || rethrow(e)
         mm = changetype(BigInt, mm_orig)
         bar = do_bareiss!(mm, mm_orig, is_linear_variables)
     end

--- a/src/systems/alias_elimination.jl
+++ b/src/systems/alias_elimination.jl
@@ -224,7 +224,6 @@ the `constraint`.
         if constraint(length(vertices))
             for (j, v) in enumerate(vertices)
                 if (mask === nothing || mask[v])
-                    iszero(M.row_vals[i][j]) && error("zero found in sparse matrix")
                     return (CartesianIndex(i, v), M.row_vals[i][j])
                 end
             end
@@ -240,7 +239,6 @@ end
     for i in range
         row = @view M[i, :]
         if constraint(count(!iszero, row))
-            iszero(val) && continue
             for (v, val) in enumerate(row)
                 if mask === nothing || mask[v]
                     return CartesianIndex(i, v), val

--- a/src/systems/alias_elimination.jl
+++ b/src/systems/alias_elimination.jl
@@ -323,7 +323,8 @@ function Base.setindex!(ag::AliasGraph, v::Integer, i::Integer)
     return 0 => 0
 end
 
-function Base.setindex!(ag::AliasGraph, p::Union{Pair{<:Integer, Int}, Tuple{<:Integer, Int}},
+function Base.setindex!(ag::AliasGraph,
+                        p::Union{Pair{<:Integer, Int}, Tuple{<:Integer, Int}},
                         i::Integer)
     (c, v) = p
     if c == 0 || v == 0

--- a/src/systems/sparsematrixclil.jl
+++ b/src/systems/sparsematrixclil.jl
@@ -201,7 +201,7 @@ function bareiss_update_virtual_colswap_mtk!(zero!, M::SparseMatrixCLIL, k, swap
             ci = getcoeff(ivars, icoeffs, v)
             p1 = Base.Checked.checked_mul(pivot, ci)
             p2 = Base.Checked.checked_mul(coeff, ck)
-            ci = exactdiv(p1 - p2, last_pivot)
+            ci = exactdiv(Base.Checked.checked_sub(p1, p2), last_pivot)
             if !iszero(ci)
                 push!(tmp_incidence, v)
                 push!(tmp_coeffs, ci)

--- a/src/systems/sparsematrixclil.jl
+++ b/src/systems/sparsematrixclil.jl
@@ -35,7 +35,7 @@ function swaprows!(S::SparseMatrixCLIL, i, j)
     swap!(S.row_vals, i, j)
 end
 
-function convert(::Type{SparseMatrixCLIL{T, Ti}}, S::SparseMatrixCLIL) where {T, Ti}
+function Base.convert(::Type{SparseMatrixCLIL{T, Ti}}, S::SparseMatrixCLIL) where {T, Ti}
     return SparseMatrixCLIL(S.nparentrows,
                             S.ncols,
                             copy.(S.nzrows),

--- a/src/systems/sparsematrixclil.jl
+++ b/src/systems/sparsematrixclil.jl
@@ -29,9 +29,18 @@ function Base.copy(S::SparseMatrixCLIL{T, Ti}) where {T, Ti}
                      map(copy, S.row_vals))
 end
 function swaprows!(S::SparseMatrixCLIL, i, j)
+    i == j && return
     swap!(S.nzrows, i, j)
     swap!(S.row_cols, i, j)
     swap!(S.row_vals, i, j)
+end
+
+function changetype(T, S::SparseMatrixCLIL)
+    return SparseMatrixCLIL(S.nparentrows,
+                            S.ncols,
+                            copy.(S.nzrows),
+                            copy.(S.row_cols),
+                            [T.(row) for row in S.row_vals])
 end
 
 function SparseMatrixCLIL(mm::AbstractMatrix)
@@ -59,6 +68,7 @@ function Base.setindex!(S::SparseMatrixCLIL, v::CLILVector, i::Integer, c::Colon
     if v.vec.n != S.ncols
         throw(BoundsError(v, 1:(S.ncols)))
     end
+    any(iszero, v.vec.nzval) && error("setindex failed")
     S.row_cols[i] = copy(v.vec.nzind)
     S.row_vals[i] = copy(v.vec.nzval)
     return v
@@ -91,7 +101,7 @@ function Base.iterate(nzp::NonZerosPairs{<:CLILVector}, (idx, col))
         idx = length(col)
     end
     oldcol = nzind[idx]
-    if col !== oldcol
+    if col != oldcol
         # The vector was changed since the last iteration. Find our
         # place in the vector again.
         tail = col > oldcol ? (@view nzind[(idx + 1):end]) : (@view nzind[1:idx])
@@ -189,13 +199,12 @@ function bareiss_update_virtual_colswap_mtk!(zero!, M::SparseMatrixCLIL, k, swap
             v == vpivot && continue
             ck = getcoeff(kvars, kcoeffs, v)
             ci = getcoeff(ivars, icoeffs, v)
-            ci = (pivot * ci - coeff * ck) ÷ last_pivot
-            if ci !== 0
+            ci = exactdiv((pivot * ci - coeff * ck), last_pivot)
+            if ci != 0
                 push!(tmp_incidence, v)
                 push!(tmp_coeffs, ci)
             end
         end
-
         eadj[ei] = tmp_incidence
         old_cadj[ei] = tmp_coeffs
     end

--- a/src/systems/sparsematrixclil.jl
+++ b/src/systems/sparsematrixclil.jl
@@ -199,7 +199,9 @@ function bareiss_update_virtual_colswap_mtk!(zero!, M::SparseMatrixCLIL, k, swap
             v == vpivot && continue
             ck = getcoeff(kvars, kcoeffs, v)
             ci = getcoeff(ivars, icoeffs, v)
-            ci = exactdiv((pivot * ci - coeff * ck), last_pivot)
+            p1 = Base.Checked.checked_mul(pivot, ci)
+            p2 = Base.Checked.checked_mul(coeff, ck)
+            ci = exactdiv(p1 - p2, last_pivot)
             if ci != 0
                 push!(tmp_incidence, v)
                 push!(tmp_coeffs, ci)

--- a/src/systems/sparsematrixclil.jl
+++ b/src/systems/sparsematrixclil.jl
@@ -202,7 +202,7 @@ function bareiss_update_virtual_colswap_mtk!(zero!, M::SparseMatrixCLIL, k, swap
             p1 = Base.Checked.checked_mul(pivot, ci)
             p2 = Base.Checked.checked_mul(coeff, ck)
             ci = exactdiv(p1 - p2, last_pivot)
-            if ci != 0
+            if !iszero(ci)
                 push!(tmp_incidence, v)
                 push!(tmp_coeffs, ci)
             end

--- a/src/systems/sparsematrixclil.jl
+++ b/src/systems/sparsematrixclil.jl
@@ -35,7 +35,7 @@ function swaprows!(S::SparseMatrixCLIL, i, j)
     swap!(S.row_vals, i, j)
 end
 
-function convert(SparseMatrixCLIL{T, Ti}, S::SparseMatrixCLIL) where{T, Ti}
+function convert(::Type{SparseMatrixCLIL{T, Ti}}, S::SparseMatrixCLIL) where {T, Ti}
     return SparseMatrixCLIL(S.nparentrows,
                             S.ncols,
                             copy.(S.nzrows),

--- a/src/systems/sparsematrixclil.jl
+++ b/src/systems/sparsematrixclil.jl
@@ -35,7 +35,7 @@ function swaprows!(S::SparseMatrixCLIL, i, j)
     swap!(S.row_vals, i, j)
 end
 
-function changetype(T, S::SparseMatrixCLIL)
+function convert(SparseMatrixCLIL{T, Ti}, S::SparseMatrixCLIL) where{T, Ti}
     return SparseMatrixCLIL(S.nparentrows,
                             S.ncols,
                             copy.(S.nzrows),


### PR DESCRIPTION
This has a number of changes.
The first is that we were using ÷ instead of exact_div in bareiss_update_virtual_colswap_mtk which led to undetected overflows. We also had a number of bugs that arise when using BigInt precsion in bareiss (e.g. checking `!==0` vs `!=0`. This PR makes it so we first try to bareiss with the regular Int64 matrix, but if that gets an overflow, we fallback to the BigInt version.
@YingboMa I'm not 100% convinced that the `exact_div` is a sufficient check. Is it obvious that it always suffices to check the remainder or should we instead be checking for overflow on the multiplications?