### PR TITLE
Fix `_varmap_to_vars`, re-enable dde.jl test

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -115,6 +115,7 @@ AmplNLWriter = "7c4d4715-977e-5154-bfe0-e096adeac482"
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 ControlSystemsBase = "aaaaaaaa-a6ca-5380-bf3e-84a91bcd477e"
 DeepDiffs = "ab62b9b5-e342-54a8-a765-a90f495de1a6"
+DelayDiffEq = "bcd4f6db-9728-5f36-b5f7-82caef46ccdb"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 Ipopt = "b6b21f68-93f8-5de0-b562-5493be1d77c9"
 Ipopt_jll = "9cc047cb-c261-5740-88fc-0cf96f7bdcc7"
@@ -136,4 +137,4 @@ Sundials = "c3572dad-4567-51f8-b174-8c6c989267f4"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["AmplNLWriter", "BenchmarkTools", "ControlSystemsBase", "NonlinearSolve", "ForwardDiff", "Ipopt", "Ipopt_jll", "ModelingToolkitStandardLibrary", "Optimization", "OptimizationOptimJL", "OptimizationMOI", "Random", "ReferenceTests", "SafeTestsets", "StableRNGs", "Statistics", "SteadyStateDiffEq", "Test", "StochasticDiffEq", "Sundials", "StochasticDelayDiffEq", "Pkg"]
+test = ["AmplNLWriter", "BenchmarkTools", "ControlSystemsBase", "DelayDiffEq", "NonlinearSolve", "ForwardDiff", "Ipopt", "Ipopt_jll", "ModelingToolkitStandardLibrary", "Optimization", "OptimizationOptimJL", "OptimizationMOI", "Random", "ReferenceTests", "SafeTestsets", "StableRNGs", "Statistics", "SteadyStateDiffEq", "Test", "StochasticDiffEq", "Sundials", "StochasticDelayDiffEq", "Pkg"]

--- a/src/systems/diffeqs/abstractodesystem.jl
+++ b/src/systems/diffeqs/abstractodesystem.jl
@@ -957,7 +957,6 @@ function process_DEProblem(constructor, sys::AbstractODESystem, u0map, parammap;
         ddvs = nothing
     end
     check_eqs_u0(eqs, dvs, u0; kwargs...)
-
     f = constructor(sys, dvs, ps, u0; ddvs = ddvs, tgrad = tgrad, jac = jac,
         checkbounds = checkbounds, p = p,
         linenumbers = linenumbers, parallel = parallel, simplify = simplify,
@@ -1243,6 +1242,8 @@ function DiffEqBase.SDDEProblem{iip}(sys::AbstractODESystem, u0map = [],
     h_oop, h_iip = generate_history(sys, u0)
     h(out, p, t) = h_iip(out, p, t)
     h(p, t) = h_oop(p, t)
+    h(p::MTKParameters, t) = h_oop(p..., t)
+    h(out, p::MTKParameters, t) = h_iip(out, p..., t)
     u0 = h(p, tspan[1])
     cbs = process_events(sys; callback, kwargs...)
     if has_discrete_subsystems(sys) && (dss = get_discrete_subsystems(sys)) !== nothing

--- a/src/systems/parameter_buffer.jl
+++ b/src/systems/parameter_buffer.jl
@@ -90,7 +90,7 @@ function MTKParameters(
     for (sym, val) in p
         sym = unwrap(sym)
         ctype = concrete_symtype(sym)
-        val = symconvert(ctype, fixpoint_sub(val, p))
+        val = symconvert(ctype, unwrap(fixpoint_sub(val, p)))
         done = set_value(sym, val)
         if !done && Symbolics.isarraysymbolic(sym)
             done = all(set_value.(collect(sym), val))

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -197,7 +197,7 @@ function _varmap_to_vars(varmap::Dict, varlist; defaults = Dict(), check = false
     for var in varlist
         var = unwrap(var)
         val = unwrap(fixpoint_sub(var, varmap; operator = Symbolics.Operator))
-        if symbolic_type(val) === NotSymbolic()
+        if !isequal(val, var)
             values[var] = val
         end
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -34,6 +34,7 @@ end
             @safetestset "Mass Matrix Test" include("mass_matrix.jl")
             @safetestset "SteadyStateSystem Test" include("steadystatesystems.jl")
             @safetestset "SDESystem Test" include("sdesystem.jl")
+            @safetestset "DDESystem Test" include("dde.jl")
             @safetestset "NonlinearSystem Test" include("nonlinearsystem.jl")
             @safetestset "InitializationSystem Test" include("initializationsystem.jl")
             @safetestset "PDE Construction Test" include("pde.jl")


### PR DESCRIPTION
Closes https://github.com/SciML/ModelingToolkit.jl/issues/2543

cc @AayushSabharwal 

It turns out the problem was actually just that we weren't putting symbolic constraints into the `values` dict, it wasn't about `t` being missing from the initial `u0map` (adding that gives the wrong answer actually).  I thought I had checked this before but I must have done something else that was breaking alongside it, so this took me way longer to track down than it should have.

This has made it so I can now re-enable the `dde.jl` test file which was previously excluded from the test suite. 

## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
