### PR TITLE
feat: add `SolverStepClock`

### DIFF
--- a/src/clock.jl
+++ b/src/clock.jl
@@ -124,3 +124,26 @@ function Base.:(==)(c1::Clock, c2::Clock)
 end
 
 is_concrete_time_domain(x) = x isa Union{AbstractClock, Continuous}
+
+"""
+    SolverStepClock <: AbstractClock
+    SolverStepClock()
+    SolverStepClock(t)
+
+A clock that ticks at each solver step (sometimes referred to as "continuous sample time"). This clock **does generally not have equidistant tick intervals**, instead, the tick interval depends on the adaptive step-size slection of the continuous solver, as well as any continuous event handling. If adaptivity of the solver is turned off and there are no continuous events, the tick interval will be given by the fixed solver time step `dt`. 
+
+Due to possibly non-equidistant tick intervals, this clock should typically not be used with discrete-time systems that assume a fixed sample time, such as PID controllers and digital filters.
+"""
+struct SolverStepClock <: AbstractClock
+    "Independent variable"
+    t::Union{Nothing, Symbolic}
+    "Period"
+    SolverStepClock(t::Union{Num, Symbolic}) = new(value(t))
+end
+SolverStepClock() = SolverStepClock(nothing)
+
+sampletime(c) = nothing
+Base.hash(c::SolverStepClock, seed::UInt) = seed ⊻ 0x953d7b9a18874b91
+function Base.:(==)(c1::SolverStepClock, c2::SolverStepClock)
+    ((c1.t === nothing || c2.t === nothing) || isequal(c1.t, c2.t))
+end

--- a/src/systems/diffeqs/abstractodesystem.jl
+++ b/src/systems/diffeqs/abstractodesystem.jl
@@ -1053,6 +1053,10 @@ function DiffEqBase.ODEProblem{iip, specialize}(sys::AbstractODESystem, u0map = 
         discrete_cbs = map(affects, clocks, svs) do affect, clock, sv
             if clock isa Clock
                 PeriodicCallback(DiscreteSaveAffect(affect, sv), clock.dt)
+            elseif clock isa SolverStepClock
+                affect = DiscreteSaveAffect(affect, sv)
+                DiscreteCallback(Returns(true), affect,
+                    initialize = (c, u, t, integrator) -> affect(integrator))
             else
                 error("$clock is not a supported clock type.")
             end

--- a/test/clock.jl
+++ b/test/clock.jl
@@ -481,6 +481,7 @@ end
 ## Test continuous clock
 
 c = ModelingToolkit.SolverStepClock(t)
+k = ShiftIndex(c)
 
 @mtkmodel CounterSys begin
     @variables begin


### PR DESCRIPTION
A ContinuousClock ticks at every solver step

## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

This allows using discrete-time systems that are triggered at each solver step, useful to model discrete stateful behavior attached to continuous events.
