### PR TITLE
fix: avoid infinite loops in MTKParameters initialization

### DIFF
--- a/src/systems/parameter_buffer.jl
+++ b/src/systems/parameter_buffer.jl
@@ -43,10 +43,10 @@ function MTKParameters(
     end
     defs = merge(defs, u0)
     defs = merge(Dict(eq.lhs => eq.rhs for eq in observed(sys)), defs)
-    p = merge(defs, p)
+    bigdefs = merge(defs, p)
     p = merge(Dict(unwrap(k) => v for (k, v) in p),
         Dict(default_toterm(unwrap(k)) => v for (k, v) in p))
-    p = Dict(unwrap(k) => fixpoint_sub(v, p) for (k, v) in p)
+    p = Dict(unwrap(k) => fixpoint_sub(v, bigdefs) for (k, v) in p)
     for (sym, _) in p
         if iscall(sym) && operation(sym) === getindex &&
            first(arguments(sym)) in all_ps


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
