### PR TITLE
bareiss: Fix corner case assertion failure

### DIFF
--- a/src/systems/sparsematrixclil.jl
+++ b/src/systems/sparsematrixclil.jl
@@ -174,11 +174,9 @@ function bareiss_update_virtual_colswap_mtk!(zero!, M::SparseMatrixCLIL, k, swap
         # eliminate `v`
         coeff = 0
         ivars = eadj[ei]
-        vj = findfirstequal(vpivot, ivars)
-        if vj !== nothing
+        vj = something(findfirstequal(vpivot, ivars), 0)
+        if vj !== 0
             coeff = old_cadj[ei][vj]
-            deleteat!(old_cadj[ei], vj)
-            deleteat!(eadj[ei], vj)
         elseif pivot_equal
             continue
         end
@@ -208,10 +206,9 @@ function bareiss_update_virtual_colswap_mtk!(zero!, M::SparseMatrixCLIL, k, swap
             dobreak = false
             while true
                 # M[j, i] = div(M[j, i] * pivot - M[j, k] * M[k, i], prev_pivot)
+                ci = 0
                 if kvv == ivv
                     v = kvv
-                    ck = kcoeffs[kvind]
-                    ci = icoeffs[ivind]
                     kvind += 1
                     ivind += 1
                     if kvind > numkvars
@@ -224,44 +221,46 @@ function bareiss_update_virtual_colswap_mtk!(zero!, M::SparseMatrixCLIL, k, swap
                     else
                         ivv = ivars[ivind]
                     end
-                    p1 = Base.Checked.checked_mul(pivot, ci)
-                    p2 = Base.Checked.checked_mul(coeff, ck)
-                    ci = exactdiv(Base.Checked.checked_sub(p1, p2), last_pivot)
+                    if v != vpivot
+                        ck = kcoeffs[kvind-1]
+                        ci = icoeffs[ivind-1]
+                        p1 = Base.Checked.checked_mul(pivot, ci)
+                        p2 = Base.Checked.checked_mul(coeff, ck)
+                        ci = exactdiv(Base.Checked.checked_sub(p1, p2), last_pivot)
+                    end
                 elseif kvv < ivv
                     # M[j, i] == 0
                     v = kvv
-                    ck = kcoeffs[kvind]
                     kvind += 1
                     if kvind > numkvars
                         dobreak = true
                     else
                         kvv = kvars[kvind]
                     end
-                    if v == vpivot
-                        # Already done above
-                        _debug_mode && (vi += 1)
-                        dobreak && break
-                        continue
+                    if v != vpivot
+                        ck = kcoeffs[kvind-1]
+                        p2 = Base.Checked.checked_mul(coeff, ck)
+                        ci = exactdiv(Base.Checked.checked_neg(p2), last_pivot)
                     end
-                    p2 = Base.Checked.checked_mul(coeff, ck)
-                    ci = exactdiv(Base.Checked.checked_neg(p2), last_pivot)
                 else # kvv > ivv
                     # M[k, i] == 0
                     v = ivv
-                    ci = icoeffs[ivind]
                     ivind += 1
                     if ivind > numivars
                         dobreak = true
                     else
                         ivv = ivars[ivind]
                     end
-                    ci = exactdiv(Base.Checked.checked_mul(pivot, ci), last_pivot)
+                    if v != vpivot
+                        ci = icoeffs[ivind-1]
+                        ci = exactdiv(Base.Checked.checked_mul(pivot, ci), last_pivot)
+                    end
                 end
                 if _debug_mode
                     @assert v == vars[vi += 1]
-                    @assert v != vpivot
                 end
                 if !iszero(ci)
+                    @assert v != vpivot
                     tmp_incidence[tmp_len += 1] = v
                     tmp_coeffs[tmp_len] = ci
                 end

--- a/test/structural_transformation/bareiss.jl
+++ b/test/structural_transformation/bareiss.jl
@@ -26,3 +26,12 @@ end
         end
     end
 end
+
+# Bareiss regression test for relatively prime matrix
+let M = reshape(collect(Iterators.take(nextprimes(), 9)), 3, 3)
+    morig = ModelingToolkit.SparseMatrixCLIL(M)
+    m = copy(morig)
+    # Primarily we care about that this does not throw, but it does also have full rank,
+    # so let's test that
+    @test ModelingToolkit.do_bareiss!(m, morig, [true for i = 1:3], [true for i = 1:3])[1:3] == (3,3,3)
+end

--- a/test/structural_transformation/bareiss.jl
+++ b/test/structural_transformation/bareiss.jl
@@ -28,7 +28,7 @@ end
 end
 
 # Bareiss regression test for relatively prime matrix
-let M = reshape(collect(Iterators.take(nextprimes(), 9)), 3, 3)
+let M = reshape([2, 3, 5, 7, 11, 13, 17, 19, 23], 3, 3)
     morig = ModelingToolkit.SparseMatrixCLIL(M)
     m = copy(morig)
     # Primarily we care about that this does not throw, but it does also have full rank,


### PR DESCRIPTION
This failure was reported by @oxinabox on an equation-reordered of one of the MSL examples [1].
Essentially the bug was the we were doing a consistency check on the post-update coefficient,
rather than the pre-update one. See commit message for details. There's two commits here.
One to fix the actual bug and add a test and one to just improve the code slightly to remove the
code pattern that led to the bug and also speed up this code slightly.

[1] https://github.com/SciML/ModelingToolkitStandardLibrary.jl/blob/main/test/Mechanical/rotational.jl#L134