### PR TITLE
Update abstractsystem.jl with :get_name

### DIFF
--- a/src/systems/abstractsystem.jl
+++ b/src/systems/abstractsystem.jl
@@ -305,6 +305,7 @@ for prop in [:eqs
     :states
     :ps
     :tspan
+    :name
     :var_to_name
     :ctrls
     :defaults


### PR DESCRIPTION
The `get_name` method was missing from the getter list; this commit adds `:name` to the getter generation block.

## Checklist

- [X] Appropriate tests were added
- [X] Any code changes were done in a way that does not break public API
- [X] All documentation related to code changes were updated
- [X] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [X] Any new documentation only uses public API
