### PR TITLE
fix(pdesystem): parameters are vector of Num instead of vector of pairs when analytic is also passed

### DIFF
--- a/src/systems/pde/pdesystem.jl
+++ b/src/systems/pde/pdesystem.jl
@@ -113,7 +113,7 @@ struct PDESystem <: ModelingToolkit.AbstractMultivariateSystem
             if isnothing(analytic_func)
                 analytic_func = map(analytic) do eq
                     args = arguments(eq.lhs)
-                    p = ps isa SciMLBase.NullParameters ? [] : map(a -> a.first, ps)
+                    p = ps isa SciMLBase.NullParameters ? [] : ps
                     args = vcat(DestructuredArgs(p), args)
                     ex = Func(args, [], eq.rhs) |> toexpr
                     eq.lhs => drop_expr(@RuntimeGeneratedFunction(eval_module, ex))

--- a/test/pde.jl
+++ b/test/pde.jl
@@ -16,7 +16,7 @@ domains = [t ∈ (0.0, 1.0),
 analytic = [u(t, x) ~ -h * x * (x - 1) * sin(x) * exp(-2 * h * t)]
 analytic_function = (ps, t, x) -> -ps[1] * x * (x - 1) * sin(x) * exp(-2 * ps[1] * t)
 
-@named pdesys = PDESystem(eq, bcs, domains, [t, x], [u], [h => 1], analytic = analytic)
+@named pdesys = PDESystem(eq, bcs, domains, [t, x], [u], [h], analytic = analytic)
 @show pdesys
 
 @test all(isequal.(independent_variables(pdesys), [t, x]))

--- a/test/symbolic_indexing_interface.jl
+++ b/test/symbolic_indexing_interface.jl
@@ -72,8 +72,8 @@ domains = [t ∈ (0.0, 1.0),
 analytic = [u(t, x) ~ -h * x * (x - 1) * sin(x) * exp(-2 * h * t)]
 analytic_function = (ps, t, x) -> -ps[1] * x * (x - 1) * sin(x) * exp(-2 * ps[1] * t)
 
-@named pdesys = PDESystem(eq, bcs, domains, [t, x], [u], [h => 1], analytic = analytic)
+@named pdesys = PDESystem(eq, bcs, domains, [t, x], [u], [h], analytic = analytic)
 
-@test isequal(pdesys.ps, [h => 1])
+@test isequal(pdesys.ps, [h])
 @test isequal(parameter_symbols(pdesys), [h])
 @test isequal(parameters(pdesys), [h])


### PR DESCRIPTION
Parameters are vector of Nums. If we pass a vector of Nums when we pass `analytic` as well, it fails.

MWE:

```julia
using ModelingTookit, DomainSets

@variables x t u(..)
@parameters D

Dxx = Differential(x)
Dt = Differential(t)
eqs = [Dt(u(t, x)) ~ D * Dxx(u(t, x))]
bcs = [u(0, x) ~ sin(2pi * x), u(t, 0) ~ 0.0, u(t, 1) ~ 0.0]

domains = [t ∈ Interval(0.0, 1.0), x ∈ Interval(0.0, 1.0)]

analytic = [u(t, x) ~ exp(-4pi^2 * D * t) * sin(2pi * x)]
@named heat_1d1 = PDESystem(eqs, bcs, domains, [t, x], [u(t, x)], [D], analytic = analytic) # fails
@named heat_1d1 = PDESystem(eqs, bcs, domains, [t, x], [u(t, x)], [D => 1.0], analytic = analytic) # passes
@named heat_1d1 = PDESystem(eqs, bcs, domains, [t, x], [u(t, x)], [D]) # passes
```