### PR TITLE
Provision to enforce types in parameters, variables and structural_parameters in `@mtkmodel`

### DIFF
--- a/docs/src/basics/MTKModel_Connector.md
+++ b/docs/src/basics/MTKModel_Connector.md
@@ -220,7 +220,7 @@ end
 ```
 
 !!! note
-
+    
     For more examples of usage, checkout [ModelingToolkitStandardLibrary.jl](https://github.com/SciML/ModelingToolkitStandardLibrary.jl/)
 
 ## More on `Model.structure`
@@ -229,7 +229,7 @@ end
 
   - `:components`: List of sub-components in the form of [[name, sub_component_name],...].
   - `:extend`: The list of extended unknowns, name given to the base system, and name of the base system.
-  - `:structural_parameters`: Dictionary of structural parameters mapped to their default values.
+  - `:structural_parameters`: Dictionary of structural parameters mapped to their metadata.
   - `:parameters`: Dictionary of symbolic parameters mapped to their metadata. For
     parameter arrays, length is added to the metadata as `:size`.
   - `:variables`: Dictionary of symbolic variables mapped to their metadata. For
@@ -243,13 +243,14 @@ For example, the structure of `ModelC` is:
 ```julia
 julia> ModelC.structure
 Dict{Symbol, Any} with 7 entries:
-  :components           => [[:model_a, :ModelA]]
-  :variables            => Dict{Symbol, Dict{Symbol, Any}}(:v=>Dict(:default=>:v_var), :v_array=>Dict(:size=>(2, 3)))
-  :icon                 => URI("https://github.com/SciML/SciMLDocs/blob/main/docs/src/assets/logo.png")
-  :kwargs               => Dict{Symbol, Dict}(:f=>Dict(:value=>:sin), :v=>Dict{Symbol, Union{Nothing, Symbol}}(:value=>:v_var, :type=>nothing), :v_array=>Dict(:value=>nothing, :type=>nothing), :p1=>Dict(:value=>nothing))
-  :independent_variable => t
-  :extend               => Any[[:p2, :p1], Symbol("#mtkmodel__anonymous__ModelB"), :ModelB]
-  :equations            => ["model_a.k ~ f(v)"]
+  :components            => [[:model_a, :ModelA]]
+  :variables             => Dict{Symbol, Dict{Symbol, Any}}(:v=>Dict(:default=>:v_var), :v_array=>Dict(:size=>(2, 3)))
+  :icon                  => URI("https://github.com/SciML/SciMLDocs/blob/main/docs/src/assets/logo.png")
+  :kwargs                => Dict{Symbol, Dict}(:f=>Dict(:value=>:sin), :v=>Dict{Symbol, Union{Nothing, Symbol}}(:value=>:v_var, :type=>nothing), :v_array=>Dict(:value=>nothing, :type=>nothing), :p1=>Dict(:value=>nothing))
+  :structural_parameters => Dict{Symbol, Dict}(:f=>Dict(:value=>:sin))
+  :independent_variable  => t
+  :extend                => Any[[:p2, :p1], Symbol("#mtkmodel__anonymous__ModelB"), :ModelB]
+  :equations             => ["model_a.k ~ f(v)"]
 ```
 
 ### Using conditional statements
@@ -322,11 +323,12 @@ The conditional parts are reflected in the `structure`. For `BranchOutsideTheBlo
 ```julia
 julia> BranchOutsideTheBlock.structure
 Dict{Symbol, Any} with 5 entries:
-  :components           => Any[(:if, :flag, [[:sys1, :C]], Any[])]
-  :kwargs               => Dict{Symbol, Dict}(:flag=>Dict{Symbol, Bool}(:value=>1))
-  :independent_variable => t
-  :parameters           => Dict{Symbol, Dict{Symbol, Any}}(:a1=>Dict(:condition=>(:if, :flag, Dict{Symbol, Any}(:kwargs => Dict{Any, Any}(:a1 => nothing), :parameters => Any[Dict{Symbol, Dict{Symbol, Any}}(:a1 => Dict())]), Dict{Symbol, Any}(:kwargs => Dict{Any, Any}(:a2 => nothing), :parameters => Any[Dict{Symbol, Dict{Symbol, Any}}(:a2 => Dict())]))
-  :equations            => Any[(:if, :flag, ["a1 ~ 0"], ["a2 ~ 0"])]
+  :components            => Any[(:if, :flag, [[:sys1, :C]], Any[])]
+  :kwargs                => Dict{Symbol, Dict}(:flag=>Dict{Symbol, Bool}(:value=>1))
+  :structural_parameters => Dict{Symbol, Dict}(:flag=>Dict{Symbol, Bool}(:value=>1))
+  :independent_variable  => t
+  :parameters            => Dict{Symbol, Dict{Symbol, Any}}(:a1=>Dict(:condition=>(:if, :flag, Dict{Symbol, Any}(:kwargs => Dict{Any, Any}(:a1 => nothing), :parameters => Any[Dict{Symbol, Dict{Symbol, Any}}(:a1 => Dict())]), Dict{Symbol, Any}(:kwargs => Dict{Any, Any}(:a2 => nothing), :parameters => Any[Dict{Symbol, Dict{Symbol, Any}}(:a2 => Dict())]))
+  :equations             => Any[(:if, :flag, ["a1 ~ 0"], ["a2 ~ 0"])]
 ```
 
 Conditional entries are entered in the format of `(branch, condition, [case when it is true], [case when it is false])`;

