### PR TITLE
Don't bold model name etc in show

### DIFF
--- a/src/systems/abstractsystem.jl
+++ b/src/systems/abstractsystem.jl
@@ -1229,16 +1229,21 @@ function Base.show(io::IO, mime::MIME"text/plain", sys::AbstractSystem)
     nvars = length(vars)
     if eqs isa AbstractArray && eltype(eqs) <: Equation
         neqs = count(eq -> !(eq.lhs isa Connection), eqs)
-        Base.printstyled(io, "Model $(nameof(sys)) with $neqs "; bold = true)
+        Base.printstyled(io, "Model "; bold = true)
+        Base.print(io, nameof(sys))
+        Base.printstyled(io, " with "; bold = true)
+        Base.print(io, neqs, " ")
+
         nextras = n_extra_equations(sys)
         if nextras > 0
             Base.printstyled(io, "("; bold = true)
-            Base.printstyled(io, neqs + nextras; bold = true, color = :magenta)
+            Base.printstyled(io, neqs + nextras; color = :magenta)
             Base.printstyled(io, ") "; bold = true)
         end
         Base.printstyled(io, "equations\n"; bold = true)
     else
-        Base.printstyled(io, "Model $(nameof(sys))\n"; bold = true)
+        Base.printstyled(io, "Model "; bold = true)
+        Base.println(io, nameof(sys))
     end
     # The reduced equations are usually very long. It's not that useful to print
     # them.
@@ -1248,7 +1253,9 @@ function Base.show(io::IO, mime::MIME"text/plain", sys::AbstractSystem)
     rows = first(displaysize(io)) ÷ 5
     limit = get(io, :limit, false)
 
-    Base.printstyled(io, "Unknowns ($nvars):"; bold = true)
+    Base.printstyled(io, "Unknowns ("; bold = true)
+    Base.print(io, nvars)
+    Base.printstyled(io, "):"; bold = true)
     nrows = min(nvars, limit ? rows : nvars)
     limited = nrows < length(vars)
     defs = has_defaults(sys) ? defaults(sys) : nothing
@@ -1277,7 +1284,9 @@ function Base.show(io::IO, mime::MIME"text/plain", sys::AbstractSystem)
 
     vars = parameters(sys)
     nvars = length(vars)
-    Base.printstyled(io, "Parameters ($nvars):"; bold = true)
+    Base.printstyled(io, "Parameters ("; bold = true)
+    Base.print(io, nvars)
+    Base.printstyled(io, "):"; bold = true)
     nrows = min(nvars, limit ? rows : nvars)
     limited = nrows < length(vars)
     for i in 1:nrows


### PR DESCRIPTION
The idea i propose is that nothing that is derived from the model should be printed bold.
That then makes it stand out more because of contrast.
This is however very bike-shed-able

**before**
![Screenshot from 2024-03-26 23-58-32](https://github.com/SciML/ModelingToolkit.jl/assets/5127634/4f351783-852f-45b2-93d7-12a829b08c18)

**after**
![image](https://github.com/SciML/ModelingToolkit.jl/assets/5127634/c8135ef4-2bb1-4a77-9754-68575efc8e9b)



## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

I didn't even realize that the model name was printed til today when I was like "why isn't the model name printed?"