### PR TITLE
fix allocations in affects for jump problems.

### DIFF
--- a/src/systems/jumps/jumpsystem.jl
+++ b/src/systems/jumps/jumpsystem.jl
@@ -199,8 +199,9 @@ function assemble_vrj(js, vrj, statetoid)
     rate = @RuntimeGeneratedFunction(generate_rate_function(js, vrj.rate))
     outputvars = (value(affect.lhs) for affect in vrj.affect!)
     outputidxs = [statetoid[var] for var in outputvars]
-    affect = @RuntimeGeneratedFunction(generate_affect_function(js, vrj.affect!,
-                                                                outputidxs))
+    # affect = @RuntimeGeneratedFunction(generate_affect_function(js, vrj.affect!,
+    #                                                             outputidxs))
+    affect = eval(generate_affect_function(js, vrj.affect!, outputidxs))
     VariableRateJump(rate, affect)
 end
 
@@ -220,8 +221,9 @@ function assemble_crj(js, crj, statetoid)
     rate = @RuntimeGeneratedFunction(generate_rate_function(js, crj.rate))
     outputvars = (value(affect.lhs) for affect in crj.affect!)
     outputidxs = [statetoid[var] for var in outputvars]
-    affect = @RuntimeGeneratedFunction(generate_affect_function(js, crj.affect!,
-                                                                outputidxs))
+    # affect = @RuntimeGeneratedFunction(generate_affect_function(js, crj.affect!,
+    #                                                             outputidxs))
+    affect = eval(generate_affect_function(js, crj.affect!, outputidxs))
     ConstantRateJump(rate, affect)
 end
 

--- a/src/systems/jumps/jumpsystem.jl
+++ b/src/systems/jumps/jumpsystem.jl
@@ -396,7 +396,8 @@ function JumpProcesses.JumpProblem(js::JumpSystem, prob, aggregator; callback = 
 
     majpmapper = JumpSysMajParamMapper(js, p; jseqs = eqs, rateconsttype = invttype)
     majs = isempty(eqs.x[1]) ? nothing : assemble_maj(eqs.x[1], statetoid, majpmapper)
-    crjs = ConstantRateJump[assemble_crj(js, j, statetoid; eval_jump_affects) for j in eqs.x[2]]
+    crjs = ConstantRateJump[assemble_crj(js, j, statetoid; eval_jump_affects)
+                            for j in eqs.x[2]]
     vrjs = VariableRateJump[assemble_vrj(js, j, statetoid) for j in eqs.x[3]]
     ((prob isa DiscreteProblem) && !isempty(vrjs)) &&
         error("Use continuous problems such as an ODEProblem or a SDEProblem with VariableRateJumps")


### PR DESCRIPTION
This appears to fix the allocations that now appear when FunctionWrappers are applied around a `RuntimeGeneratedFunction`, see https://github.com/SciML/JumpProcesses.jl/issues/308. This can lead to enormous allocations when simply running a jump process that executes many jumps...

If there is alternative solution that allows keeping RuntimeGeneratedFunctions for jump affects I'd happy to switch to that here or in JumpProcesses, but I'd like to get a fix for this in soon given how limiting this is.

As a comparison on 1.9-rc1 before this:
```julia
using Catalyst, JumpProcesses

function catalyst_plasmid(;T::Float64=250.0, alg = Direct())    
           function rate(η,X,Y,K)
               return η*(1-(X+Y)/K)
           end
           
           fp_model = @reaction_network begin
               rate(η,F,P,K), F --> 2F   # Background reproduction F
               rate(η,P,F,K), P --> 2P   # Background reproduction P  !NOTE: order of F & P are switched
               μ, F --> 0                # Background mortality F
               μ, P --> 0                # Background mortality P
               γ, F + P --> 2P           # Infection (conjugation)
               ρ, P --> F                # Recovery (segregation error)
           end    
           p = (:η => 1.0, :μ => 0.1, :γ => 1e-5, :ρ => 0.01, :K => 1e4)
           u0 = [:F => 100, :P => 10]
           tspan = (0.0, T)

           dprob = DiscreteProblem(fp_model, u0, tspan, p)
           jump_prob = JumpProblem(fp_model, dprob, alg; save_positions=(false,false))
           return jump_prob
       end

short_prob = catalyst_plasmid(T=1e3, alg = DirectFW())
```
I get
```julia
julia> @btime solve($short_prob, $stepper)
  245.197 ms (902669 allocations: 13.78 MiB)
retcode: Success
Interpolation: Piecewise constant interpolation
t: 2-element Vector{Float64}:
    0.0
 1000.0
u: 2-element Vector{Vector{Int64}}:
 [100, 10]
 [1028, 7986]
```

while with this I get
```julia
julia> @btime solve($short_prob, $stepper)
  186.820 ms (11 allocations: 2.14 KiB)
retcode: Success
Interpolation: Piecewise constant interpolation
t: 2-element Vector{Float64}:
    0.0
 1000.0
u: 2-element Vector{Vector{Int64}}:
 [100, 10]
 [1066, 7942]
```