### PR TITLE
Promote `vs` to a `Union{Bool, ...}` whenever a Boolean value is present

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -680,6 +680,7 @@ function promote_to_concrete(vs; tofloat = true, use_union = false)
         I = Int8
         has_int = false
         has_array = false
+        has_bool = false
         array_T = nothing
         for v in vs
             if v isa AbstractArray
@@ -692,15 +693,21 @@ function promote_to_concrete(vs; tofloat = true, use_union = false)
                 has_int = true
                 I = promote_type(I, E)
             end
+            if E <: Bool
+                has_bool = true
+            end
         end
-        if tofloat && !has_array
+        if tofloat && !has_array && !has_bool
             C = float(C)
-        elseif has_array || (use_union && has_int && C !== I)
+        elseif has_array || (use_union && has_int && C !== I) || has_bool
             if has_array
                 C = Union{C, array_T}
             end
             if has_int
                 C = Union{C, I}
+            end
+            if has_bool
+                C = Union{C, Bool}
             end
             return copyto!(similar(vs, C), vs)
         end


### PR DESCRIPTION
- With MTKModel macro all input vars are parameters. This introduces, boolean values to `vs`.

Ref: https://github.com/SciML/ModelingToolkitStandardLibrary.jl/issues/213