### PR TITLE
ODEProblem Parameter type for driving models with data

### DIFF
--- a/src/parameters.jl
+++ b/src/parameters.jl
@@ -118,9 +118,9 @@ Base.isless(y::Number, x::Parameter) = Base.isless(y, x.ref)
 
 Base.copy(x::Parameter{T}) where {T} = Parameter{T}(copy(x.data), x.ref)
 
-Base.ifelse(c::Bool, x::Parameter, y::Parameter) = ifelse(c, x.ref, y.ref)
-Base.ifelse(c::Bool, x::Parameter, y::Number) = ifelse(c, x.ref, y)
-Base.ifelse(c::Bool, x::Number, y::Parameter) = ifelse(c, x, y.ref)
+IfElse.ifelse(c::Bool, x::Parameter, y::Parameter) = ifelse(c, x.ref, y.ref)
+IfElse.ifelse(c::Bool, x::Parameter, y::Number) = ifelse(c, x.ref, y)
+IfElse.ifelse(c::Bool, x::Number, y::Parameter) = ifelse(c, x, y.ref)
 Base.max(x::Number, y::Parameter) = max(x, y.ref)
 Base.max(x::Parameter, y::Number) = max(x.ref, y)
 Base.max(x::Parameter, y::Parameter) = max(x.ref, y.ref)

--- a/src/parameters.jl
+++ b/src/parameters.jl
@@ -61,3 +61,83 @@ macro parameters(xs...)
         xs,
         toparam) |> esc
 end
+
+struct Parameter{T <: Real}
+    data::Vector{T}
+    ref::T
+    circular_buffer::Bool
+end
+
+Parameter(data::Vector{T}, ref::T) where {T <: Real} = Parameter(data, ref, true)
+Parameter(x::Parameter) = x
+function Parameter(x::T; tofloat = true) where {T <: Real}
+    if tofloat
+        x = float(x)
+        P = typeof(x)
+    else
+        P = T
+    end
+
+    return Parameter(P[], x)
+end
+
+function Base.isequal(x::Parameter, y::Parameter)
+    b0 = length(x.data) == length(y.data)
+    if b0
+        b1 = all(x.data .== y.data)
+        b2 = x.ref == y.ref
+        return b1 & b2
+    else
+        return false
+    end
+end
+
+Base.:*(x::Number, y::Parameter) = x * y.ref
+Base.:*(y::Parameter, x::Number) = Base.:*(x, y)
+Base.:*(x::Parameter, y::Parameter) = x.ref * y.ref
+
+Base.:/(x::Number, y::Parameter) = x / y.ref
+Base.:/(y::Parameter, x::Number) = y.ref / x
+Base.:/(x::Parameter, y::Parameter) = x.ref / y.ref
+
+Base.:+(x::Number, y::Parameter) = x + y.ref
+Base.:+(y::Parameter, x::Number) = Base.:+(x, y)
+Base.:+(x::Parameter, y::Parameter) = x.ref + y.ref
+
+Base.:-(y::Parameter) = -y.ref
+Base.:-(x::Number, y::Parameter) = x - y.ref
+Base.:-(y::Parameter, x::Number) = y.ref - x
+Base.:-(x::Parameter, y::Parameter) = x.ref - y.ref
+
+Base.:^(x::Number, y::Parameter) = Base.:^(x, y.ref)
+Base.:^(y::Parameter, x::Number) = Base.:^(y.ref, x)
+Base.:^(x::Parameter, y::Parameter) = Base.:^(x.ref, y.ref)
+
+Base.isless(x::Parameter, y::Number) = Base.isless(x.ref, y)
+Base.isless(y::Number, x::Parameter) = Base.isless(y, x.ref)
+
+Base.copy(x::Parameter{T}) where {T} = Parameter{T}(copy(x.data), x.ref)
+
+Base.ifelse(c::Bool, x::Parameter, y::Parameter) = ifelse(c, x.ref, y.ref)
+Base.ifelse(c::Bool, x::Parameter, y::Number) = ifelse(c, x.ref, y)
+Base.ifelse(c::Bool, x::Number, y::Parameter) = ifelse(c, x, y.ref)
+Base.max(x::Number, y::Parameter) = max(x, y.ref)
+Base.max(x::Parameter, y::Number) = max(x.ref, y)
+Base.max(x::Parameter, y::Parameter) = max(x.ref, y.ref)
+
+Base.min(x::Number, y::Parameter) = min(x, y.ref)
+Base.min(x::Parameter, y::Number) = min(x.ref, y)
+Base.min(x::Parameter, y::Parameter) = min(x.ref, y.ref)
+
+function Base.show(io::IO, m::MIME"text/plain", p::Parameter)
+    if !isempty(p.data)
+        print(io, p.data)
+    else
+        print(io, p.ref)
+    end
+end
+
+Base.convert(::Type{T}, x::Parameter{T}) where {T <: Real} = x.ref
+function Base.convert(::Type{<:Parameter{T}}, x::Number) where {T <: Real}
+    Parameter{T}(T[], x, true)
+end

