### PR TITLE
Setup tests for MTKstdlib v2

### DIFF
--- a/test/linearize.jl
+++ b/test/linearize.jl
@@ -197,7 +197,7 @@ if VERSION >= v"1.8"
     D = Differential(t)
 
     @named link1 = Link(; m = 0.2, l = 10, I = 1, g = -9.807)
-    @named cart = Translational.Mass(; m = 1, s_0 = 0)
+    @named cart = Translational.Mass(; m = 1, s = 0)
     @named fixed = Fixed()
     @named force = Force()
 


### PR DESCRIPTION
We don't have a dep on it (it would be circular anyways), but this is all that's needed for mtkstdlib v2. I just did `@test_broken` on the two using Torque because they need to handle the booleans in the `@mtkmodel`, and we can skip that for now.