### PR TITLE
refactor: use common implementation of `observedfun`

### DIFF
--- a/src/systems/abstractsystem.jl
+++ b/src/systems/abstractsystem.jl
@@ -1192,6 +1192,30 @@ end
 ###
 ### System utils
 ###
+struct ObservedFunctionCache{S}
+    sys::S
+    dict::Dict{Any, Any}
+end
+
+function ObservedFunctionCache(sys)
+    return ObservedFunctionCache(sys, Dict())
+    let sys = sys, dict = Dict()
+        function generated_observed(obsvar, args...)
+        end
+    end
+end
+
+function (ofc::ObservedFunctionCache)(obsvar, args...)
+    obs = get!(ofc.dict, value(obsvar)) do
+        SymbolicIndexingInterface.observed(ofc.sys, obsvar)
+    end
+    if args === ()
+        return obs
+    else
+        return obs(args...)
+    end
+end
+
 function push_vars!(stmt, name, typ, vars)
     isempty(vars) && return
     vars_expr = Expr(:macrocall, typ, nothing)

--- a/src/systems/diffeqs/sdesystem.jl
+++ b/src/systems/diffeqs/sdesystem.jl
@@ -484,19 +484,7 @@ function DiffEqBase.SDEFunction{iip}(sys::SDESystem, dvs = unknowns(sys),
     M = calculate_massmatrix(sys)
     _M = (u0 === nothing || M == I) ? M : ArrayInterface.restructure(u0 .* u0', M)
 
-    obs = observed(sys)
-    observedfun = let sys = sys, dict = Dict()
-        function generated_observed(obsvar, u, p, t)
-            obs = get!(dict, value(obsvar)) do
-                build_explicit_observed_function(sys, obsvar; checkbounds = checkbounds)
-            end
-            if p isa MTKParameters
-                obs(u, p..., t)
-            else
-                obs(u, p, t)
-            end
-        end
-    end
+    observedfun = ObservedFunctionCache(sys)
 
     SDEFunction{iip}(f, g,
         sys = sys,

--- a/src/systems/discrete_system/discrete_system.jl
+++ b/src/systems/discrete_system/discrete_system.jl
@@ -330,14 +330,7 @@ function SciMLBase.DiscreteFunction{iip, specialize}(
         f = SciMLBase.wrapfun_iip(f, (u0, u0, p, t))
     end
 
-    observedfun = let sys = sys, dict = Dict()
-        function generate_observed(obsvar, u, p, t)
-            obs = get!(dict, value(obsvar)) do
-                build_explicit_observed_function(sys, obsvar)
-            end
-            p isa MTKParameters ? obs(u, p..., t) : obs(u, p, t)
-        end
-    end
+    observedfun = ObservedFunctionCache(sys)
 
     DiscreteFunction{iip, specialize}(f;
         sys = sys,

--- a/src/systems/jumps/jumpsystem.jl
+++ b/src/systems/jumps/jumpsystem.jl
@@ -345,16 +345,7 @@ function DiffEqBase.DiscreteProblem(sys::JumpSystem, u0map, tspan::Union{Tuple, 
 
     f = DiffEqBase.DISCRETE_INPLACE_DEFAULT
 
-    # just taken from abstractodesystem.jl for ODEFunction def
-    obs = observed(sys)
-    observedfun = let sys = sys, dict = Dict()
-        function generated_observed(obsvar, u, p, t)
-            obs = get!(dict, value(obsvar)) do
-                build_explicit_observed_function(sys, obsvar; checkbounds = checkbounds)
-            end
-            p isa MTKParameters ? obs(u, p..., t) : obs(u, p, t)
-        end
-    end
+    observedfun = ObservedFunctionCache(sys)
 
     df = DiscreteFunction{true, true}(f; sys = sys, observed = observedfun)
     DiscreteProblem(df, u0, tspan, p; kwargs...)

--- a/src/systems/optimization/optimizationsystem.jl
+++ b/src/systems/optimization/optimizationsystem.jl
@@ -337,27 +337,7 @@ function DiffEqBase.OptimizationProblem{iip}(sys::OptimizationSystem, u0map,
         hess_prototype = nothing
     end
 
-    observedfun = let sys = sys, dict = Dict()
-        function generated_observed(obsvar, args...)
-            obs = get!(dict, value(obsvar)) do
-                build_explicit_observed_function(sys, obsvar)
-            end
-            if args === ()
-                let obs = obs
-                    _obs(u, p) = obs(u, p)
-                    _obs(u, p::MTKParameters) = obs(u, p...)
-                    _obs
-                end
-            else
-                u, p = args
-                if p isa MTKParameters
-                    obs(u, p...)
-                else
-                    obs(u, p)
-                end
-            end
-        end
-    end
+    observedfun = ObservedFunctionCache(sys)
 
     if length(cstr) > 0
         @named cons_sys = ConstraintsSystem(cstr, dvs, ps)


### PR DESCRIPTION
This is necessary because while #2791 fixed `SII.observed`, SII doesn't use it since `SciMLFunction` has its own implementation which uses `f.observed` instead. This makes `f.observed` use `SII.observed`, and allows all systems to have a common implementation to avoid inconsistencies.

## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
