### PR TITLE
Pass arguments (including hierarchal ones) to `Model`s

### DIFF
--- a/src/ModelingToolkit.jl
+++ b/src/ModelingToolkit.jl
@@ -49,6 +49,8 @@ import SymbolicUtils.Code: toexpr
 import SymbolicUtils.Rewriters: Chain, Postwalk, Prewalk, Fixpoint
 import JuliaFormatter
 
+using MLStyle
+
 using Reexport
 using Symbolics: degree
 @reexport using Symbolics

--- a/test/model_parsing.jl
+++ b/test/model_parsing.jl
@@ -25,11 +25,14 @@ end
 @variables t
 D = Differential(t)
 
-@connector Pin begin
-    v(t) = 0                  # Potential at the pin [V]
+@connector Pin(; v_start = 0) begin
+    v(t) = v_start                  # Potential at the pin [V]
     i(t), [connect = Flow]    # Current flowing into the pin [A]
     @icon "pin.png"
 end
+
+@named p = Pin(; v_start = π)
+@test getdefault(p.v) == π
 
 @model OnePort begin
     @components begin

--- a/test/model_parsing.jl
+++ b/test/model_parsing.jl
@@ -152,7 +152,7 @@ end
         cval
         jval
         kval
-        c(t) = cval + cval
+        c(t) = cval + jval
         d = 2
         e, [description = "e"]
         f = 3, [description = "f"]
@@ -173,11 +173,12 @@ kval = 5
 @test hasmetadata(model.j, VariableDescription)
 @test hasmetadata(model.k, VariableDescription)
 
+model = complete(model)
 @test getdefault(model.cval) == 1
-@test getdefault(model.c) == 2
+@test isequal(getdefault(model.c), model.cval + model.jval)
 @test getdefault(model.d) == 2
 @test_throws KeyError getdefault(model.e)
 @test getdefault(model.f) == 3
 @test getdefault(model.i) == 4
-@test getdefault(model.j) == :jval
-@test getdefault(model.k) == kval
+@test isequal(getdefault(model.j), model.jval)
+@test isequal(getdefault(model.k), model.kval)

--- a/test/model_parsing.jl
+++ b/test/model_parsing.jl
@@ -1,5 +1,5 @@
 using ModelingToolkit, Test
-using ModelingToolkit: get_gui_metadata
+using ModelingToolkit: get_gui_metadata, VariableDescription, getdefault
 using URIs: URI
 
 ENV["MTK_ICONS_DIR"] = "$(@__DIR__)/icons"
@@ -10,12 +10,12 @@ end
 @connector RealOutput begin
     u(t), [output = true]
 end
-@model Constant begin
+@model Constant(; k = 1) begin
     @components begin
         output = RealOutput()
     end
     @parameters begin
-        k, [description = "Constant output value of block"]
+        k = k, [description = "Constant output value of block"]
     end
     @equations begin
         output.u ~ k
@@ -61,10 +61,10 @@ end
 end
 
 resistor_log = "$(@__DIR__)/logo/resistor.svg"
-@model Resistor begin
+@model Resistor(; R = 1) begin
     @extend v, i = oneport = OnePort()
     @parameters begin
-        R = 1
+        R = R
     end
     @icon begin
         """<?xml version="1.0" encoding="UTF-8"?>
@@ -87,10 +87,10 @@ l15 0" stroke="black" stroke-width="1" stroke-linejoin="bevel" fill="none"></pat
     end
 end
 
-@model Capacitor begin
+@model Capacitor(; C = 1) begin
     @extend v, i = oneport = OnePort()
     @parameters begin
-        C = 1
+        C = C
     end
     @icon "https://upload.wikimedia.org/wikipedia/commons/7/78/Capacitor_symbol.svg"
     @equations begin
@@ -110,8 +110,8 @@ end
 
 @model RC begin
     @components begin
-        resistor = Resistor()
-        capacitor = Capacitor()
+        resistor = Resistor(; R)
+        capacitor = Capacitor(; C = 10)
         source = Voltage()
         constant = Constant()
         ground = Ground()
@@ -123,7 +123,11 @@ end
         connect(capacitor.n, source.n, ground.g)
     end
 end
-@named rc = RC()
+
+@named rc = RC(; resistor.R = 20)
+@test getdefault(rc.resistor.R) == 20
+@test getdefault(rc.capacitor.C) == 10
+@test getdefault(rc.constant.k) == 1
 
 @test get_gui_metadata(rc.resistor).layout == Resistor.structure[:icon] ==
       read(joinpath(ENV["MTK_ICONS_DIR"], "resistor.svg"), String)
@@ -137,3 +141,34 @@ end
       URI("file:///" * abspath(ENV["MTK_ICONS_DIR"], "pin.png"))
 
 @test length(equations(structural_simplify(rc))) == 1
+
+@model MockModel(; cval, gval, jval = 6) begin
+    @parameters begin
+        a
+        b(t)
+        c(t) = cval
+        d = 2
+        e, [description = "e"]
+        f = 3, [description = "f"]
+        g = gval, [description = "g"]
+        h(t), [description = "h(t)"]
+        i(t) = 5, [description = "i(t)"]
+        j(t) = jval, [description = "j(t)"]
+    end
+end
+
+@named model = MockModel(cval = 1, gval = 4)
+
+@test hasmetadata(model.e, VariableDescription)
+@test hasmetadata(model.f, VariableDescription)
+@test hasmetadata(model.g, VariableDescription)
+@test hasmetadata(model.h, VariableDescription)
+@test hasmetadata(model.i, VariableDescription)
+@test hasmetadata(model.j, VariableDescription)
+
+@test getdefault(model.c) == 1
+@test getdefault(model.d) == 2
+@test getdefault(model.f) == 3
+@test getdefault(model.g) == 4
+@test getdefault(model.i) == 5
+@test getdefault(model.j) == 6


### PR DESCRIPTION
- The kwargs and args can be specified for a Model.
- It checks the `@components` for respective kwargs/args and sets up necessary ways to access them with a `.`
This works:
```julia
@model A(; cval=1, kval) begin                       
                  @components begin                         
                      mb = B(; t3 = 1, t4 = t4val)          
                  end                                       
              @parameters begin                             
                     c(t) = cval                            
                     k(t) = kval                            
              end                                           
       end

 @named ma = A(; mb.t4 = 100, kval = 20)
```

-----
While here, fixes following conditions:
```
@variables begin
    a(t), [description = ""]
    b(t) = bval, [description = ""]
    c(t) = 1, [description = ""]
end
```