### PR TITLE
feat: support components with fully-qualified names with `@mtkmodel`

### DIFF
--- a/src/systems/model_parsing.jl
+++ b/src/systems/model_parsing.jl
@@ -673,7 +673,7 @@ function _parse_components!(exprs, body, kwargs)
     expr = Expr(:block)
     varexpr = Expr(:block)
     # push!(exprs, varexpr)
-    comps = Vector{Symbol}[]
+    comps = Vector{Union{Symbol, Expr}}[]
     comp_names = []
 
     for arg in body.args
@@ -692,7 +692,9 @@ function _parse_components!(exprs, body, kwargs)
                 arg.args[2] = b
                 push!(expr.args, arg)
                 push!(comp_names, a)
-                push!(comps, [a, b.args[1]])
+                if (isa(b.args[1], Symbol) || Meta.isexpr(b.args[1], :.))
+                    push!(comps, [a, b.args[1]])
+                end
             end
             _ => error("Couldn't parse the component body: $arg")
         end

--- a/test/model_parsing.jl
+++ b/test/model_parsing.jl
@@ -7,6 +7,30 @@ using Unitful
 
 ENV["MTK_ICONS_DIR"] = "$(@__DIR__)/icons"
 
+# Mock module used to test if the `@mtkmodel` macro works with fully-qualified names as well.
+module MyMockModule
+using ..ModelingToolkit, ..Unitful
+
+export Pin
+@connector Pin begin
+    v(t), [unit = u"V"]                    # Potential at the pin [V]
+    i(t), [connect = Flow, unit = u"A"]    # Current flowing into the pin [A]
+    @icon "pin.png"
+end
+
+@mtkmodel Ground begin
+    @components begin
+        g = Pin()
+    end
+    @icon read(abspath(ENV["MTK_ICONS_DIR"], "ground.svg"), String)
+    @equations begin
+        g.v ~ 0
+    end
+end
+end
+
+using .MyMockModule
+
 @connector RealInput begin
     u(t), [input = true, unit = u"V"]
 end
@@ -27,12 +51,6 @@ end
 
 @variables t [unit = u"s"]
 D = Differential(t)
-
-@connector Pin begin
-    v(t), [unit = u"V"]                    # Potential at the pin [V]
-    i(t), [connect = Flow, unit = u"A"]    # Current flowing into the pin [A]
-    @icon "pin.png"
-end
 
 @named p = Pin(; v = π)
 @test getdefault(p.v) == π
@@ -56,16 +74,6 @@ end
 end
 
 @test OnePort.isconnector == false
-
-@mtkmodel Ground begin
-    @components begin
-        g = Pin()
-    end
-    @icon read(abspath(ENV["MTK_ICONS_DIR"], "ground.svg"), String)
-    @equations begin
-        g.v ~ 0
-    end
-end
 
 resistor_log = "$(@__DIR__)/logo/resistor.svg"
 @mtkmodel Resistor begin
@@ -127,7 +135,7 @@ end
         capacitor = Capacitor(; C = C_val)
         source = Voltage()
         constant = Constant(; k = k_val)
-        ground = Ground()
+        ground = MyMockModule.Ground()
     end
 
     @equations begin


### PR DESCRIPTION
With the `@named` macro, we could use fully-qualified names for components (for instance, while importing components from the MTKStdLib). However, trying to do the same with `@mtkmodel`,
```julia
@mtkmodel Model begin
     @components begin
          resistor = ModelingToolkitStandardLibrary.Electrical.Resistor(R = 1)
          ...
     end
     ...
end
```
throws the following error.
```julia
ERROR: LoadError: MethodError: Cannot `convert` an object of type Expr to an object of type Symbol

Closest candidates are:
  convert(::Type{T}, ::T) where T
   @ Base Base.jl:84
  Symbol(::Any...)
   @ Base strings/basic.jl:229
```

Fix this and support fully qualified names by considering the fully-qualifed name's Expr while parsing components.