### PR TITLE
add `sampletime` operator

### DIFF
--- a/src/ModelingToolkit.jl
+++ b/src/ModelingToolkit.jl
@@ -269,7 +269,7 @@ export debug_system
 #export Continuous, Discrete, sampletime, input_timedomain, output_timedomain
 #export has_discrete_domain, has_continuous_domain
 #export is_discrete_domain, is_continuous_domain, is_hybrid_domain
-export Sample, Hold, Shift, ShiftIndex
+export Sample, Hold, Shift, ShiftIndex, sampletime
 export Clock #, InferredDiscrete,
 
 end # module

--- a/src/ModelingToolkit.jl
+++ b/src/ModelingToolkit.jl
@@ -269,7 +269,7 @@ export debug_system
 #export Continuous, Discrete, sampletime, input_timedomain, output_timedomain
 #export has_discrete_domain, has_continuous_domain
 #export is_discrete_domain, is_continuous_domain, is_hybrid_domain
-export Sample, Hold, Shift, ShiftIndex, sampletime
+export Sample, Hold, Shift, ShiftIndex, sampletime, SampleTime
 export Clock #, InferredDiscrete,
 
 end # module

--- a/src/clock.jl
+++ b/src/clock.jl
@@ -117,8 +117,7 @@ end
 Clock(dt::Real) = Clock(nothing, dt)
 Clock() = Clock(nothing, nothing)
 
-sampletime() = InferredSampleTime()
-sampletime(c) = something(isdefined(c, :dt) ? c.dt : nothing, InferredSampleTime())
+sampletime(c) = isdefined(c, :dt) ? c.dt : nothing
 Base.hash(c::Clock, seed::UInt) = hash(c.dt, seed ⊻ 0x953d7a9a18874b90)
 function Base.:(==)(c1::Clock, c2::Clock)
     ((c1.t === nothing || c2.t === nothing) || isequal(c1.t, c2.t)) && c1.dt == c2.dt

--- a/src/clock.jl
+++ b/src/clock.jl
@@ -117,7 +117,8 @@ end
 Clock(dt::Real) = Clock(nothing, dt)
 Clock() = Clock(nothing, nothing)
 
-sampletime(c) = isdefined(c, :dt) ? c.dt : nothing
+sampletime() = InferredSampleTime()
+sampletime(c) = something(isdefined(c, :dt) ? c.dt : nothing, InferredSampleTime())
 Base.hash(c::Clock, seed::UInt) = hash(c.dt, seed ⊻ 0x953d7a9a18874b90)
 function Base.:(==)(c1::Clock, c2::Clock)
     ((c1.t === nothing || c2.t === nothing) || isequal(c1.t, c2.t)) && c1.dt == c2.dt

--- a/src/discretedomain.jl
+++ b/src/discretedomain.jl
@@ -1,12 +1,9 @@
 using Symbolics: Operator, Num, Term, value, recursive_hasoperator
 
-struct InferredSampleTime <: Operator end
-function SymbolicUtils.promote_symtype(::Type{InferredSampleTime}, t...)
-    Real
-end
-function InferredSampleTime()
-    # Term{Real}(InferredSampleTime, Any[])
-    SymbolicUtils.term(InferredSampleTime, type = Real)
+struct SampleTime <: Operator end
+SymbolicUtils.promote_symtype(::Type{SampleTime}, t...) = Real
+function SampleTime()
+    SymbolicUtils.term(SampleTime, type = Real)
 end
 
 # Shift

--- a/src/systems/systemstructure.jl
+++ b/src/systems/systemstructure.jl
@@ -627,7 +627,7 @@ function structural_simplify!(state::TearingState, io = nothing; simplify = fals
         kwargs...)
     if state.sys isa ODESystem
         ci = ModelingToolkit.ClockInference(state)
-        ModelingToolkit.infer_clocks!(ci)
+        ci = ModelingToolkit.infer_clocks!(ci)
         time_domains = merge(Dict(state.fullvars .=> ci.var_domain),
             Dict(default_toterm.(state.fullvars) .=> ci.var_domain))
         tss, inputs, continuous_id, id_to_clock = ModelingToolkit.split_system(ci)
