### PR TITLE
Add `isconnector` to `Model` type + add all metadata to `Model.structure` 

### DIFF
--- a/src/systems/model_parsing.jl
+++ b/src/systems/model_parsing.jl
@@ -241,13 +241,13 @@ end
 function parse_components!(exprs, cs, dict, body, kwargs)
     expr = Expr(:block)
     push!(exprs, expr)
-    comps = Vector{String}[]
+    comps = Vector{Symbol}[]
     for arg in body.args
         arg isa LineNumberNode && continue
         MLStyle.@match arg begin
             Expr(:(=), a, b) => begin
                 push!(cs, a)
-                push!(comps, [String(a), String(b.args[1])])
+                push!(comps, [a, b.args[1]])
                 arg = deepcopy(arg)
                 b = deepcopy(arg.args[2])
 

--- a/src/systems/model_parsing.jl
+++ b/src/systems/model_parsing.jl
@@ -1,6 +1,7 @@
 struct Model{F, S}
     f::F
     structure::S
+    isconnector::Bool
 end
 (m::Model)(args...; kw...) = m.f(args...; kw...)
 
@@ -54,7 +55,7 @@ function connector_macro(mod, name, body)
                 var"#___sys___" = $ODESystem($(Equation[]), $iv, [$(vs...)], $([]);
                     name, gui_metadata = $gui_metadata)
                 $Setfield.@set!(var"#___sys___".connector_type=$connector_type(var"#___sys___"))
-            end, $dict)
+            end, $dict, true)
     end
 end
 
@@ -213,7 +214,7 @@ function mtkmodel_macro(mod, name, expr)
         push!(exprs.args, :($extend($sys, $(ext[]))))
     end
 
-    :($name = $Model((; name, $(kwargs...)) -> $exprs, $dict))
+    :($name = $Model((; name, $(kwargs...)) -> $exprs, $dict, false))
 end
 
 function parse_model!(exprs, comps, ext, eqs, icon, vs, ps, dict,

--- a/test/model_parsing.jl
+++ b/test/model_parsing.jl
@@ -33,6 +33,7 @@ end
 
 @named p = Pin(; v = π)
 @test getdefault(p.v) == π
+@test Pin.isconnector == true
 
 @mtkmodel OnePort begin
     @components begin
@@ -50,6 +51,8 @@ end
         i ~ p.i
     end
 end
+
+@test OnePort.isconnector == false
 
 @mtkmodel Ground begin
     @components begin

--- a/test/model_parsing.jl
+++ b/test/model_parsing.jl
@@ -97,15 +97,15 @@ end
     @parameters begin
         C
     end
-    @variables begin
-        v = 0.0
-    end
-    @extend v, i = oneport = OnePort(; v = v)
+    @extend v, i = oneport = OnePort(; v = 0.0)
     @icon "https://upload.wikimedia.org/wikipedia/commons/7/78/Capacitor_symbol.svg"
     @equations begin
         D(v) ~ i / C
     end
 end
+
+@named capacitor = Capacitor(C = 10, oneport.v = 10.0)
+@test getdefault(capacitor.v) == 10.0
 
 @mtkmodel Voltage begin
     @extend v, i = oneport = OnePort()
@@ -136,6 +136,7 @@ end
 @named rc = RC(; resistor.R = 20)
 @test getdefault(rc.resistor.R) == 20
 @test getdefault(rc.capacitor.C) == 10
+@test getdefault(rc.capacitor.v) == 0.0
 @test getdefault(rc.constant.k) == 1
 
 @test get_gui_metadata(rc.resistor).layout == Resistor.structure[:icon] ==

--- a/test/model_parsing.jl
+++ b/test/model_parsing.jl
@@ -216,3 +216,18 @@ getdefault(a.b.k) == 1
 getdefault(a.b.i) == 20
 getdefault(a.b.j) == 30
 getdefault(a.b.k) == 40
+
+metadata = Dict(:description => "Variable to test metadata in the Model.structure",
+    :input => true, :bounds => :((-1, 1)), :connection_type => :Flow, :integer => true,
+    :binary => false, :tunable => false, :disturbance => true, :dist => :(Normal(1, 1)))
+
+@connector MockMeta begin
+    m(t),
+    [description = "Variable to test metadata in the Model.structure",
+        input = true, bounds = (-1, 1), connect = Flow, integer = true,
+        binary = false, tunable = false, disturbance = true, dist = Normal(1, 1)]
+end
+
+for (k, v) in metadata
+    @test MockMeta.structure[:variables][:m][k] == v
+end


### PR DESCRIPTION
- While here, changes, the typeof `Model.structure[:components]` as Vector{Symbols} to match the rest.
- Adds the test to default value of an extended component (here Capacitor)