--- a/docs/src/basics/MTKModel_Connector.md
+++ b/docs/src/basics/MTKModel_Connector.md
@@ -220,7 +220,7 @@ end
 ```
 
 !!! note
-    
+
     For more examples of usage, checkout [ModelingToolkitStandardLibrary.jl](https://github.com/SciML/ModelingToolkitStandardLibrary.jl/)
 
 ## More on `Model.structure`
@@ -234,7 +234,7 @@ end
     parameter arrays, length is added to the metadata as `:size`.
   - `:variables`: Dictionary of symbolic variables mapped to their metadata. For
     variable arrays, length is added to the metadata as `:size`.
-  - `:kwargs`: Dictionary of keyword arguments mapped to their default values.
+  - `:kwargs`: Dictionary of keyword arguments mapped to their metadata.
   - `:independent_variable`: Independent variable, which is added while generating the Model.
   - `:equations`: List of equations (represented as strings).
 
@@ -246,7 +246,7 @@ Dict{Symbol, Any} with 7 entries:
   :components           => [[:model_a, :ModelA]]
   :variables            => Dict{Symbol, Dict{Symbol, Any}}(:v=>Dict(:default=>:v_var), :v_array=>Dict(:size=>(2, 3)))
   :icon                 => URI("https://github.com/SciML/SciMLDocs/blob/main/docs/src/assets/logo.png")
-  :kwargs               => Dict{Symbol, Any}(:f=>:sin, :v=>:v_var, :v_array=>nothing, :model_a__k_array=>nothing, :p1=>nothing)
+  :kwargs               => Dict{Symbol, Dict}(:f=>Dict(:value=>:sin), :v=>Dict{Symbol, Union{Nothing, Symbol}}(:value=>:v_var, :type=>nothing), :v_array=>Dict(:value=>nothing, :type=>nothing), :p1=>Dict(:value=>nothing))
   :independent_variable => t
   :extend               => Any[[:p2, :p1], Symbol("#mtkmodel__anonymous__ModelB"), :ModelB]
   :equations            => ["model_a.k ~ f(v)"]
@@ -323,7 +323,7 @@ The conditional parts are reflected in the `structure`. For `BranchOutsideTheBlo
 julia> BranchOutsideTheBlock.structure
 Dict{Symbol, Any} with 5 entries:
   :components           => Any[(:if, :flag, [[:sys1, :C]], Any[])]
-  :kwargs               => Dict{Symbol, Any}(:flag=>true)
+  :kwargs               => Dict{Symbol, Dict}(:flag=>Dict{Symbol, Bool}(:value=>1))
   :independent_variable => t
   :parameters           => Dict{Symbol, Dict{Symbol, Any}}(:a1=>Dict(:condition=>(:if, :flag, Dict{Symbol, Any}(:kwargs => Dict{Any, Any}(:a1 => nothing), :parameters => Any[Dict{Symbol, Dict{Symbol, Any}}(:a1 => Dict())]), Dict{Symbol, Any}(:kwargs => Dict{Any, Any}(:a2 => nothing), :parameters => Any[Dict{Symbol, Dict{Symbol, Any}}(:a2 => Dict())]))
   :equations            => Any[(:if, :flag, ["a1 ~ 0"], ["a2 ~ 0"])]

--- a/src/systems/model_parsing.jl
+++ b/src/systems/model_parsing.jl
@@ -37,6 +37,7 @@ function _model_macro(mod, name, expr, isconnector)
     exprs = Expr(:block)
     dict = Dict{Symbol, Any}(
         :kwargs => Dict{Symbol, Dict}(),
+        :structural_parameters => Dict{Symbol, Dict}()
     )
     comps = Symbol[]
     ext = Ref{Any}(nothing)
@@ -332,17 +333,18 @@ function parse_structural_parameters!(exprs, sps, dict, mod, body, kwargs)
                 b = _type_check!(Core.eval(mod, b), a, type)
                 push!(sps, a)
                 push!(kwargs, Expr(:kw, Expr(:(::), a, type), b))
-                dict[:kwargs][a] = Dict(:value => b, :type => type)
+                dict[:structural_parameters][a] = dict[:kwargs][a] = Dict(
+                    :value => b, :type => type)
             end
             Expr(:(=), a, b) => begin
                 push!(sps, a)
                 push!(kwargs, Expr(:kw, a, b))
-                dict[:kwargs][a] = Dict(:value => b)
+                dict[:structural_parameters][a] = dict[:kwargs][a] = Dict(:value => b)
             end
             a => begin
                 push!(sps, a)
                 push!(kwargs, a)
-                dict[:kwargs][a] = Dict(:value => nothing)
+                dict[:structural_parameters][a] = dict[:kwargs][a] = Dict(:value => nothing)
             end
         end
     end


### PR DESCRIPTION
Closes #2491 

Check that specified default for a variable is of specified type.
Add types to corresponding keyword arg.

While here, fix the missing metadata of structural_parameters in model-structure.

## Checklist

- [x] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

Note that `@variables t k(t)::Int = 1.5` works just fine. So here, `@mtkmodel` enforces its own checks for defaults and restricts users providing incorrect input by adding types to the keyword argument.