### PR TITLE
Make `SystemStructure` colorful again 🌈 

### DIFF
--- a/src/bipartite_graph.jl
+++ b/src/bipartite_graph.jl
@@ -228,7 +228,7 @@ end
 
 function Base.show(io::IO, l::BipartiteAdjacencyList)
     if l.match === true
-        printstyled(io, "∫ ")
+        printstyled(io, "∫ ", color = :cyan)
     else
         printstyled(io, "  ")
     end
@@ -242,7 +242,17 @@ function Base.show(io::IO, l::BipartiteAdjacencyList)
         match = l.match
         isa(match, Bool) && (match = unassigned)
         function choose_color(i)
-            i in l.highligh_u ? :default : :light_black
+            solvable = i in l.highligh_u
+            matched = i == match
+            if !matched && solvable
+                :default
+            elseif !matched && !solvable
+                :light_black
+            elseif matched && solvable
+                :light_yellow
+            elseif matched && !solvable
+                :yellow
+            end
         end
         if !isempty(setdiff(l.highligh_u, l.u))
             # Only for debugging, shouldn't happen in practice

--- a/src/systems/systemstructure.jl
+++ b/src/systems/systemstructure.jl
@@ -507,11 +507,14 @@ function Base.show(io::IO, mime::MIME"text/plain", ms::MatchedSystemStructure)
     printstyled(io, "\n\nLegend: ")
     printstyled(io, "Solvable")
     print(io, " | ")
+    printstyled(io, "(Solvable + Matched)", color = :light_yellow)
+    print(io, " | ")
     printstyled(io, "Unsolvable", color = :light_black)
     print(io, " | ")
-    printstyled(io, "(Matched)")
+    printstyled(io, "(Unsolvable + Matched)", color = :yellow)
     print(io, " | ")
-    printstyled(io, " ∫ SelectedState ")
+    printstyled(io, " ∫", color = :cyan)
+    printstyled(io, " SelectedState")
 end
 
 # TODO: clean up


### PR DESCRIPTION
By special request, this change adds back some of the coloring that was lost in #2101  

![image](https://user-images.githubusercontent.com/84105208/232814102-4208d59f-5490-4e1d-9391-23caa843579d.png)

 `deepdiff(mss_old, mss_new)` does not use any of this coloring, so its output is unaffected