### PR TITLE
Change `show` format for `MatchedSystemStructure` and add DeepDiffs.jl support

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -46,6 +46,12 @@ Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
 UnPack = "3a884ed6-31ef-47d7-9d2a-63182c4928ed"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
+[weakdeps]
+DeepDiffs = "ab62b9b5-e342-54a8-a765-a90f495de1a6"
+
+[extensions]
+MTKDeepDiffsExt = "DeepDiffs"
+
 [compat]
 AbstractTrees = "0.3, 0.4"
 ArrayInterface = "6, 7"
@@ -88,6 +94,7 @@ julia = "1.6"
 AmplNLWriter = "7c4d4715-977e-5154-bfe0-e096adeac482"
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 ControlSystemsMTK = "687d7614-c7e5-45fc-bfc3-9ee385575c88"
+DeepDiffs = "ab62b9b5-e342-54a8-a765-a90f495de1a6"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 Ipopt = "b6b21f68-93f8-5de0-b562-5493be1d77c9"
 Ipopt_jll = "9cc047cb-c261-5740-88fc-0cf96f7bdcc7"

--- a/ext/MTKDeepDiffsExt.jl
+++ b/ext/MTKDeepDiffsExt.jl
@@ -1,0 +1,126 @@
+module MTKDeepDiffsExt
+
+using DeepDiffs, ModelingToolkit
+using ModelingToolkit.BipartiteGraphs: Label, BipartiteAdjacencyList, unassigned
+using ModelingToolkit.SystemStructures: SystemStructure, MatchedSystemStructure,
+                                        SystemStructurePrintMatrix, HighlightInt
+
+struct HighlightIntDiff
+    new::HighlightInt
+    old::HighlightInt
+end
+
+function Base.show(io::IO, d::HighlightIntDiff)
+    p_color = d.new.highlight
+    (d.new.match && !d.old.match) && (p_color = :light_green)
+    (!d.new.match && d.old.match) && (p_color = :light_red)
+
+    (d.new.match || d.old.match) && printstyled(io, "(", color = p_color)
+    if d.new.i != d.old.i
+        Base.show(io, HighlightInt(d.old.i, :light_red, d.old.match))
+        print(io, " ")
+        Base.show(io, HighlightInt(d.new.i, :light_green, d.new.match))
+    else
+        Base.show(io, HighlightInt(d.new.i, d.new.highlight, false))
+    end
+    (d.new.match || d.old.match) && printstyled(io, ")", color = p_color)
+end
+
+struct BipartiteAdjacencyListDiff
+    new::BipartiteAdjacencyList
+    old::BipartiteAdjacencyList
+end
+
+function Base.show(io::IO, l::BipartiteAdjacencyListDiff)
+    print(io,
+          LabelDiff(Label(l.new.match === true ? "∫ " : ""),
+                    Label(l.old.match === true ? "∫ " : "")))
+    (l.new.match !== true && l.old.match !== true) && print(io, "  ")
+
+    new_nonempty = isnothing(l.new.u) ? nothing : !isempty(l.new.u)
+    old_nonempty = isnothing(l.old.u) ? nothing : !isempty(l.old.u)
+    if new_nonempty === true && old_nonempty === true
+        if (!isempty(setdiff(l.new.highligh_u, l.new.u)) ||
+            !isempty(setdiff(l.old.highligh_u, l.old.u)))
+            throw(ArgumentError("The provided `highligh_u` must be a sub-graph of `u`."))
+        end
+
+        new_items = Dict(i => HighlightInt(i, :nothing, i === l.new.match) for i in l.new.u)
+        old_items = Dict(i => HighlightInt(i, :nothing, i === l.old.match) for i in l.old.u)
+
+        highlighted = union(map(intersect(l.new.u, l.old.u)) do i
+                                HighlightIntDiff(new_items[i], old_items[i])
+                            end,
+                            map(setdiff(l.new.u, l.old.u)) do i
+                                HighlightInt(new_items[i].i, :light_green,
+                                             new_items[i].match)
+                            end,
+                            map(setdiff(l.old.u, l.new.u)) do i
+                                HighlightInt(old_items[i].i, :light_red,
+                                             old_items[i].match)
+                            end)
+        print(IOContext(io, :typeinfo => typeof(highlighted)), highlighted)
+    elseif new_nonempty === true
+        printstyled(io, map(l.new.u) do i
+                        HighlightInt(i, :nothing, i === l.new.match)
+                    end, color = :light_green)
+    elseif old_nonempty === true
+        printstyled(io, map(l.old.u) do i
+                        HighlightInt(i, :nothing, i === l.old.match)
+                    end, color = :light_red)
+    elseif old_nonempty !== nothing || new_nonempty !== nothing
+        print(io,
+              LabelDiff(Label(new_nonempty === false ? "∅" : "", :light_black),
+                        Label(old_nonempty === false ? "∅" : "", :light_black)))
+    else
+        printstyled(io, '⋅', color = :light_black)
+    end
+end
+
+struct LabelDiff
+    new::Label
+    old::Label
+end
+function Base.show(io::IO, l::LabelDiff)
+    if l.new != l.old
+        printstyled(io, l.old.s, color = :light_red)
+        length(l.new.s) != 0 && length(l.old.s) != 0 && print(io, " ")
+        printstyled(io, l.new.s, color = :light_green)
+    else
+        print(io, l.new)
+    end
+end
+
+struct SystemStructureDiffPrintMatrix <:
+       AbstractMatrix{Union{LabelDiff, BipartiteAdjacencyListDiff}}
+    new::SystemStructurePrintMatrix
+    old::SystemStructurePrintMatrix
+end
+
+function DeepDiffs.deepdiff(old::Union{MatchedSystemStructure, SystemStructure},
+                            new::Union{MatchedSystemStructure, SystemStructure})
+    new_sspm = SystemStructurePrintMatrix(new)
+    old_sspm = SystemStructurePrintMatrix(old)
+    Base.print_matrix(stdout, SystemStructureDiffPrintMatrix(new_sspm, old_sspm))
+end
+
+function Base.size(ssdpm::SystemStructureDiffPrintMatrix)
+    max.(Base.size(ssdpm.new), Base.size(ssdpm.old))
+end
+
+function Base.getindex(ssdpm::SystemStructureDiffPrintMatrix, i::Integer, j::Integer)
+    checkbounds(ssdpm, i, j)
+    if i > 1 && (j == 3 || j == 7)
+        old = new = BipartiteAdjacencyList(nothing, nothing, unassigned)
+        (i <= size(ssdpm.new, 1)) && (new = ssdpm.new[i, j])
+        (i <= size(ssdpm.old, 1)) && (old = ssdpm.old[i, j])
+        BipartiteAdjacencyListDiff(new, old)
+    else
+        old = new = Label("")
+        (i <= size(ssdpm.new, 1)) && (new = ssdpm.new[i, j])
+        (i <= size(ssdpm.old, 1)) && (old = ssdpm.old[i, j])
+        LabelDiff(new, old)
+    end
+end
+
+end # module

