### PR TITLE
add input signals to `build_explicit_observed_function`

### DIFF
--- a/src/systems/diffeqs/odesystem.jl
+++ b/src/systems/diffeqs/odesystem.jl
@@ -304,6 +304,7 @@ Build the observed function assuming the observed equations are all explicit,
 i.e. there are no cycles.
 """
 function build_explicit_observed_function(sys, ts;
+    inputs = nothing,
     expression = false,
     output_type = Array,
     checkbounds = true,
@@ -378,9 +379,18 @@ function build_explicit_observed_function(sys, ts;
         push!(obsexprs, lhs ← rhs)
     end
 
+    pars = parameters(sys)
+    if inputs !== nothing
+        pars = setdiff(pars, inputs) # Inputs have been converted to parameters by io_preprocessing, remove those from the parameter list
+    end
+    ps = DestructuredArgs(pars, inbounds = !checkbounds)
     dvs = DestructuredArgs(states(sys), inbounds = !checkbounds)
-    ps = DestructuredArgs(parameters(sys), inbounds = !checkbounds)
-    args = [dvs, ps, ivs...]
+    if inputs === nothing
+        args = [dvs, ps, ivs...]
+    else
+        ipts = DestructuredArgs(inputs, inbounds = !checkbounds)
+        args = [dvs, ipts, ps, ivs...]
+    end
     pre = get_postprocess_fbody(sys)
 
     ex = Func(args, [],

--- a/src/systems/diffeqs/odesystem.jl
+++ b/src/systems/diffeqs/odesystem.jl
@@ -308,6 +308,7 @@ function build_explicit_observed_function(sys, ts;
     expression = false,
     output_type = Array,
     checkbounds = true,
+    drop_expr = drop_expr,
     throw = true)
     if (isscalar = !(ts isa AbstractVector))
         ts = [ts]

--- a/test/input_output_handling.jl
+++ b/test/input_output_handling.jl
@@ -138,7 +138,10 @@ matrices, ssys = linearize(model, model_inputs, model_outputs)
 @test length(ModelingToolkit.outputs(ssys)) == 4
 
 (; A, B, C, D) = matrices
-obsf = ModelingToolkit.build_explicit_observed_function(ssys, [inertia2.w], inputs = [torque.tau.u], drop_expr = identity)
+obsf = ModelingToolkit.build_explicit_observed_function(ssys,
+    [inertia2.w],
+    inputs = [torque.tau.u],
+    drop_expr = identity)
 x = randn(size(A, 1))
 u = randn(size(B, 2))
 p = getindex.(Ref(ModelingToolkit.defaults(ssys)), parameters(ssys))

--- a/test/input_output_handling.jl
+++ b/test/input_output_handling.jl
@@ -137,6 +137,15 @@ model_inputs = [torque.tau.u]
 matrices, ssys = linearize(model, model_inputs, model_outputs)
 @test length(ModelingToolkit.outputs(ssys)) == 4
 
+(; A, B, C, D) = matrices
+obsf = ModelingToolkit.build_explicit_observed_function(ssys, [inertia2.w], inputs = [torque.tau.u], drop_expr = identity)
+x = randn(size(A, 1))
+u = randn(size(B, 2))
+p = getindex.(Ref(ModelingToolkit.defaults(ssys)), parameters(ssys))
+y1 = obsf(x, u, p, 0)
+y2 = C * x + D * u
+@test y1[] ≈ y2[2]
+
 ## Code generation with unbound inputs
 
 @variables t x(t)=0 u(t)=0 [input = true]

--- a/test/input_output_handling.jl
+++ b/test/input_output_handling.jl
@@ -138,16 +138,18 @@ matrices, ssys = linearize(model, model_inputs, model_outputs)
 @test length(ModelingToolkit.outputs(ssys)) == 4
 
 A, B, C, D = matrices
-obsf = ModelingToolkit.build_explicit_observed_function(ssys,
-    [inertia2.w],
-    inputs = [torque.tau.u],
-    drop_expr = identity)
-x = randn(size(A, 1))
-u = randn(size(B, 2))
-p = getindex.(Ref(ModelingToolkit.defaults(ssys)), parameters(ssys))
-y1 = obsf(x, u, p, 0)
-y2 = C * x + D * u
-@test y1[] ≈ y2[2]
+if VERSION >= v"1.8" # :opaque_closure not supported before
+    obsf = ModelingToolkit.build_explicit_observed_function(ssys,
+        [inertia2.w],
+        inputs = [torque.tau.u],
+        drop_expr = identity)
+    x = randn(size(A, 1))
+    u = randn(size(B, 2))
+    p = getindex.(Ref(ModelingToolkit.defaults(ssys)), parameters(ssys))
+    y1 = obsf(x, u, p, 0)
+    y2 = C * x + D * u
+    @test y1[] ≈ y2[2]
+end
 
 ## Code generation with unbound inputs
 

--- a/test/input_output_handling.jl
+++ b/test/input_output_handling.jl
@@ -137,7 +137,7 @@ model_inputs = [torque.tau.u]
 matrices, ssys = linearize(model, model_inputs, model_outputs)
 @test length(ModelingToolkit.outputs(ssys)) == 4
 
-(; A, B, C, D) = matrices
+A, B, C, D = matrices
 obsf = ModelingToolkit.build_explicit_observed_function(ssys,
     [inertia2.w],
     inputs = [torque.tau.u],


### PR DESCRIPTION
The PR adds the possibility to specify input signals when building an observed function, this is useful for control systems. The resulting function signature will be
```math
y = h(x, u, p, t)
```
where $u$ are the inputs.

If this looks reasonable, I can add a few tests. 