### PR TITLE
Support for time-dependent parameterizations

### DIFF
--- a/src/systems/diffeqs/abstractodesystem.jl
+++ b/src/systems/diffeqs/abstractodesystem.jl
@@ -178,7 +178,11 @@ function generate_function(sys::AbstractODESystem, dvs = states(sys), ps = param
             if p isa Tuple
                 build_function(rhss, u, p..., t; postprocess_fbody = pre,
                     states = sol_states,
-                    kwargs...)
+                               kwargs...)
+            elseif (length(p) > 1)
+                p = arguments(p[1])[1]
+                build_function(rhss, u, p, t; postprocess_fbody = pre, states = sol_states,
+                               kwargs...)
             else
                 build_function(rhss, u, p, t; postprocess_fbody = pre, states = sol_states,
                     kwargs...)


### PR DESCRIPTION
Currently variable/parameter substitution is "eager", in that `build_function` replaces according to a dictionary that looks like `x(t)[1] => _-arg1[1], ..., p[1]=>_-arg2[1], ...`

Which is safe nominal behavior, but if we don't know apriori what index will be used, (e.g., parameters depend on time), and we want to retain a symbolic form like `p[floor(Int, t/10)+1]` `build_function` does not recognize this, and instead retains this as part of the equations, i.e., symbolic result would look like something like `_-arg1[1] = p[floor(Int, t/10)+1]` instead of `_-arg1[1] = _-arg2[floor(Int, t/10)+1]`. The former leads to an undefined variable error, and the latter is the desired behavior.

Currently the proposed change is a hack, but maybe a keyword argument like `eager` which defaults to `true` and maintains the current behavior, while `false` would "weaken" the dictionary to simply find all `x,p` and replace with corresponding args. 
