### PR TITLE
Cancel concurrent jobs stemming from PRs & Don't run Downstream and Invalidation tests for changes in `docs` 

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -7,6 +7,12 @@ on:
     tags: '*'
   pull_request:
 
+concurrency:
+  # Skip intermediate builds: always, but for the master branch.
+  # Cancel intermediate builds: always, but for the master branch.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' && github.refs != 'refs/tags/*'}}
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -7,6 +7,12 @@ on:
     paths-ignore:
         - 'docs/**'
 
+concurrency:
+  # Skip intermediate builds: always, but for the master branch and tags.
+  # Cancel intermediate builds: always, but for the master branch and tags.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' && github.refs != 'refs/tags/*' }}
+
 jobs:
   test:
     name: ${{ matrix.package.repo }}/${{ matrix.package.group }}/${{ matrix.julia-version }}

--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -4,6 +4,8 @@ on:
     branches: [master]
     tags: [v*]
   pull_request:
+    paths-ignore:
+        - 'docs/**'
 
 jobs:
   test:

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -8,6 +8,12 @@ on:
     tags: '*'
   pull_request:
 
+concurrency:
+  # Skip intermediate builds: always, but for the master branch and tags.
+  # Cancel intermediate builds: always, but for the master branch and tags.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' && github.refs != 'refs/tags/*'}}
+
 jobs:
   build:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/Invalidations.yml
+++ b/.github/workflows/Invalidations.yml
@@ -2,6 +2,8 @@ name: Invalidations
 
 on:
   pull_request:
+    paths-ignore:
+        - 'docs/**'
 
 concurrency:
   # Skip intermediate builds: always.
@@ -30,7 +32,7 @@ jobs:
     - uses: julia-actions/julia-buildpkg@v1
     - uses: julia-actions/julia-invalidations@v1
       id: invs_default
-    
+
     - name: Report invalidation counts
       run: |
         echo "Invalidations on default branch: ${{ steps.invs_default.outputs.total }} (${{ steps.invs_default.outputs.deps }} via deps)" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,13 @@ on:
       - master
     paths-ignore:
       - 'docs/**'
+
+concurrency:
+  # Skip intermediate builds: always, but for the master branch.
+  # Cancel intermediate builds: always, but for the master branch.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
- This **doesn't** cancel any concurrent jobs of master or tags
- This will clear out queues by cancelling unnecessary (see title) jobs