### PR TITLE
Speed up `replace` and `canonicalize` by improving type stability

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -119,6 +119,7 @@ DelayDiffEq = "bcd4f6db-9728-5f36-b5f7-82caef46ccdb"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 Ipopt = "b6b21f68-93f8-5de0-b562-5493be1d77c9"
 Ipopt_jll = "9cc047cb-c261-5740-88fc-0cf96f7bdcc7"
+JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 ModelingToolkitStandardLibrary = "16a59e39-deab-5bd0-87e4-056b12336739"
 NonlinearSolve = "8913a72c-1f9b-4ce2-8d82-65094dcecaec"
 Optimization = "7f7a1694-90dd-40f0-9382-eb1efda571ba"
@@ -137,4 +138,4 @@ Sundials = "c3572dad-4567-51f8-b174-8c6c989267f4"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["AmplNLWriter", "BenchmarkTools", "ControlSystemsBase", "DelayDiffEq", "NonlinearSolve", "ForwardDiff", "Ipopt", "Ipopt_jll", "ModelingToolkitStandardLibrary", "Optimization", "OptimizationOptimJL", "OptimizationMOI", "Random", "ReferenceTests", "SafeTestsets", "StableRNGs", "Statistics", "SteadyStateDiffEq", "Test", "StochasticDiffEq", "Sundials", "StochasticDelayDiffEq", "Pkg"]
+test = ["AmplNLWriter", "BenchmarkTools", "ControlSystemsBase", "DelayDiffEq", "NonlinearSolve", "ForwardDiff", "Ipopt", "Ipopt_jll", "ModelingToolkitStandardLibrary", "Optimization", "OptimizationOptimJL", "OptimizationMOI", "Random", "ReferenceTests", "SafeTestsets", "StableRNGs", "Statistics", "SteadyStateDiffEq", "Test", "StochasticDiffEq", "Sundials", "StochasticDelayDiffEq", "Pkg", "JET"]

--- a/src/systems/parameter_buffer.jl
+++ b/src/systems/parameter_buffer.jl
@@ -137,9 +137,12 @@ function MTKParameters(
 end
 
 function buffer_to_arraypartition(buf)
-    return ArrayPartition(Tuple(eltype(v) <: AbstractArray ? buffer_to_arraypartition(v) :
-                                v for v in buf))
+    return ArrayPartition(ntuple(i -> _buffer_to_arrp_helper(buf[i]), Val(length(buf))))
 end
+
+_buffer_to_arrp_helper(v::T) where {T} = _buffer_to_arrp_helper(eltype(T), v)
+_buffer_to_arrp_helper(::Type{<:AbstractArray}, v) = buffer_to_arraypartition(v)
+_buffer_to_arrp_helper(::Any, v) = v
 
 function _split_helper(buf_v::T, recurse, raw, idx) where {T}
     _split_helper(eltype(T), buf_v, recurse, raw, idx)

--- a/src/systems/parameter_buffer.jl
+++ b/src/systems/parameter_buffer.jl
@@ -172,17 +172,18 @@ function _update_tuple_helper(buf_v::T, raw, idx) where {T}
 end
 
 function _update_tuple_helper(::Type{<:AbstractArray}, buf_v, raw, idx)
-    map(b -> _update_tuple_helper(b, raw, idx), buf_v)
+    ntuple(i -> _update_tuple_helper(buf_v[i], raw, idx), Val(length(buf_v)))
 end
 
 function _update_tuple_helper(::Any, buf_v, raw, idx)
     copyto!(buf_v, view(raw, idx[]:(idx[] + length(buf_v) - 1)))
     idx[] += length(buf_v)
+    return nothing
 end
 
 function update_tuple_of_buffers(raw::AbstractArray, buf)
     idx = Ref(1)
-    map(b -> _update_tuple_helper(b, raw, idx), buf)
+    ntuple(i -> _update_tuple_helper(buf[i], raw, idx), Val(length(buf)))
 end
 
 SciMLStructures.isscimlstructure(::MTKParameters) = true

--- a/test/mtkparameters.jl
+++ b/test/mtkparameters.jl
@@ -136,12 +136,11 @@ ps = [p => 1.0] # Value for `d` is missing
 @test_throws ModelingToolkit.MissingVariablesError ODEProblem(sys, u0, tspan, ps)
 @test_nowarn ODEProblem(sys, u0, tspan, [ps..., d => 1.0])
 
-  
 # JET tests
 
 # scalar parameters only
 function level1()
-    @parameters p1=0.5 [tunable = true] p2 = 1 [tunable=true] p3 = 3 [tunable = false] p4=3 [tunable = true] y0=1
+    @parameters p1=0.5 [tunable = true] p2=1 [tunable = true] p3=3 [tunable = false] p4=3 [tunable = true] y0=1
     @variables x(t)=2 y(t)=y0
     D = Differential(t)
 
@@ -183,14 +182,14 @@ end
 
 @testset "level$i" for (i, prob) in enumerate([level1(), level2(), level3()])
     ps = prob.p
-    @testset "Type stability of $portion" for portion in [Tunable(), Discrete(), Constants()]
+    @testset "Type stability of $portion" for portion in [
+        Tunable(), Discrete(), Constants()]
         @test_call canonicalize(portion, ps)
         # @inferred canonicalize(portion, ps)
-        broken =
-            (i ∈ [2,3] && portion == Tunable())
+        broken = (i ∈ [2, 3] && portion == Tunable())
 
         # broken because the size of a vector of vectors can't be determined at compile time
-        @test_opt broken=broken target_modules = (ModelingToolkit,) canonicalize(
+        @test_opt broken=broken target_modules=(ModelingToolkit,) canonicalize(
             portion, ps)
 
         buffer, repack, alias = canonicalize(portion, ps)
@@ -200,7 +199,7 @@ end
         @test_opt target_modules=(ModelingToolkit,) SciMLStructures.replace(
             portion, ps, ones(length(buffer)))
 
-        @test_call target_modules = (ModelingToolkit,) SciMLStructures.replace!(
+        @test_call target_modules=(ModelingToolkit,) SciMLStructures.replace!(
             portion, ps, ones(length(buffer)))
         @inferred SciMLStructures.replace!(portion, ps, ones(length(buffer)))
         @test_opt target_modules=(ModelingToolkit,) SciMLStructures.replace!(


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

This PR attempts to fix #2608 by avoiding boxing and runtime dispatch. So far this works for the case of homogeneous parameters, but for heterogeneous ones, we end up iterating over a tuple of  different types, which is unstable.