### PR TITLE
set tension correctly

### DIFF
--- a/test/structural_transformation/index_reduction.jl
+++ b/test/structural_transformation/index_reduction.jl
@@ -148,7 +148,7 @@ for sys in [
         D(D(y)) => 0.0,
         x => sqrt(2) / 2,
         y => sqrt(2) / 2,
-        T => 0.0,
+        T => g / sqrt(2),
     ]
     p = [
         L => 1.0,


### PR DESCRIPTION
This was causing the dae init to fail silently (which turns into a loud failure with https://github.com/SciML/OrdinaryDiffEq.jl/pull/1909).