### PR TITLE
Revive `pss_graph_modia!`

### DIFF
--- a/test/structural_transformation/index_reduction.jl
+++ b/test/structural_transformation/index_reduction.jl
@@ -118,7 +118,7 @@ sol = solve(prob_auto, Rodas5());
 #plot(sol, idxs=(D(x), y))
 
 let pss_pendulum2 = partial_state_selection(pendulum2)
-    @test_broken length(equations(pss_pendulum2)) <= 6
+    @test length(equations(pss_pendulum2)) <= 6
 end
 
 eqs = [D(x) ~ w,


### PR DESCRIPTION
When I originally wrote this code, I didn't really understand how it was supposed to work, simply copying the algorithm from modia. As a result, the algorithm was somewhat incomplete, and we ended up switching to dummy_derivative_graph! instead. However, we are now seeing issues where the state selection from `dummy_derivative_graph!` (ddg) is resulting in state selections that are numerically sub-optimal because ddg does not respect solvability. With the benefit of hindsight, fix pss_graph_modia! to be actually correct.

The keen eyed reader will notice that the changes to pss_graph_modia! are essentially exactly what ddg does right now, except that I don't currently implement the linear case. I think it would make sense to further unify this and fully switch over MTK to the new `pss_graph_modia!`, but past experience has shown the MTK/Downstream tests to be quite sensitive to the exact state selection, so this does not attempt to make that change yet.