### PR TITLE
fix: drop the closure in `component_post_processing`

### DIFF
--- a/src/systems/abstractsystem.jl
+++ b/src/systems/abstractsystem.jl
@@ -1130,10 +1130,7 @@ function component_post_processing(expr, isconnector)
 
     quote
         function $fname($(args...))
-            function f()
-                $body
-            end
-            res = f()
+            res = $body
             if $isdefined(res, :gui_metadata) && $getfield(res, :gui_metadata) === nothing
                 name = $(Meta.quot(fname))
                 if $isconnector


### PR DESCRIPTION
- This allows to define components with `f` as arg

Fixes this error:
```julia
julia> @component function A(; name, f)
           ODESystem(Equation[], t, [], []; name=name)
       end
ERROR: syntax: cannot add method to function argument f
Stacktrace:
 [1] top-level scope
   @ REPL[3]:1
```