### PR TITLE
Array paramter scoping

### DIFF
--- a/src/systems/abstractsystem.jl
+++ b/src/systems/abstractsystem.jl
@@ -394,7 +394,7 @@ end
 abstract type SymScope end
 
 struct LocalScope <: SymScope end
-function LocalScope(sym::Union{Num, Symbolic})
+function LocalScope(sym::Union{Num, Symbolic, Symbolics.Arr{Num, N}}) where N
     apply_to_variables(sym) do sym
         setmetadata(sym, SymScope, LocalScope())
     end
@@ -403,7 +403,7 @@ end
 struct ParentScope <: SymScope
     parent::SymScope
 end
-function ParentScope(sym::Union{Num, Symbolic})
+function ParentScope(sym::Union{Num, Symbolic, Symbolics.Arr{Num, N}}) where N
     apply_to_variables(sym) do sym
         setmetadata(sym, SymScope,
             ParentScope(getmetadata(value(sym), SymScope, LocalScope())))
@@ -414,16 +414,16 @@ struct DelayParentScope <: SymScope
     parent::SymScope
     N::Int
 end
-function DelayParentScope(sym::Union{Num, Symbolic}, N)
+function DelayParentScope(sym::Union{Num, Symbolic, Symbolics.Arr{Num, M}}, N) where M
     apply_to_variables(sym) do sym
         setmetadata(sym, SymScope,
             DelayParentScope(getmetadata(value(sym), SymScope, LocalScope()), N))
     end
 end
-DelayParentScope(sym::Union{Num, Symbolic}) = DelayParentScope(sym, 1)
+DelayParentScope(sym::Union{Num, Symbolic, Symbolics.Arr{Num, N}}) where N = DelayParentScope(sym, 1)
 
 struct GlobalScope <: SymScope end
-function GlobalScope(sym::Union{Num, Symbolic})
+function GlobalScope(sym::Union{Num, Symbolic, Symbolics.Arr{Num, N}}) where N
     apply_to_variables(sym) do sym
         setmetadata(sym, SymScope, GlobalScope())
     end

--- a/src/systems/abstractsystem.jl
+++ b/src/systems/abstractsystem.jl
@@ -503,8 +503,13 @@ function namespace_expr(O, sys, n = nameof(sys); ivs = independent_variables(sys
         return O
     elseif istree(O)
         T = typeof(O)
+        op = operation(O)
+        args = arguments(O)
+        if op == getindex && hasmetadata(O, SymScope)
+            args[1] = setmetadata(args[1], SymScope, getmetadata(O, SymScope))
+        end
         renamed = let sys = sys, n = n, T = T
-            map(a -> namespace_expr(a, sys, n; ivs)::Any, arguments(O))
+            map(a -> namespace_expr(a, sys, n; ivs)::Any, args)
         end
         if isvariable(O)
             # Use renamespace so the scope is correct, and make sure to use the

--- a/src/systems/abstractsystem.jl
+++ b/src/systems/abstractsystem.jl
@@ -394,7 +394,7 @@ end
 abstract type SymScope end
 
 struct LocalScope <: SymScope end
-function LocalScope(sym::Union{Num, Symbolic, Symbolics.Arr{Num, N}}) where N
+function LocalScope(sym::Union{Num, Symbolic, Symbolics.Arr{Num, N}}) where {N}
     apply_to_variables(sym) do sym
         setmetadata(sym, SymScope, LocalScope())
     end
@@ -403,7 +403,7 @@ end
 struct ParentScope <: SymScope
     parent::SymScope
 end
-function ParentScope(sym::Union{Num, Symbolic, Symbolics.Arr{Num, N}}) where N
+function ParentScope(sym::Union{Num, Symbolic, Symbolics.Arr{Num, N}}) where {N}
     apply_to_variables(sym) do sym
         setmetadata(sym, SymScope,
             ParentScope(getmetadata(value(sym), SymScope, LocalScope())))
@@ -414,16 +414,18 @@ struct DelayParentScope <: SymScope
     parent::SymScope
     N::Int
 end
-function DelayParentScope(sym::Union{Num, Symbolic, Symbolics.Arr{Num, M}}, N) where M
+function DelayParentScope(sym::Union{Num, Symbolic, Symbolics.Arr{Num, M}}, N) where {M}
     apply_to_variables(sym) do sym
         setmetadata(sym, SymScope,
             DelayParentScope(getmetadata(value(sym), SymScope, LocalScope()), N))
     end
 end
-DelayParentScope(sym::Union{Num, Symbolic, Symbolics.Arr{Num, N}}) where N = DelayParentScope(sym, 1)
+function DelayParentScope(sym::Union{Num, Symbolic, Symbolics.Arr{Num, N}}) where {N}
+    DelayParentScope(sym, 1)
+end
 
 struct GlobalScope <: SymScope end
-function GlobalScope(sym::Union{Num, Symbolic, Symbolics.Arr{Num, N}}) where N
+function GlobalScope(sym::Union{Num, Symbolic, Symbolics.Arr{Num, N}}) where {N}
     apply_to_variables(sym) do sym
         setmetadata(sym, SymScope, GlobalScope())
     end

--- a/test/variable_scope.jl
+++ b/test/variable_scope.jl
@@ -75,8 +75,8 @@ ps = ModelingToolkit.getname.(parameters(level3))
 
 @parameters xx[1:2]
 arr_p = [ParentScope(xx[1]), xx[2]]
-arr0 = ODESystem(Equation[], t, [], arr_p; name=:arr0)
-arr1 = ODESystem(Equation[], t, [], []; name=:arr1) ∘ arr0
+arr0 = ODESystem(Equation[], t, [], arr_p; name = :arr0)
+arr1 = ODESystem(Equation[], t, [], []; name = :arr1) ∘ arr0
 arr_ps = ModelingToolkit.getname.(parameters(arr1))
 @test isequal(arr_ps[1], Symbol("xx"))
 @test isequal(arr_ps[2], Symbol("arr0₊xx"))

--- a/test/variable_scope.jl
+++ b/test/variable_scope.jl
@@ -72,3 +72,11 @@ ps = ModelingToolkit.getname.(parameters(level3))
 @test isequal(ps[4], :level2₊level0₊d)
 @test isequal(ps[5], :level1₊level0₊e)
 @test isequal(ps[6], :f)
+
+@parameters xx[1:2]
+arr_p = [ParentScope(xx[1]), xx[2]]
+arr0 = ODESystem(Equation[], t, [], arr_p; name=:arr0)
+arr1 = ODESystem(Equation[], t, [], []; name=:arr1) ∘ arr0
+arr_ps = ModelingToolkit.getname.(parameters(arr1))
+@test isequal(arr_ps[1], Symbol("xx"))
+@test isequal(arr_ps[2], Symbol("arr0₊xx"))


### PR DESCRIPTION
This patch requires [Symbolics.jl#1010](https://github.com/JuliaSymbolics/Symbolics.jl/pull/1010) to ensure metadata is preserved across the `scalarize` call.

This fixes #2252.