### PR TITLE
Document and export `continuous_events` and `discrete_events`

### DIFF
--- a/docs/src/basics/Events.md
+++ b/docs/src/basics/Events.md
@@ -58,6 +58,10 @@ be handled via more [general functional affects](@ref func_affects).
 
 Finally, multiple events can be encoded via a `Vector{Pair{Vector{Equation}, Vector{Equation}}}`.
 
+Given an `AbstractSystem`, one can fetch its continuous events, and the continuous events of any
+subsystem inside of it using the `continuous_events(::AbstractSystem)` method, returning a vector
+of `ModelingToolkit.SymbolicContinuousCallback` objects.
+
 ### Example: Friction
 
 The system below illustrates how continuous events can be used to model Coulomb
@@ -220,6 +224,10 @@ as for continuous events. As before, for any *one* event the symbolic affect
 equations can either all change unknowns (i.e. variables) or all change
 parameters, but one cannot currently mix unknown variable and parameter changes within one
 individual event.
+
+Given an `AbstractSystem`, one can fetch its discrete events, and the discrete events of any
+subsystem inside of it using the `discrete_events(::AbstractSystem)` method, returning a vector
+of `ModelingToolkit.SymbolicDiscreteCallback` objects.
 
 ### Example: Injecting cells into a population
 

--- a/docs/src/basics/Events.md
+++ b/docs/src/basics/Events.md
@@ -58,10 +58,6 @@ be handled via more [general functional affects](@ref func_affects).
 
 Finally, multiple events can be encoded via a `Vector{Pair{Vector{Equation}, Vector{Equation}}}`.
 
-Given an `AbstractSystem`, one can fetch its continuous events, and the continuous events of any
-subsystem inside of it using the `continuous_events(::AbstractSystem)` method, returning a vector
-of `ModelingToolkit.SymbolicContinuousCallback` objects.
-
 ### Example: Friction
 
 The system below illustrates how continuous events can be used to model Coulomb
@@ -224,10 +220,6 @@ as for continuous events. As before, for any *one* event the symbolic affect
 equations can either all change unknowns (i.e. variables) or all change
 parameters, but one cannot currently mix unknown variable and parameter changes within one
 individual event.
-
-Given an `AbstractSystem`, one can fetch its discrete events, and the discrete events of any
-subsystem inside of it using the `discrete_events(::AbstractSystem)` method, returning a vector
-of `ModelingToolkit.SymbolicDiscreteCallback` objects.
 
 ### Example: Injecting cells into a population
 

--- a/docs/src/systems/JumpSystem.md
+++ b/docs/src/systems/JumpSystem.md
@@ -12,6 +12,7 @@ JumpSystem
   - `get_unknowns(sys)` or `unknowns(sys)`: The set of unknowns in the jump system.
   - `get_ps(sys)` or `parameters(sys)`: The parameters of the jump system.
   - `get_iv(sys)`: The independent variable of the jump system.
+  - `discrete_events(sys)`: The set of discrete events in the jump system.
 
 ## Transformations
 

--- a/docs/src/systems/ODESystem.md
+++ b/docs/src/systems/ODESystem.md
@@ -13,6 +13,8 @@ ODESystem
   - `get_ps(sys)` or `parameters(sys)`: The parameters of the ODE.
   - `get_iv(sys)`: The independent variable of the ODE.
   - `get_u0_p(sys, u0map, parammap)` Numeric arrays for the initial condition and parameters given `var => value` maps.
+  - `continuous_events(sys)`: The set of continuous events in the ODE
+  - `discrete_events(sys)`: The set of discrete events in the ODE
 
 ## Transformations
 

--- a/docs/src/systems/SDESystem.md
+++ b/docs/src/systems/SDESystem.md
@@ -19,6 +19,8 @@ sde = SDESystem(ode, noiseeqs)
   - `get_unknowns(sys)` or `unknowns(sys)`: The set of unknowns in the SDE.
   - `get_ps(sys)` or `parameters(sys)`: The parameters of the SDE.
   - `get_iv(sys)`: The independent variable of the SDE.
+  - `continuous_events(sys)`: The set of continuous events in the SDE
+  - `discrete_events(sys)`: The set of discrete events in the SDE
 
 ## Transformations
 

