### PR TITLE
Enable specification of completeness on ODE/SDE/Nonlinear/Jump system creation (required for conversions from Catalyst's `ReactionSystem`s)

### DIFF
--- a/src/systems/diffeqs/odesystem.jl
+++ b/src/systems/diffeqs/odesystem.jl
@@ -192,7 +192,8 @@ function ODESystem(deqs::AbstractVector{<:Equation}, iv, dvs, ps;
         discrete_events = nothing,
         checks = true,
         metadata = nothing,
-        gui_metadata = nothing)
+        gui_metadata = nothing,
+        complete = false)
     name === nothing &&
         throw(ArgumentError("The `name` keyword must be provided. Please consider using the `@named` macro"))
     deqs = scalarize(deqs)
@@ -232,7 +233,8 @@ function ODESystem(deqs::AbstractVector{<:Equation}, iv, dvs, ps;
         deqs, iv′, dvs′, ps′, tspan, var_to_name, ctrl′, observed, tgrad, jac,
         ctrl_jac, Wfact, Wfact_t, name, systems, defaults, nothing,
         connector_type, preface, cont_callbacks, disc_callbacks,
-        metadata, gui_metadata, checks = checks)
+        metadata, gui_metadata, 
+        nothing, nothing, complete, checks = checks)
 end
 
 function ODESystem(eqs, iv; kwargs...)

--- a/src/systems/diffeqs/sdesystem.jl
+++ b/src/systems/diffeqs/sdesystem.jl
@@ -162,7 +162,8 @@ function SDESystem(deqs::AbstractVector{<:Equation}, neqs::AbstractArray, iv, dv
         continuous_events = nothing,
         discrete_events = nothing,
         metadata = nothing,
-        gui_metadata = nothing)
+        gui_metadata = nothing,
+        complete = false)
     name === nothing &&
         throw(ArgumentError("The `name` keyword must be provided. Please consider using the `@named` macro"))
     deqs = scalarize(deqs)
@@ -199,7 +200,7 @@ function SDESystem(deqs::AbstractVector{<:Equation}, neqs::AbstractArray, iv, dv
     SDESystem(Threads.atomic_add!(SYSTEM_COUNT, UInt(1)),
         deqs, neqs, iv′, dvs′, ps′, tspan, var_to_name, ctrl′, observed, tgrad, jac,
         ctrl_jac, Wfact, Wfact_t, name, systems, defaults, connector_type,
-        cont_callbacks, disc_callbacks, metadata, gui_metadata; checks = checks)
+        cont_callbacks, disc_callbacks, metadata, gui_metadata, complete; checks = checks)
 end
 
 function SDESystem(sys::ODESystem, neqs; kwargs...)

--- a/src/systems/jumps/jumpsystem.jl
+++ b/src/systems/jumps/jumpsystem.jl
@@ -141,6 +141,7 @@ function JumpSystem(eqs, iv, unknowns, ps;
         discrete_events = nothing,
         metadata = nothing,
         gui_metadata = nothing,
+        complete = false,
         kwargs...)
     name === nothing &&
         throw(ArgumentError("The `name` keyword must be provided. Please consider using the `@named` macro"))
@@ -181,7 +182,7 @@ function JumpSystem(eqs, iv, unknowns, ps;
     JumpSystem{typeof(ap)}(Threads.atomic_add!(SYSTEM_COUNT, UInt(1)),
         ap, value(iv), unknowns, ps, var_to_name, observed, name, systems,
         defaults, connector_type, disc_callbacks, metadata, gui_metadata,
-        checks = checks)
+        complete, checks = checks)
 end
 
 function generate_rate_function(js::JumpSystem, rate)

--- a/src/systems/nonlinear/nonlinearsystem.jl
+++ b/src/systems/nonlinear/nonlinearsystem.jl
@@ -96,6 +96,7 @@ struct NonlinearSystem <: AbstractTimeIndependentSystem
             u = __get_unit_type(unknowns, ps)
             check_units(u, eqs)
         end
+        
         new(tag, eqs, unknowns, ps, var_to_name, observed, jac, name, systems, defaults,
             connector_type, metadata, gui_metadata, tearing_state, substitutions, complete,
             index_cache, parent)
@@ -114,7 +115,8 @@ function NonlinearSystem(eqs, unknowns, ps;
         discrete_events = nothing,   # this argument is only required for ODESystems, but is added here for the constructor to accept it without error
         checks = true,
         metadata = nothing,
-        gui_metadata = nothing)
+        gui_metadata = nothing,
+        complete = false)
     continuous_events === nothing || isempty(continuous_events) ||
         throw(ArgumentError("NonlinearSystem does not accept `continuous_events`, you provided $continuous_events"))
     discrete_events === nothing || isempty(discrete_events) ||
@@ -151,7 +153,8 @@ function NonlinearSystem(eqs, unknowns, ps;
 
     NonlinearSystem(Threads.atomic_add!(SYSTEM_COUNT, UInt(1)),
         eqs, unknowns, ps, var_to_name, observed, jac, name, systems, defaults,
-        connector_type, metadata, gui_metadata, checks = checks)
+        connector_type, metadata, gui_metadata, 
+        nothing, nothing, complete, checks = checks)
 end
 
 function calculate_jacobian(sys::NonlinearSystem; sparse = false, simplify = false)


### PR DESCRIPTION
With MTK v9, systems must be complete when used to create e.g. `ODEProblem`. Catalyst creates `ReactionSystem`, which can be converted to e.g. `ODE`/`SDE`/`Nonlinear`/`Jump` `System`s (which are done internally when `ReactionSystem`s are used as input to e.g. `ODEProblem`s).

Here, if a `ReactionSystem` is marked as `complete`, the `ODESystem`s (and other systems) created from it should also be complete. Currently, it is not possible to set a `ODESystem` as `complete` on creation (using the internal stuff). This PR adds keyword arguments to set `complete = true` (`false` default) for  `ODE`/`SDE`/`Nonlinear`/`Jump` `System`s (which Catalyst can use).

E.g. currently we have
```julia
using Catalyst
rs = @reaction_network begin
    (kp,kd), 0 <--> X
    (k1,k2), X <--> Y
end
rs = complete(rs)
ModelingToolkit.iscomplete(rs)  # true

osys = convert(ODESystem, rs)
ssys = convert(SDESystem, rs)
nsys = convert(NonlinearSystem, rs)
jsys = convert(JumpSystem, rs)

ModelingToolkit.iscomplete(osys) # false
ModelingToolkit.iscomplete(ssys) # false
ModelingToolkit.iscomplete(nsys) # false
ModelingToolkit.iscomplete(jsys) # false
```
This allows me to add an argument:
```julia
function Base.convert(::Type{<:ODESystem}, rs::ReactionSystem; ...)
     ....
    return ODESystem(...,
              complete = ModelingToolkit.iscomplete(rs),
              ...)
end
```
which is used in `convert(ODESystem, rs)`. This turns things to
```julia
ModelingToolkit.iscomplete(osys) # true
ModelingToolkit.iscomplete(ssys) # true
ModelingToolkit.iscomplete(nsys) # true
ModelingToolkit.iscomplete(jsys) # true
end