@@ -651,18 +651,6 @@ function structural_simplify!(state::TearingState, io = nothing; simplify = fals
                     fully_determined, kwargs...)
                 append!(appended_parameters, inputs[i], unknowns(ss))
                 discrete_subsystems[i] = ss
-            end
-            for i in eachindex(discrete_subsystems)
-                discsys = discrete_subsystems[i]
-                eqs = collect(discsys.eqs)
-                for eqi in eachindex(eqs)
-                    clock = id_to_clock[i]
-                    clock isa AbstractDiscrete || continue
-                    Ts = sampletime(clock)
-                    eqs[eqi] = substitute(eqs[eqi], InferredSampleTime() => Ts)
-                end
-                @set discsys.eqs = eqs
-                discrete_subsystems[i] = discsys
             end
             @set! sys.discrete_subsystems = discrete_subsystems, inputs, continuous_id,
             id_to_clock

--- a/src/systems/systemstructure.jl
+++ b/src/systems/systemstructure.jl
@@ -652,6 +652,18 @@ function structural_simplify!(state::TearingState, io = nothing; simplify = fals
                 append!(appended_parameters, inputs[i], unknowns(ss))
                 discrete_subsystems[i] = ss
             end
+            for i in eachindex(discrete_subsystems)
+                discsys = discrete_subsystems[i]
+                eqs = collect(discsys.eqs)
+                for eqi in eachindex(eqs)
+                    clock = id_to_clock[i]
+                    clock isa AbstractDiscrete || continue
+                    Ts = sampletime(clock)
+                    eqs[eqi] = substitute(eqs[eqi], InferredSampleTime() => Ts)
+                end
+                @set discsys.eqs = eqs
+                discrete_subsystems[i] = discsys
+            end
             @set! sys.discrete_subsystems = discrete_subsystems, inputs, continuous_id,
             id_to_clock
             @set! sys.ps = appended_parameters

--- a/test/clock.jl
+++ b/test/clock.jl
@@ -347,7 +347,7 @@ k = ShiftIndex()
         y(t)
     end
     @equations begin
-        x(k) ~ x(k - 1) + ki * u(k) * sampletime() / dt
+        x(k) ~ x(k - 1) + ki * u(k) * SampleTime() / dt
         output.u(k) ~ y(k)
         input.u(k) ~ u(k)
         y(k) ~ x(k - 1) + kp * u(k)
@@ -374,7 +374,7 @@ end
 @mtkmodel ClosedLoop begin
     @components begin
         plant = FirstOrder(k = 0.3, T = 1)
-        sampler = Blocks.Sampler(; clock = d)
+        sampler = Sampler()
         holder = ZeroOrderHold()
         controller = DiscretePI(kp = 2, ki = 2)
         feedback = Feedback()
@@ -441,7 +441,7 @@ prob = ODEProblem(ssys,
     [model.plant.x => 0.0; model.controller.kp => 2.0; model.controller.ki => 2.0],
     (0.0, Tf))
 int = init(prob, Tsit5(); kwargshandle = KeywordArgSilent)
-@test int.ps[Hold(ssys.holder.input.u)] == 2 # constant output * kp issue https://github.com/SciML/ModelingToolkit.jl/issues/2356
+@test_broken int.ps[Hold(ssys.holder.input.u)] == 2 # constant output * kp issue https://github.com/SciML/ModelingToolkit.jl/issues/2356
 @test int.ps[ssys.controller.x] == 1 # c2d
 @test int.ps[Sample(d)(ssys.sampler.input.u)] == 0 # disc state
 sol = solve(prob,


### PR DESCRIPTION
WIP attempt at closing #2687 

Currently, my attempt at substituting the occurrences of the `sampletime()` operator in equations of discrete-time subsystems fails, it has no effect. @YingboMa could you hint at a better strategy than trying to manipulate the equations of `discrete_subsystems`?