### PR TITLE
fix: pass `VariableUnit` of diff var while converting it to a `Term`

### DIFF
--- a/src/variables.jl
+++ b/src/variables.jl
@@ -109,7 +109,7 @@ function default_toterm(x)
             end
             x = normalize_to_differential(op)(arguments(x)...)
         end
-        Symbolics.diff2term(x)
+        Symbolics.diff2term(x, Dict(VariableUnit => get_unit(x)))
     else
         x
     end

--- a/test/variable_utils.jl
+++ b/test/variable_utils.jl
@@ -19,7 +19,7 @@ new = (((1 / β - 1) + δ) / γ)^(1 / (γ - 1))
 using ModelingToolkit: isdifferential, vars, collect_differential_variables,
                        collect_ivs
 @variables t u(t) y(t)
-D = Differential(t)
+using ModelingToolkit: D
 eq = D(y) ~ u
 v = vars(eq)
 @test v == Set([D(y), u])
@@ -32,3 +32,9 @@ aov = ModelingToolkit.collect_applied_operators(eq, Differential)
 
 ts = collect_ivs([eq])
 @test ts == Set([t])
+
+# Test units of diff vars of `Term` type.
+using ModelingToolkit: t, get_unit, default_toterm
+@variables k(t)
+k2 = D(D(k))
+get_unit(default_toterm(k2)) == get_unit(k2)


### PR DESCRIPTION
Units are defined only in MTK, so pass this piece of info to `Symbolics.diff2term` to add this to the returning term-var.

With this PR: `k_t`'s unit will be `1.0 s⁻¹` 
```julia
using ModelingToolkit
using ModelingToolkit: t, D, get_unit, value, VariableUnit, default_toterm
@variables k(t)
get_unit(default_toterm(D(k))) # returns 1.0 s⁻¹
```

Needs https://github.com/JuliaSymbolics/Symbolics.jl/pull/1104.

## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
