### PR TITLE
refactor: use the `t` defined in the module

### DIFF
--- a/docs/src/basics/MTKModel_Connector.md
+++ b/docs/src/basics/MTKModel_Connector.md
@@ -39,6 +39,7 @@ Let's explore these in more detail with the following example:
 
 ```@example mtkmodel-example
 using ModelingToolkit
+using ModelingToolkit: t
 
 @mtkmodel ModelA begin
     @parameters begin
@@ -191,6 +192,7 @@ getdefault(model_c3.model_a.k_array[2])
 
 ```@example mtkmodel-example
 using ModelingToolkit
+using ModelingToolkit: t
 
 @mtkmodel M begin
     @parameters begin
@@ -262,6 +264,7 @@ A simple connector can be defined with syntax similar to following example:
 
 ```@example connector
 using ModelingToolkit
+using ModelingToolkit: t
 
 @connector Pin begin
     v(t) = 0.0, [description = "Voltage"]
@@ -344,6 +347,7 @@ The if-elseif-else statements can be used inside `@equations`, `@parameters`,
 
 ```@example branches-in-components
 using ModelingToolkit
+using ModelingToolkit: t
 
 @mtkmodel C begin end
 

--- a/src/systems/model_parsing.jl
+++ b/src/systems/model_parsing.jl
@@ -92,7 +92,7 @@ function _model_macro(mod, name, expr, isconnector)
 
     iv = get(dict, :independent_variable, nothing)
     if iv === nothing
-        iv = dict[:independent_variable] = variable(:t)
+        iv = dict[:independent_variable] = get_t(mod, :t)
     end
 
     push!(exprs.args, :(push!(equations, $(eqs...))))
@@ -199,7 +199,7 @@ function parse_variable_def!(dict, mod, arg, varclass, kwargs, where_types;
             parse_variable_def!(dict, mod, a, varclass, kwargs, where_types; def, type)
         end
         Expr(:call, a, b) => begin
-            var = generate_var!(dict, a, b, varclass; indices, type)
+            var = generate_var!(dict, a, b, varclass, mod; indices, type)
             update_kwargs_and_metadata!(dict, kwargs, a, def, indices, type, var,
                 varclass, where_types)
             (var, def)
@@ -280,11 +280,10 @@ function generate_var!(dict, a, varclass;
     generate_var(a, varclass; indices, type)
 end
 
-function generate_var!(dict, a, b, varclass;
+function generate_var!(dict, a, b, varclass, mod;
         indices::Union{Vector{UnitRange{Int}}, Nothing} = nothing,
         type = Real)
-    # (type isa Nothing && type = Real)
-    iv = generate_var(b, :variables)
+    iv = b == :t ? get_t(mod, b) : generate_var(b, :variables)
     prev_iv = get!(dict, :independent_variable) do
         iv
     end
@@ -304,6 +303,20 @@ function generate_var!(dict, a, b, varclass;
         var = toparam(var)
     end
     var
+end
+
+# Use the `t` defined in the `mod`. When it is unavailable, generate a new `t` with a warning.
+function get_t(mod, t)
+    try
+        get_var(mod, t)
+    catch e
+        if e isa UndefVarError
+            @warn("Could not find a predefined `t` in `$mod`; generating a new one within this model.\nConsider defining it or importing `t` (or `t_nounits`, `t_unitful` as `t`) from ModelingToolkit.")
+            variable(:t)
+        else
+            throw(e)
+        end
+    end
 end
 
 function parse_default(mod, a)

--- a/test/model_parsing.jl
+++ b/test/model_parsing.jl
@@ -184,10 +184,15 @@ resistor = getproperty(rc, :resistor; namespace = false)
 @testset "Constants" begin
     @mtkmodel PiModel begin
         @constants begin
-            _p::Irrational = π, [description = "Value of Pi."]
+            _p::Irrational = π, [description = "Value of Pi.", unit = u"V"]
         end
         @parameters begin
             p = _p, [description = "Assign constant `_p` value."]
+            e, [unit = u"V"]
+        end
+        @equations begin
+            # This validates units; indirectly verifies that metadata was correctly passed.
+            e ~ _p
         end
     end
 

--- a/test/model_parsing.jl
+++ b/test/model_parsing.jl
@@ -47,7 +47,7 @@ end
         output = RealOutput()
     end
     @parameters begin
-        k, [description = "Constant output value of block"]
+        k, [description = "Constant output value of block", unit = u"V"]
     end
     @equations begin
         output.u ~ k
@@ -426,6 +426,7 @@ end
     @test A.structure[:components] == [[:cc, :C]]
 end
 
+using ModelingToolkit: D_nounits
 @testset "Event handling in MTKModel" begin
     @mtkmodel M begin
         @variables begin
@@ -434,9 +435,9 @@ end
             z(t)
         end
         @equations begin
-            x ~ -D(x)
-            D(y) ~ 0
-            D(z) ~ 0
+            x ~ -D_nounits(x)
+            D_nounits(y) ~ 0
+            D_nounits(z) ~ 0
         end
         @continuous_events begin
             [x ~ 1.5] => [x ~ 5, y ~ 1]

--- a/test/precompile_test/ModelParsingPrecompile.jl
+++ b/test/precompile_test/ModelParsingPrecompile.jl
@@ -1,6 +1,7 @@
 module ModelParsingPrecompile
 
 using ModelingToolkit, Unitful
+using ModelingToolkit: t
 
 @mtkmodel ModelWithComponentArray begin
     @constants begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -94,5 +94,3 @@ end
         @safetestset "BifurcationKit Extension Test" include("extensions/bifurcationkit.jl")
     end
 end
-
-@safetestset "Model Parsing Test" include("model_parsing.jl")


### PR DESCRIPTION
`t` is now available in three flavours. Thus, allow a downstream package to import the appropriate one, and use that to define variables in the mtk-models.

## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
 