### PR TITLE
Fixes for dependent parameters

### DIFF
--- a/src/systems/abstractsystem.jl
+++ b/src/systems/abstractsystem.jl
@@ -880,7 +880,7 @@ end
 
 function namespace_parameter_dependencies(sys)
     pdeps = get_parameter_dependencies(sys)
-    Dict(dependent_parameters(sys, k) => namespace_expr(v, sys) for (k, v) in pdeps)
+    Dict(parameters(sys, k) => namespace_expr(v, sys) for (k, v) in pdeps)
 end
 
 function namespace_equations(sys::AbstractSystem, ivs = independent_variables(sys))
@@ -1065,8 +1065,6 @@ for f in [:unknowns, :parameters]
         map(v -> $f(sys, v), vs)
     end
 end
-
-dependent_parameters(sys::Union{AbstractSystem, Nothing}, v) = renamespace(sys, v)
 
 flatten(sys::AbstractSystem, args...) = sys
 

--- a/src/systems/abstractsystem.jl
+++ b/src/systems/abstractsystem.jl
@@ -996,8 +996,6 @@ function parameter_dependencies(sys::AbstractSystem)
     systems = get_systems(sys)
     isempty(systems) && return pdeps
     for subsys in systems
-        isnothing(get_parameter_dependencies(subsys)) && continue
-
         pdeps = merge(pdeps, namespace_parameter_dependencies(subsys))
     end
     # @info pdeps

--- a/src/systems/abstractsystem.jl
+++ b/src/systems/abstractsystem.jl
@@ -879,7 +879,7 @@ function namespace_guesses(sys)
 end
 
 function namespace_parameter_dependencies(sys)
-    pdeps = get_parameter_dependencies(sys)
+    pdeps = parameter_dependencies(sys)
     Dict(parameters(sys, k) => namespace_expr(v, sys) for (k, v) in pdeps)
 end
 

--- a/src/systems/abstractsystem.jl
+++ b/src/systems/abstractsystem.jl
@@ -970,7 +970,7 @@ function parameters(sys::AbstractSystem)
     result = unique(isempty(systems) ? ps :
                     [ps; reduce(vcat, namespace_parameters.(systems))])
     if has_parameter_dependencies(sys) &&
-       (pdeps = get_parameter_dependencies(sys)) !== nothing
+       (pdeps = parameter_dependencies(sys)) !== nothing
         filter(result) do sym
             !haskey(pdeps, sym)
         end
