### PR TITLE
Correct number of srcs in `complete`

### DIFF
--- a/src/bipartite_graph.jl
+++ b/src/bipartite_graph.jl
@@ -88,7 +88,7 @@ function Base.push!(m::Matching, v)
     end
 end
 
-function complete(m::Matching{U}, N = length(m.match)) where {U}
+function complete(m::Matching{U}, N = maximum((x for x in m.match if isa(x, Int)); init=0)) where {U}
     m.inv_match !== nothing && return m
     inv_match = Union{U, Int}[unassigned for _ in 1:N]
     for (i, eq) in enumerate(m.match)

--- a/src/structural_transformation/partial_state_selection.jl
+++ b/src/structural_transformation/partial_state_selection.jl
@@ -51,7 +51,7 @@ function pss_graph_modia!(structure::SystemStructure, maximal_top_matching, varl
         old_level_vars = ()
         ict = IncrementalCycleTracker(
             DiCMOBiGraph{true}(graph,
-                complete(Matching(ndsts(graph))));
+			       complete(Matching(ndsts(graph)), nsrcs(graph))),
             dir = :in)
 
         while level >= 0
@@ -124,7 +124,7 @@ function pss_graph_modia!(structure::SystemStructure, maximal_top_matching, varl
             level -= 1
         end
     end
-    return complete(var_eq_matching)
+    return complete(var_eq_matching, nsrcs(graph))
 end
 
 struct SelectedUnknown end


### PR DESCRIPTION
When constructing the inverse match, `complete` was allocating a vector with length of the forward match. This isn't quite the right number. What you want is to use the actual number of srcs (or failing that the maximum number that appears in the matching). In practice, this was mostly working out, because an overestimate is fine here and usually there are more variables than equations, but there don't have to be in all places where Matching is used. Fix that by defaulting `complete` to the maximum used src and explicitly passing the correct number of sources in a few places.