### PR TITLE
RFC: handle multibody frames in `connection2set!`

### DIFF
--- a/src/systems/connectors.jl
+++ b/src/systems/connectors.jl
@@ -188,7 +188,7 @@ function isframe(sys)
 end
 
 "Return orienation object of a multibody frame."
-function ori(sys::ODESystem)
+function ori(sys)
     if sys.metadata isa Dict && (O = get(sys.metadata, :orientation, nothing)) !== nothing
         return O
     else


### PR DESCRIPTION
I have more or less zero clue as to what this code is doing so this is most likely a complete hack, but it might be a starting point at least.

The idea is that when a multibody frame connector is detected, as indicated by the `metadata` field, the orientation variables of the frame are extracted, also from the metadata, and added to the connector variables. 

This PR changes 
```julia
connect(world.frame_b, body.frame_a)
```
into
```julia
 (world₊frame_b₊r_0(t))[1] ~ (body₊frame_a₊r_0(t))[1]
 (world₊frame_b₊r_0(t))[2] ~ (body₊frame_a₊r_0(t))[2]
 (world₊frame_b₊r_0(t))[3] ~ (body₊frame_a₊r_0(t))[3]
 0 ~ (body₊frame_a₊f(t))[1] + (world₊frame_b₊f(t))[1]
 0 ~ (body₊frame_a₊f(t))[2] + (world₊frame_b₊f(t))[2]
 0 ~ (body₊frame_a₊f(t))[3] + (world₊frame_b₊f(t))[3]
 0 ~ (body₊frame_a₊tau(t))[1] + (world₊frame_b₊tau(t))[1]
 0 ~ (body₊frame_a₊tau(t))[2] + (world₊frame_b₊tau(t))[2]
 0 ~ (body₊frame_a₊tau(t))[3] + (world₊frame_b₊tau(t))[3]
 (world₊frame_b₊R(t))[1, 1] ~ (body₊frame_a₊R(t))[1, 1]
 (world₊frame_b₊R(t))[2, 1] ~ (body₊frame_a₊R(t))[2, 1]
 (world₊frame_b₊R(t))[3, 1] ~ (body₊frame_a₊R(t))[3, 1]
 (world₊frame_b₊R(t))[1, 2] ~ (body₊frame_a₊R(t))[1, 2]
 (world₊frame_b₊R(t))[2, 2] ~ (body₊frame_a₊R(t))[2, 2]
 (world₊frame_b₊R(t))[3, 2] ~ (body₊frame_a₊R(t))[3, 2]
 (world₊frame_b₊R(t))[1, 3] ~ (body₊frame_a₊R(t))[1, 3]
 (world₊frame_b₊R(t))[2, 3] ~ (body₊frame_a₊R(t))[2, 3]
 (world₊frame_b₊R(t))[3, 3] ~ (body₊frame_a₊R(t))[3, 3]
```
which, at least on the surface, looks correct for simple models without kinematic loops.