### PR TITLE
fix: propagate parameter dependencies in `extend`

### DIFF
--- a/src/systems/abstractsystem.jl
+++ b/src/systems/abstractsystem.jl
@@ -2225,6 +2225,10 @@ function extend(sys::AbstractSystem, basesys::AbstractSystem; name::Symbol = nam
     eqs = union(get_eqs(basesys), get_eqs(sys))
     sts = union(get_unknowns(basesys), get_unknowns(sys))
     ps = union(get_ps(basesys), get_ps(sys))
+    base_deps = get_parameter_dependencies(basesys)
+    deps = get_parameter_dependencies(sys)
+    dep_ps = isnothing(base_deps) ? deps :
+             isnothing(deps) ? base_deps : union(base_deps, deps)
     obs = union(get_observed(basesys), get_observed(sys))
     cevs = union(get_continuous_events(basesys), get_continuous_events(sys))
     devs = union(get_discrete_events(basesys), get_discrete_events(sys))
@@ -2233,11 +2237,12 @@ function extend(sys::AbstractSystem, basesys::AbstractSystem; name::Symbol = nam
 
     if length(ivs) == 0
         T(eqs, sts, ps, observed = obs, defaults = defs, name = name, systems = syss,
-            continuous_events = cevs, discrete_events = devs, gui_metadata = gui_metadata)
+            continuous_events = cevs, discrete_events = devs, gui_metadata = gui_metadata,
+            parameter_dependencies = dep_ps)
     elseif length(ivs) == 1
         T(eqs, ivs[1], sts, ps, observed = obs, defaults = defs, name = name,
             systems = syss, continuous_events = cevs, discrete_events = devs,
-            gui_metadata = gui_metadata)
+            gui_metadata = gui_metadata, parameter_dependencies = dep_ps)
     end
 end
 
@@ -2395,7 +2400,7 @@ end
 """
     is_diff_equation(eq)
 
-Returns `true` if the input is a differential equation, i.e. is an equatation that contain some 
+Returns `true` if the input is a differential equation, i.e. is an equatation that contain some
 form of differential.
 
 Example:
@@ -2421,7 +2426,7 @@ end
 """
     is_alg_equation(eq)
 
-Returns `true` if the input is an algebraic equation, i.e. is an equatation that does not contain 
+Returns `true` if the input is an algebraic equation, i.e. is an equatation that does not contain
 any differentials.
 
 Example:
@@ -2603,7 +2608,7 @@ has_alg_eqs(sys::AbstractSystem) = any(is_alg_equation, get_eqs(sys))
 """
     has_diff_eqs(sys::AbstractSystem)
 
-For a system, returns true if it contain at least one differential equation (i.e. that contain a 
+For a system, returns true if it contain at least one differential equation (i.e. that contain a
 differential) in its *top-level system*.
 
 Example:

--- a/src/systems/abstractsystem.jl
+++ b/src/systems/abstractsystem.jl
@@ -2400,8 +2400,8 @@ end
 """
     is_diff_equation(eq)
 
-Returns `true` if the input is a differential equation, i.e. is an equatation that contain some
-form of differential.
+Return `true` if the input is a differential equation, i.e. an equation that contains a
+differential term.
 
 Example:
 ```julia
@@ -2426,7 +2426,7 @@ end
 """
     is_alg_equation(eq)
 
-Returns `true` if the input is an algebraic equation, i.e. is an equatation that does not contain
+Return `true` if the input is an algebraic equation, i.e. an equation that does not contain
 any differentials.
 
 Example:
@@ -2608,8 +2608,9 @@ has_alg_eqs(sys::AbstractSystem) = any(is_alg_equation, get_eqs(sys))
 """
     has_diff_eqs(sys::AbstractSystem)
 
-For a system, returns true if it contain at least one differential equation (i.e. that contain a
-differential) in its *top-level system*.
+Return `true` if a system contains at least one differential equation (i.e. an equation with a
+differential term). Note that this does not consider subsystems, and only takes into account
+equations in the top-level system.
 
 Example:
 ```julia

--- a/test/parameter_dependencies.jl
+++ b/test/parameter_dependencies.jl
@@ -49,6 +49,24 @@ using NonlinearSolve
     @test integ.ps[p2] == 10.0
 end
 
+@testset "extend" begin
+    @parameters p1=1.0 p2=1.0
+    @variables x(t)
+
+    @mtkbuild sys1 = ODESystem(
+        [D(x) ~ p1 * t + p2],
+        t
+    )
+    @named sys2 = ODESystem(
+        [],
+        t;
+        parameter_dependencies = [p2 => 2p1]
+    )
+    sys = extend(sys2, sys1)
+    @test isequal(only(parameters(sys)), p1)
+    @test Set(full_parameters(sys)) == Set([p1, p2])
+end
+
 @testset "Clock system" begin
     dt = 0.1
     @variables x(t) y(t) u(t) yd(t) ud(t) r(t) z(t)


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

It looks like `parameter_dependencies` are not propagated when extending the system.