--- a/src/systems/diffeqs/abstractodesystem.jl
+++ b/src/systems/diffeqs/abstractodesystem.jl
@@ -684,9 +684,8 @@ Take dictionaries with initial conditions and parameters and convert them to num
 function get_u0_p(sys,
     u0map,
     parammap;
-    p_type = nothing,
     use_union = false,
-    tofloat = !use_union & p_type === nothing,
+    tofloat = !use_union,
     symbolic_u0 = false)
     eqs = equations(sys)
     dvs = states(sys)
@@ -701,7 +700,7 @@ function get_u0_p(sys,
     else
         u0 = varmap_to_vars(u0map, dvs; defaults = defs, tofloat = true)
     end
-    p = varmap_to_vars(parammap, ps; defaults = defs, tofloat, use_union, type = p_type)
+    p = varmap_to_vars(parammap, ps; defaults = defs, tofloat, use_union)
     p = p === nothing ? SciMLBase.NullParameters() : p
     u0, p, defs
 end
@@ -714,9 +713,8 @@ function process_DEProblem(constructor, sys::AbstractODESystem, u0map, parammap;
     simplify = false,
     linenumbers = true, parallel = SerialForm(),
     eval_expression = true,
-    p_type = nothing,
     use_union = false,
-    tofloat = !use_union & (p_type === nothing),
+    tofloat = !use_union,
     symbolic_u0 = false,
     kwargs...)
     eqs = equations(sys)
@@ -724,7 +722,7 @@ function process_DEProblem(constructor, sys::AbstractODESystem, u0map, parammap;
     ps = parameters(sys)
     iv = get_iv(sys)
 
-    u0, p, defs = get_u0_p(sys, u0map, parammap; tofloat, use_union, symbolic_u0, p_type)
+    u0, p, defs = get_u0_p(sys, u0map, parammap; tofloat, use_union, symbolic_u0)
 
     if implicit_dae && du0map !== nothing
         ddvs = map(Differential(iv), dvs)

--- a/src/systems/diffeqs/abstractodesystem.jl
+++ b/src/systems/diffeqs/abstractodesystem.jl
@@ -677,9 +677,9 @@ function ODEFunctionExpr{iip}(sys::AbstractODESystem, dvs = states(sys),
 end
 
 """
-    u0, p, defs = get_u0_p(sys, u0map, parammap; use_union=false, tofloat=!use_union)
+    u0, p, defs = get_u0_p(sys, u0map, parammap; p_type = nothing, use_union=false, tofloat=!use_union & p_type === nothing)
 
-Take dictionaries with initial conditions and parameters and convert them to numeric arrays `u0` and `p`. Also return the merged dictionary `defs` containing the entire operating point.
+Take dictionaries with initial conditions and parameters and convert them to numeric arrays `u0` and `p`. Also return the merged dictionary `defs` containing the entire operating point.  Use `p_type` to specify the element type the parameter vector should be converted to.    
 """
 function get_u0_p(sys,
     u0map,
@@ -716,7 +716,7 @@ function process_DEProblem(constructor, sys::AbstractODESystem, u0map, parammap;
     eval_expression = true,
     p_type = nothing,
     use_union = false,
-    tofloat = !use_union & isnothing(p_type),
+    tofloat = !use_union & p_type === nothing,
     symbolic_u0 = false,
     kwargs...)
     eqs = equations(sys)

--- a/src/systems/diffeqs/abstractodesystem.jl
+++ b/src/systems/diffeqs/abstractodesystem.jl
@@ -684,8 +684,9 @@ Take dictionaries with initial conditions and parameters and convert them to num
 function get_u0_p(sys,
     u0map,
     parammap;
+    p_type = nothing,
     use_union = false,
-    tofloat = !use_union,
+    tofloat = !use_union & p_type === nothing,
     symbolic_u0 = false)
     eqs = equations(sys)
     dvs = states(sys)
@@ -700,7 +701,7 @@ function get_u0_p(sys,
     else
         u0 = varmap_to_vars(u0map, dvs; defaults = defs, tofloat = true)
     end
-    p = varmap_to_vars(parammap, ps; defaults = defs, tofloat, use_union)
+    p = varmap_to_vars(parammap, ps; defaults = defs, tofloat, use_union, type = p_type)
     p = p === nothing ? SciMLBase.NullParameters() : p
     u0, p, defs
 end
@@ -713,8 +714,9 @@ function process_DEProblem(constructor, sys::AbstractODESystem, u0map, parammap;
     simplify = false,
     linenumbers = true, parallel = SerialForm(),
     eval_expression = true,
+    p_type = nothing,
     use_union = false,
-    tofloat = !use_union,
+    tofloat = !use_union & isnothing(p_type),
     symbolic_u0 = false,
     kwargs...)
     eqs = equations(sys)
@@ -722,7 +724,7 @@ function process_DEProblem(constructor, sys::AbstractODESystem, u0map, parammap;
     ps = parameters(sys)
     iv = get_iv(sys)
 
-    u0, p, defs = get_u0_p(sys, u0map, parammap; tofloat, use_union, symbolic_u0)
+    u0, p, defs = get_u0_p(sys, u0map, parammap; tofloat, use_union, symbolic_u0, p_type)
 
     if implicit_dae && du0map !== nothing
         ddvs = map(Differential(iv), dvs)

--- a/src/systems/diffeqs/abstractodesystem.jl
+++ b/src/systems/diffeqs/abstractodesystem.jl
@@ -677,9 +677,9 @@ function ODEFunctionExpr{iip}(sys::AbstractODESystem, dvs = states(sys),
 end
 
 """
-    u0, p, defs = get_u0_p(sys, u0map, parammap; p_type = nothing, use_union=false, tofloat=!use_union & p_type === nothing)
+    u0, p, defs = get_u0_p(sys, u0map, parammap; use_union=false, tofloat=!use_union)
 
-Take dictionaries with initial conditions and parameters and convert them to numeric arrays `u0` and `p`. Also return the merged dictionary `defs` containing the entire operating point.  Use `p_type` to specify the element type the parameter vector should be converted to.    
+Take dictionaries with initial conditions and parameters and convert them to numeric arrays `u0` and `p`. Also return the merged dictionary `defs` containing the entire operating point.
 """
 function get_u0_p(sys,
     u0map,

--- a/src/systems/diffeqs/abstractodesystem.jl
+++ b/src/systems/diffeqs/abstractodesystem.jl
@@ -716,7 +716,7 @@ function process_DEProblem(constructor, sys::AbstractODESystem, u0map, parammap;
     eval_expression = true,
     p_type = nothing,
     use_union = false,
-    tofloat = !use_union & p_type === nothing,
+    tofloat = !use_union & (p_type === nothing),
     symbolic_u0 = false,
     kwargs...)
     eqs = equations(sys)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -694,10 +694,11 @@ function promote_to_concrete(vs; tofloat = true, use_union = false)
             end
             if v isa Parameter{<:Number}
                 @assert !use_union "a vector `Union` with `Parameter{T}` is not supported"
-                @assert tofloat "`Parameter{T}` type will convert all single values to float, `tofloat` must be true"
-
                 if !has_Parameter
                     C = typeof(v)
+                    if !tofloat
+                        @warn "use of `Parameter{T}` type will convert all single values to floats, however `tofloat=false`"
+                    end
                 else
                     @assert C==typeof(v) "mixing element `T` type when using `Parameter{T}` is not allowed"
                 end

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -58,7 +58,7 @@ applicable.
 """
 function varmap_to_vars(varmap, varlist; defaults = Dict(), check = true,
     toterm = default_toterm, promotetoconcrete = nothing,
-    tofloat = true, use_union = false)
+    tofloat = true, use_union = false, kwargs...)
     varlist = collect(map(unwrap, varlist))
 
     # Edge cases where one of the arguments is effectively empty.
@@ -89,7 +89,7 @@ function varmap_to_vars(varmap, varlist; defaults = Dict(), check = true,
 
     promotetoconcrete === nothing && (promotetoconcrete = container_type <: AbstractArray)
     if promotetoconcrete
-        vals = promote_to_concrete(vals; tofloat = tofloat, use_union = use_union)
+        vals = promote_to_concrete(vals; tofloat, use_union, kwargs...)
     end
 
     if isempty(vals)

--- a/test/odesystem.jl
+++ b/test/odesystem.jl
@@ -1042,4 +1042,9 @@ let
 
     @test eltype(prob.p) == Parameter{Float64}
     @test eltype(prob.u0) == Float64
+
+    defs = ModelingToolkit.defaults(iosys)
+    ps = parameters(iosys)
+    pv = ModelingToolkit.varmap_to_vars(defs, ps; tofloat = false)
+    @test eltype(pv) == Parameter{Float64}
 end

--- a/test/serialization.jl
+++ b/test/serialization.jl
@@ -11,13 +11,13 @@ for prob in [
     eval(ModelingToolkit.ODEProblemExpr{false}(sys, nothing, nothing,
         SciMLBase.NullParameters())),
 ]
-    _fn = tempname()
+    _fn = tempname() * ".jld"
 
     open(_fn, "w") do f
         serialize(f, prob)
     end
 
-    _cmd = "using ModelingToolkit, Serialization; deserialize(\"$_fn\")"
+    _cmd = "using ModelingToolkit, Serialization; deserialize(raw\"$_fn\")"
 
     run(`$(Base.julia_cmd()) -e $(_cmd)`)
 end


### PR DESCRIPTION
Currently using the parameter space for a mix of single values and vectors is not so easy using ModelingToolkit.  See the `SampleData` component for example (https://docs.sciml.ai/ModelingToolkitStandardLibrary/stable/tutorials/input_component/).  The code for this component needs to explicitly convert the parameter vector to the `Parameter` type for the `SampleData` component and remake the ODEProblem...

```julia
    p = Parameter.(ModelingToolkit.varmap_to_vars(defs, parameters(sys); tofloat = false))
    remake(prob; p)
```

This code is now simply...

```julia
prob = ODEProblem(sys, [], (0.0, t_end))
```

To achieve this the `Parameter{T}` type is moved from ModelingToolkitStandardLibrary.jl to ModelingToolkit.jl 