### PR TITLE
Fix updating default value metadata of conditional parameters

### DIFF
--- a/src/systems/model_parsing.jl
+++ b/src/systems/model_parsing.jl
@@ -162,7 +162,11 @@ function parse_variable_def!(dict, mod, arg, varclass, kwargs;
             Base.remove_linenums!(b)
             def, meta = parse_default(mod, b)
             var, def = parse_variable_def!(dict, mod, a, varclass, kwargs; def, type)
-            dict[varclass][getname(var)][:default] = def
+            if dict[varclass] isa Vector
+                dict[varclass][1][getname(var)][:default] = def
+            else
+                dict[varclass][getname(var)][:default] = def
+            end
             if meta !== nothing
                 for (type, key) in metatypes
                     if (mt = get(meta, key, nothing)) !== nothing
@@ -185,7 +189,6 @@ function parse_variable_def!(dict, mod, arg, varclass, kwargs;
                 for (type, key) in metatypes
                     if (mt = get(meta, key, nothing)) !== nothing
                         key == VariableConnectType && (mt = nameof(mt))
-                        # @info dict 164
                         if dict[varclass] isa Vector
                             dict[varclass][1][getname(var)][type] = mt
                         else

--- a/test/model_parsing.jl
+++ b/test/model_parsing.jl
@@ -393,11 +393,11 @@ end
         @parameters begin
             eq = flag == 1 ? 1 : 0
             if flag == 1
-                if_parameter
+                if_parameter = 100
             elseif flag == 2
-                elseif_parameter
+                elseif_parameter = 101
             else
-                else_parameter
+                else_parameter = 102
             end
         end
         @components begin
@@ -433,6 +433,10 @@ end
     @test getname.(parameters(if_in_sys)) == [:if_parameter, :eq]
     @test getname.(parameters(elseif_in_sys)) == [:elseif_parameter, :eq]
     @test getname.(parameters(else_in_sys)) == [:else_parameter, :eq]
+
+    @test getdefault(if_in_sys.if_parameter) == 100
+    @test getdefault(elseif_in_sys.elseif_parameter) == 101
+    @test getdefault(else_in_sys.else_parameter) == 102
 
     @test nameof.(get_systems(if_in_sys)) == [:if_sys, :default_sys]
     @test nameof.(get_systems(elseif_in_sys)) == [:elseif_sys, :default_sys]
@@ -479,7 +483,7 @@ end
 
         if condition == 1
             @parameters begin
-                if_parameter
+                if_parameter = 100
             end
             @equations begin
                 if_parameter ~ 0
@@ -489,7 +493,7 @@ end
             end
         elseif condition == 2
             @parameters begin
-                elseif_parameter
+                elseif_parameter = 101
             end
             @equations begin
                 elseif_parameter ~ 0
@@ -499,7 +503,7 @@ end
             end
         else
             @parameters begin
-                else_parameter
+                else_parameter = 102
             end
             @equations begin
                 else_parameter ~ 0
@@ -522,6 +526,10 @@ end
     @test getname.(parameters(if_out_sys)) == [:if_parameter, :default_parameter]
     @test getname.(parameters(elseif_out_sys)) == [:elseif_parameter, :default_parameter]
     @test getname.(parameters(else_out_sys)) == [:else_parameter, :default_parameter]
+
+    @test getdefault(if_out_sys.if_parameter) == 100
+    @test getdefault(elseif_out_sys.elseif_parameter) == 101
+    @test getdefault(else_out_sys.else_parameter) == 102
 
     @test nameof.(get_systems(if_out_sys)) == [:if_sys, :default_sys]
     @test nameof.(get_systems(elseif_out_sys)) == [:elseif_sys, :default_sys]


### PR DESCRIPTION
This fixes the bug in populating structure dict for defaults of conditional parameters

## Fixes:
```julia
julia> a = true; @mtkmodel A begin
                  @parameters begin
                      if a
                          b = 2, [description = "sjodf"]
                      end
                  end
              end
ERROR: LoadError: ArgumentError: invalid index: :b of type Symbol
```
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
~- [ ] All documentation related to code changes were updated~
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
~- [ ] Any new documentation only uses public API~
  
## Additional context

No doc changes are required.