### PR TITLE
add export getp, setp

### DIFF
--- a/src/ModelingToolkit.jl
+++ b/src/ModelingToolkit.jl
@@ -244,6 +244,8 @@ export @variables, @parameters, @constants, @brownian
 export @named, @nonamespace, @namespace, extend, compose, complete
 export debug_system
 
+export getp, setp
+
 export show_with_compare
 
 #export Continuous, Discrete, sampletime, input_timedomain, output_timedomain


### PR DESCRIPTION
Simply adds a line
```julia
export getp, setp
```
to ModelingToolkit.jl to ensure that these functions are exported to the user.