### PR TITLE
fix: fix `build_explicit_observed_function` for array parameter expressions

### DIFF
--- a/src/systems/diffeqs/odesystem.jl
+++ b/src/systems/diffeqs/odesystem.jl
@@ -420,7 +420,10 @@ function build_explicit_observed_function(sys, ts;
     subs = Dict()
     maxidx = 0
     for s in dep_vars
-        if s in param_set || s in param_set_ns
+        if s in param_set || s in param_set_ns ||
+           iscall(s) &&
+           operation(s) === getindex &&
+           (arguments(s)[1] in param_set || arguments(s)[1] in param_set_ns)
             continue
         end
         idx = get(observed_idx, s, nothing)

--- a/test/symbolic_indexing_interface.jl
+++ b/test/symbolic_indexing_interface.jl
@@ -85,3 +85,19 @@ analytic_function = (ps, t, x) -> -ps[1] * x * (x - 1) * sin(x) * exp(-2 * ps[1]
 @test isequal(pdesys.ps, [h])
 @test isequal(parameter_symbols(pdesys), [h])
 @test isequal(parameters(pdesys), [h])
+
+# Issue#2767
+using ModelingToolkit
+using ModelingToolkit: t_nounits as t, D_nounits as D
+using SymbolicIndexingInterface
+
+@parameters p1[1:2]=[1.0, 2.0] p2[1:2]=[0.0, 0.0]
+@variables x(t) = 0
+
+@named sys = ODESystem(
+    [D(x) ~ sum(p1) * t + sum(p2)],
+    t;
+)
+prob = ODEProblem(complete(sys))
+get_dep = @test_nowarn getu(prob, 2p1)
+@test get_dep(prob) == [2.0, 4.0]


### PR DESCRIPTION
Close #2767

## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