--- a/ext/MTKDeepDiffsExt.jl
+++ b/ext/MTKDeepDiffsExt.jl
@@ -1,9 +1,10 @@
 module MTKDeepDiffsExt
 
 using DeepDiffs, ModelingToolkit
-using ModelingToolkit.BipartiteGraphs: Label, BipartiteAdjacencyList, unassigned
+using ModelingToolkit.BipartiteGraphs: Label, BipartiteAdjacencyList, unassigned,
+                                       HighlightInt
 using ModelingToolkit.SystemStructures: SystemStructure, MatchedSystemStructure,
-                                        SystemStructurePrintMatrix, HighlightInt
+                                        SystemStructurePrintMatrix
 
 """
 A utility struct for displaying the difference between two HighlightInts.
@@ -162,7 +163,7 @@ end
 
 function Base.getindex(ssdpm::SystemStructureDiffPrintMatrix, i::Integer, j::Integer)
     checkbounds(ssdpm, i, j)
-    if i > 1 && (j == 3 || j == 7)
+    if i > 1 && (j == 4 || j == 9)
         old = new = BipartiteAdjacencyList(nothing, nothing, unassigned)
         (i <= size(ssdpm.new, 1)) && (new = ssdpm.new[i, j])
         (i <= size(ssdpm.old, 1)) && (old = ssdpm.old[i, j])

--- a/ext/MTKDeepDiffsExt.jl
+++ b/ext/MTKDeepDiffsExt.jl
@@ -5,6 +5,20 @@ using ModelingToolkit.BipartiteGraphs: Label, BipartiteAdjacencyList, unassigned
 using ModelingToolkit.SystemStructures: SystemStructure, MatchedSystemStructure,
                                         SystemStructurePrintMatrix, HighlightInt
 
+"""
+A utility struct for displaying the difference between two HighlightInts.
+
+# Example
+```julia
+using ModelingToolkit, DeepDiffs
+
+old_i = HighlightInt(1, :default, true)
+new_i = HighlightInt(2, :default, false)
+diff = HighlightIntDiff(new_i, old_i)
+
+show(diff)
+```
+"""
 struct HighlightIntDiff
     new::HighlightInt
     old::HighlightInt
@@ -26,6 +40,21 @@ function Base.show(io::IO, d::HighlightIntDiff)
     (d.new.match || d.old.match) && printstyled(io, ")", color = p_color)
 end
 
+"""
+A utility struct for displaying the difference between two
+BipartiteAdjacencyList's.
+
+# Example
+```julia
+using ModelingToolkit, DeepDiffs
+
+old = BipartiteAdjacencyList(...)
+new = BipartiteAdjacencyList(...)
+diff = BipartiteAdjacencyListDiff(new, old)
+
+show(diff)
+```
+"""
 struct BipartiteAdjacencyListDiff
     new::BipartiteAdjacencyList
     old::BipartiteAdjacencyList
@@ -77,6 +106,21 @@ function Base.show(io::IO, l::BipartiteAdjacencyListDiff)
     end
 end
 
+"""
+A utility struct for displaying the difference between two Labels
+in git-style red/green highlighting.
+
+# Example
+```julia
+using ModelingToolkit, DeepDiffs
+
+old = Label("before")
+new = Label("after")
+diff = LabelDiff(new, old)
+
+show(diff)
+```
+"""
 struct LabelDiff
     new::Label
     old::Label
@@ -91,17 +135,25 @@ function Base.show(io::IO, l::LabelDiff)
     end
 end
 
+"""
+A utility struct for displaying the difference between two
+(Matched)SystemStructure's in git-style red/green highlighting.
+
+# Example
+```julia
+using ModelingToolkit, DeepDiffs
+
+old = SystemStructurePrintMatrix(...)
+new = SystemStructurePrintMatrix(...)
+diff = SystemStructureDiffPrintMatrix(new, old)
+
+show(diff)
+```
+"""
 struct SystemStructureDiffPrintMatrix <:
        AbstractMatrix{Union{LabelDiff, BipartiteAdjacencyListDiff}}
     new::SystemStructurePrintMatrix
     old::SystemStructurePrintMatrix
-end
-
-function DeepDiffs.deepdiff(old::Union{MatchedSystemStructure, SystemStructure},
-                            new::Union{MatchedSystemStructure, SystemStructure})
-    new_sspm = SystemStructurePrintMatrix(new)
-    old_sspm = SystemStructurePrintMatrix(old)
-    Base.print_matrix(stdout, SystemStructureDiffPrintMatrix(new_sspm, old_sspm))
 end
 
 function Base.size(ssdpm::SystemStructureDiffPrintMatrix)
@@ -121,6 +173,13 @@ function Base.getindex(ssdpm::SystemStructureDiffPrintMatrix, i::Integer, j::Int
         (i <= size(ssdpm.old, 1)) && (old = ssdpm.old[i, j])
         LabelDiff(new, old)
     end
+end
+
+function DeepDiffs.deepdiff(old::Union{MatchedSystemStructure, SystemStructure},
+                            new::Union{MatchedSystemStructure, SystemStructure})
+    new_sspm = SystemStructurePrintMatrix(new)
+    old_sspm = SystemStructurePrintMatrix(old)
+    Base.print_matrix(stdout, SystemStructureDiffPrintMatrix(new_sspm, old_sspm))
 end
 
 end # module

--- a/src/ModelingToolkit.jl
+++ b/src/ModelingToolkit.jl
@@ -221,6 +221,8 @@ export @variables, @parameters, @constants, @brownian
 export @named, @nonamespace, @namespace, extend, compose, complete
 export debug_system
 
+export show_with_compare
+
 #export Continuous, Discrete, sampletime, input_timedomain, output_timedomain
 #export has_discrete_domain, has_continuous_domain
 #export is_discrete_domain, is_continuous_domain, is_hybrid_domain

--- a/src/bipartite_graph.jl
+++ b/src/bipartite_graph.jl
@@ -213,12 +213,14 @@ end
 struct HighlightInt
     i::Int
     highlight::Symbol
-    underline::Bool
+    match::Bool
 end
 Base.typeinfo_implicit(::Type{HighlightInt}) = true
 function Base.show(io::IO, hi::HighlightInt)
-    if hi.underline
-        printstyled(io, hi.i, color = hi.highlight, underline = true)
+    if hi.match
+        printstyled(io, "(", color = hi.highlight)
+        printstyled(io, hi.i, color = hi.highlight)
+        printstyled(io, ")", color = hi.highlight)
     else
         printstyled(io, hi.i, color = hi.highlight)
     end
@@ -227,6 +229,8 @@ end
 function Base.show(io::IO, l::BipartiteAdjacencyList)
     if l.match === true
         printstyled(io, "∫ ")
+    else
+        printstyled(io, "  ")
     end
     if l.u === nothing
         printstyled(io, '⋅', color = :light_black)

--- a/src/systems/systemstructure.jl
+++ b/src/systems/systemstructure.jl
@@ -12,7 +12,7 @@ import ..ModelingToolkit: isdiffeq, var_from_nested_derivative, vars!, flatten,
                           equations, isirreducible, input_timedomain, TimeDomain,
                           VariableType, getvariabletype
 using ..BipartiteGraphs
-import ..BipartiteGraphs: invview, complete, HighlightInt
+import ..BipartiteGraphs: invview, complete
 using Graphs
 using UnPack
 using Setfield
@@ -393,6 +393,11 @@ struct SystemStructurePrintMatrix <:
     eq_to_diff::DiffGraph
     var_eq_matching::Union{Matching, Nothing}
 end
+
+"""
+Create a SystemStructurePrintMatrix to display the contents
+of the provided SystemStructure.
+"""
 function SystemStructurePrintMatrix(s::SystemStructure)
     return SystemStructurePrintMatrix(complete(s.graph),
                                       complete(s.solvable_graph),
@@ -469,6 +474,10 @@ struct MatchedSystemStructure
     var_eq_matching::Matching
 end
 
+"""
+Create a SystemStructurePrintMatrix to display the contents
+of the provided MatchedSystemStructure.
+"""
 function SystemStructurePrintMatrix(ms::MatchedSystemStructure)
     return SystemStructurePrintMatrix(complete(ms.structure.graph),
                                       complete(ms.structure.solvable_graph),

--- a/src/systems/systemstructure.jl
+++ b/src/systems/systemstructure.jl
@@ -405,30 +405,31 @@ function SystemStructurePrintMatrix(s::SystemStructure)
                                       complete(s.eq_to_diff),
                                       nothing)
 end
-Base.size(bgpm::SystemStructurePrintMatrix) = (max(nsrcs(bgpm.bpg), ndsts(bgpm.bpg)) + 1, 7)
-function compute_diff_label(diff_graph, i)
+Base.size(bgpm::SystemStructurePrintMatrix) = (max(nsrcs(bgpm.bpg), ndsts(bgpm.bpg)) + 1, 9)
+function compute_diff_label(diff_graph, i, symbol)
     di = i - 1 <= length(diff_graph) ? diff_graph[i - 1] : nothing
-    ii = i - 1 <= length(invview(diff_graph)) ? invview(diff_graph)[i - 1] : nothing
-    return Label(string(di === nothing ? "" : string(di, '↑'),
-                        di !== nothing && ii !== nothing ? " " : "",
-                        ii === nothing ? "" : string(ii, '↓')))
+    return di === nothing ? Label("") : Label(string(di, symbol))
 end
 function Base.getindex(bgpm::SystemStructurePrintMatrix, i::Integer, j::Integer)
     checkbounds(bgpm, i, j)
     if i <= 1
-        return (Label.(("#", "∂ₜ", "  eq", "", "#", "∂ₜ", "  v")))[j]
-    elseif j == 4
+        return (Label.(("#", "∂ₜ", " ", "  eq", "", "#", "∂ₜ", " ", "  v")))[j]
+    elseif j == 5
         colors = Base.text_colors
         return Label("|", :light_black)
     elseif j == 2
-        return compute_diff_label(bgpm.eq_to_diff, i)
-    elseif j == 6
-        return compute_diff_label(bgpm.var_to_diff, i)
+        return compute_diff_label(bgpm.eq_to_diff, i, '↑')
+    elseif j == 3
+        return compute_diff_label(invview(bgpm.eq_to_diff), i, '↓')
+    elseif j == 7
+        return compute_diff_label(bgpm.var_to_diff, i, '↑')
+    elseif j == 8
+        return compute_diff_label(invview(bgpm.var_to_diff), i, '↓')
     elseif j == 1
         return Label((i - 1 <= length(bgpm.eq_to_diff)) ? string(i - 1) : "")
-    elseif j == 5
+    elseif j == 6
         return Label((i - 1 <= length(bgpm.var_to_diff)) ? string(i - 1) : "")
-    elseif j == 3
+    elseif j == 4
         return BipartiteAdjacencyList(i - 1 <= nsrcs(bgpm.bpg) ?
                                       𝑠neighbors(bgpm.bpg, i - 1) : nothing,
                                       bgpm.highlight_graph !== nothing &&
@@ -438,7 +439,7 @@ function Base.getindex(bgpm::SystemStructurePrintMatrix, i::Integer, j::Integer)
                                       bgpm.var_eq_matching !== nothing &&
                                       (i - 1 <= length(invview(bgpm.var_eq_matching))) ?
                                       invview(bgpm.var_eq_matching)[i - 1] : unassigned)
-    elseif j == 7
+    elseif j == 9
         match = unassigned
         if bgpm.var_eq_matching !== nothing && i - 1 <= length(bgpm.var_eq_matching)
             match = bgpm.var_eq_matching[i - 1]

--- a/src/systems/systemstructure.jl
+++ b/src/systems/systemstructure.jl
@@ -393,6 +393,13 @@ struct SystemStructurePrintMatrix <:
     eq_to_diff::DiffGraph
     var_eq_matching::Union{Matching, Nothing}
 end
+function SystemStructurePrintMatrix(s::SystemStructure)
+    return SystemStructurePrintMatrix(complete(s.graph),
+                                      complete(s.solvable_graph),
+                                      complete(s.var_to_diff),
+                                      complete(s.eq_to_diff),
+                                      nothing)
+end
 Base.size(bgpm::SystemStructurePrintMatrix) = (max(nsrcs(bgpm.bpg), ndsts(bgpm.bpg)) + 1, 7)
 function compute_diff_label(diff_graph, i)
     di = i - 1 <= length(diff_graph) ? diff_graph[i - 1] : nothing
@@ -404,7 +411,7 @@ end
 function Base.getindex(bgpm::SystemStructurePrintMatrix, i::Integer, j::Integer)
     checkbounds(bgpm, i, j)
     if i <= 1
-        return (Label.(("#", "∂ₜ", "eq", "", "#", "∂ₜ", "v")))[j]
+        return (Label.(("#", "∂ₜ", "  eq", "", "#", "∂ₜ", "  v")))[j]
     elseif j == 4
         colors = Base.text_colors
         return Label("|", :light_black)
@@ -446,16 +453,12 @@ end
 function Base.show(io::IO, mime::MIME"text/plain", s::SystemStructure)
     @unpack graph, solvable_graph, var_to_diff, eq_to_diff = s
     if !get(io, :limit, true) || !get(io, :mtk_limit, true)
-        print(io, "SystemStructure with ", length(graph.fadjlist), " equations and ",
-              isa(graph.badjlist, Int) ? graph.badjlist : length(graph.badjlist),
+        print(io, "SystemStructure with ", length(s.graph.fadjlist), " equations and ",
+              isa(s.graph.badjlist, Int) ? s.graph.badjlist : length(s.graph.badjlist),
               " variables\n")
-        Base.print_matrix(io,
-                          SystemStructurePrintMatrix(complete(graph),
-                                                     complete(solvable_graph),
-                                                     complete(var_to_diff),
-                                                     complete(eq_to_diff), nothing))
+        Base.print_matrix(io, SystemStructurePrintMatrix(s))
     else
-        S = incidence_matrix(graph, Num(Sym{Real}(:×)))
+        S = incidence_matrix(s.graph, Num(Sym{Real}(:×)))
         print(io, "Incidence matrix:")
         show(io, mime, S)
     end
@@ -466,18 +469,34 @@ struct MatchedSystemStructure
     var_eq_matching::Matching
 end
 
+function SystemStructurePrintMatrix(ms::MatchedSystemStructure)
+    return SystemStructurePrintMatrix(complete(ms.structure.graph),
+                                      complete(ms.structure.solvable_graph),
+                                      complete(ms.structure.var_to_diff),
+                                      complete(ms.structure.eq_to_diff),
+                                      complete(ms.var_eq_matching,
+                                               nsrcs(ms.structure.graph)))
+end
+
+function Base.copy(ms::MatchedSystemStructure)
+    MatchedSystemStructure(Base.copy(ms.structure), Base.copy(ms.var_eq_matching))
+end
+
 function Base.show(io::IO, mime::MIME"text/plain", ms::MatchedSystemStructure)
     s = ms.structure
     @unpack graph, solvable_graph, var_to_diff, eq_to_diff = s
     print(io, "Matched SystemStructure with ", length(graph.fadjlist), " equations and ",
           isa(graph.badjlist, Int) ? graph.badjlist : length(graph.badjlist),
           " variables\n")
-    Base.print_matrix(io,
-                      SystemStructurePrintMatrix(complete(graph),
-                                                 complete(solvable_graph),
-                                                 complete(var_to_diff),
-                                                 complete(eq_to_diff),
-                                                 complete(ms.var_eq_matching, nsrcs(graph))))
+    Base.print_matrix(io, SystemStructurePrintMatrix(ms))
+    printstyled(io, "\n\nLegend: ")
+    printstyled(io, "Solvable")
+    print(io, " | ")
+    printstyled(io, "Unsolvable", color = :light_black)
+    print(io, " | ")
+    printstyled(io, "(Matched)")
+    print(io, " | ")
+    printstyled(io, " ∫ SelectedState ")
 end
 
 # TODO: clean up


### PR DESCRIPTION
This PR adds a "diff" view for `MatchedSystemStructure`, and modifies `show` to rely less on text coloring.

#### `Base.show(::IO, ::MatchedSystemStructure)`

<img src="https://user-images.githubusercontent.com/84105208/225408822-1bfe03a3-d176-427c-b677-bb9cfe23872e.png" width="60%" />

  - **var ⇔ eq matches** - marked with (parentheses) (previously, yellow)
  - **(un)solvable vars/eqs** - printed in dark gray and white, respectively (previously, white/green)
  - **selected states (∫)** - the ∫ symbol is printed without coloring and positioned more prominently
  - **legend** - A one-line glossary for how to read the table is provided at the bottom.

The var/eq table also have an added separator, and the indices are repeated.

#### `deepdiff(::MatchedSystemStructure, ::MatchedSystemStructure)`
<img src="https://user-images.githubusercontent.com/84105208/225408924-58b43cf4-3be0-45d5-a097-819bced010f5.png" width="65%" />

- Color-highlights any added/removed variables and equations
- Color-highlights changes to the dependency graph and the var ⇔ eq matching graph
- Does **not** highlight any differences in the solvable sub-graph (`old.structure.solvable_graph`)