### PR TITLE
fix: avoid scalarizing params in structural_simplify, variable defaults in get_u0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
         #
         # julia  -e 'using Pkg; Pkg.add(PackageSpec(name="JuliaFormatter", version="0.13.0"))'
         run: |
-          julia  -e 'using Pkg; Pkg.add(PackageSpec(name="JuliaFormatter"))'
+          julia  -e 'using Pkg; Pkg.add(PackageSpec(name="JuliaFormatter", version="1.0.50"))'
           julia  -e 'using JuliaFormatter; format(".", verbose=true)'
       - name: Format check
         run: |

--- a/src/clock.jl
+++ b/src/clock.jl
@@ -142,7 +142,6 @@ struct SolverStepClock <: AbstractClock
 end
 SolverStepClock() = SolverStepClock(nothing)
 
-sampletime(c) = nothing
 Base.hash(c::SolverStepClock, seed::UInt) = seed ⊻ 0x953d7b9a18874b91
 function Base.:(==)(c1::SolverStepClock, c2::SolverStepClock)
     ((c1.t === nothing || c2.t === nothing) || isequal(c1.t, c2.t))

--- a/src/systems/abstractsystem.jl
+++ b/src/systems/abstractsystem.jl
@@ -207,7 +207,7 @@ function wrap_array_vars(sys::AbstractSystem, exprs; dvs = unknowns(sys))
     for (j, x) in enumerate(dvs)
         if istree(x) && operation(x) == getindex
             arg = arguments(x)[1]
-            arg in allvars || continue
+            any(isequal(arg), allvars) || continue
             inds = get!(() -> Int[], array_vars, arg)
             push!(inds, j)
         end

--- a/src/systems/diffeqs/abstractodesystem.jl
+++ b/src/systems/diffeqs/abstractodesystem.jl
@@ -820,19 +820,6 @@ function get_u0(sys, u0map, parammap = nothing; symbolic_u0 = false)
         defs = mergedefaults(defs, parammap, ps)
     end
     defs = mergedefaults(defs, u0map, dvs)
-    for (k, v) in defs
-        if Symbolics.isarraysymbolic(k) &&
-           Symbolics.shape(unwrap(k)) !== Symbolics.Unknown()
-            ks = scalarize(k)
-            length(ks) == length(v) || error("$k has default value $v with unmatched size")
-            for (kk, vv) in zip(ks, v)
-                if !haskey(defs, kk)
-                    defs[kk] = vv
-                end
-            end
-        end
-    end
-
     if symbolic_u0
         u0 = varmap_to_vars(u0map, dvs; defaults = defs, tofloat = false, use_union = false)
     else

--- a/src/systems/systemstructure.jl
+++ b/src/systems/systemstructure.jl
@@ -285,6 +285,12 @@ function TearingState(sys; quick_cancel = false, check = true)
         end
         vars!(vars, eq.rhs, op = Symbolics.Operator)
         for v in vars
+            _var, _ = var_from_nested_derivative(v)
+            any(isequal(_var), ivs) && continue
+            if isparameter(_var) ||
+               (istree(_var) && isparameter(operation(_var)) || isconstant(_var))
+                continue
+            end
             v = scalarize(v)
             if v isa AbstractArray
                 v = setmetadata.(v, VariableIrreducible, true)

--- a/test/initial_values.jl
+++ b/test/initial_values.jl
@@ -1,0 +1,35 @@
+using ModelingToolkit
+using ModelingToolkit: t_nounits as t, D_nounits as D, get_u0
+using SymbolicIndexingInterface: getu
+
+@variables x(t)[1:3]=[1.0, 2.0, 3.0] y(t) z(t)[1:2]
+
+@mtkbuild sys=ODESystem([D(x) ~ t * x], t) simplify=false
+@test get_u0(sys, [])[1] == [1.0, 2.0, 3.0]
+@test get_u0(sys, [x => [2.0, 3.0, 4.0]])[1] == [2.0, 3.0, 4.0]
+@test get_u0(sys, [x[1] => 2.0, x[2] => 3.0, x[3] => 4.0])[1] == [2.0, 3.0, 4.0]
+@test get_u0(sys, [2.0, 3.0, 4.0])[1] == [2.0, 3.0, 4.0]
+
+@mtkbuild sys=ODESystem([
+        D(x) ~ 3x,
+        D(y) ~ t,
+        D(z[1]) ~ z[2] + t,
+        D(z[2]) ~ y + z[1]
+    ], t) simplify=false
+
+@test_throws ModelingToolkit.MissingVariablesError get_u0(sys, [])
+getter = getu(sys, [x..., y, z...])
+@test getter(get_u0(sys, [y => 4.0, z => [5.0, 6.0]])[1]) == collect(1.0:6.0)
+@test getter(get_u0(sys, [y => 4.0, z => [3y, 4y]])[1]) == [1.0, 2.0, 3.0, 4.0, 12.0, 16.0]
+@test getter(get_u0(sys, [y => 3.0, z[1] => 3y, z[2] => 2x[1]])[1]) ==
+      [1.0, 2.0, 3.0, 3.0, 9.0, 2.0]
+
+@variables w(t)
+@parameters p1 p2
+
+@test getter(get_u0(sys, [y => 2p1, z => [3y, 2p2]], [p1 => 5.0, p2 => 6.0])[1]) ==
+      [1.0, 2.0, 3.0, 10.0, 30.0, 12.0]
+@test_throws Any getter(get_u0(sys, [y => 2w, w => 3.0, z[1] => 2p1, z[2] => 3p2]))
+@test getter(get_u0(
+    sys, [y => 2w, w => 3.0, z[1] => 2p1, z[2] => 3p2], [p1 => 3.0, p2 => 4.0])[1]) ==
+      [1.0, 2.0, 3.0, 6.0, 6.0, 12.0]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,5 @@
 using SafeTestsets, Pkg, Test
 
-#=
 const GROUP = get(ENV, "GROUP", "All")
 
 function activate_extensions_env()
@@ -67,6 +66,7 @@ end
             @safetestset "Constants Test" include("constants.jl")
             @safetestset "Parameter Dependency Test" include("parameter_dependencies.jl")
             @safetestset "Generate Custom Function Test" include("generate_custom_function.jl")
+            @safetestset "Initial Values Test" include("initial_values.jl")
         end
     end
 
@@ -92,7 +92,5 @@ end
         @safetestset "BifurcationKit Extension Test" include("extensions/bifurcationkit.jl")
     end
 end
-
-=#
 
 @safetestset "Model Parsing Test" include("model_parsing.jl")


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
