### PR TITLE
avoid latex rendering if system has too many equations

### DIFF
--- a/src/systems/abstractsystem.jl
+++ b/src/systems/abstractsystem.jl
@@ -1703,6 +1703,9 @@ end
 end
 
 function Base.show(io::IO, ::MIME"text/latex", x::AbstractSystem)
+    if length(equations(sys)) > 50
+        return Base.show(io::IO, ::MIME"text/plain", x)
+    end
     print(io, "\$\$ " * latexify(x) * " \$\$")
 end
 


### PR DESCRIPTION
The latex rendering of systems in Pluto notebooks and the documentation looks very bad for large systems. This PR reverts to the standard printing of systems if the number of equations is > 50.

Ideally, I'd like to avoid automatic latexification at all times, it is currently poorly implemented and has a ton of known issues. It would be better to ask the user to opt into latexification and use something that is more robust by default.