### PR TITLE
add ClockChange operator

### DIFF
--- a/src/ModelingToolkit.jl
+++ b/src/ModelingToolkit.jl
@@ -268,7 +268,7 @@ export debug_system
 #export Continuous, Discrete, sampletime, input_timedomain, output_timedomain
 #export has_discrete_domain, has_continuous_domain
 #export is_discrete_domain, is_continuous_domain, is_hybrid_domain
-export Sample, Hold, Shift, ShiftIndex, sampletime, SampleTime
+export Sample, Hold, Shift, ShiftIndex, sampletime, SampleTime, ClockChange
 export Clock #, InferredDiscrete,
 
 end # module

--- a/src/clock.jl
+++ b/src/clock.jl
@@ -55,7 +55,7 @@ See also [`is_discrete_domain`](@ref)
 """
 function has_discrete_domain(x)
     issym(x) && return is_discrete_domain(x)
-    hasshift(x) || hassample(x) || hashold(x)
+    hasshift(x) || hassample(x) || hashold(x) || hasclockchange(x)
 end
 
 """

--- a/src/discretedomain.jl
+++ b/src/discretedomain.jl
@@ -166,10 +166,10 @@ end
 SymbolicUtils.promote_symtype(::ClockChange, x) = x
 
 function Base.:(==)(D1::ClockChange, D2::ClockChange)
-    isequal(D1.to, D2.to) && isequal(D1.from, D2.from)
+    ==(D1.to, D2.to) && ==(D1.from, D2.from)
 end
 Base.hash(D::ClockChange, u::UInt) = hash(D.from, hash(D.to, xor(u, 0xa5b640d6d952f101)))
