### PR TITLE
Add support for parameters, equations... for `@connector`s

### DIFF
--- a/test/model_parsing.jl
+++ b/test/model_parsing.jl
@@ -1,5 +1,5 @@
 using ModelingToolkit, Test
-using ModelingToolkit: get_gui_metadata, VariableDescription, getdefault
+using ModelingToolkit: get_gui_metadata, VariableDescription, getdefault, RegularConnector
 using URIs: URI
 using Distributions
 using Unitful
@@ -232,4 +232,42 @@ end
 
 for (k, v) in metadata
     @test MockMeta.structure[:variables][:m][k] == v
+end
+
+@testset "Connector with parameters, equations..." begin
+    @connector A begin
+        @extend (e,) = extended_e = E()
+        @icon "pin.png"
+        @parameters begin
+            p
+        end
+        @variables begin
+            v(t)
+        end
+        @components begin
+            cc = C()
+        end
+        @equations begin
+            e ~ 0
+        end
+    end
+
+    @connector C begin
+        c(t)
+    end
+
+    @connector E begin
+        e(t)
+    end
+
+    @named aa = A()
+    @test aa.connector_type == RegularConnector()
+
+    @test A.isconnector == true
+
+    @test A.structure[:parameters] == Dict(:p => Dict())
+    @test A.structure[:extend] == [[:e], :extended_e, :E]
+    @test A.structure[:equations] == ["e ~ 0"]
+    @test A.structure[:kwargs] == Dict(:p => nothing, :v => nothing)
+    @test A.structure[:components] == [[:cc, :C]]
 end


### PR DESCRIPTION
- `@connector` now supports `@parameters`, `@equations`, `@extend`, `@variables`, `@components` and a `begin...end` block along with variables specified without a begin block.
- This is useful for connectors like `HydraulicFluid`[^1]
- Replaces internal functions `connect_macro` and `mtkmodel_macro` with `_model_macro`, which handles both based on the `isconnector` flag
- Adds `"Connector with parameters, equations..." ` for testing the enhancement.

[^1]:https://github.com/SciML/ModelingToolkitStandardLibrary.jl/blob/main/src/Hydraulic/IsothermalCompressible/utils.jl#L53-L75