### PR TITLE
Bifurcation kit extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 Manifest.toml
 .vscode
 .vscode/*
+docs/src/assets/Project.toml
+docs/src/assets/Manifest.toml

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ModelingToolkit"
 uuid = "961ee093-0014-501f-94e3-6117800e7a78"
 authors = ["Yingbo Ma <mayingbo5@gmail.com>", "Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
-version = "8.72.1"
+version = "8.72.2"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/Project.toml
+++ b/Project.toml
@@ -51,9 +51,11 @@ UnPack = "3a884ed6-31ef-47d7-9d2a-63182c4928ed"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [weakdeps]
+BifurcationKit = "0f109fa4-8a5d-4b75-95aa-f515264e7665"
 DeepDiffs = "ab62b9b5-e342-54a8-a765-a90f495de1a6"
 
 [extensions]
+MTKBifurcationKitExt = "BifurcationKit"
 MTKDeepDiffsExt = "DeepDiffs"
 
 [compat]

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ModelingToolkit"
 uuid = "961ee093-0014-501f-94e3-6117800e7a78"
 authors = ["Yingbo Ma <mayingbo5@gmail.com>", "Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
-version = "8.72.0"
+version = "8.72.1"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ModelingToolkit"
 uuid = "961ee093-0014-501f-94e3-6117800e7a78"
 authors = ["Yingbo Ma <mayingbo5@gmail.com>", "Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
-version = "8.71.1"
+version = "8.71.2"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/Project.toml
+++ b/Project.toml
@@ -102,6 +102,7 @@ julia = "1.6"
 
 [extras]
 AmplNLWriter = "7c4d4715-977e-5154-bfe0-e096adeac482"
+BifurcationKit = "0f109fa4-8a5d-4b75-95aa-f515264e7665"
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 ControlSystemsMTK = "687d7614-c7e5-45fc-bfc3-9ee385575c88"
 DeepDiffs = "ab62b9b5-e342-54a8-a765-a90f495de1a6"
@@ -125,4 +126,4 @@ Sundials = "c3572dad-4567-51f8-b174-8c6c989267f4"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["AmplNLWriter", "BenchmarkTools", "ControlSystemsMTK", "NonlinearSolve", "ForwardDiff", "Ipopt", "Ipopt_jll", "ModelingToolkitStandardLibrary", "Optimization", "OptimizationOptimJL", "OptimizationMOI", "Random", "ReferenceTests", "SafeTestsets", "StableRNGs", "Statistics", "SteadyStateDiffEq", "Test", "StochasticDiffEq", "Sundials", "StochasticDelayDiffEq"]
+test = ["AmplNLWriter", "BifurcationKit", "BenchmarkTools", "ControlSystemsMTK", "NonlinearSolve", "ForwardDiff", "Ipopt", "Ipopt_jll", "ModelingToolkitStandardLibrary", "Optimization", "OptimizationOptimJL", "OptimizationMOI", "Random", "ReferenceTests", "SafeTestsets", "StableRNGs", "Statistics", "SteadyStateDiffEq", "Test", "StochasticDiffEq", "Sundials", "StochasticDelayDiffEq"]

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ModelingToolkit"
 uuid = "961ee093-0014-501f-94e3-6117800e7a78"
 authors = ["Yingbo Ma <mayingbo5@gmail.com>", "Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
-version = "8.71.2"
+version = "8.72.0"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,5 +1,6 @@
 [deps]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
+BifurcationKit = "0f109fa4-8a5d-4b75-95aa-f515264e7665"
 DifferentialEquations = "0c46a032-eb83-5123-abaf-570d42b7fbaa"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"

--- a/docs/pages.jl
+++ b/docs/pages.jl
@@ -5,6 +5,7 @@ pages = [
         "tutorials/nonlinear.md",
         "tutorials/optimization.md",
         "tutorials/modelingtoolkitize.md",
+        "tutorials/programmatically_generating.md",
         "tutorials/stochastic_diffeq.md",
         "tutorials/parameter_identifiability.md",
         "tutorials/domain_connections.md"],

--- a/docs/pages.jl
+++ b/docs/pages.jl
@@ -8,6 +8,7 @@ pages = [
         "tutorials/programmatically_generating.md",
         "tutorials/stochastic_diffeq.md",
         "tutorials/parameter_identifiability.md",
+        "tutorials/bifurcation_diagram_computation.md",
         "tutorials/domain_connections.md"],
     "Examples" => Any["Basic Examples" => Any["examples/higher_order.md",
             "examples/spring_mass.md",

--- a/docs/src/basics/ContextualVariables.md
+++ b/docs/src/basics/ContextualVariables.md
@@ -48,7 +48,7 @@ for which its arguments must be specified each time it is used. This is useful w
 PDEs for example, where one may need to use `u(t, x)` in the equations, but will
 need to be able to write `u(t, 0.0)` to define a boundary condition at `x = 0`.
 
-## Variable metadata [Experimental/TODO]
+## Variable metadata
 
 In many engineering systems, some variables act like “flows” while others do not.
 For example, in circuit models you have current which flows, and the related
@@ -69,15 +69,17 @@ the metadata. One can get and set metadata by
 ```julia
 julia> @variables x [unit = u"m^3/s"];
 
-julia> hasmetadata(x, Symbolics.option_to_metadata_type(Val(:unit)))
+julia> hasmetadata(x, VariableUnit)
 true
 
-julia> getmetadata(x, Symbolics.option_to_metadata_type(Val(:unit)))
+julia> ModelingToolkit.get_unit(x)
 m³ s⁻¹
 
-julia> x = setmetadata(x, Symbolics.option_to_metadata_type(Val(:unit)), u"m/s")
+julia> x = setmetadata(x, VariableUnit, u"m/s")
 x
 
-julia> getmetadata(x, Symbolics.option_to_metadata_type(Val(:unit)))
+julia> ModelingToolkit.get_unit(x)
 m s⁻¹
 ```
+
+See [Symbolic Metadata](@ref symbolic_metadata) for more details on variable metadata.

--- a/docs/src/basics/MTKModel_Connector.md
+++ b/docs/src/basics/MTKModel_Connector.md
@@ -1,6 +1,23 @@
-# Defining components with `@mtkmodel`
+# [Components and Connectors](@id mtkmodel_connector)
 
-`@mtkmodel` is a convenience macro to define ModelingToolkit components. It returns `ModelingToolkit.Model`, which includes a constructor that returns an ODESystem, a `structure` dictionary with metadata and flag `isconnector` which is set to `false`.
+## MTK Model
+
+MTK represents components and connectors with `Model`.
+
+```@docs
+ModelingToolkit.Model
+```
+
+## Components
+
+Components are models from various domains. These models contain states and their
+equations.
+
+### [Defining components with `@mtkmodel`](@id mtkmodel)
+
+`@mtkmodel` is a convenience macro to define components. It returns
+`ModelingToolkit.Model`, which includes a constructor that returns the ODESystem, a
+`structure` dictionary with metadata, and flag `isconnector` which is set to `false`.
 
 ## What can an MTK-Model definition have?
 
@@ -56,9 +73,9 @@ end
 
   - Parameters and variables are declared with respective begin blocks.
   - Variables must be functions of an independent variable.
-  - Optionally, default values and metadata can be specified for these parameters and variables. See `ModelB` in the above example.
+  - Optionally, initial guess and metadata can be specified for these parameters and variables. See `ModelB` in the above example.
   - Along with creating parameters and variables, keyword arguments of same name with default value `nothing` are created.
-  - Whenever a parameter or variable has default value, for example `v(t) = 0.0`, a symbolic variable named `v` with default value 0.0 and a keyword argument `v`, with default value `nothing` are created. <br> This way, users can optionally pass new value of `v` while creating a component.
+  - Whenever a parameter or variable has initial value, for example `v(t) = 0.0`, a symbolic variable named `v` with initial value 0.0 and a keyword argument `v`, with default value `nothing` are created. <br> This way, users can optionally pass new value of `v` while creating a component.
 
 ```julia
 julia > @named model_c = ModelC(; v = 2.0);
@@ -72,7 +89,7 @@ julia > ModelingToolkit.getdefault(model_c.v)
   - This block is for non symbolic input arguements. These are for inputs that usually are not meant to be part of components; but influence how they are defined. One can list inputs like boolean flags, functions etc... here.
   - Whenever default values are specified, unlike parameters/variables, they are reflected in the keyword argument list.
 
-### `@extend` block
+#### `@extend` begin block
 
 To extend a partial system,
 
@@ -86,7 +103,8 @@ julia> @named model_c = ModelC(; p1 = 2.0)
 
 ```
 
-However, as `p2` isn't listed in the model definition, its default can't be modified by users.
+However, as `p2` isn't listed in the model definition, its initial guess can't
+specified while creating an instance of `ModelC`.
 
 ### `@components` begin block
 
@@ -110,13 +128,26 @@ And as `k2` isn't listed in the sub-component definition of `ModelC`, its defaul
 
   - Any other Julia operations can be included with dedicated begin blocks.
 
-## Defining connectors with `@connector`
+## Connectors
 
-`@connector` returns `ModelingToolkit.Model`. It includes a constructor that returns a connector ODESystem, a `structure` dictionary with metadata and flag `isconnector` which is set to `true`.
+Connectors are special models that can be used to connect different components together.
+MTK provides 3 distinct connectors:
+
+  - `DomainConnector`: A connector which has only one state which is of `Flow` type,
+    specified by `[connect = Flow]`.
+  - `StreamConnector`: A connector which has atleast one stream variable, specified by
+    `[connect = Stream]`. A `StreamConnector` must have exactly one flow variable.
+  - `RegularConnector`: Connectors that don't fall under above categories.
+
+### [Defining connectors with `@connector`](@id connector)
+
+`@connector` returns `ModelingToolkit.Model`. It includes a constructor that returns
+a connector ODESystem, a `structure` dictionary with metadata, and flag `isconnector`
+which is set to `true`.
 
 A simple connector can be defined with syntax similar to following example:
 
-```julia
+```@example connector
 using ModelingToolkit
 
 @connector Pin begin
@@ -125,17 +156,47 @@ using ModelingToolkit
 end
 ```
 
-  - Variables (as function of independent variable) are listed out in the definition. These variables can optionally have default values and metadata like `descrption`, `connect` and so on.
+Variables (as functions of independent variable) are listed out in the definition. These variables can optionally have initial values and metadata like `description`, `connect` and so on. For more details on setting metadata, check out [Symbolic Metadata](@ref symbolic_metadata).
 
-`@connector`s accepts begin blocks of `@components`, `@equations`, `@extend`, `@parameters`, `@structural_parameters`, `@variables`. These keywords mean the same as described above for `@mtkmodel`.
+Similar to `@mtkmodel`, `@connector` accepts begin blocks of `@components`, `@equations`, `@extend`, `@parameters`, `@structural_parameters`, `@variables`. These keywords mean the same as described above for `@mtkmodel`.
+For example, the following `HydraulicFluid` connector is defined with parameters, variables and equations.
+
+```@example connector
+@connector HydraulicFluid begin
+    @parameters begin
+        ρ = 997
+        β = 2.09e9
+        μ = 0.0010016
+        n = 1
+        let_gas = 1
+        ρ_gas = 0.0073955
+        p_gas = -1000
+    end
+    @variables begin
+        dm(t) = 0.0, [connect = Flow]
+    end
+    @equations begin
+        dm ~ 0
+    end
+end
+```
 
 !!! note
     
     For more examples of usage, checkout [ModelingToolkitStandardLibrary.jl](https://github.com/SciML/ModelingToolkitStandardLibrary.jl/)
 
-### What's a `structure` dictionary?
+## More on `Model.structure`
 
-For components defined with `@mtkmodel` or `@connector`, a dictionary with metadata is created. It lists `:components` (sub-component list), `:extend` (the extended states and base system), `:parameters`, `:variables`, ``:kwargs`` (list of keyword arguments), `:independent_variable`, `:equations`.
+`structure` stores metadata that describes composition of a model. It includes:
+
+  - `:components`: List of sub-components in the form of [[name, sub_component_name],...].
+  - `:extend`: The list of extended states, name given to the base system, and name of the base system.
+  - `:structural_parameters`: Dictionary of structural parameters mapped to their default values.
+  - `:parameters`: Dictionary of symbolic parameters mapped to their metadata.
+  - `:variables`: Dictionary of symbolic variables mapped to their metadata.
+  - `:kwargs`: Dictionary of keyword arguments mapped to their default values.
+  - `:independent_variable`: Independent variable, which is added while generating the Model.
+  - `:equations`: List of equations (represented as strings).
 
 For example, the structure of `ModelC` is:
 

--- a/docs/src/basics/MTKModel_Connector.md
+++ b/docs/src/basics/MTKModel_Connector.md
@@ -130,6 +130,7 @@ end
 `@connector`s accepts begin blocks of `@components`, `@equations`, `@extend`, `@parameters`, `@structural_parameters`, `@variables`. These keywords mean the same as described above for `@mtkmodel`.
 
 !!! note
+    
     For more examples of usage, checkout [ModelingToolkitStandardLibrary.jl](https://github.com/SciML/ModelingToolkitStandardLibrary.jl/)
 
 ### What's a `structure` dictionary?

--- a/docs/src/basics/Variable_metadata.md
+++ b/docs/src/basics/Variable_metadata.md
@@ -1,4 +1,4 @@
-# Symbolic metadata
+# [Symbolic Metadata](@id symbolic_metadata)
 
 It is possible to add metadata to symbolic variables, the metadata will be displayed when calling help on a variable.
 
@@ -37,6 +37,22 @@ help?> u
   ModelingToolkit.VariableDescription: This is my input
 
   Symbolics.VariableSource: (:variables, :u)
+```
+
+## Connect
+
+Variables in connectors can have `connect` metadata which describes the type of connections.
+
+`Flow` is used for variables that represent physical quantities that "flow" ex:
+current in a resistor. These variables sum up to zero in connections.
+
+`Stream` can be specified for variables that flow bi-directionally.
+
+```@example connect
+using ModelingToolkit
+
+@variables t, i(t) [connect = Flow]
+@variables k(t) [connect = Stream]
 ```
 
 ## Input or output

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -173,13 +173,16 @@ system:
 
   - Please refer to the
     [SciML ColPrac: Contributor's Guide on Collaborative Practices for Community Packages](https://github.com/SciML/ColPrac/blob/master/README.md)
-    for guidance on PRs, issues, and other matters relating to contributing to ModelingToolkit.
+    for guidance on PRs, issues, and other matters relating to contributing to SciML.
 
+  - See the [SciML Style Guide](https://github.com/SciML/SciMLStyle) for common coding practices and other style decisions.
   - There are a few community forums:
     
-      + The #diffeq-bridged channel in the [Julia Slack](https://julialang.org/slack/)
-      + [JuliaDiffEq](https://gitter.im/JuliaDiffEq/Lobby) on Gitter
-      + On the Julia Discourse forums (look for the [modelingtoolkit tag](https://discourse.julialang.org/tag/modelingtoolkit))
+      + The #diffeq-bridged and #sciml-bridged channels in the
+        [Julia Slack](https://julialang.org/slack/)
+      + The #diffeq-bridged and #sciml-bridged channels in the
+        [Julia Zulip](https://julialang.zulipchat.com/#narrow/stream/279055-sciml-bridged)
+      + On the [Julia Discourse forums](https://discourse.julialang.org)
       + See also [SciML Community page](https://sciml.ai/community/)
 
 ## Reproducibility

--- a/docs/src/systems/DiscreteSystem.md
+++ b/docs/src/systems/DiscreteSystem.md
@@ -23,7 +23,7 @@ DiscreteSystem
 
 ```@docs
 DiscreteFunction(sys::ModelingToolkit.DiscreteSystem, args...)
-DiscreteProblem(sys::ModelingToolkit.DiscreteSystem, args...)
+DiscreteProblem(sys::ModelingToolkit.DiscreteSystem, u0map, tspan)
 ```
 
 ## Expression Constructors

--- a/docs/src/systems/JumpSystem.md
+++ b/docs/src/systems/JumpSystem.md
@@ -15,7 +15,7 @@ JumpSystem
 
 ## Transformations
 
-```@docs
+```@docs; canonical=false
 structural_simplify
 ```
 
@@ -23,7 +23,9 @@ structural_simplify
 
 ## Problem Constructors
 
+```@docs; canonical=false
+DiscreteProblem(sys::ModelingToolkit.DiscreteSystem, u0map, tspan)
+```
 ```@docs
-SciMLBase.DiscreteProblem(sys::JumpSystem,args...)
-JumpProcesses.JumpProblem(sys::JumpSystem,args...)
+JumpProblem(sys::JumpSystem, prob, aggregator)
 ```

--- a/docs/src/systems/NonlinearSystem.md
+++ b/docs/src/systems/NonlinearSystem.md
@@ -15,7 +15,7 @@ NonlinearSystem
 
 ## Transformations
 
-```@docs
+```@docs; canonical=false
 structural_simplify
 alias_elimination
 tearing
@@ -23,14 +23,14 @@ tearing
 
 ## Analyses
 
-```@docs
+```@docs; canonical=false
 ModelingToolkit.isaffine
 ModelingToolkit.islinear
 ```
 
 ## Applicable Calculation and Generation Functions
 
-```julia
+```@docs; canonical=false
 calculate_jacobian
 generate_jacobian
 jacobian_sparsity

--- a/docs/src/systems/ODESystem.md
+++ b/docs/src/systems/ODESystem.md
@@ -35,7 +35,7 @@ ModelingToolkit.isaffine
 
 ## Applicable Calculation and Generation Functions
 
-```julia
+```@docs; canonical=false
 calculate_jacobian
 calculate_tgrad
 calculate_factorized_W
@@ -56,7 +56,7 @@ SteadyStateProblem(sys::ModelingToolkit.AbstractODESystem, args...)
 ## Torn Problem Constructors
 
 ```@docs
-ODAEProblem(sys::ModelingToolkit.AbstractODESystem, args...)
+ODAEProblem
 ```
 
 ## Expression Constructors

--- a/docs/src/systems/SDESystem.md
+++ b/docs/src/systems/SDESystem.md
@@ -22,17 +22,19 @@ sde = SDESystem(ode, noiseeqs)
 
 ## Transformations
 
-```@docs
+```@docs; canonical=false
 structural_simplify
 alias_elimination
-Girsanov_transform
+```
+```@docs
+ModelingToolkit.Girsanov_transform
 ```
 
 ## Analyses
 
 ## Applicable Calculation and Generation Functions
 
-```julia
+```@docs; canonical=false
 calculate_jacobian
 calculate_tgrad
 calculate_factorized_W

--- a/docs/src/tutorials/acausal_components.md
+++ b/docs/src/tutorials/acausal_components.md
@@ -104,8 +104,8 @@ end
 u0 = [
     rc_model.capacitor.v => 0.0,
 ]
-prob = ODAEProblem(rc_model, u0, (0, 10.0))
-sol = solve(prob, Tsit5())
+prob = ODEProblem(rc_model, u0, (0, 10.0))
+sol = solve(prob)
 plot(sol)
 ```
 
@@ -319,24 +319,9 @@ u0 = [rc_model.capacitor.v => 0.0
     rc_model.capacitor.p.i => 0.0]
 
 prob = ODEProblem(rc_model, u0, (0, 10.0))
-sol = solve(prob, Rodas4())
+sol = solve(prob)
 plot(sol)
 ```
-
-MTK can numerically solve all the
-unreduced algebraic equations using the `ODAEProblem` (note the
-letter `A`):
-
-```@example acausal
-u0 = [
-    rc_model.capacitor.v => 0.0,
-]
-prob = ODAEProblem(rc_model, u0, (0, 10.0))
-sol = solve(prob, Rodas4())
-plot(sol)
-```
-
-Notice that this solves the whole system by only solving for one variable!
 
 However, what if we wanted to plot the timeseries of a different variable? Do
 not worry, that information was not thrown away! Instead, transformations

--- a/docs/src/tutorials/acausal_components.md
+++ b/docs/src/tutorials/acausal_components.md
@@ -54,7 +54,7 @@ end
 end
 
 @mtkmodel Resistor begin
-    @extend v, i = oneport = OnePort()
+    @extend OnePort()
     @parameters begin
         R = 1.0 # Sets the default resistance
     end
@@ -66,7 +66,7 @@ end
 D = Differential(t)
 
 @mtkmodel Capacitor begin
-    @extend v, i = oneport = OnePort()
+    @extend OnePort()
     @parameters begin
         C = 1.0
     end
@@ -76,7 +76,7 @@ D = Differential(t)
 end
 
 @mtkmodel ConstantVoltage begin
-    @extend (v,) = oneport = OnePort()
+    @extend OnePort()
     @parameters begin
         V = 1.0
     end
@@ -193,7 +193,7 @@ zero. This leads to our resistor equations:
 
 ```@example acausal
 @mtkmodel Resistor begin
-    @extend v, i = oneport = OnePort()
+    @extend OnePort()
     @parameters begin
         R = 1.0
     end
@@ -216,7 +216,7 @@ Using our knowledge of circuits, we similarly construct the `Capacitor`:
 D = Differential(t)
 
 @mtkmodel Capacitor begin
-    @extend v, i = oneport = OnePort()
+    @extend OnePort()
     @parameters begin
         C = 1.0
     end
@@ -233,7 +233,7 @@ model this as:
 
 ```@example acausal
 @mtkmodel ConstantVoltage begin
-    @extend (v,) = oneport = OnePort()
+    @extend OnePort()
     @parameters begin
         V = 1.0
     end

--- a/docs/src/tutorials/bifurcation_diagram_computation.md
+++ b/docs/src/tutorials/bifurcation_diagram_computation.md
@@ -1,0 +1,93 @@
+# [Bifurcation Diagrams](@id bifurcation_diagrams)
+Bifurcation diagrams describes how, for a dynamic system, the quantity and quality of its steady states changes with a parameter's value. These can be computed through the [BifurcationKit.jl](https://github.com/bifurcationkit/BifurcationKit.jl) package. ModelingToolkit provides a simple interface for creating BifurcationKit compatible `BifurcationProblem`s from `NonlinearSystem`s and `ODESystem`s. All teh features provided by BifurcationKit can then be applied to these systems. This tutorial provides a brief introduction for these features, with BifurcationKit.jl providing [a more extensive documentation](https://bifurcationkit.github.io/BifurcationKitDocs.jl/stable/).
+
+### Creating a `BifurcationProblem`
+Let us first consider a simple `NonlinearSystem`:
+```@example Bif1
+using ModelingToolkit
+@variables t x(t) y(t)
+@parameters μ α
+eqs = [0 ~ μ*x - x^3 + α*y,
+        0 ~ -y]
+@named nsys = NonlinearSystem(eqs, [x, y], [μ, α])
+```
+we wish to compute a bifurcation diagram for this system as we vary the parameter `μ`. For this, we need to provide the following information:
+1. The system for which we wish to compute the bifurcation diagram (`nsys`).
+2. The parameter which we wish to vary (`μ`).
+3. The parameter set for which we want to compute the bifurcation diagram.
+4. An initial guess of the state of the system for which there is a steady state at our provided parameter value.
+5. The variable which value we wish to plot in the bifurcation diagram (this argument is optional, if not provided, BifurcationKit default plot functions are used).
+
+We declare this additional information:
+```@example Bif1
+bif_par = μ
+p_start = [μ => -1.0, α => 1.0]
+u0_guess = [x => 1.0, y => 1.0]
+plot_var = x;
+```
+For the initial state guess (`u0_guess`), typically any value can be provided, however, read BifurcatioKit's documentation for more details.
+
+We can now create our `BifurcationProblem`, which can be provided as input to BifurcationKit's various functions.
+```@example Bif1
+using BifurcationKit
+bprob = BifurcationProblem(nsys, u0_guess, p_start, bif_par; plot_var=plot_var, jac=false)
+```
+Here, the `jac` argument (by default set to `true`) sets whenever to provide BifurcationKit with a Jacobian or not.
+
+
+### Computing a bifurcation diagram
+
+Let us consider the `BifurcationProblem` from the last section. If we wish to compute the corresponding bifurcation diagram we must first declare various settings used by BifurcationKit to compute the diagram. These are stored in a `ContinuationPar` structure (which also contain a `NewtonPar` structure). 
+```@example Bif1
+p_span = (-4.0, 6.0)
+opt_newton = NewtonPar(tol = 1e-9, max_iterations = 20)
+opts_br = ContinuationPar(dsmin = 0.001, dsmax = 0.05, ds = 0.01,
+	max_steps = 100, nev = 2, newton_options = opt_newton,
+	p_min = p_span[1], p_max = p_span[2],
+	detect_bifurcation = 3, n_inversion = 4, tol_bisection_eigenvalue = 1e-8, dsmin_bisection = 1e-9);
+```
+Here, `p_span` sets the interval over which we wish to compute the diagram.
+
+Next, we can use this as input to our bifurcation diagram, and then plot it.
+```@example Bif1
+bf = bifurcationdiagram(bprob, PALC(), 2, (args...) -> opts_br; bothside=true)
+```
+Here, the value `2` sets how sub-branches of the diagram that BifurcationKit should compute. Generally, for bifurcation diagrams, it is recommended to use the `bothside=true` argument.
+```@example Bif1
+using Plots
+plot(bf; putspecialptlegend=false, markersize=2, plotfold=false, xguide="μ", yguide = "x")
+```
+Here, the system exhibits a pitchfork bifurcation at *μ=0.0*.
+
+### Using `ODESystem` inputs
+It is also possible to use `ODESystem`s (rather than `NonlinearSystem`s) as input to `BifurcationProblem`. Here follows a brief such example.
+
+```@example Bif2
+using BifurcationKit, ModelingToolkit, Plots
+
+@variables t x(t) y(t)
+@parameters μ
+D = Differential(t)
+eqs = [D(x) ~ μ*x - y - x*(x^2+y^2), 
+        D(y) ~ x + μ*y - y*(x^2+y^2)]
+@named osys = ODESystem(eqs, t)
+
+bif_par = μ
+plot_var = x
+p_start = [μ => 1.0]
+u0_guess = [x => 0.0, y=> 0.0]
+
+bprob = BifurcationProblem(osys, u0_guess, p_start, bif_par; plot_var=plot_var, jac=false)
+
+p_span = (-3.0, 3.0)
+opt_newton = NewtonPar(tol = 1e-9, max_iterations = 20)
+opts_br = ContinuationPar(dsmin = 0.001, dsmax = 0.05, ds = 0.01,
+	max_steps = 100, nev = 2, newton_options = opt_newton,
+	p_max = p_span[2], p_min = p_span[1],
+	detect_bifurcation = 3, n_inversion = 4, tol_bisection_eigenvalue = 1e-8, dsmin_bisection = 1e-9)
+
+bf = bifurcationdiagram(bprob, PALC(), 2, (args...) -> opts_br; bothside=true)
+using Plots
+plot(bf; putspecialptlegend=false, markersize=2, plotfold=false, xguide="μ", yguide = "x")
+```
+Here, the value of `x` in the steady state does not change, however, at `μ=0` a Hopf bifurcation occur and the steady state turn unstable.

--- a/docs/src/tutorials/ode_modeling.md
+++ b/docs/src/tutorials/ode_modeling.md
@@ -243,9 +243,8 @@ f_fun(t) = t >= 10 ? value_vector[end] : value_vector[Int(floor(t)) + 1]
     end
 end
 
-@named fol_external_f = FOLExternalFunction()
-fol_external_f = complete(fol_external_f)
-prob = ODEProblem(structural_simplify(fol_external_f),
+@mtkbuild fol_external_f = FOLExternalFunction()
+prob = ODEProblem(fol_external_f,
     [fol_external_f.x => 0.0],
     (0.0, 10.0),
     [fol_external_f.τ => 0.75])

--- a/docs/src/tutorials/ode_modeling.md
+++ b/docs/src/tutorials/ode_modeling.md
@@ -154,12 +154,12 @@ along with the state variable. Note that this has to be requested explicitly
 like as follows:
 
 ```@example ode2
-prob = ODEProblem(fol_simplified,
-    [fol_simplified.x => 0.0],
+prob = ODEProblem(fol,
+    [fol.x => 0.0],
     (0.0, 10.0),
-    [fol_simplified.τ => 3.0])
+    [fol.τ => 3.0])
 sol = solve(prob)
-plot(sol, vars = [fol_simplified.x, fol_simplified.RHS])
+plot(sol, vars = [fol.x, fol.RHS])
 ```
 
 ## Named Indexing of Solutions

--- a/docs/src/tutorials/optimization.md
+++ b/docs/src/tutorials/optimization.md
@@ -69,8 +69,8 @@ cons = [
     x^2 + y^2 ≲ 1,
 ]
 @named sys = OptimizationSystem(loss, [x, y], [a, b], constraints = cons)
-u0 = [x => 1.0
-    y => 2.0]
+u0 = [x => 0.14
+    y => 0.14]
 prob = OptimizationProblem(sys, u0, grad = true, hess = true, cons_j = true, cons_h = true)
 solve(prob, IPNewton())
 ```

--- a/docs/src/tutorials/programmatically_generating.md
+++ b/docs/src/tutorials/programmatically_generating.md
@@ -1,0 +1,106 @@
+# [Programmatically Generating and Scripting ODESystems](@id programmatically)
+
+In the following tutorial we will discuss how to programmatically generate `ODESystem`s.
+This is for cases where one is writing functions that generating `ODESystem`s, for example
+if implementing a reader which parses some file format to generate an `ODESystem` (for example,
+SBML), or for writing functions that transform an `ODESystem` (for example, if you write a
+function that log-transforms a variable in an `ODESystem`).
+
+## The Representation of a ModelingToolkit System
+
+ModelingToolkit is built on [Symbolics.jl](https://symbolics.juliasymbolics.org/dev/),
+a symbolic Computer Algebra System (CAS) developed in Julia. As such, all CAS functionality
+is available on ModelingToolkit systems, such as symbolic differentiation, Groebner basis
+calculations, and whatever else you can think of. Under the hood, all ModelingToolkit
+variables and expressions are Symbolics.jl variables and expressions. Thus when scripting
+a ModelingToolkit system, one simply needs to generate Symbolics.jl variables and equations
+as demonstrated in the Symbolics.jl documentation. This looks like:
+
+```@example scripting
+using Symbolics
+@variables t x(t) y(t) # Define variables
+D = Differential(t) # Define a differential operator
+eqs = [D(x) ~ y
+    D(y) ~ x] # Define an array of equations
+```
+
+## The Non-DSL (non-`@mtkmodel`) Way of Defining an ODESystem
+
+Using `@mtkmodel` is the preferred way of defining ODEs with MTK. However, let us
+look at how we can define the same system without `@mtkmodel`. This is useful for
+defining PDESystem etc.
+
+```@example scripting
+using ModelingToolkit
+
+@variables t x(t)   # independent and dependent variables
+@parameters τ       # parameters
+@constants h = 1    # constants
+D = Differential(t) # define an operator for the differentiation w.r.t. time
+eqs = [D(x) ~ (h - x) / τ] # create an array of equations
+
+# your first ODE, consisting of a single equation, indicated by ~
+@named fol_model = ODESystem(eqs, t)
+
+# Perform the standard transformations and mark the model complete
+# Note: Complete models cannot be subsystems of other models!
+fol_model = complete(structural_simplify(fol_model))
+```
+
+As you can see, generating an ODESystem is as simple as creating the array of equations
+and passing it to the `ODESystem` constructor.
+
+## Understanding the Difference Between the Julia Variable and the Symbolic Variable
+
+In the most basic usage of ModelingToolkit and Symbolics, the name of the Julia variable
+and the symbolic variable are the same. For example, when we do:
+
+```@example scripting
+@variables a
+```
+
+the name of the symbolic variable is `a` and same with the Julia variable. However, we can
+de-couple these by setting `a` to a new symbolic variable, for example:
+
+```@example scripting
+b = only(@variables(a))
+```
+
+Now the Julia variable `b` refers to the variable named `a`. However, the downside of this current
+approach is that it requires that the user writing the script knows the name `a` that they want to
+place to the variable. But what if for example we needed to get the variable's name from a file?
+
+To do this, one can interpolate a symbol into the `@variables` macro using `$`. For example:
+
+```@example scripting
+a = :c
+b = only(@variables($a))
+```
+
+In this example, `@variables($a)` created a variable named `c`, and set this variable to `b`.
+
+Variables are not the only thing with names. For example, when you build a system, it knows its name
+that name is used in the namespacing. In the standard usage, again the Julia variable and the
+symbolic name are made the same via:
+
+```@example scripting
+@named fol_model = ODESystem(eqs, t)
+```
+
+However, one can decouple these two properties by noting that `@named` is simply shorthand for the
+following:
+
+```@example scripting
+fol_model = ODESystem(eqs, t; name = :fol_model)
+```
+
+Thus if we had read a name from a file and wish to populate an `ODESystem` with said name, we could do:
+
+```@example scripting
+namesym = :name_from_file
+fol_model = ODESystem(eqs, t; name = namesym)
+```
+
+## Warning About Mutation
+
+Be advsied that it's never a good idea to mutate an `ODESystem`, or any `AbstractSystem`.

--- a/ext/MTKBifurcationKitExt.jl
+++ b/ext/MTKBifurcationKitExt.jl
@@ -1,0 +1,44 @@
+module MTKBifurcationKitExt
+
+println("BifurcationKit extension loaded")
+
+### Preparations ###
+
+# Imports
+using ModelingToolkit, Setfield
+import BifurcationKit: BifurcationProblem
+
+### Creates BifurcationProblem Overloads ###
+
+# When input is a NonlinearProblem.
+function BifurcationKit.BifurcationProblem(nprob::NonlinearProblem, u0, p, bif_par, args...; plot_variable=nothing, record_from_solution=record_sol_default, kwargs...)
+    # check if jac does nto exist and modify.
+    F = nprob.f.f
+    J = nprob.f.jac.f
+
+    bif_idx = findfirst(isequal(bif_par), parameters(nsys))
+    if isnothing(plot_variable) 
+        plot_idx = findfirst(isequal(plot_variable), variables(nsys))
+        record_from_solution = (x, p) -> x[plot_idx]
+    end
+    return BifurcationProblem(F, u0, p, (@lens _[bif_idx]), args...; record_from_solution = record_from_solution, J = J, kwargs...)
+end
+
+# When input is a NonlinearSystem.
+function BifurcationKit.BifurcationProblem(nsys::NonlinearSystem, u0, p, args...; kwargs...)
+    return BifurcationProblem(NonlinearProblem(nsys, u0, p; jac=true), args...; kwargs...)
+end
+
+# When input is a ODEProblem.
+function BifurcationKit.BifurcationProblem(oprob::ODEProblem, u0, p, args...; kwargs...)
+    return BifurcationProblem(convert(NonlinearProblem, oprob), args...; kwargs...)
+end
+
+# When input is a ODESystem.
+function BifurcationKit.BifurcationProblem(osys::ODESystem, u0, p, args...; kwargs...)
+    return BifurcationProblem(convert(NonlinearProblem, osys), args...; kwargs...)
+end
+
+
+
+end # module

--- a/ext/MTKDeepDiffsExt.jl
+++ b/ext/MTKDeepDiffsExt.jl
@@ -4,7 +4,7 @@ using DeepDiffs, ModelingToolkit
 using ModelingToolkit.BipartiteGraphs: Label,
     BipartiteAdjacencyList, unassigned,
     HighlightInt
-using ModelingToolkit.SystemStructures: SystemStructure,
+using ModelingToolkit: SystemStructure,
     MatchedSystemStructure,
     SystemStructurePrintMatrix
 

--- a/src/ModelingToolkit.jl
+++ b/src/ModelingToolkit.jl
@@ -201,7 +201,7 @@ export JumpProblem, DiscreteProblem
 export NonlinearSystem, OptimizationSystem, ConstraintsSystem
 export alias_elimination, flatten
 export connect, domain_connect, @connector, Connection, Flow, Stream, instream
-export @component, @mtkmodel
+export @component, @mtkmodel, @mtkbuild
 export isinput, isoutput, getbounds, hasbounds, isdisturbance, istunable, getdist, hasdist,
     tunable_parameters, isirreducible, getdescription, hasdescription, isbinaryvar,
     isintegervar

--- a/src/structural_transformation/StructuralTransformations.jl
+++ b/src/structural_transformation/StructuralTransformations.jl
@@ -23,14 +23,18 @@ using ModelingToolkit: ODESystem, AbstractSystem, var_from_nested_derivative, Di
     IncrementalCycleTracker, add_edge_checked!, topological_sort,
     invalidate_cache!, Substitutions, get_or_construct_tearing_state,
     filter_kwargs, lower_varname, setio, SparseMatrixCLIL,
-    fast_substitute, get_fullvars, has_equations
+    fast_substitute, get_fullvars, has_equations, observed
 
 using ModelingToolkit.BipartiteGraphs
 import .BipartiteGraphs: invview, complete
 import ModelingToolkit: var_derivative!, var_derivative_graph!
 using Graphs
-using ModelingToolkit.SystemStructures
-using ModelingToolkit.SystemStructures: algeqs, EquationsView
+using ModelingToolkit: algeqs, EquationsView,
+    SystemStructure, TransformationState, TearingState, structural_simplify!,
+    isdiffvar, isdervar, isalgvar, isdiffeq, algeqs, is_only_discrete,
+    dervars_range, diffvars_range, algvars_range,
+    DiffGraph, complete!,
+    get_fullvars, system_subset
 
 using ModelingToolkit.DiffEqBase
 using ModelingToolkit.StaticArrays

--- a/src/systems/diffeqs/odesystem.jl
+++ b/src/systems/diffeqs/odesystem.jl
@@ -143,6 +143,10 @@ struct ODESystem <: AbstractODESystem
     split_idxs: a vector of vectors of indices for the split parameters.
     """
     split_idxs::Union{Nothing, Vector{Vector{Int}}}
+    """
+    parent: the hierarchical parent system before simplification.
+    """
+    parent::Any
 
     function ODESystem(tag, deqs, iv, dvs, ps, tspan, var_to_name, ctrls, observed, tgrad,
         jac, ctrl_jac, Wfact, Wfact_t, name, systems, defaults,
@@ -151,7 +155,7 @@ struct ODESystem <: AbstractODESystem
         tearing_state = nothing,
         substitutions = nothing, complete = false,
         discrete_subsystems = nothing, unknown_states = nothing,
-        split_idxs = nothing; checks::Union{Bool, Int} = true)
+        split_idxs = nothing, parent = nothing; checks::Union{Bool, Int} = true)
         if checks == true || (checks & CheckComponents) > 0
             check_variables(dvs, iv)
             check_parameters(ps, iv)
@@ -165,7 +169,7 @@ struct ODESystem <: AbstractODESystem
             ctrl_jac, Wfact, Wfact_t, name, systems, defaults, torn_matching,
             connector_type, preface, cevents, devents, metadata, gui_metadata,
             tearing_state, substitutions, complete, discrete_subsystems,
-            unknown_states, split_idxs)
+            unknown_states, split_idxs, parent)
     end
 end
 

--- a/src/systems/diffeqs/odesystem.jl
+++ b/src/systems/diffeqs/odesystem.jl
@@ -139,6 +139,10 @@ struct ODESystem <: AbstractODESystem
     used for ODAEProblem.
     """
     unknown_states::Union{Nothing, Vector{Any}}
+    """
+    split_idxs: a vector of vectors of indices for the split parameters.
+    """
+    split_idxs::Union{Nothing, Vector{Vector{Int}}}
 
     function ODESystem(tag, deqs, iv, dvs, ps, tspan, var_to_name, ctrls, observed, tgrad,
         jac, ctrl_jac, Wfact, Wfact_t, name, systems, defaults,
@@ -146,8 +150,8 @@ struct ODESystem <: AbstractODESystem
         devents, metadata = nothing, gui_metadata = nothing,
         tearing_state = nothing,
         substitutions = nothing, complete = false,
-        discrete_subsystems = nothing, unknown_states = nothing;
-        checks::Union{Bool, Int} = true)
+        discrete_subsystems = nothing, unknown_states = nothing,
+        split_idxs = nothing; checks::Union{Bool, Int} = true)
         if checks == true || (checks & CheckComponents) > 0
             check_variables(dvs, iv)
             check_parameters(ps, iv)
@@ -161,7 +165,7 @@ struct ODESystem <: AbstractODESystem
             ctrl_jac, Wfact, Wfact_t, name, systems, defaults, torn_matching,
             connector_type, preface, cevents, devents, metadata, gui_metadata,
             tearing_state, substitutions, complete, discrete_subsystems,
-            unknown_states)
+            unknown_states, split_idxs)
     end
 end
 

--- a/src/systems/diffeqs/sdesystem.jl
+++ b/src/systems/diffeqs/sdesystem.jl
@@ -115,13 +115,17 @@ struct SDESystem <: AbstractODESystem
     complete: if a model `sys` is complete, then `sys.x` no longer performs namespacing.
     """
     complete::Bool
+    """
+    parent: the hierarchical parent system before simplification.
+    """
+    parent::Any
 
     function SDESystem(tag, deqs, neqs, iv, dvs, ps, tspan, var_to_name, ctrls, observed,
         tgrad,
         jac,
         ctrl_jac, Wfact, Wfact_t, name, systems, defaults, connector_type,
         cevents, devents, metadata = nothing, gui_metadata = nothing,
-        complete = false;
+        complete = false, parent = nothing;
         checks::Union{Bool, Int} = true)
         if checks == true || (checks & CheckComponents) > 0
             check_variables(dvs, iv)
@@ -135,7 +139,7 @@ struct SDESystem <: AbstractODESystem
         new(tag, deqs, neqs, iv, dvs, ps, tspan, var_to_name, ctrls, observed, tgrad, jac,
             ctrl_jac,
             Wfact, Wfact_t, name, systems, defaults, connector_type, cevents, devents,
-            metadata, gui_metadata, complete)
+            metadata, gui_metadata, complete, parent)
     end
 end
 

--- a/src/systems/discrete_system/discrete_system.jl
+++ b/src/systems/discrete_system/discrete_system.jl
@@ -86,6 +86,10 @@ struct DiscreteSystem <: AbstractTimeDependentSystem
     complete: if a model `sys` is complete, then `sys.x` no longer performs namespacing.
     """
     complete::Bool
+    """
+    parent: the hierarchical parent system before simplification.
+    """
+    parent::Any
 
     function DiscreteSystem(tag, discreteEqs, iv, dvs, ps, tspan, var_to_name, ctrls,
         observed,
@@ -93,7 +97,7 @@ struct DiscreteSystem <: AbstractTimeDependentSystem
         systems, defaults, preface, connector_type,
         metadata = nothing, gui_metadata = nothing,
         tearing_state = nothing, substitutions = nothing,
-        complete = false; checks::Union{Bool, Int} = true)
+        complete = false, parent = nothing; checks::Union{Bool, Int} = true)
         if checks == true || (checks & CheckComponents) > 0
             check_variables(dvs, iv)
             check_parameters(ps, iv)
@@ -105,7 +109,7 @@ struct DiscreteSystem <: AbstractTimeDependentSystem
             systems,
             defaults,
             preface, connector_type, metadata, gui_metadata,
-            tearing_state, substitutions, complete)
+            tearing_state, substitutions, complete, parent)
     end
 end
 

--- a/src/systems/jumps/jumpsystem.jl
+++ b/src/systems/jumps/jumpsystem.jl
@@ -293,7 +293,7 @@ dprob = DiscreteProblem(js, u₀map, tspan, parammap)
 function DiffEqBase.DiscreteProblem(sys::JumpSystem, u0map, tspan::Union{Tuple, Nothing},
     parammap = DiffEqBase.NullParameters();
     checkbounds = false,
-    use_union = false,
+    use_union = true,
     kwargs...)
     dvs = states(sys)
     ps = parameters(sys)

--- a/src/systems/nonlinear/nonlinearsystem.jl
+++ b/src/systems/nonlinear/nonlinearsystem.jl
@@ -75,18 +75,23 @@ struct NonlinearSystem <: AbstractTimeIndependentSystem
     complete: if a model `sys` is complete, then `sys.x` no longer performs namespacing.
     """
     complete::Bool
+    """
+    parent: the hierarchical parent system before simplification.
+    """
+    parent::Any
 
     function NonlinearSystem(tag, eqs, states, ps, var_to_name, observed, jac, name,
         systems,
         defaults, connector_type, metadata = nothing,
         gui_metadata = nothing,
         tearing_state = nothing, substitutions = nothing,
-        complete = false; checks::Union{Bool, Int} = true)
+        complete = false, parent = nothing; checks::Union{Bool, Int} = true)
         if checks == true || (checks & CheckUnits) > 0
             all_dimensionless([states; ps]) || check_units(eqs)
         end
         new(tag, eqs, states, ps, var_to_name, observed, jac, name, systems, defaults,
-            connector_type, metadata, gui_metadata, tearing_state, substitutions, complete)
+            connector_type, metadata, gui_metadata, tearing_state, substitutions, complete,
+            parent)
     end
 end
 

--- a/src/systems/optimization/optimizationsystem.jl
+++ b/src/systems/optimization/optimizationsystem.jl
@@ -56,10 +56,14 @@ struct OptimizationSystem <: AbstractOptimizationSystem
     complete: if a model `sys` is complete, then `sys.x` no longer performs namespacing.
     """
     complete::Bool
+    """
+    parent: the hierarchical parent system before simplification.
+    """
+    parent::Any
 
     function OptimizationSystem(tag, op, states, ps, var_to_name, observed,
         constraints, name, systems, defaults, metadata = nothing,
-        gui_metadata = nothing, complete = false;
+        gui_metadata = nothing, complete = false, parent = nothing;
         checks::Union{Bool, Int} = true)
         if checks == true || (checks & CheckUnits) > 0
             unwrap(op) isa Symbolic && check_units(op)
@@ -67,7 +71,8 @@ struct OptimizationSystem <: AbstractOptimizationSystem
             all_dimensionless([states; ps]) || check_units(constraints)
         end
         new(tag, op, states, ps, var_to_name, observed,
-            constraints, name, systems, defaults, metadata, gui_metadata, complete)
+            constraints, name, systems, defaults, metadata, gui_metadata, complete,
+            parent)
     end
 end
 

--- a/src/systems/systems.jl
+++ b/src/systems/systems.jl
@@ -18,6 +18,23 @@ simplification will allow models where `n_states = n_equations - n_inputs`.
 """
 function structural_simplify(sys::AbstractSystem, io = nothing; simplify = false,
     kwargs...)
+    newsys′ = __structural_simplify(sys, io; simplify, kwargs...)
+    if newsys′ isa Tuple
+        @assert length(newsys′) == 2
+        newsys = newsys′[1]
+    else
+        newsys = newsys′
+    end
+    @set! newsys.parent = complete(sys)
+    newsys = complete(newsys)
+    if newsys′ isa Tuple
+        return newsys, newsys′[2]
+    else
+        return newsys
+    end
+end
+function __structural_simplify(sys::AbstractSystem, io = nothing; simplify = false,
+    kwargs...)
     sys = expand_connections(sys)
     sys isa DiscreteSystem && return sys
     state = TearingState(sys)

--- a/src/systems/systemstructure.jl
+++ b/src/systems/systemstructure.jl
@@ -1,7 +1,5 @@
-module SystemStructures
-
 using DataStructures
-using Symbolics: linear_expansion, unwrap
+using Symbolics: linear_expansion, unwrap, Connection
 using SymbolicUtils: istree, operation, arguments, Symbolic
 using SymbolicUtils: quick_cancel, similarterm
 using ..ModelingToolkit
@@ -10,7 +8,7 @@ import ..ModelingToolkit: isdiffeq, var_from_nested_derivative, vars!, flatten,
     isparameter, isconstant,
     independent_variables, SparseMatrixCLIL, AbstractSystem,
     equations, isirreducible, input_timedomain, TimeDomain,
-    VariableType, getvariabletype, has_equations
+    VariableType, getvariabletype, has_equations, ODESystem
 using ..BipartiteGraphs
 import ..BipartiteGraphs: invview, complete
 using Graphs
@@ -27,8 +25,7 @@ function quick_cancel_expr(expr)
 end
 
 export SystemStructure, TransformationState, TearingState, structural_simplify!
-export initialize_system_structure, find_linear_equations
-export isdiffvar, isdervar, isalgvar, isdiffeq, isalgeq, algeqs, is_only_discrete
+export isdiffvar, isdervar, isalgvar, isdiffeq, algeqs, is_only_discrete
 export dervars_range, diffvars_range, algvars_range
 export DiffGraph, complete!
 export get_fullvars, system_subset
@@ -620,5 +617,3 @@ function _structural_simplify!(state::TearingState, io; simplify = false,
     @set! sys.observed = ModelingToolkit.topsort_equations(observed(sys), fullstates)
     ModelingToolkit.invalidate_cache!(sys), input_idxs
 end
-
-end # module

--- a/test/clock.jl
+++ b/test/clock.jl
@@ -62,13 +62,12 @@ By inference:
 =>   Shift(x, 0, dt) := (Shift(x, -1, dt) + dt) / (1 - dt) # Discrete system
 =#
 
-using ModelingToolkit.SystemStructures
 ci, varmap = infer_clocks(sys)
 eqmap = ci.eq_domain
 tss, inputs = ModelingToolkit.split_system(deepcopy(ci))
-sss, = SystemStructures._structural_simplify!(deepcopy(tss[1]), (inputs[1], ()))
+sss, = ModelingToolkit._structural_simplify!(deepcopy(tss[1]), (inputs[1], ()))
 @test equations(sss) == [D(x) ~ u - x]
-sss, = SystemStructures._structural_simplify!(deepcopy(tss[2]), (inputs[2], ()))
+sss, = ModelingToolkit._structural_simplify!(deepcopy(tss[2]), (inputs[2], ()))
 @test isempty(equations(sss))
 @test observed(sss) == [yd ~ Sample(t, dt)(y); r ~ 1.0; ud ~ kp * (r - yd)]
 

--- a/test/extensions/bifurcationkit.jl
+++ b/test/extensions/bifurcationkit.jl
@@ -1,0 +1,29 @@
+using BifurcationKit, ModelingToolkit, Test
+
+# Checks pitchfork diagram and that there are the correct number of branches (a main one and two children)
+let 
+    @variables t x(t) y(t)
+    @parameters μ α
+    eqs = [0 ~ μ*x - x^3 + α*y,
+            0 ~ -y]
+    @named nsys = NonlinearSystem(eqs, [x, y], [μ, α])
+
+    bif_par = μ
+    p_start = [μ => -1.0, α => 1.0]
+    u0_guess = [x => 1.0, y => 1.0]
+    plot_var = x;
+
+    using BifurcationKit
+    bprob = BifurcationProblem(nsys, u0_guess, p_start, bif_par; plot_var=plot_var, jac=false)
+
+    p_span = (-4.0, 6.0)
+    opt_newton = NewtonPar(tol = 1e-9, max_iterations = 20)
+    opts_br = ContinuationPar(dsmin = 0.001, dsmax = 0.05, ds = 0.01,
+        max_steps = 100, nev = 2, newton_options = opt_newton,
+        p_min = p_span[1], p_max = p_span[2],
+        detect_bifurcation = 3, n_inversion = 4, tol_bisection_eigenvalue = 1e-8, dsmin_bisection = 1e-9);
+
+    bf = bifurcationdiagram(bprob, PALC(), 2, (args...) -> opts_br; bothside=true)
+
+    @test length(bf.child) == 2
+end

--- a/test/input_output_handling.jl
+++ b/test/input_output_handling.jl
@@ -124,8 +124,8 @@ using ModelingToolkitStandardLibrary.Mechanical.Rotational
 t = ModelingToolkitStandardLibrary.Mechanical.Rotational.t
 @named inertia1 = Inertia(; J = 1)
 @named inertia2 = Inertia(; J = 1)
-@named spring = Spring(; c = 10)
-@named damper = Damper(; d = 3)
+@named spring = Rotational.Spring(; c = 10)
+@named damper = Rotational.Damper(; d = 3)
 @named torque = Torque(; use_support = false)
 @variables y(t) = 0
 eqs = [connect(torque.flange, inertia1.flange_a)

--- a/test/latexify/10.tex
+++ b/test/latexify/10.tex
@@ -1,5 +1,5 @@
 \begin{align}
-\frac{\mathrm{d} x\left( t \right)}{\mathrm{d}t} =& \frac{\sigma \left(  - x\left( t \right) + y\left( t \right) \right) \frac{\mathrm{d}}{\mathrm{d}t} \left(  - y\left( t \right) + x\left( t \right) \right)}{\frac{\mathrm{d} z\left( t \right)}{\mathrm{d}t}} \\
-0 =&  - y\left( t \right) + \frac{1}{10} \sigma \left( \rho - z\left( t \right) \right) x\left( t \right) \\
-\frac{\mathrm{d} z\left( t \right)}{\mathrm{d}t} =& \left( y\left( t \right) \right)^{\frac{2}{3}} x\left( t \right) - \beta z\left( t \right)
+\frac{\mathrm{d} x\left( t \right)}{\mathrm{d}t} =& \frac{\left(  - x\left( t \right) + y\left( t \right) \right) \frac{\mathrm{d}}{\mathrm{d}t} \left( x\left( t \right) - y\left( t \right) \right) \sigma}{\frac{\mathrm{d} z\left( t \right)}{\mathrm{d}t}} \\
+0 =&  - y\left( t \right) + \frac{1}{10} x\left( t \right) \left(  - z\left( t \right) + \rho \right) \sigma \\
+\frac{\mathrm{d} z\left( t \right)}{\mathrm{d}t} =& \left( y\left( t \right) \right)^{\frac{2}{3}} x\left( t \right) - z\left( t \right) \beta
 \end{align}

--- a/test/latexify/20.tex
+++ b/test/latexify/20.tex
@@ -1,5 +1,5 @@
 \begin{align}
-\frac{\mathrm{d}}{\mathrm{d}t} u(t)_1 =& \left(  - u(t)_1 + u(t)_2 \right) p_3 \\
-0 =&  - u(t)_2 + \frac{1}{10} \left(  - u(t)_1 + p_1 \right) p_2 p_3 u(t)_1 \\
+\frac{\mathrm{d}}{\mathrm{d}t} u(t)_1 =& p_3 \left(  - u(t)_1 + u(t)_2 \right) \\
+0 =&  - u(t)_2 + \frac{1}{10} \left( p_1 - u(t)_1 \right) p_2 p_3 u(t)_1 \\
 \frac{\mathrm{d}}{\mathrm{d}t} u(t)_3 =& u(t)_2^{\frac{2}{3}} u(t)_1 - p_3 u(t)_3
 \end{align}

--- a/test/latexify/30.tex
+++ b/test/latexify/30.tex
@@ -1,5 +1,5 @@
 \begin{align}
-\frac{\mathrm{d}}{\mathrm{d}t} u(t)_1 =& \left(  - u(t)_1 + u(t)_2 \right) p_3 \\
-\frac{\mathrm{d}}{\mathrm{d}t} u(t)_2 =&  - u(t)_2 + \frac{1}{10} \left(  - u(t)_1 + p_1 \right) p_2 p_3 u(t)_1 \\
+\frac{\mathrm{d}}{\mathrm{d}t} u(t)_1 =& p_3 \left(  - u(t)_1 + u(t)_2 \right) \\
+\frac{\mathrm{d}}{\mathrm{d}t} u(t)_2 =&  - u(t)_2 + \frac{1}{10} \left( p_1 - u(t)_1 \right) p_2 p_3 u(t)_1 \\
 \frac{\mathrm{d}}{\mathrm{d}t} u(t)_3 =& u(t)_2^{\frac{2}{3}} u(t)_1 - p_3 u(t)_3
 \end{align}

--- a/test/model_parsing.jl
+++ b/test/model_parsing.jl
@@ -100,7 +100,7 @@ end
     @parameters begin
         C, [unit = u"F"]
     end
-    @extend oneport = OnePort(; v = 0.0)
+    @extend OnePort(; v = 0.0)
     @icon "https://upload.wikimedia.org/wikipedia/commons/7/78/Capacitor_symbol.svg"
     @equations begin
         D(v) ~ i / C

--- a/test/model_parsing.jl
+++ b/test/model_parsing.jl
@@ -1,6 +1,6 @@
 using ModelingToolkit, Test
 using ModelingToolkit: get_gui_metadata,
-    VariableDescription, getdefault, RegularConnector, get_ps
+    VariableDescription, getdefault, RegularConnector, get_ps, getname
 using URIs: URI
 using Distributions
 using Unitful
@@ -146,7 +146,11 @@ l15 0" stroke="black" stroke-width="1" stroke-linejoin="bevel" fill="none"></pat
     C_val = 20
     R_val = 20
     res__R = 100
-    @named rc = RC(; C_val, R_val, resistor.R = res__R)
+    @mtkbuild rc = RC(; C_val, R_val, resistor.R = res__R)
+    resistor = getproperty(rc, :resistor; namespace = false)
+    @test getname(rc.resistor) === getname(resistor)
+    @test getname(rc.resistor.R) === getname(resistor.R)
+    @test getname(rc.resistor.v) === getname(resistor.v)
     # Test that `resistor.R` overrides `R_val` in the argument.
     @test getdefault(rc.resistor.R) == res__R != R_val
     # Test that `C_val` passed via argument is set as default of C.
@@ -166,7 +170,7 @@ l15 0" stroke="black" stroke-width="1" stroke-linejoin="bevel" fill="none"></pat
     @test ModelingToolkit.get_gui_metadata(rc.resistor.p).layout == Pin.structure[:icon] ==
           URI("file:///" * abspath(ENV["MTK_ICONS_DIR"], "pin.png"))
 
-    @test length(equations(structural_simplify(rc))) == 1
+    @test length(equations(rc)) == 1
 end
 
 @testset "Parameters and Structural parameters in various modes" begin

--- a/test/odesystem.jl
+++ b/test/odesystem.jl
@@ -23,7 +23,8 @@ eqs = [D(x) ~ σ * (y - x),
 ModelingToolkit.toexpr.(eqs)[1]
 @named de = ODESystem(eqs; defaults = Dict(x => 1))
 subed = substitute(de, [σ => k])
-@test isequal(sort(parameters(subed), by = string), [k, β, ρ])
+ssort(eqs) = sort(eqs, by = string)
+@test isequal(ssort(parameters(subed)), [k, β, ρ])
 @test isequal(equations(subed),
     [D(x) ~ k * (y - x)
         D(y) ~ (ρ - z) * x - y
@@ -241,7 +242,7 @@ p2 = (k₁ => 0.04,
     k₃ => 1e4)
 tspan = (0.0, 100000.0)
 prob1 = ODEProblem(sys, u0, tspan, p)
-@test prob1.f.sys === sys
+@test prob1.f.sys == sys
 prob12 = ODEProblem(sys, u0, tspan, [0.04, 3e7, 1e4])
 prob13 = ODEProblem(sys, u0, tspan, (0.04, 3e7, 1e4))
 prob14 = ODEProblem(sys, u0, tspan, p2)
@@ -348,14 +349,14 @@ eqs = [0 ~ x + z
     D(accumulation_y) ~ y
     D(accumulation_z) ~ z
     D(x) ~ y]
-@test sort(equations(asys), by = string) == eqs
+@test ssort(equations(asys)) == ssort(eqs)
 @variables ac(t)
 asys = add_accumulations(sys, [ac => (x + y)^2])
 eqs = [0 ~ x + z
     0 ~ x - y
     D(ac) ~ (x + y)^2
     D(x) ~ y]
-@test sort(equations(asys), by = string) == eqs
+@test ssort(equations(asys)) == ssort(eqs)
 
 sys2 = ode_order_lowering(sys)
 M = ModelingToolkit.calculate_massmatrix(sys2)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -56,4 +56,6 @@ end
 @safetestset "FuncAffect Test" include("funcaffect.jl")
 @safetestset "Constants Test" include("constants.jl")
 # Reference tests go Last
-@safetestset "Latexify recipes Test" include("latexify.jl")
+if VERSION >= v"1.9"
+    @safetestset "Latexify recipes Test" include("latexify.jl")
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -55,6 +55,7 @@ end
 @safetestset "OptimizationSystem Test" include("optimizationsystem.jl")
 @safetestset "FuncAffect Test" include("funcaffect.jl")
 @safetestset "Constants Test" include("constants.jl")
+@safetestset "BifurcationKit Extension Test" include("extensions/bifurcationkit.jl")
 # Reference tests go Last
 if VERSION >= v"1.9"
     @safetestset "Latexify recipes Test" include("latexify.jl")

--- a/test/split_parameters.jl
+++ b/test/split_parameters.jl
@@ -2,6 +2,29 @@ using ModelingToolkit, Test
 using ModelingToolkitStandardLibrary.Blocks
 using OrdinaryDiffEq
 
+x = [1, 2.0, false, [1, 2, 3], Parameter(1.0)]
+
+y = ModelingToolkit.promote_to_concrete(x)
+@test eltype(y) == Union{Float64, Parameter{Float64}, Vector{Int64}}
+
+y = ModelingToolkit.promote_to_concrete(x; tofloat = false)
+@test eltype(y) == Union{Bool, Float64, Int64, Parameter{Float64}, Vector{Int64}}
+
+x = [1, 2.0, false, [1, 2, 3]]
+y = ModelingToolkit.promote_to_concrete(x)
+@test eltype(y) == Union{Float64, Vector{Int64}}
+
+x = Any[1, 2.0, false]
+y = ModelingToolkit.promote_to_concrete(x; tofloat = false)
+@test eltype(y) == Union{Bool, Float64, Int64}
+
+y = ModelingToolkit.promote_to_concrete(x; use_union = false)
+@test eltype(y) == Float64
+
+x = Float16[1.0, 2.0, 3.0]
+y = ModelingToolkit.promote_to_concrete(x)
+@test eltype(y) == Float16
+
 # ------------------------ Mixed Single Values and Vector
 
 dt = 4e-4
@@ -46,11 +69,24 @@ eqs = [y ~ src.output.u
 @named sys = ODESystem(eqs, t, vars, []; systems = [int, src])
 s = complete(sys)
 sys = structural_simplify(sys)
-prob = ODEProblem(sys, [], (0.0, t_end), [s.src.data => x])
+prob = ODEProblem(sys, [], (0.0, t_end), [s.src.data => x]; tofloat = false)
 @test prob.p isa Tuple{Vector{Float64}, Vector{Int}, Vector{Vector{Float64}}}
 sol = solve(prob, ImplicitEuler());
 @test sol.retcode == ReturnCode.Success
 @test sol[y][end] == x[end]
+
+#TODO: remake becomes more complicated now, how to improve?
+defs = ModelingToolkit.defaults(sys)
+defs[s.src.data] = 2x
+p′ = ModelingToolkit.varmap_to_vars(defs, parameters(sys); tofloat = false)
+p′, = ModelingToolkit.split_parameters_by_type(p′) #NOTE: we need to ensure this is called now before calling remake()
+prob′ = remake(prob; p = p′)
+sol = solve(prob′, ImplicitEuler());
+@test sol.retcode == ReturnCode.Success
+@test sol[y][end] == 2x[end]
+
+prob′′ = remake(prob; p = [s.src.data => x])
+@test_broken prob′′.p isa Tuple
 
 # ------------------------ Mixed Type Converted to float (default behavior)
 
@@ -77,3 +113,74 @@ prob = ODEProblem(sys, [], tspan, []; tofloat = false)
 @test prob.p isa Tuple{Vector{Float64}, Vector{Int64}}
 sol = solve(prob, ImplicitEuler());
 @test sol.retcode == ReturnCode.Success
+
+# ------------------------- Bug
+using ModelingToolkit, LinearAlgebra
+using ModelingToolkitStandardLibrary.Mechanical.Rotational
+using ModelingToolkitStandardLibrary.Blocks
+using ModelingToolkitStandardLibrary.Blocks: t
+using ModelingToolkit: connect
+
+"A wrapper function to make symbolic indexing easier"
+function wr(sys)
+    ODESystem(Equation[], ModelingToolkit.get_iv(sys), systems = [sys], name = :a_wrapper)
+end
+indexof(sym, syms) = findfirst(isequal(sym), syms)
+
+# Parameters
+m1 = 1.0
+m2 = 1.0
+k = 10.0 # Spring stiffness
+c = 3.0  # Damping coefficient
+
+@named inertia1 = Inertia(; J = m1)
+@named inertia2 = Inertia(; J = m2)
+@named spring = Spring(; c = k)
+@named damper = Damper(; d = c)
+@named torque = Torque(use_support = false)
+
+function SystemModel(u = nothing; name = :model)
+    eqs = [connect(torque.flange, inertia1.flange_a)
+        connect(inertia1.flange_b, spring.flange_a, damper.flange_a)
+        connect(inertia2.flange_a, spring.flange_b, damper.flange_b)]
+    if u !== nothing
+        push!(eqs, connect(torque.tau, u.output))
+        return @named model = ODESystem(eqs,
+            t;
+            systems = [torque, inertia1, inertia2, spring, damper, u])
+    end
+    ODESystem(eqs, t; systems = [torque, inertia1, inertia2, spring, damper], name)
+end
+
+model = SystemModel() # Model with load disturbance
+@named d = Step(start_time = 1.0, duration = 10.0, offset = 0.0, height = 1.0) # Disturbance
+model_outputs = [model.inertia1.w, model.inertia2.w, model.inertia1.phi, model.inertia2.phi] # This is the state realization we want to control
+inputs = [model.torque.tau.u]
+matrices, ssys = ModelingToolkit.linearize(wr(model), inputs, model_outputs)
+
+# Design state-feedback gain using LQR
+# Define cost matrices
+x_costs = [model.inertia1.w => 1.0
+    model.inertia2.w => 1.0
+    model.inertia1.phi => 1.0
+    model.inertia2.phi => 1.0]
+L = randn(1, 4) # Post-multiply by `C` to get the correct input to the controller
+
+# This old definition of MatrixGain will work because the parameter space does not include K (an Array term)
+# @component function MatrixGainAlt(K::AbstractArray; name)
+#     nout, nin = size(K, 1), size(K, 2)
+#     @named input = RealInput(; nin = nin)
+#     @named output = RealOutput(; nout = nout)
+#     eqs = [output.u[i] ~ sum(K[i, j] * input.u[j] for j in 1:nin) for i in 1:nout]
+#     compose(ODESystem(eqs, t, [], []; name = name), [input, output])
+# end
+
+@named state_feedback = MatrixGain(K = -L) # Build negative feedback into the feedback matrix
+@named add = Add(; k1 = 1.0, k2 = 1.0) # To add the control signal and the disturbance
+
+connections = [[state_feedback.input.u[i] ~ model_outputs[i] for i in 1:4]
+    connect(d.output, :d, add.input1)
+    connect(add.input2, state_feedback.output)
+    connect(add.output, :u, model.torque.tau)]
+@named closed_loop = ODESystem(connections, t, systems = [model, state_feedback, add, d])
+S = get_sensitivity(closed_loop, :u)

--- a/test/stream_connectors.jl
+++ b/test/stream_connectors.jl
@@ -136,29 +136,30 @@ eqns = [domain_connect(fluid, n1m1.port_a)
 
 @test_nowarn structural_simplify(n1m1Test)
 @unpack source, port_a = n1m1
-@test sort(equations(expand_connections(n1m1)), by = string) == [0 ~ port_a.m_flow
+ssort(eqs) = sort(eqs, by = string)
+@test ssort(equations(expand_connections(n1m1))) == ssort([0 ~ port_a.m_flow
     0 ~ source.port1.m_flow - port_a.m_flow
     source.port1.P ~ port_a.P
     source.port1.P ~ source.P
     source.port1.h_outflow ~ port_a.h_outflow
-    source.port1.h_outflow ~ source.h]
+    source.port1.h_outflow ~ source.h])
 @unpack port_a, port_b = pipe
-@test sort(equations(expand_connections(pipe)), by = string) ==
-      [0 ~ -port_a.m_flow - port_b.m_flow
+@test ssort(equations(expand_connections(pipe))) ==
+      ssort([0 ~ -port_a.m_flow - port_b.m_flow
     0 ~ port_a.m_flow
     0 ~ port_b.m_flow
     port_a.P ~ port_b.P
     port_a.h_outflow ~ instream(port_b.h_outflow)
-    port_b.h_outflow ~ instream(port_a.h_outflow)]
-@test sort(equations(expand_connections(sys)), by = string) ==
-      [0 ~ n1m1.port_a.m_flow + pipe.port_a.m_flow
+    port_b.h_outflow ~ instream(port_a.h_outflow)])
+@test ssort(equations(expand_connections(sys))) ==
+      ssort([0 ~ n1m1.port_a.m_flow + pipe.port_a.m_flow
     0 ~ pipe.port_b.m_flow + sink.port.m_flow
     n1m1.port_a.P ~ pipe.port_a.P
-    pipe.port_b.P ~ sink.port.P]
-@test sort(equations(expand_connections(n1m1Test)), by = string) ==
-      [0 ~ -pipe.port_a.m_flow - pipe.port_b.m_flow
-    0 ~ n1m1.port_a.m_flow + pipe.port_a.m_flow
+    pipe.port_b.P ~ sink.port.P])
+@test ssort(equations(expand_connections(n1m1Test))) ==
+      ssort([0 ~ -pipe.port_a.m_flow - pipe.port_b.m_flow
     0 ~ n1m1.source.port1.m_flow - n1m1.port_a.m_flow
+    0 ~ n1m1.port_a.m_flow + pipe.port_a.m_flow
     0 ~ pipe.port_b.m_flow + sink.port.m_flow
     fluid.m_flow ~ 0
     n1m1.port_a.P ~ pipe.port_a.P
@@ -172,7 +173,7 @@ eqns = [domain_connect(fluid, n1m1.port_a)
     pipe.port_b.h_outflow ~ n1m1.port_a.h_outflow
     sink.port.P ~ sink.P
     sink.port.h_outflow ~ sink.h_in
-    sink.port.m_flow ~ -sink.m_flow_in]
+    sink.port.m_flow ~ -sink.m_flow_in])
 
 # N1M2 model and test code.
 function N1M2(; name,
@@ -255,12 +256,12 @@ eqns = [connect(source.port, n2m2.port_a)
 @named sp2 = TwoPhaseFluidPort()
 @named sys = ODESystem([connect(sp1, sp2)], t)
 sys_exp = expand_connections(compose(sys, [sp1, sp2]))
-@test sort(equations(sys_exp), by = string) == [0 ~ -sp1.m_flow - sp2.m_flow
+@test ssort(equations(sys_exp)) == ssort([0 ~ -sp1.m_flow - sp2.m_flow
     0 ~ sp1.m_flow
     0 ~ sp2.m_flow
     sp1.P ~ sp2.P
     sp1.h_outflow ~ ModelingToolkit.instream(sp2.h_outflow)
-    sp2.h_outflow ~ ModelingToolkit.instream(sp1.h_outflow)]
+    sp2.h_outflow ~ ModelingToolkit.instream(sp1.h_outflow)])
 
 # array var
 @connector function VecPin(; name)
@@ -274,15 +275,15 @@ end
 
 @named simple = ODESystem([connect(vp1, vp2, vp3)], t)
 sys = expand_connections(compose(simple, [vp1, vp2, vp3]))
-@test sort(equations(sys), by = string) == sort([0 .~ collect(vp1.i)
-        0 .~ collect(vp2.i)
-        0 .~ collect(vp3.i)
-        vp1.v[1] ~ vp2.v[1]
-        vp1.v[2] ~ vp2.v[2]
-        vp1.v[1] ~ vp3.v[1]
-        vp1.v[2] ~ vp3.v[2]
-        0 ~ -vp1.i[1] - vp2.i[1] - vp3.i[1]
-        0 ~ -vp1.i[2] - vp2.i[2] - vp3.i[2]], by = string)
+@test ssort(equations(sys)) == ssort([0 .~ collect(vp1.i)
+    0 .~ collect(vp2.i)
+    0 .~ collect(vp3.i)
+    vp1.v[1] ~ vp2.v[1]
+    vp1.v[2] ~ vp2.v[2]
+    vp1.v[1] ~ vp3.v[1]
+    vp1.v[2] ~ vp3.v[2]
+    0 ~ -vp1.i[1] - vp2.i[1] - vp3.i[1]
+    0 ~ -vp1.i[2] - vp2.i[2] - vp3.i[2]])
 
 @connector function VectorHeatPort(; name, N = 100, T0 = 0.0, Q0 = 0.0)
     @variables (T(t))[1:N]=T0 (Q(t))[1:N]=Q0 [connect = Flow]


### PR DESCRIPTION
This extension creates dispatches for BifurcationKit.jl's `BifurcationProblem` when used on `NonlinearSystem` or `ODESystem`s.

This should work now:
```julia
using ModelingToolkit
using BifurcationKit

# Define ODEFunction
begin
    @variables t x(t) y(t)
    @parameters μ α
    eqs = [0 ~ μ*x - x^3 + α*y,
           0 ~ -y]
    @named nsys = NonlinearSystem(eqs, [x, y], [μ, α])
end

# Define other bifurcation inputs
begin
    p_span = (-4.0, 6.0)
    bif_par = μ
    plot_var = x
    p_start = [μ => -1.0, α => 1.0]
    u0_guess = [x => 1.0, y => 1.0]
end

# Creates a BifurcationProblem.
# This dispatch is what is implemented here, then it is BK stuff all the way.
bprob = BifurcationProblem(nsys, u0_guess, p_start, bif_par; plot_var=plot_var, jac=false)

# Sets bifurcation parameters
opt_newton = NewtonPar(tol = 1e-9, max_iterations = 20)
opts_br = ContinuationPar(dsmin = 0.001, dsmax = 0.05, ds = 0.01,
	max_steps = 100, nev = 2, newton_options = opt_newton,
	p_max = p_span[2], p_min = p_span[1],
	detect_bifurcation = 3, n_inversion = 4, tol_bisection_eigenvalue = 1e-8, dsmin_bisection = 1e-9)

# Creates the bifurcation diagram.
bf = bifurcationdiagram(bprob, PALC(), 2, (args...) -> opts_br; bothside=true)

# You can plot the diagram like
using Plots
plot(bf; putspecialptlegend=false, markersize=2, plotfold=false, title = "#branches = $(size(bf))")
```
![image](https://github.com/SciML/ModelingToolkit.jl/assets/18099310/f1ccb18b-aaf5-4d04-8311-a812fac0f72e)

Tests and docs not added yet, will do if people think this approach looks good.