-
+hasclockchange(O) = recursive_hasoperator(ClockChange, unwrap(O))
 # ShiftIndex
 
 """

--- a/src/systems/alias_elimination.jl
+++ b/src/systems/alias_elimination.jl
@@ -441,6 +441,9 @@ function topsort_equations(eqs, unknowns; check = true)
     return ordered_eqs
 end
 
+function is_op_execpt_clock_change(x)
+    x isa Symbolics.Operator && !(x isa ClockChange)
+end
 function observed2graph(eqs, unknowns)
     graph = BipartiteGraph(length(eqs), length(unknowns))
     v2j = Dict(unknowns .=> 1:length(unknowns))
@@ -453,7 +456,7 @@ function observed2graph(eqs, unknowns)
         lhs_j === nothing &&
             throw(ArgumentError("The lhs $(eq.lhs) of $eq, doesn't appear in unknowns."))
         assigns[i] = lhs_j
-        vs = vars(eq.rhs; op = Symbolics.Operator)
+        vs = vars(eq.rhs; op = is_op_execpt_clock_change)
         for v in vs
             j = get(v2j, v, nothing)
             j !== nothing && add_edge!(graph, i, j)

--- a/src/systems/clock_inference.jl
+++ b/src/systems/clock_inference.jl
@@ -250,9 +250,10 @@ function generate_discrete_affect(
         cont_to_disc_obs = build_explicit_observed_function(
             use_index_cache ? osys : syss[continuous_id],
             needed_cont_to_disc_obs,
-            throw = false,
+            throw = true,
             expression = true,
             output_type = SVector)
+
         disc_to_cont_obs = build_explicit_observed_function(sys, needed_disc_to_cont_obs,
             throw = false,
             expression = true,

--- a/src/systems/clock_inference.jl
+++ b/src/systems/clock_inference.jl
@@ -190,9 +190,11 @@ function split_system(ci::ClockInference{S}) where {S}
         tss[id] = ts_i
     end
     dops = Union{Sample, Hold, ClockChange}
-    for i in eachindex(inputs)
-        inputs[i] = StructuralTransformations.simplify_shifts(fast_substitute(
-            inputs[i], shift_subs; operator = dops))
+    for input in inputs
+        for i in eachindex(input)
+            input[i] = StructuralTransformations.simplify_shifts(fast_substitute(
+                input[i], shift_subs; operator = dops))
+        end
     end
 
     return tss, inputs, continuous_id, id_to_clock
@@ -226,7 +228,7 @@ function generate_discrete_affect(
         assignments = map(s -> Assignment(s.lhs, s.rhs), subs.subs)
         let_body = SetArray(!checkbounds, out, rhss(equations(sys)))
         let_block = Let(assignments, let_body, false)
-        needed_cont_to_disc_obs = map(v -> arguments(v)[1], input)
+        needed_cont_to_disc_obs = map(v -> arguments(v)[1], filter(x->!(operation(x) isa ClockChange), input))
         # TODO: filter the needed ones
         fullvars = Set{Any}(eq.lhs for eq in observed(sys))
         for s in unknowns(sys)

--- a/src/systems/discrete_system/discrete_system.jl
+++ b/src/systems/discrete_system/discrete_system.jl
@@ -139,7 +139,8 @@ function DiscreteSystem(eqs::AbstractVector{<:Equation}, iv, dvs, ps;
     iv′ = value(iv)
     dvs′ = value.(dvs)
     ps′ = value.(ps)
-    if any(hasderiv, eqs) || any(hashold, eqs) || any(hassample, eqs) || any(hasdiff, eqs)
+    if any(hasderiv, eqs) || any(hashold, eqs) || any(hassample, eqs) ||
+       any(hasdiff, eqs) || any(hasclockchange, eqs)
         error("Equations in a `DiscreteSystem` can only have `Shift` operators.")
     end
     if !(isempty(default_u0) && isempty(default_p))

--- a/src/systems/systemstructure.jl
+++ b/src/systems/systemstructure.jl
@@ -457,23 +457,24 @@ function lower_order_var(dervar, t)
 end
 
 function shift_discrete_system(ts::TearingState)
+    dops = Union{Sample, Hold, ClockChange}
     @unpack fullvars, sys = ts
     discvars = OrderedSet()
     eqs = equations(sys)
     for eq in eqs
-        vars!(discvars, eq; op = Union{Sample, Hold})
+        vars!(discvars, eq; op = dops)
     end
     iv = get_iv(sys)
     discmap = Dict(k => StructuralTransformations.simplify_shifts(Shift(iv, 1)(k))
     for k in discvars
-    if any(isequal(k), fullvars) && !isa(operation(k), Union{Sample, Hold}))
+    if any(isequal(k), fullvars) && !isa(operation(k), dops))
     for i in eachindex(fullvars)
         fullvars[i] = StructuralTransformations.simplify_shifts(fast_substitute(
-            fullvars[i], discmap; operator = Union{Sample, Hold}))
+            fullvars[i], discmap; operator = dops))
     end
     for i in eachindex(eqs)
         eqs[i] = StructuralTransformations.simplify_shifts(fast_substitute(
-            eqs[i], discmap; operator = Union{Sample, Hold}))
+            eqs[i], discmap; operator = dops))
     end
     @set! ts.sys.eqs = eqs
     @set! ts.fullvars = fullvars

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -354,17 +354,20 @@ vars(eq::Equation; op = Differential) = vars!(Set(), eq; op = op)
 function vars!(vars, eq::Equation; op = Differential)
     (vars!(vars, eq.lhs; op = op); vars!(vars, eq.rhs; op = op); vars)
 end
+is_op(op::Type{<:T}) where {T} = x -> x isa op
+is_op(op::T) where {T} = op
 function vars!(vars, O; op = Differential)
+    isop = is_op(op)
     if isvariable(O)
         return push!(vars, O)
     end
     !istree(O) && return vars
 
-    operation(O) isa op && return push!(vars, O)
+    isop(operation(O)) && return push!(vars, O)
 
     if operation(O) === (getindex)
         arr = first(arguments(O))
-        istree(arr) && operation(arr) isa op && return push!(vars, O)
+        istree(arr) && isop(operation(arr)) && return push!(vars, O)
         isvariable(arr) && return push!(vars, O)
     end
 

--- a/test/clock.jl
+++ b/test/clock.jl
@@ -549,3 +549,25 @@ end
 @mtkbuild cc = CC()
 prob = ODEProblem(cc, [], (0, 10))
 sol = solve(prob, Tsit5(); kwargshandle = KeywordArgSilent)
+d1 = reduce(vcat, sol.prob.kwargs[:disc_saved_values][1].saveval)
+d2 = reduce(vcat, sol.prob.kwargs[:disc_saved_values][2].saveval)
+
+if length(d1) < length(d2)
+    d1, d2 = d2, d1
+end
+
+@test d2 == 1:6 # y
+
+X = [0, 0] # xy
+ti = 0
+for ti in 0:10
+    i = ti + 1
+    x, y = X
+    if ti % 2 == 0
+        y = y + 1
+    end
+    x = x + y
+
+    @test d1[i] == x
+    X = [x, y]
+end

--- a/test/clock.jl
+++ b/test/clock.jl
@@ -528,3 +528,24 @@ prob = ODEProblem(sys, [], (0.0, 10.0), [x(k - 1) => 2.0])
 int = init(prob, Tsit5(); kwargshandle = KeywordArgSilent)
 @test int.ps[x] == 3.0
 @test int.ps[x(k - 1)] == 2.0
+
+## ClockChange
+using ModelingToolkit: D_nounits as D
+k1 = ShiftIndex(Clock(t, 1))
+k2 = ShiftIndex(Clock(t, 2))
+@mtkmodel CC begin
+    @variables begin
+        x(t) = 0
+        y(t) = 0
+        dummy(t) = 0
+    end
+    @equations begin
+        x(k1) ~ x(k1 - 1) +
+                ModelingToolkit.ClockChange(from = k2.clock, to = k1.clock)(y(k2))
+        y(k2) ~ y(k2 - 1) + 1
+        D(dummy) ~ 0
+    end
+end
+@mtkbuild cc = CC()
+prob = ODEProblem(cc, [], (0, 10))
+sol = solve(prob, Tsit5(); kwargshandle = KeywordArgSilent)

--- a/test/clock.jl
+++ b/test/clock.jl
@@ -558,16 +558,21 @@ end
 
 @test d2 == 1:6 # y
 
-X = [0, 0] # xy
-ti = 0
-for ti in 0:10
-    i = ti + 1
-    x, y = X
-    if ti % 2 == 0
-        y = y + 1
-    end
-    x = x + y
+# Manual implementation of the dynamics
+function manualtest()
+    x, y = 0, 0
+    X = [[x, y]] # xy
+    ti = 0
+    for ti in 0:10
+        i = ti + 1
+        if ti % 2 == 0
+            y = y + 1
+        end
+        x = x + y
 
-    @test d1[i] == x
-    X = [x, y]
+        @test d1[i] == x
+        push!(X, [x, y])
+    end
+    X
 end
+X = manualtest()


### PR DESCRIPTION
This PR adds a discrete-time operator `ClockChange` that changes the clock of a discrete-time variable. This allows for sub and super sampling.

**Status:** In the simple test model added to the tests, I get an error from the compiler 
```julia
julia> @mtkbuild cc = CC()
ERROR: Some specified inputs were not found in system. The following variables were not found Any[ModelingToolkit.ClockChange(Clock(t, 2.0), Clock(t, 1.0))(y(t))]
Stacktrace:
  [1] error(::String, ::Base.KeySet{Any, Dict{Any, Bool}})
    @ Base ./error.jl:44
  [2] markio!(state::TearingState{ODESystem}, orig_inputs::Set{Any}, inputs::Vector{Any}, outputs::Vector{Any}; check::Bool)
    @ ModelingToolkit ~/.julia/dev/ModelingToolkit/src/systems/abstractsystem.jl:2038
  [3] markio!
    @ ~/.julia/dev/ModelingToolkit/src/systems/abstractsystem.jl:2009 [inlined]
  [4] _structural_simplify!(state::TearingState{…}, io::Tuple{…}; simplify::Bool, check_consistency::Bool, fully_determined::Bool, warn_initialize_determined::Bool, dummy_derivative::Bool, kwargs::@Kwargs{})
    @ ModelingToolkit ~/.julia/dev/ModelingToolkit/src/systems/systemstructure.jl:680
```

The problem appears realted to the hacky forward shift employed by the compiler, since
```julia
fullvars[end]
ModelingToolkit.ClockChange(Clock(t, 2.0), Clock(t, 1.0))(Shift(t, 2)(y(t)))
```
while the operator variable is not shifted
```julia
collect(keys(inputset))[]
ModelingToolkit.ClockChange(Clock(t, 2.0), Clock(t, 1.0))(y(t))
```

---

EDIT: I pushed a commit that applies the shift to the new operator as well. The remaining problem is that `x` is updated before `y`, while it should be the opposite, the equation for `x` depends on `y` and has to come after.