### PR TITLE
Add a check that user-provided initial conditions are respected

### DIFF
--- a/src/systems/diffeqs/abstractodesystem.jl
+++ b/src/systems/diffeqs/abstractodesystem.jl
@@ -843,10 +843,10 @@ function DiffEqBase.ODEProblem{iip, specialize}(sys::AbstractODESystem, u0map = 
         for (var, val) in u0map
             i = get(obsmap, var, nothing)
             i === nothing && continue
-            val ≈ y[i] || error("The user-provided initial condition for $var = $val is conflicting with another initial condition ($(y[i])) that takes precedent.")
+            val ≈ y[i] ||
+                error("The user-provided initial condition for $var = $val is conflicting with another initial condition ($(y[i])) that takes precedent.")
         end
     end
-
 
     cbs = process_events(sys; callback, has_difference, kwargs...)
     if has_discrete_subsystems(sys) && (dss = get_discrete_subsystems(sys)) !== nothing

--- a/src/systems/diffeqs/abstractodesystem.jl
+++ b/src/systems/diffeqs/abstractodesystem.jl
@@ -835,6 +835,19 @@ function DiffEqBase.ODEProblem{iip, specialize}(sys::AbstractODESystem, u0map = 
         t = tspan !== nothing ? tspan[1] : tspan,
         has_difference = has_difference,
         check_length, kwargs...)
+    if !isempty(u0map) # Check that user-provided initial conditions are repsected, otherwise error
+        # y = f.observed.obs.contents(u0, p, tspan[1])
+        obsvars = [eq.lhs for eq in getfield(sys, :observed)]
+        y = [f.observed(var, u0, p, tspan[1]) for var in obsvars]
+        obsmap = Dict(obsvars .=> eachindex(obsvars))
+        for (var, val) in u0map
+            i = get(obsmap, var, nothing)
+            i === nothing && continue
+            val ≈ y[i] || error("The user-provided initial condition for $var = $val is conflicting with another initial condition ($(y[i])) that takes precedent.")
+        end
+    end
+
+
     cbs = process_events(sys; callback, has_difference, kwargs...)
     if has_discrete_subsystems(sys) && (dss = get_discrete_subsystems(sys)) !== nothing
         affects, clocks, svs = ModelingToolkit.generate_discrete_affect(dss...)

--- a/test/initial_condition.jl
+++ b/test/initial_condition.jl
@@ -5,18 +5,16 @@ using OrdinaryDiffEq
 # The user then supplies an initial condition for y which is in conflict with the default initial condition for x
 @variables t x(t)=1 y(t)
 D = Differential(t)
-eqs = [
-    D(x) ~ -x
-    y ~ x
-]
+eqs = [D(x) ~ -x
+    y ~ x]
 
 @named sys = ODESystem(eqs, t)
 ssys = structural_simplify(sys)
 
 if VERSION >= v"1.8"
     @test_throws "The user-provided initial condition for y(t) = 2.0 is conflicting with another initial condition (1.0) that takes precedent." begin
-        prob = ODEProblem(ssys, [y=>2.0], (0.0, 1.0))
+        prob = ODEProblem(ssys, [y => 2.0], (0.0, 1.0))
         sol = solve(prob, Tsit5())
-        @test sol(0.0, idxs=y) == 2.0
-    end   
+        @test sol(0.0, idxs = y) == 2.0
+    end
 end

--- a/test/initial_condition.jl
+++ b/test/initial_condition.jl
@@ -1,0 +1,22 @@
+using ModelingToolkit
+using OrdinaryDiffEq
+
+# This example adds a default initial condition for x, and makes sure x is chosen as the state variables
+# The user then supplies an initial condition for y which is in conflict with the default initial condition for x
+@variables t x(t)=1 y(t)
+D = Differential(t)
+eqs = [
+    D(x) ~ -x
+    y ~ x
+]
+
+@named sys = ODESystem(eqs, t)
+ssys = structural_simplify(sys)
+
+if VERSION >= v"1.8"
+    @test_throws "The user-provided initial condition for y(t) = 2.0 is conflicting with another initial condition (1.0) that takes precedent." begin
+        prob = ODEProblem(ssys, [y=>2.0], (0.0, 1.0))
+        sol = solve(prob, Tsit5())
+        @test sol(0.0, idxs=y) == 2.0
+    end   
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -28,6 +28,7 @@ using SafeTestsets, Test
 @safetestset "Model Parsing Test" include("model_parsing.jl")
 @safetestset "print_tree" include("print_tree.jl")
 @safetestset "Error Handling" include("error_handling.jl")
+@safetestset "initial condition" include("initial_condition.jl")
 @safetestset "StructuralTransformations" include("structural_transformation/runtests.jl")
 @safetestset "State Selection Test" include("state_selection.jl")
 @safetestset "Symbolic Event Test" include("symbolic_events.jl")


### PR DESCRIPTION
Previously, initial conditions provided by the user were silently ignored if they applied to variables that were moved to observed. This PR throws an error in that case, informing the user that their IC cannot be met.

In the future, it would be good if MTK
1. Distinguished between default IC and user-provided IC
2. Could solve for an initial condition that respects IC provided despite some variables with specified IC having been moved to observed variables