### PR TITLE
Remove Ai4EComponentLib.jl from downstream test

### DIFF
--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -29,7 +29,6 @@ jobs:
           - {user: SciML, repo: MethodOfLines.jl, group: Interface}
           - {user: SciML, repo: MethodOfLines.jl, group: 2D_Diffusion}
           - {user: SciML, repo: MethodOfLines.jl, group: DAE}
-          - {user: ai4energy, repo: Ai4EComponentLib.jl, group: Downstream}
     steps:
       - uses: actions/checkout@v3
       - uses: julia-actions/setup-julia@v1


### PR DESCRIPTION
Ai4EComponentLib is stuck on pre-1.0 SymbolicUtils.jl for a bit over 2 months. We can add the downstream tests back when it's compatible with the current MTK version.