### PR TITLE
Refactor: Migrate from deprecated `unsorted_arguments` to `arguments`

### DIFF
--- a/src/systems/connectors.jl
+++ b/src/systems/connectors.jl
@@ -85,7 +85,7 @@ function collect_instream!(set, expr, occurs = false)
     iscall(expr) || return occurs
     op = operation(expr)
     op === instream && (push!(set, expr); occurs = true)
-    for a in SymbolicUtils.unsorted_arguments(expr)
+    for a in SymbolicUtils.arguments(expr)
         occurs |= collect_instream!(set, a, occurs)
     end
     return occurs

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -281,7 +281,7 @@ function _check_operator_variables(eq, op::T, expr = eq.rhs) where {T}
         throw_invalid_operator(expr, eq, op)
     end
     foreach(expr -> _check_operator_variables(eq, op, expr),
-        SymbolicUtils.unsorted_arguments(expr))
+        SymbolicUtils.arguments(expr))
 end
 """
 Check if all the LHS are unique


### PR DESCRIPTION
This PR migrates ModelingToolkit.jl from the deprecated `unsorted_arguments` to `arguments`, following the changes introduced in PR https://github.com/JuliaSymbolics/SymbolicUtils.jl/pull/615 and https://github.com/JuliaSymbolics/Symbolics.jl/pull/1179.

Specifically, this PR replaces all instances of `unsorted_arguments` with `arguments` to align with the updated SymbolicUtils API.

This change ensures compatibility with the latest version of SymbolicUtils.jl and eliminates deprecation warnings.

## Checklist

- [ ] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
