### PR TITLE
changed ParentScope docs to better reflect best usage

### DIFF
--- a/docs/src/basics/Composition.md
+++ b/docs/src/basics/Composition.md
@@ -137,12 +137,15 @@ In a hierarchical system, variables of the subsystem get namespaced by the name 
 
 ```julia
 @parameters t a b c d e f
-p = [a #a is a local variable
-    ParentScope(b) # b is a variable that belongs to one level up in the hierarchy
-    ParentScope(ParentScope(c))# ParentScope can be nested
-    DelayParentScope(d) # skips one level before applying ParentScope
-    DelayParentScope(e, 2) # second argument allows skipping N levels
-    GlobalScope(f)]
+
+# a is a local variable
+b = ParentScope(b) # b is a variable that belongs to one level up in the hierarchy
+c = ParentScope(ParentScope(c)) # ParentScope can be nested
+d = DelayParentScope(d) # skips one level before applying ParentScope
+e = DelayParentScope(e, 2) # second argument allows skipping N levels
+f = GlobalScope(f)
+
+p = [a, b, c, d, e, f]
 
 level0 = ODESystem(Equation[], t, [], p; name = :level0)
 level1 = ODESystem(Equation[], t, [], []; name = :level1) ∘ level0


### PR DESCRIPTION
@YingboMa @ChrisRackauckas 
I rewrote the example with ParentScope to better reflect how ParentScope/DelayParentScope should be used.  The problem with the old example is that the local definitions of the parameters do not agree with the parameter list.  If you define equations, then the parameters in the equations don't match the parameter list, which leads to a situation where parameters(sys) are different than the parameters in equations(sys)
