### PR TITLE
Add `getindex`/`setindex!` methods for `MTKParameters` with `ParameterIndex`

### DIFF
--- a/src/systems/parameter_buffer.jl
+++ b/src/systems/parameter_buffer.jl
@@ -362,12 +362,12 @@ function Base.setindex!(p::MTKParameters, val, i)
 end
 
 function Base.getindex(p::MTKParameters, pind::ParameterIndex)
-    (;portion, idx) = pind
+    (; portion, idx) = pind
     i, j, k... = idx
     if isempty(k)
         indexer = (v) -> v[i][j]
     else
-        indexer = (v) -> v[i][j][k...] 
+        indexer = (v) -> v[i][j][k...]
     end
     if portion isa SciMLStructures.Tunable
         indexer(p.tunable)

--- a/src/systems/parameter_buffer.jl
+++ b/src/systems/parameter_buffer.jl
@@ -361,6 +361,41 @@ function Base.setindex!(p::MTKParameters, val, i)
     end
 end
 
+function Base.getindex(p::MTKParameters, pind::ParameterIndex)
+    (;portion, idx) = pind, (i,j) = idx
+    if portion isa SciMLStructures.Tunable
+        p.tunable[i][j]
+    elseif portion isa SciMLStructures.Discrete
+        p.discrete[i][j]
+    elseif portion isa SciMLStructures.Constants
+        p.constant[i][j]
+    elseif portion === DEPENDENT_PORTION
+        p.dependent[i][j]
+    elseif portion === NONNUMERIC_PORTION
+        p.nonnumeric[i][j]
+    else
+        error("Unhandled portion $portion")
+    end
+end
+
+function Base.setindex!(p::MTKParameters, val, pind::ParameterIndex)
+    (;portion, idx) = pind
+    (i,j) = idx
+    if portion isa SciMLStructures.Tunable
+        p.tunable[i][j] = val
+    elseif portion isa SciMLStructures.Discrete
+        p.discrete[i][j] = val
+    elseif portion isa SciMLStructures.Constants
+        p.constant[i][j] = val
+    elseif portion === DEPENDENT_PORTION
+        p.dependent[i][j] = val
+    elseif portion === NONNUMERIC_PORTION
+        p.nonnumeric[i][j] = val
+    else
+        error("Unhandled portion $portion")
+    end
+end
+
 function Base.iterate(buf::MTKParameters, state = 1)
     total_len = 0
     total_len += _num_subarrays(buf.tunable)

--- a/src/systems/parameter_buffer.jl
+++ b/src/systems/parameter_buffer.jl
@@ -385,26 +385,7 @@ function Base.getindex(p::MTKParameters, pind::ParameterIndex)
 end
 
 function Base.setindex!(p::MTKParameters, val, pind::ParameterIndex)
-    (;portion, idx) = pind
-    i, j, k... = idx
-    if isempty(k)
-        setindexer = (v) -> v[i][j] = val
-    else
-        setindexer = (v) -> v[i][j][k...] = val 
-    end
-    if portion isa SciMLStructures.Tunable
-        setindexer(p.tunable)
-    elseif portion isa SciMLStructures.Discrete
-        setindexer(p.discrete)
-    elseif portion isa SciMLStructures.Constants
-        setindexer(p.constant)
-    elseif portion === DEPENDENT_PORTION
-        setindexer(p.dependent)
-    elseif portion === NONNUMERIC_PORTION
-        setindexer(p.nonnumeric)
-    else
-        error("Unhandled portion", portion)
-    end
+    SymbolicIndexingInterface.set_parameter!(p, val, pind)
 end
 
 function Base.iterate(buf::MTKParameters, state = 1)

--- a/src/systems/parameter_buffer.jl
+++ b/src/systems/parameter_buffer.jl
@@ -362,37 +362,50 @@ function Base.setindex!(p::MTKParameters, val, i)
 end
 
 function Base.getindex(p::MTKParameters, pind::ParameterIndex)
-    (;portion, idx) = pind, (i,j) = idx
-    if portion isa SciMLStructures.Tunable
-        p.tunable[i][j]
-    elseif portion isa SciMLStructures.Discrete
-        p.discrete[i][j]
-    elseif portion isa SciMLStructures.Constants
-        p.constant[i][j]
-    elseif portion === DEPENDENT_PORTION
-        p.dependent[i][j]
-    elseif portion === NONNUMERIC_PORTION
-        p.nonnumeric[i][j]
+    (;portion, idx) = pind
+    if length(idx) > 2
+        i, j, k... = idx
+        indexer = (v) -> v[i][j][k...] 
     else
-        error("Unhandled portion $portion")
+        i, j = idx
+        indexer = (v) -> v[i][j]
+    end
+    if portion isa SciMLStructures.Tunable
+        indexer(p.tunable)
+    elseif portion isa SciMLStructures.Discrete
+        indexer(p.discrete)
+    elseif portion isa SciMLStructures.Constants
+        indexer(p.constant)
+    elseif portion === DEPENDENT_PORTION
+        indexer(p.dependent)
+    elseif portion === NONNUMERIC_PORTION
+        indexer(p.nonnumeric)
+    else
+        error("Unhandled portion ", portion)
     end
 end
 
 function Base.setindex!(p::MTKParameters, val, pind::ParameterIndex)
     (;portion, idx) = pind
