### PR TITLE
Handle dummy derivatives in `linearization_function`

### DIFF
--- a/src/systems/abstractsystem.jl
+++ b/src/systems/abstractsystem.jl
@@ -1303,7 +1303,7 @@ function linearization_function(sys::AbstractSystem, inputs,
         op = merge(defs, op)
     end
     sys = ssys
-    x0 = merge(defaults(sys), op)
+    x0 = merge(defaults(sys), Dict(missing_variable_defaults(sys)), op)
     u0, p, _ = get_u0_p(sys, x0, p; use_union = false, tofloat = true)
     p, split_idxs = split_parameters_by_type(p)
     ps = parameters(sys)


### PR DESCRIPTION
The issue here is that the homogenous parameter PR that was merged broke `linearization_function`, which led to [a further PR](https://github.com/SciML/ModelingToolkit.jl/pull/2283) that broke the user interface to `linearization_function` such that [the user now needs to provide an "example input" that encodes the types](https://github.com/SciML/ModelingToolkit.jl/pull/2283#discussion_r1343062310) that the generated function would eventually be called with.

I find this a very bad design and a quite unfortunate breaking change. The fundamental problem is that state and parameter types are important, but the modeling language does not allow the user to encode this information in the model, instead we now ask the users to provide the type information in the form of an example input.

This PR mitigates the effect of the breakage slightly be setting missing variables to `0.0`, a floating point type. This should be okay since dummy derivatives are always floats. The value is not important here, only the type.

Test is coming