### PR TITLE
Rename `namespace_variables` -> `namespace_unknowns`

### DIFF
--- a/src/systems/abstractsystem.jl
+++ b/src/systems/abstractsystem.jl
@@ -813,7 +813,7 @@ function renamespace(sys, x)
     end
 end
 
-namespace_variables(sys::AbstractSystem) = unknowns(sys, unknowns(sys))
+namespace_unknowns(sys::AbstractSystem) = unknowns(sys, unknowns(sys))
 namespace_parameters(sys::AbstractSystem) = parameters(sys, parameters(sys))
 namespace_controls(sys::AbstractSystem) = controls(sys, controls(sys))
 
@@ -882,7 +882,7 @@ function unknowns(sys::AbstractSystem)
     nonunique_unknowns = if isempty(systems)
         sts
     else
-        system_unknowns = reduce(vcat, namespace_variables.(systems))
+        system_unknowns = reduce(vcat, namespace_unknowns.(systems))
         isempty(sts) ? system_unknowns : [sts; system_unknowns]
     end
     isempty(nonunique_unknowns) && return nonunique_unknowns


### PR DESCRIPTION
This moves `namespace_variables` to reflect the new naming (`unknowns`). 