-    (i,j) = idx
-    if portion isa SciMLStructures.Tunable
-        p.tunable[i][j] = val
-    elseif portion isa SciMLStructures.Discrete
-        p.discrete[i][j] = val
-    elseif portion isa SciMLStructures.Constants
-        p.constant[i][j] = val
-    elseif portion === DEPENDENT_PORTION
-        p.dependent[i][j] = val
-    elseif portion === NONNUMERIC_PORTION
-        p.nonnumeric[i][j] = val
+    if length(idx) > 2
+        i, j, k... = idx
+        setindexer = (v) -> v[i][j][k...] = val
     else
-        error("Unhandled portion $portion")
+        i, j = idx
+        setindexer = (v) -> v[i][j] = val
+    end
+    if portion isa SciMLStructures.Tunable
+        setindexer(p.tunable)
+    elseif portion isa SciMLStructures.Discrete
+        setindexer(p.discrete)
+    elseif portion isa SciMLStructures.Constants
+        setindexer(p.constant)
+    elseif portion === DEPENDENT_PORTION
+        setindexer(p.dependent)
+    elseif portion === NONNUMERIC_PORTION
+        setindexer(p.nonnumeric)
+    else
+        error("Unhandled portion", portion)
     end
 end
 

--- a/src/systems/parameter_buffer.jl
+++ b/src/systems/parameter_buffer.jl
@@ -363,12 +363,11 @@ end
 
 function Base.getindex(p::MTKParameters, pind::ParameterIndex)
     (;portion, idx) = pind
-    if length(idx) > 2
-        i, j, k... = idx
-        indexer = (v) -> v[i][j][k...] 
-    else
-        i, j = idx
+    i, j, k... = idx
+    if isempty(k)
         indexer = (v) -> v[i][j]
+    else
+        indexer = (v) -> v[i][j][k...] 
     end
     if portion isa SciMLStructures.Tunable
         indexer(p.tunable)
@@ -387,12 +386,11 @@ end
 
 function Base.setindex!(p::MTKParameters, val, pind::ParameterIndex)
     (;portion, idx) = pind
-    if length(idx) > 2
-        i, j, k... = idx
-        setindexer = (v) -> v[i][j][k...] = val
-    else
-        i, j = idx
+    i, j, k... = idx
+    if isempty(k)
         setindexer = (v) -> v[i][j] = val
+    else
+        setindexer = (v) -> v[i][j][k...] = val 
     end
     if portion isa SciMLStructures.Tunable
         setindexer(p.tunable)

--- a/test/split_parameters.jl
+++ b/test/split_parameters.jl
@@ -2,6 +2,8 @@ using ModelingToolkit, Test
 using ModelingToolkitStandardLibrary.Blocks
 using OrdinaryDiffEq
 using ModelingToolkit: t_nounits as t, D_nounits as D
+using ModelingToolkit: MTKParameters, ParameterIndex, DEPENDENT_PORTION, NONNUMERIC_PORTION
+using SciMLStructures: Tunable, Discrete, Constants
 
 x = [1, 2.0, false, [1, 2, 3], Parameter(1.0)]
 
@@ -189,3 +191,27 @@ connections = [[state_feedback.input.u[i] ~ model_outputs[i] for i in 1:4]
                connect(add.output, :u, model.torque.tau)]
 @named closed_loop = ODESystem(connections, t, systems = [model, state_feedback, add, d])
 S = get_sensitivity(closed_loop, :u)
+
+
+@testset "Indexing MTKParameters with ParameterIndex" begin
+    ps = MTKParameters(([1.0, 2.0], [3, 4]),
+        ([true, false], [[1 2; 3 4]]),
+        ([5, 6],),
+        ([7.0, 8.0],),
+        (["hi", "bye"], [:lie, :die]),
+        nothing,
+        nothing)
+    @test ps[ParameterIndex(Tunable(), (1, 2))] === 2.0
+    @test ps[ParameterIndex(Tunable(), (2, 2))] === 4
+    @test ps[ParameterIndex(Discrete(), (2, 1, 2, 2))] === 4
+    @test ps[ParameterIndex(Discrete(), (2, 1))] == [1 2; 3 4]
+    @test ps[ParameterIndex(Constants(), (1, 1))] === 5
+    @test ps[ParameterIndex(DEPENDENT_PORTION, (1, 1))] === 7.0
+    @test ps[ParameterIndex(NONNUMERIC_PORTION, (2, 2))] === :die
+
+    ps[ParameterIndex(Tunable(), (1, 2))] = 3.0
+    ps[ParameterIndex(Discrete(), (2, 1, 2, 2))] = 5
+    @test ps[ParameterIndex(Tunable(), (1, 2))] === 3.0
+    @test ps[ParameterIndex(Discrete(), (2, 1, 2, 2))] === 5
+end
+

--- a/test/split_parameters.jl
+++ b/test/split_parameters.jl
@@ -192,7 +192,6 @@ connections = [[state_feedback.input.u[i] ~ model_outputs[i] for i in 1:4]
 @named closed_loop = ODESystem(connections, t, systems = [model, state_feedback, add, d])
 S = get_sensitivity(closed_loop, :u)
 
-
 @testset "Indexing MTKParameters with ParameterIndex" begin
     ps = MTKParameters(([1.0, 2.0], [3, 4]),
         ([true, false], [[1 2; 3 4]]),
@@ -214,4 +213,3 @@ S = get_sensitivity(closed_loop, :u)
     @test ps[ParameterIndex(Tunable(), (1, 2))] === 3.0
     @test ps[ParameterIndex(Discrete(), (2, 1, 2, 2))] === 5
 end
-


### PR DESCRIPTION
Without this method, we hit the generic methods for `MTKParameters` which assumes `ParameterIndex` is an integer

## Checklist

- [x] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context