@@ -2391,8 +2391,8 @@ function extend(sys::AbstractSystem, basesys::AbstractSystem; name::Symbol = nam
     eqs = union(get_eqs(basesys), get_eqs(sys))
     sts = union(get_unknowns(basesys), get_unknowns(sys))
     ps = union(get_ps(basesys), get_ps(sys))
-    base_deps = get_parameter_dependencies(basesys)
-    deps = get_parameter_dependencies(sys)
+    base_deps = parameter_dependencies(basesys)
+    deps = parameter_dependencies(sys)
     dep_ps = isnothing(base_deps) ? deps :
              isnothing(deps) ? base_deps : union(base_deps, deps)
     obs = union(get_observed(basesys), get_observed(sys))

--- a/src/systems/diffeqs/odesystem.jl
+++ b/src/systems/diffeqs/odesystem.jl
@@ -355,6 +355,7 @@ function flatten(sys::ODESystem, noeqs = false)
             get_iv(sys),
             unknowns(sys),
             parameters(sys),
+            parameter_dependencies = get_parameter_dependencies(sys),
             guesses = guesses(sys),
             observed = observed(sys),
             continuous_events = continuous_events(sys),

--- a/src/systems/diffeqs/odesystem.jl
+++ b/src/systems/diffeqs/odesystem.jl
@@ -355,7 +355,7 @@ function flatten(sys::ODESystem, noeqs = false)
             get_iv(sys),
             unknowns(sys),
             parameters(sys),
-            parameter_dependencies = get_parameter_dependencies(sys),
+            parameter_dependencies = parameter_dependencies(sys),
             guesses = guesses(sys),
             observed = observed(sys),
             continuous_events = continuous_events(sys),

--- a/src/systems/diffeqs/odesystem.jl
+++ b/src/systems/diffeqs/odesystem.jl
@@ -405,10 +405,10 @@ function build_explicit_observed_function(sys, ts;
         Set(arguments(st)[1] for st in sts if iscall(st) && operation(st) === getindex))
 
     observed_idx = Dict(x.lhs => i for (i, x) in enumerate(obs))
-    param_set = Set(parameters(sys))
+    param_set = Set(full_parameters(sys))
     param_set = union(param_set,
         Set(arguments(p)[1] for p in param_set if iscall(p) && operation(p) === getindex))
-    param_set_ns = Set(unknowns(sys, p) for p in parameters(sys))
+    param_set_ns = Set(unknowns(sys, p) for p in full_parameters(sys))
     param_set_ns = union(param_set_ns,
         Set(arguments(p)[1]
         for p in param_set_ns if iscall(p) && operation(p) === getindex))

--- a/src/systems/diffeqs/sdesystem.jl
+++ b/src/systems/diffeqs/sdesystem.jl
@@ -291,7 +291,7 @@ function stochastic_integral_transform(sys::SDESystem, correction_factor)
     end
 
     SDESystem(deqs, get_noiseeqs(sys), get_iv(sys), unknowns(sys), parameters(sys),
-        name = name, parameter_dependencies = get_parameter_dependencies(sys), checks = false)
+        name = name, parameter_dependencies = parameter_dependencies(sys), checks = false)
 end
 
 """
@@ -399,7 +399,7 @@ function Girsanov_transform(sys::SDESystem, u; θ0 = 1.0)
     # return modified SDE System
     SDESystem(deqs, noiseeqs, get_iv(sys), unknown_vars, parameters(sys);
         defaults = Dict(θ => θ0), observed = [weight ~ θ / θ0],
-        name = name, parameter_dependencies = get_parameter_dependencies(sys),
+        name = name, parameter_dependencies = parameter_dependencies(sys),
         checks = false)
 end
 

--- a/src/systems/index_cache.jl
+++ b/src/systems/index_cache.jl
@@ -115,8 +115,8 @@ function IndexCache(sys::AbstractSystem)
         end
     end
 
-    if has_parameter_dependencies(sys) &&
-       (pdeps = get_parameter_dependencies(sys)) !== nothing
+    if has_parameter_dependencies(sys)
+        pdeps = parameter_dependencies(sys)
         for (sym, value) in pdeps
             sym = unwrap(sym)
             insert_by_type!(dependent_buffers, sym)

--- a/src/systems/nonlinear/initializesystem.jl
+++ b/src/systems/nonlinear/initializesystem.jl
@@ -102,6 +102,7 @@ function generate_initializesystem(sys::ODESystem;
         full_states,
         pars;
         defaults = merge(ModelingToolkit.defaults(sys), todict(u0), dd_guess),
+        parameter_dependencies = get_parameter_dependencies(sys),
         name,
         kwargs...)
 

--- a/src/systems/nonlinear/initializesystem.jl
+++ b/src/systems/nonlinear/initializesystem.jl
@@ -102,7 +102,7 @@ function generate_initializesystem(sys::ODESystem;
         full_states,
         pars;
         defaults = merge(ModelingToolkit.defaults(sys), todict(u0), dd_guess),
-        parameter_dependencies = get_parameter_dependencies(sys),
+        parameter_dependencies = parameter_dependencies(sys),
         name,
         kwargs...)
 

--- a/src/systems/parameter_buffer.jl
+++ b/src/systems/parameter_buffer.jl
@@ -136,7 +136,7 @@ function MTKParameters(
     nonnumeric_buffer = nonnumeric_buffer
 
     if has_parameter_dependencies(sys) &&
-       (pdeps = get_parameter_dependencies(sys)) !== nothing
+       (pdeps = parameter_dependencies(sys)) !== nothing
         pdeps = Dict(k => fixpoint_sub(v, pdeps) for (k, v) in pdeps)
         dep_exprs = ArrayPartition((Any[missing for _ in 1:length(v)] for v in dep_buffer)...)
         for (sym, val) in pdeps

--- a/test/parameter_dependencies.jl
+++ b/test/parameter_dependencies.jl
@@ -69,7 +69,7 @@ end
 
 @testset "getu with parameter deps" begin
     @parameters p1=1.0 p2=1.0
-    @variables x(t)=0
+    @variables x(t) = 0
 
     @named sys = ODESystem(
         [D(x) ~ p1 * t + p2],

--- a/test/parameter_dependencies.jl
+++ b/test/parameter_dependencies.jl
@@ -67,6 +67,20 @@ end
     @test Set(full_parameters(sys)) == Set([p1, p2])
 end
 
+@testset "getu with parameter deps" begin
+    @parameters p1=1.0 p2=1.0
+    @variables x(t)=0
+
+    @named sys = ODESystem(
+        [D(x) ~ p1 * t + p2],
+        t;
+        parameter_dependencies = [p2 => 2p1]
+    )
+    prob = ODEProblem(complete(sys))
+    get_dep = getu(prob, 2p2)
+    @test get_dep(prob) == 4
+end
+
 @testset "Clock system" begin
     dt = 0.1
     @variables x(t) y(t) u(t) yd(t) ud(t) r(t) z(t)


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

When `build_explicit_observed_function` [was updated](https://github.com/SebastianM-C/ModelingToolkit.jl/blob/9184ebe8d9450646553082b2cd9f0e141cb5ec9f/src/systems/diffeqs/odesystem.jl#L381) for parameter dependencies, only the `ps` argument was updated, but internally the function still ckecked for the `parameters` instead of the `full_parameters`.