### PR TITLE
Handle derivatives of observed variables

### DIFF
--- a/src/systems/nonlinear/initializesystem.jl
+++ b/src/systems/nonlinear/initializesystem.jl
@@ -20,6 +20,7 @@ function generate_initializesystem(sys::ODESystem;
 
     eqs_diff = eqs[idxs_diff]
     diffmap = Dict(getfield.(eqs_diff, :lhs) .=> getfield.(eqs_diff, :rhs))
+    observed_diffmap = Dict(Differential(get_iv(sys)).(getfield.((observed(sys)), :lhs)) .=> Differential(get_iv(sys)).(getfield.((observed(sys)), :rhs)))
 
     full_states = unique([sts; getfield.((observed(sys)), :lhs)])
     set_full_states = Set(full_states)
@@ -36,7 +37,9 @@ function generate_initializesystem(sys::ODESystem;
             filtered_u0 = Pair[]
             for x in u0map
                 y = get(schedule.dummy_sub, x[1], x[1])
+                y = ModelingToolkit.fixpoint_sub(y, observed_diffmap)
                 y = get(diffmap, y, y)
+
                 if y isa Symbolics.Arr
                     _y = collect(y)
 

--- a/src/systems/nonlinear/initializesystem.jl
+++ b/src/systems/nonlinear/initializesystem.jl
@@ -20,7 +20,8 @@ function generate_initializesystem(sys::ODESystem;
 
     eqs_diff = eqs[idxs_diff]
     diffmap = Dict(getfield.(eqs_diff, :lhs) .=> getfield.(eqs_diff, :rhs))
-    observed_diffmap = Dict(Differential(get_iv(sys)).(getfield.((observed(sys)), :lhs)) .=> Differential(get_iv(sys)).(getfield.((observed(sys)), :rhs)))
+    observed_diffmap = Dict(Differential(get_iv(sys)).(getfield.((observed(sys)), :lhs)) .=>
+        Differential(get_iv(sys)).(getfield.((observed(sys)), :rhs)))
 
     full_states = unique([sts; getfield.((observed(sys)), :lhs)])
     set_full_states = Set(full_states)


### PR DESCRIPTION
If you have a variable `x` which is not a state and substitute it out because some equation `y ~ x`, you would hope that `D(x) => 1` effectively means `D(y) => 1`. This PR does a fixed point substitution on any derivative of observed variables in order to rephrase it into the chosen variable. This fixes the case of aliasing but not the general case of if you are doing the derivative of some observed expression, i.e. `x ~ y + z` where `x` is factored out to be an observed variable, then you want to set `D(x) => 1`.
