### PR TITLE
fix: convert `Symbol` to symbolic variables in remake, fix split_idxs

### DIFF
--- a/src/systems/diffeqs/abstractodesystem.jl
+++ b/src/systems/diffeqs/abstractodesystem.jl
@@ -822,6 +822,9 @@ function process_DEProblem(constructor, sys::AbstractODESystem, u0map, parammap;
     if p isa Tuple
         ps = Base.Fix1(getindex, parameters(sys)).(split_idxs)
         ps = (ps...,) #if p is Tuple, ps should be Tuple
+    else
+        # if there is only one type, we don't need split_idxs
+        split_idxs = nothing
     end
 
     if implicit_dae && du0map !== nothing

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -143,7 +143,7 @@ function SciMLBase.process_p_u0_symbolic(prob::Union{SciMLBase.AbstractDEProblem
             throw(ArgumentError("This problem does not support symbolic maps with `remake`, i.e. it does not have a symbolic origin." *
                                 " Please use `remake` with the `p` keyword argument as a vector of values, paying attention to parameter order."))
         p = [
-            (sym isa Symbol ? parameter_symbols(prob)[parameter_index(prob, sym)] : sym) => val
+            (symbolic_type(sym) != NotSymbolic() ? parameter_symbols(prob)[parameter_index(prob, sym)] : sym) => val
             for (sym, val) in p
         ]
     end
@@ -152,7 +152,7 @@ function SciMLBase.process_p_u0_symbolic(prob::Union{SciMLBase.AbstractDEProblem
             throw(ArgumentError("This problem does not support symbolic maps with `remake`, i.e. it does not have a symbolic origin." *
                                 " Please use `remake` with the `u0` keyword argument as a vector of values, paying attention to state order."))
         u0 = [
-            (sym isa Symbol ? variable_symbols(prob)[variable_index(prob, sym)] : sym) => val
+            (symbolic_type(sym) != NotSymbolic() ? variable_symbols(prob)[variable_index(prob, sym)] : sym) => val
             for (sym, val) in u0
         ]
     end


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
