### PR TITLE
Alias Elimination: Try harder to identify the correct stem

### DIFF
--- a/src/structural_transformation/partial_state_selection.jl
+++ b/src/structural_transformation/partial_state_selection.jl
@@ -248,6 +248,7 @@ function dummy_derivative_graph!(structure::SystemStructure, var_eq_matching, ja
             vars = [diff_to_var[var] for var in vars if diff_to_var[var] !== nothing]
         end
     end
+
     if diff_va !== nothing
         # differentiated alias
         n_dummys = length(dummy_derivatives)

--- a/src/systems/systemstructure.jl
+++ b/src/systems/systemstructure.jl
@@ -416,7 +416,7 @@ using .BipartiteGraphs: Label, BipartiteAdjacencyList
 struct SystemStructurePrintMatrix <:
        AbstractMatrix{Union{Label, BipartiteAdjacencyList}}
     bpg::BipartiteGraph
-    highlight_graph::BipartiteGraph
+    highlight_graph::Union{Nothing, BipartiteGraph}
     var_to_diff::DiffGraph
     eq_to_diff::DiffGraph
     var_eq_matching::Union{Matching, Nothing}
@@ -428,6 +428,7 @@ of the provided SystemStructure.
 """
 function SystemStructurePrintMatrix(s::SystemStructure)
     return SystemStructurePrintMatrix(complete(s.graph),
+                                      s.solvable_graph === nothing ? nothing :
                                       complete(s.solvable_graph),
                                       complete(s.var_to_diff),
                                       complete(s.eq_to_diff),


### PR DESCRIPTION
We were observing alias elimination failing to introduce all stem variables on "Electrical/analog/sensors" test from ModelingToolkitStandardLibrary [1] with variable numbers permuted (since the choice of stem currently depends on variable ordering). In particular, there were problem when the differention edges were present between variables in the reachable set, rather than the stem set. Try to fix that by splitting the stem identification into two phases, first accumulating the entire equality set, then filtering out any differentiation edges from the reachable set.

[1] https://github.com/SciML/ModelingToolkitStandardLibrary.jl/blob/main/test/Electrical/analog.jl#L11