### PR TITLE
fix: fix varmap_to_vars for variables with unspecified size

### DIFF
--- a/src/variables.jl
+++ b/src/variables.jl
@@ -209,8 +209,10 @@ end
 function canonicalize_varmap(varmap; toterm = Symbolics.diff2term)
     new_varmap = Dict()
     for (k, v) in varmap
-        new_varmap[unwrap(k)] = unwrap(v)
-        new_varmap[toterm(unwrap(k))] = unwrap(v)
+        k = unwrap(k)
+        v = unwrap(v)
+        new_varmap[k] = v
+        new_varmap[toterm(k)] = v
         if Symbolics.isarraysymbolic(k) && Symbolics.shape(k) !== Symbolics.Unknown()
             for i in eachindex(k)
                 new_varmap[k[i]] = v[i]

--- a/test/initial_values.jl
+++ b/test/initial_values.jl
@@ -60,3 +60,10 @@ u0 = [X1 => 1.0, X2 => 2.0]
 tspan = (0.0, 1.0)
 ps = [k1 => 1.0, k2 => 5.0]
 @test_nowarn oprob = ODEProblem(osys_m, u0, tspan, ps)
+
+# Make sure it doesn't error on array variables with unspecified size
+@parameters p::Vector{Real} q[1:3]
+varmap = Dict(p => ones(3), q => 2ones(3))
+cvarmap = ModelingToolkit.canonicalize_varmap(varmap)
+target_varmap = Dict(p => ones(3), q => 2ones(3), q[1] => 2.0, q[2] => 2.0, q[3] => 2.0)
+@test cvarmap == target_varmap


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
