### PR TITLE
fix: remove `eval`s from model parsing

### DIFF
--- a/format/Project.toml
+++ b/format/Project.toml
@@ -1,0 +1,2 @@
+[deps]
+JuliaFormatter = "98e50ef6-434e-11e9-1051-2b60c6c9e899"

--- a/test/model_parsing.jl
+++ b/test/model_parsing.jl
@@ -165,7 +165,8 @@ resistor = getproperty(rc, :resistor; namespace = false)
 
 @test get_gui_metadata(rc.resistor).layout == Resistor.structure[:icon] ==
       read(joinpath(ENV["MTK_ICONS_DIR"], "resistor.svg"), String)
-@test get_gui_metadata(rc.ground).layout == read(abspath(ENV["MTK_ICONS_DIR"], "ground.svg"), String)
+@test get_gui_metadata(rc.ground).layout ==
+      read(abspath(ENV["MTK_ICONS_DIR"], "ground.svg"), String)
 @test get_gui_metadata(rc.capacitor).layout ==
       URI("https://upload.wikimedia.org/wikipedia/commons/7/78/Capacitor_symbol.svg")
 @test OnePort.structure[:icon] ==

--- a/test/model_parsing.jl
+++ b/test/model_parsing.jl
@@ -18,11 +18,12 @@ export Pin
     @icon "pin.png"
 end
 
+ground_logo = read(abspath(ENV["MTK_ICONS_DIR"], "ground.svg"), String)
 @mtkmodel Ground begin
     @components begin
         g = Pin()
     end
-    @icon read(abspath(ENV["MTK_ICONS_DIR"], "ground.svg"), String)
+    @icon ground_logo
     @equations begin
         g.v ~ 0
     end
@@ -164,8 +165,7 @@ resistor = getproperty(rc, :resistor; namespace = false)
 
 @test get_gui_metadata(rc.resistor).layout == Resistor.structure[:icon] ==
       read(joinpath(ENV["MTK_ICONS_DIR"], "resistor.svg"), String)
-@test get_gui_metadata(rc.ground).layout ==
-      read(abspath(ENV["MTK_ICONS_DIR"], "ground.svg"), String)
+@test get_gui_metadata(rc.ground).layout == read(abspath(ENV["MTK_ICONS_DIR"], "ground.svg"), String)
 @test get_gui_metadata(rc.capacitor).layout ==
       URI("https://upload.wikimedia.org/wikipedia/commons/7/78/Capacitor_symbol.svg")
 @test OnePort.structure[:icon] ==
@@ -319,6 +319,21 @@ end
     @test A.structure[:equations] == ["e ~ 0"]
     @test A.structure[:kwargs] == Dict(:p => nothing, :v => nothing)
     @test A.structure[:components] == [[:cc, :C]]
+end
+
+# Ensure that modules consisting MTKModels with component arrays and icons of
+# `Expr` type and `unit` metadata can be precompiled.
+@testset "Precompile packages with MTKModels" begin
+    push!(LOAD_PATH, joinpath(@__DIR__, "precompile_test"))
+
+    using ModelParsingPrecompile: ModelWithComponentArray
+
+    @named model_with_component_array = ModelWithComponentArray()
+
+    @test ModelWithComponentArray.structure[:parameters][:R][:unit] == u"Ω"
+    @test lastindex(parameters(model_with_component_array)) == 3
+
+    pop!(LOAD_PATH)
 end
 
 @testset "Conditional statements inside the blocks" begin

--- a/test/precompile_test/ModelParsingPrecompile.jl
+++ b/test/precompile_test/ModelParsingPrecompile.jl
@@ -1,0 +1,12 @@
+module ModelParsingPrecompile
+
+using ModelingToolkit
+using Unitful
+
+@mtkmodel ModelWithComponentArray begin
+    @parameters begin
+        R(t)[1:3] = 1, [description = "Parameter array", unit = u"Ω"]
+    end
+end
+
+end


### PR DESCRIPTION
Closes #2377 
- Along with MTKModels with component arrays, the ones with icons of `Expr` type had this issue.
- This PR ensures that modules with either of those can be precompiled.

## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [ScioML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
