### PR TITLE
refactor: remove undefined export `initializesystem`

### DIFF
--- a/src/ModelingToolkit.jl
+++ b/src/ModelingToolkit.jl
@@ -256,7 +256,7 @@ export toexpr, get_variables
 export simplify, substitute
 export build_function
 export modelingtoolkitize
-export initializesystem, generate_initializesystem
+export generate_initializesystem
 
 export @variables, @parameters, @constants, @brownian
 export @named, @nonamespace, @namespace, extend, compose, complete


### PR DESCRIPTION
Found in https://github.com/SciML/NeuralPDE.jl/actions/runs/8477085152/job/23227515929?pr=828#step:6:855 (MTK is reexported in NeuralPDE)