--- a/src/ModelingToolkit.jl
+++ b/src/ModelingToolkit.jl
@@ -35,7 +35,7 @@ using PrecompileTools, Reexport
     using RecursiveArrayTools
 
     using SymbolicIndexingInterface
-    export independent_variables, unknowns, parameters, full_parameters
+    export independent_variables, unknowns, parameters, full_parameters, continuous_events, discrete_events
     import SymbolicUtils
     import SymbolicUtils: istree, arguments, operation, similarterm, promote_symtype,
                           Symbolic, isadd, ismul, ispow, issym, FnType,

--- a/src/ModelingToolkit.jl
+++ b/src/ModelingToolkit.jl
@@ -35,7 +35,8 @@ using PrecompileTools, Reexport
     using RecursiveArrayTools
 
     using SymbolicIndexingInterface
-    export independent_variables, unknowns, parameters, full_parameters, continuous_events, discrete_events
+    export independent_variables, unknowns, parameters, full_parameters, continuous_events,
+           discrete_events
     import SymbolicUtils
     import SymbolicUtils: istree, arguments, operation, similarterm, promote_symtype,
                           Symbolic, isadd, ismul, ispow, issym, FnType,

--- a/src/systems/callbacks.jl
+++ b/src/systems/callbacks.jl
@@ -139,9 +139,12 @@ function namespace_callback(cb::SymbolicContinuousCallback, s)::SymbolicContinuo
 end
 
 """
-    continuous_events(sys::AbstractSystem)
+    continuous_events(sys::AbstractSystem)::Vector{SymbolicContinuousCallback}
 
-Returns a vector of all the `continuous_events` in an abstract system and its component subsystems. 
+Returns a vector of all the `continuous_events` in an abstract system and its component subsystems.
+The `SymbolicContinuousCallback`s in the returned vector are structs with two fields: `eqs` and
+`affect` which correspond to the first and second elements of a `Pair` used to define an event, i.e.
+`eqs => affect`.
 """
 function continuous_events(sys::AbstractSystem)
     obs = get_continuous_events(sys)
@@ -240,9 +243,12 @@ SymbolicDiscreteCallbacks(cbs::Vector{<:SymbolicDiscreteCallback}) = cbs
 SymbolicDiscreteCallbacks(::Nothing) = SymbolicDiscreteCallback[]
 
 """
-    discrete_events(sys::AbstractSystem)
+    discrete_events(sys::AbstractSystem) :: Vector{SymbolicDiscreteCallback}
 
-Returns a vector of all the `discrete_events` in an abstract system and its component subsystems. 
+Returns a vector of all the `discrete_events` in an abstract system and its component subsystems.
+The `SymbolicDiscreteCallback`s in the returned vector are structs with two fields: `condition` and
+`affect` which correspond to the first and second elements of a `Pair` used to define an event, i.e.
+`condition => affect`.
 """
 function discrete_events(sys::AbstractSystem)
     obs = get_discrete_events(sys)

--- a/src/systems/callbacks.jl
+++ b/src/systems/callbacks.jl
@@ -138,6 +138,11 @@ function namespace_callback(cb::SymbolicContinuousCallback, s)::SymbolicContinuo
         namespace_affects(affects(cb), s))
 end
 
+"""
+    continuous_events(sys::AbstractSystem)
+
+Returns a vector of all the `continuous_events` in an abstract system and its component subsystems. 
+"""
 function continuous_events(sys::AbstractSystem)
     obs = get_continuous_events(sys)
     filter(!isempty, obs)
@@ -234,6 +239,11 @@ SymbolicDiscreteCallbacks(cb::SymbolicDiscreteCallback) = [cb]
 SymbolicDiscreteCallbacks(cbs::Vector{<:SymbolicDiscreteCallback}) = cbs
 SymbolicDiscreteCallbacks(::Nothing) = SymbolicDiscreteCallback[]
 
+"""
+    discrete_events(sys::AbstractSystem)
+
+Returns a vector of all the `discrete_events` in an abstract system and its component subsystems. 
+"""
 function discrete_events(sys::AbstractSystem)
     obs = get_discrete_events(sys)
     systems = get_systems(sys)


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

I'd like a blessed API for fetching the callbacks of an ODESystem without reaching into internals, so I figure marking these functions as exported and giving them docstrings would be a good way to go about this. If there's a better, existing way to do that please let me know. 