### PR TITLE
Forward system in `ODEFunction` expression

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ModelingToolkit"
 uuid = "961ee093-0014-501f-94e3-6117800e7a78"
 authors = ["Yingbo Ma <mayingbo5@gmail.com>", "Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
-version = "9.13.0"
+version = "9.14.0"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/src/systems/diffeqs/abstractodesystem.jl
+++ b/src/systems/diffeqs/abstractodesystem.jl
@@ -752,6 +752,7 @@ function ODEFunctionExpr{iip}(sys::AbstractODESystem, dvs = unknowns(sys),
         $_jac
         M = $_M
         ODEFunction{$iip}($fsym,
+            sys = $sys,
             jac = $jacsym,
             tgrad = $tgradsym,
             mass_matrix = M,

--- a/test/odesystem.jl
+++ b/test/odesystem.jl
@@ -58,6 +58,9 @@ for f in [
     ODEFunction(de, [x, y, z], [σ, ρ, β], tgrad = true, jac = true),
     eval(ODEFunctionExpr(de, [x, y, z], [σ, ρ, β], tgrad = true, jac = true))
 ]
+    # system
+    @test f.sys === de
+
     # iip
     du = zeros(3)
     u = collect(1:3)


### PR DESCRIPTION
Fixes https://github.com/SciML/ModelingToolkit.jl/issues/2550.

---

Could we backport this to MTK v8? I have to use MTK v8 in a package since Catalyst does not support MTK v9 yet, but if `sys` is not specified SciMLBase will yield deprecation warnings in more recent versions (>= ~2.25.0 IIRC).