### PR TITLE
Parse constants in `@mtkmodel`

### DIFF
--- a/docs/src/basics/ContextualVariables.md
+++ b/docs/src/basics/ContextualVariables.md
@@ -20,7 +20,7 @@ All modeling projects have some form of parameters. `@parameters` marks a variab
 as being the parameter of some system, which allows automatic detection algorithms
 to ignore such variables when attempting to find the unknowns of a system.
 
-## Constants
+## [Constants](@id constants)
 
 Constants, defined by e.g. `@constants myconst1` are like parameters that:
 

--- a/docs/src/basics/MTKModel_Connector.md
+++ b/docs/src/basics/MTKModel_Connector.md
@@ -24,6 +24,7 @@ equations.
 `@mtkmodel` definition contains begin blocks of
 
   - `@components`: for listing sub-components of the system
+  - `@constants`: for declaring constants
   - `@equations`: for the list of equations
   - `@extend`: for extending a base system and unpacking its unknowns
   - `@icon` : for embedding the model icon
@@ -52,6 +53,9 @@ end
 
 @mtkmodel ModelC begin
     @icon "https://github.com/SciML/SciMLDocs/blob/main/docs/src/assets/logo.png"
+    @constants begin
+        c::Int = 1, [description = "Example constant."]
+    end
     @structural_parameters begin
         f = sin
     end
@@ -106,6 +110,12 @@ end
 
   - This block is for non symbolic input arguments. These are for inputs that usually are not meant to be part of components; but influence how they are defined. One can list inputs like boolean flags, functions etc... here.
   - Whenever default values are specified, unlike parameters/variables, they are reflected in the keyword argument list.
+
+#### `@constants` begin block
+
+  - Declare constants in the model definition.
+  - The values of these can't be changed by the user.
+  - This works similar to symbolic constants described [here](@ref constants)
 
 #### `@parameters` and `@variables` begin block
 
@@ -220,7 +230,8 @@ end
 
 `structure` stores metadata that describes composition of a model. It includes:
 
-  - `:components`: List of sub-components in the form of [[name, sub_component_name],...].
+  - `:components`: The list of sub-components in the form of [[name, sub_component_name],...].
+  - `:constants`: Dictionary of constants mapped to its metadata.
   - `:extend`: The list of extended unknowns, name given to the base system, and name of the base system.
   - `:structural_parameters`: Dictionary of structural parameters mapped to their metadata.
   - `:parameters`: Dictionary of symbolic parameters mapped to their metadata. For
@@ -239,6 +250,7 @@ Dict{Symbol, Any} with 9 entries:
   :components            => Any[Union{Expr, Symbol}[:model_a, :ModelA]]
   :variables             => Dict{Symbol, Dict{Symbol, Any}}(:v=>Dict(:default=>:v_var, :type=>Real), :v_array=>Dict(:type=>Real, :size=>(2, 3)))
   :icon                  => URI("https://github.com/SciML/SciMLDocs/blob/main/docs/src/assets/logo.png")
+  :constants             => Dict{Symbol, Dict}(:c=>Dict{Symbol, Any}(:value=>1, :type=>Int64, :description=>"Example constant."))
   :kwargs                => Dict{Symbol, Dict}(:f=>Dict(:value=>:sin), :v=>Dict{Symbol, Union{Nothing, Symbol}}(:value=>:v_var, :type=>Real), :v_array=>Dict(:value=>nothing, :type=>Real), :p1=>Dict(:value=>nothing))
   :structural_parameters => Dict{Symbol, Dict}(:f=>Dict(:value=>:sin))
   :independent_variable  => t

--- a/test/precompile_test/ModelParsingPrecompile.jl
+++ b/test/precompile_test/ModelParsingPrecompile.jl
@@ -3,8 +3,11 @@ module ModelParsingPrecompile
 using ModelingToolkit, Unitful
 
 @mtkmodel ModelWithComponentArray begin
+    @constants begin
+        k = 1, [description = "Default val of R"]
+    end
     @parameters begin
-        R(t)[1:3] = 1, [description = "Parameter array", unit = u"Ω"]
+        r(t)[1:3] = k, [description = "Parameter array", unit = u"Ω"]
     end
 end
 


### PR DESCRIPTION
Allows `@constants` in the `@mtkmodel`; this works similar to the `@constants`; and in addition, a type check is added to the assigned value.

Closes #2362 

## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
 
