### PR TITLE
Empty events should be empty

### DIFF
--- a/src/systems/callbacks.jl
+++ b/src/systems/callbacks.jl
@@ -118,16 +118,16 @@ end
 function SymbolicContinuousCallbacks(others)
     SymbolicContinuousCallbacks(SymbolicContinuousCallback(others))
 end
-SymbolicContinuousCallbacks(::Nothing) = SymbolicContinuousCallbacks(Equation[])
+SymbolicContinuousCallbacks(::Nothing) = SymbolicContinuousCallback[]
 
 equations(cb::SymbolicContinuousCallback) = cb.eqs
 function equations(cbs::Vector{<:SymbolicContinuousCallback})
-    reduce(vcat, [equations(cb) for cb in cbs])
+    mapreduce(equations, vcat, cbs, init = Equation[])
 end
 
 affects(cb::SymbolicContinuousCallback) = cb.affect
 function affects(cbs::Vector{SymbolicContinuousCallback})
-    reduce(vcat, [affects(cb) for cb in cbs], init = [])
+    mapreduce(affects, vcat, cbs, init = Equation[])
 end
 
 namespace_affects(af::Vector, s) = Equation[namespace_affect(a, s) for a in af]

--- a/src/systems/model_parsing.jl
+++ b/src/systems/model_parsing.jl
@@ -118,12 +118,12 @@ function _model_macro(mod, name, expr, isconnector)
     isconnector && push!(exprs.args,
         :($Setfield.@set!(var"#___sys___".connector_type=$connector_type(var"#___sys___"))))
 
-    !(c_evts == []) && push!(exprs.args,
+    !isempty(c_evts) && push!(exprs.args,
         :($Setfield.@set!(var"#___sys___".continuous_events=$SymbolicContinuousCallback.([
             $(c_evts...)
         ]))))
 
-    !(d_evts == []) && push!(exprs.args,
+    !isempty(d_evts) && push!(exprs.args,
         :($Setfield.@set!(var"#___sys___".discrete_events=$SymbolicDiscreteCallback.([
             $(d_evts...)
         ]))))


### PR DESCRIPTION
`ModelingToolkit.get_continuous_events(sys)` should be empty when there are no continuous events.