### PR TITLE
Enable stuff like :x and sys.x in ODEProblem

### DIFF
--- a/src/systems/diffeqs/abstractodesystem.jl
+++ b/src/systems/diffeqs/abstractodesystem.jl
@@ -896,6 +896,8 @@ function DiffEqBase.DAEProblem{iip}(sys::AbstractODESystem, du0map, u0map, tspan
     parammap = DiffEqBase.NullParameters();
     check_length = true, kwargs...) where {iip}
     has_difference = any(isdifferenceeq, equations(sys))
+    u0map = symmap_to_varmap(sys, u0map)
+    parammap = symmap_to_varmap(sys, parammap)
     f, du0, u0, p = process_DEProblem(DAEFunction{iip}, sys, u0map, parammap;
         implicit_dae = true, du0map = du0map,
         has_difference = has_difference, check_length,

--- a/src/systems/diffeqs/abstractodesystem.jl
+++ b/src/systems/diffeqs/abstractodesystem.jl
@@ -831,6 +831,8 @@ function DiffEqBase.ODEProblem{iip, specialize}(sys::AbstractODESystem, u0map = 
     check_length = true,
     kwargs...) where {iip, specialize}
     has_difference = any(isdifferenceeq, equations(sys))
+    u0map = symmap_to_varmap(sys, u0map)
+    parammap = symmap_to_varmap(sys, parammap)
     f, u0, p = process_DEProblem(ODEFunction{iip, specialize}, sys, u0map, parammap;
         t = tspan !== nothing ? tspan[1] : tspan,
         has_difference = has_difference,
@@ -902,6 +904,8 @@ function DiffEqBase.DAEProblem{iip}(sys::AbstractODESystem, du0map, u0map, tspan
     sts = states(sys)
     differential_vars = map(Base.Fix2(in, diffvars), sts)
     kwargs = filter_kwargs(kwargs)
+    u0map = symmap_to_varmap(sys, u0map)
+    parammap = symmap_to_varmap(sys, parammap)
 
     if has_difference
         DAEProblem{iip}(f, du0, u0, tspan, p;
@@ -927,6 +931,8 @@ function DiffEqBase.DDEProblem{iip}(sys::AbstractODESystem, u0map = [],
     check_length = true,
     kwargs...) where {iip}
     has_difference = any(isdifferenceeq, equations(sys))
+    u0map = symmap_to_varmap(sys, u0map)
+    parammap = symmap_to_varmap(sys, parammap)
     f, u0, p = process_DEProblem(DDEFunction{iip}, sys, u0map, parammap;
         t = tspan !== nothing ? tspan[1] : tspan,
         has_difference = has_difference,
@@ -980,6 +986,8 @@ function DiffEqBase.SDDEProblem{iip}(sys::AbstractODESystem, u0map = [],
     sparsenoise = nothing,
     kwargs...) where {iip}
     has_difference = any(isdifferenceeq, equations(sys))
+    u0map = symmap_to_varmap(sys, u0map)
+    parammap = symmap_to_varmap(sys, parammap)
     f, u0, p = process_DEProblem(SDDEFunction{iip}, sys, u0map, parammap;
         t = tspan !== nothing ? tspan[1] : tspan,
         has_difference = has_difference,
@@ -1147,6 +1155,8 @@ end
 function DiffEqBase.SteadyStateProblem{iip}(sys::AbstractODESystem, u0map,
     parammap = SciMLBase.NullParameters();
     check_length = true, kwargs...) where {iip}
+    u0map = symmap_to_varmap(sys, u0map)
+    parammap = symmap_to_varmap(sys, parammap)
     f, u0, p = process_DEProblem(ODEFunction{iip}, sys, u0map, parammap;
         steady_state = true,
         check_length, kwargs...)
@@ -1176,6 +1186,8 @@ function SteadyStateProblemExpr{iip}(sys::AbstractODESystem, u0map,
     parammap = SciMLBase.NullParameters();
     check_length = true,
     kwargs...) where {iip}
+    u0map = symmap_to_varmap(sys, u0map)
+    parammap = symmap_to_varmap(sys, parammap)
     f, u0, p = process_DEProblem(ODEFunctionExpr{iip}, sys, u0map, parammap;
         steady_state = true,
         check_length, kwargs...)

--- a/src/systems/diffeqs/sdesystem.jl
+++ b/src/systems/diffeqs/sdesystem.jl
@@ -568,6 +568,8 @@ function DiffEqBase.SDEProblem{iip}(sys::SDESystem, u0map = [], tspan = get_tspa
     parammap = DiffEqBase.NullParameters();
     sparsenoise = nothing, check_length = true,
     callback = nothing, kwargs...) where {iip}
+    u0map = symmap_to_varmap(sys, u0map)
+    parammap = symmap_to_varmap(sys, parammap)
     f, u0, p = process_DEProblem(SDEFunction{iip}, sys, u0map, parammap; check_length,
         kwargs...)
     cbs = process_events(sys; callback)

--- a/test/alt_u0_and_p_input_maps.jl
+++ b/test/alt_u0_and_p_input_maps.jl
@@ -1,0 +1,97 @@
+using ModelingToolkit, Test
+
+### Prepare test equations ###
+@parameters t p1 p2 p3
+@variables x1(t) x2(t) x3(t)
+D = Differential(t)
+
+eqs = [ D(x1) ~ p1 * (x1 - x2),
+        D(x2) ~ p2 * (x2 - x3),
+        D(x3) ~ p3 * (x3 - x1)]
+tspan = (0.0, 100.0)
+
+u0_num = [x1 => 1.0, x2 => 0.5, x3 => 0.0]
+u0_sym = [:x1 => 1.0, :x2 => 0.5, :x3 => 0.0]
+
+p_num = [p1 => 0.9, p2 => 1.0, p3 => 1.1]
+p_sym = [:p1 => 0.9, :p2 => 1.0, :p3 => 1.1]
+
+
+### ODEProblem Tests ###
+let
+    @named osys = ODESystem(eqs)
+    u0_sysnum = [osys.x1 => 1.0, osys.x2 => 0.5, osys.x3 => 0.0]
+    p_sysnum = [osys.p1 => 0.9, osys.p2 => 1.0, osys.p3 => 1.1]
+
+    prob_num = ODEProblem(osys, u0_num, tspan, p_num)
+    prob_sym = ODEProblem(osys, u0_sym, tspan, p_sym)
+    prob_sysnum = ODEProblem(osys, u0_sysnum, tspan, p_sysnum)
+
+    @test prob_num.u0 == prob_sym.u0 == prob_sysnum.u0
+    @test prob_num.p == prob_sym.p == prob_sysnum.p
+end
+
+
+### SDEProblem Tests ###
+let
+    noiseeqs = [0.1*x1, 0.1*x2, 0.1*x3]
+    @named ssys = SDESystem(eqs,noiseeqs,t,[x1,x2,x3],[p1,p2,p3]; tspan = tspan)
+    u0_sysnum = [ssys.x1 => 1.0, ssys.x2 => 0.5, ssys.x3 => 0.0]
+    p_sysnum = [ssys.p1 => 0.9, ssys.p2 => 1.0, ssys.p3 => 1.1]
+
+    prob_num = SDEProblem(ssys, u0_num, tspan, p_num)
+    prob_sym = SDEProblem(ssys, u0_sym, tspan, p_sym)
+    prob_sysnum = SDEProblem(ssys, u0_sysnum, tspan, p_sysnum)
+
+    @test prob_num.u0 == prob_sym.u0 == prob_sysnum.u0
+    @test prob_num.p == prob_sym.p == prob_sysnum.p
+end
+
+
+### DAEProblem Tests ###
+let
+    @named osys = ODESystem(eqs)
+    u0_sysnum = [osys.x1 => 1.0, osys.x2 => 0.5, osys.x3 => 0.0]
+    p_sysnum = [osys.p1 => 0.9, osys.p2 => 1.0, osys.p3 => 1.1]
+
+    prob_num = DAEProblem(osys, [1.0,2.0,3.0], u0_num, tspan, p_num)
+    prob_sym = DAEProblem(osys, [1.0,2.0,3.0], u0_sym, tspan, p_sym)
+    prob_sysnum = DAEProblem(osys, [1.0,2.0,3.0], u0_sysnum, tspan, p_sysnum)
+
+    @test prob_num.u0 == prob_sym.u0 == prob_sysnum.u0
+    @test prob_num.p == prob_sym.p == prob_sysnum.p
+end
+
+
+### ODEProblem Tests ###
+let
+    @named osys = ODESystem(eqs)
+    u0_sysnum = [osys.x1 => 1.0, osys.x2 => 0.5, osys.x3 => 0.0]
+    p_sysnum = [osys.p1 => 0.9, osys.p2 => 1.0, osys.p3 => 1.1]
+
+    # Technically not a real DDE problem ,but sufficient for tests.
+    prob_num = DDEProblem(osys, u0_num, tspan, p_num)
+    prob_sym = DDEProblem(osys, u0_sym, tspan, p_sym)
+    prob_sysnum = DDEProblem(osys, u0_sysnum, tspan, p_sysnum)
+
+    @test prob_num.u0 == prob_sym.u0 == prob_sysnum.u0
+    @test prob_num.p == prob_sym.p == prob_sysnum.p
+end
+
+
+### SDDEProblem Tests ###
+let
+    noiseeqs = [0.1*x1, 0.1*x2, 0.1*x3]
+    @named ssys = SDESystem(eqs,noiseeqs,t,[x1,x2,x3],[p1,p2,p3]; tspan = tspan)
+    u0_sysnum = [ssys.x1 => 1.0, ssys.x2 => 0.5, ssys.x3 => 0.0]
+    p_sysnum = [ssys.p1 => 0.9, ssys.p2 => 1.0, ssys.p3 => 1.1]
+
+    # Technically not a real SDDE problem ,but sufficient for tests.
+    prob_num = SDDEProblem(ssys, u0_num, tspan, p_num)
+    prob_sym = SDDEProblem(ssys, u0_sym, tspan, p_sym)
+    prob_sysnum = SDDEProblem(ssys, u0_sysnum, tspan, p_sysnum)
+
+    @test prob_num.u0 == prob_sym.u0 == prob_sysnum.u0
+    @test prob_num.p == prob_sym.p == prob_sysnum.p
+end
+


### PR DESCRIPTION
This shoudl all work now:
```julia
using ModelingToolkit, SciMLBase
@variables t
D = Differential(t)
@variables x(t) = 1.0
eqs = [D(x) ~ -x]
@named sys = ODESystem(eqs, t)

@variables y(t)

tspan = (0.0, 1.0)
prob = ODEProblem(sys, [x => 3.0], tspan)

ODEProblem(sys, [sys.x => 3.0], tspan).u0    # Did not work previously
ODEProblem(sys, [:x => 3.0], tspan).u0         # Did not work previously
ODEProblem(sys, [x => 3.0], tspan).u0
```
This might not solve some cases of `remake` though, as I need to check how it reroutes through `ODEProblem`. I probably should also add some additional tests.