### PR TITLE
Make eval great again

### DIFF
--- a/docs/pages.jl
+++ b/docs/pages.jl
@@ -31,6 +31,7 @@ pages = [
         "basics/MTKModel_Connector.md",
         "basics/Validation.md",
         "basics/DependencyGraphs.md",
+        "basics/Precompilation.md",
         "basics/FAQ.md"],
     "System Types" => Any["systems/ODESystem.md",
         "systems/SDESystem.md",

--- a/docs/src/basics/Precompilation.md
+++ b/docs/src/basics/Precompilation.md
@@ -1,0 +1,117 @@
+# Working with Precompilation and Binary Building
+
+## tl;dr, I just want precompilation to work
+
+The tl;dr is, if you want to make precompilation work then instead of
+
+```julia
+ODEProblem(sys, u0, tspan, p)
+```
+
+use:
+
+```julia
+ODEProblem(sys, u0, tspan, p, eval_module = @__MODULE__, eval_expression = true)
+```
+
+As a full example, here's an example of a module that would precompile effectively:
+
+```julia
+module PrecompilationMWE
+using ModelingToolkit
+
+@variables x(ModelingToolkit.t_nounits)
+@named sys = ODESystem([ModelingToolkit.D_nounits(x) ~ -x + 1], ModelingToolkit.t_nounits)
+prob = ODEProblem(structural_simplify(sys), [x => 30.0], (0, 100), [],
+    eval_expression = true, eval_module = @__MODULE__)
+
+end
+```
+
+If you use that in your package's code then 99% of the time that's the right answer to get
+precompilation working.
+
+## I'm doing something fancier and need a bit more of an explanation
+
+Oh you dapper soul, time for the bigger explanation. Julia's `eval` function evaluates a
+function into a module at a specified world-age. If you evaluate a function within a function
+and try to call it from within that same function, you will hit a world-age error. This looks like:
+
+```julia
+function worldageerror()
+    f = eval(:((x) -> 2x))
+    f(2)
+end
+```
+
+```
+julia> worldageerror()
+ERROR: MethodError: no method matching (::var"#5#6")(::Int64)
+
+Closest candidates are:
+  (::var"#5#6")(::Any) (method too new to be called from this world context.)
+   @ Main REPL[12]:2
+```
+
+This is done for many reasons, in particular if the code that is called within a function could change
+at any time, then Julia functions could not ever properly optimize because the meaning of any function
+or dispatch could always change and you would lose performance by guarding against that. For a full
+discussion of world-age, see [this paper](https://arxiv.org/abs/2010.07516).
+
+However, this would be greatly inhibiting to standard ModelingToolkit usage because then something as
+simple as building an ODEProblem in a function and then using it would get a world age error:
+
+```julia
+function wouldworldage()
+    prob = ODEProblem(sys, [], (0.0, 1.0))
+    sol = solve(prob)
+end
+```
+
+The reason is because `prob.f` would be constructed via `eval`, and thus `prob.f` could not be called
+in the function, which means that no solve could ever work in the same function that generated the
+problem. That does mean that:
+
+```julia
+function wouldworldage()
+    prob = ODEProblem(sys, [], (0.0, 1.0))
+end
+sol = solve(prob)
+```
+
+is fine, or putting
+
+```julia
+prob = ODEProblem(sys, [], (0.0, 1.0))
+sol = solve(prob)
+```
+
+at the top level of a module is perfectly fine too. They just cannot happen in the same function.
+
+This would be a major limitation to ModelingToolkit, and thus we developed
+[RuntimeGeneratedFunctions](https://github.com/SciML/RuntimeGeneratedFunctions.jl) to get around
+this limitation. It will not be described beyond that, it is dark art and should not be investigated.
+But it does the job. But that does mean that it plays... oddly with Julia's compilation.
+
+There are ways to force RuntimeGeneratedFunctions to perform their evaluation and caching within
+a given module, but that is not recommended because it does not play nicely with Julia v1.9's
+introduction of package images for binary caching.
+
+Thus when trying to make things work with precompilation, we recommend using `eval`. This is
+done by simply adding `eval_expression=true` to the problem constructor. However, this is not
+a silver bullet because the moment you start using eval, all potential world-age restrictions
+apply, and thus it is recommended this is simply used for evaluating at the top level of modules
+for the purpose of precompilation and ensuring binaries of your MTK functions are built correctly.
+
+However, there is one caveat that `eval` in Julia works depending on the module that it is given.
+If you have `MyPackage` that you are precompiling into, or say you are using `juliac` or PackageCompiler
+or some other static ahead-of-time (AOT) Julia compiler, then you don't want to accidentally `eval`
+that function to live in ModelingToolkit and instead want to make sure it is `eval`'d to live in `MyPackage`
+(since otherwise it will not cache into the binary). ModelingToolkit cannot know that in advance, and thus
+you have to pass in the module you wish for the functions to "live" in. This is done via the `eval_module`
+argument.
+
+Hence `ODEProblem(sys, u0, tspan, p, eval_module=@__MODULE__, eval_expression=true)` will work if you
+are running this expression in the scope of the module you wish to be precompiling. However, if you are
+attempting to AOT compile a different module, this means that `eval_module` needs to be appropriately
+chosen. And, because `eval_expression=true`, all caveats of world-age apply.

--- a/src/systems/clock_inference.jl
+++ b/src/systems/clock_inference.jl
@@ -416,10 +416,10 @@ function generate_discrete_affect(
         inits = map(a -> eval_module.eval(toexpr(LiteralExpr(a))), init_funs)
     else
         affects = map(affect_funs) do a
-            drop_expr(@RuntimeGeneratedFunction(eval_module, toexpr(LiteralExpr(a))))
+            drop_expr(RuntimeGeneratedFunction(eval_module, eval_module, toexpr(LiteralExpr(a))))
         end
         inits = map(init_funs) do a
-            drop_expr(@RuntimeGeneratedFunction(eval_module, toexpr(LiteralExpr(a))))
+            drop_expr(RuntimeGeneratedFunction(eval_module, eval_module, toexpr(LiteralExpr(a))))
         end
     end
     defaults = Dict{Any, Any}(v => 0.0 for v in Iterators.flatten(inputs))

--- a/src/systems/clock_inference.jl
+++ b/src/systems/clock_inference.jl
@@ -416,10 +416,12 @@ function generate_discrete_affect(
         inits = map(a -> eval_module.eval(toexpr(LiteralExpr(a))), init_funs)
     else
         affects = map(affect_funs) do a
-            drop_expr(RuntimeGeneratedFunction(eval_module, eval_module, toexpr(LiteralExpr(a))))
+            drop_expr(RuntimeGeneratedFunction(
+                eval_module, eval_module, toexpr(LiteralExpr(a))))
         end
         inits = map(init_funs) do a
-            drop_expr(RuntimeGeneratedFunction(eval_module, eval_module, toexpr(LiteralExpr(a))))
+            drop_expr(RuntimeGeneratedFunction(
+                eval_module, eval_module, toexpr(LiteralExpr(a))))
         end
     end
     defaults = Dict{Any, Any}(v => 0.0 for v in Iterators.flatten(inputs))

--- a/src/systems/diffeqs/abstractodesystem.jl
+++ b/src/systems/diffeqs/abstractodesystem.jl
@@ -378,7 +378,7 @@ function DiffEqBase.ODEFunction{iip, specialize}(sys::AbstractODESystem,
             checkbounds = checkbounds, kwargs...)
         jac_oop, jac_iip = eval_expression ? eval_module.eval.(jac_gen) :
                            (drop_expr(@RuntimeGeneratedFunction(eval_module, ex)) for ex in jac_gen)
-                           
+
         _jac(u, p, t) = jac_oop(u, p, t)
         _jac(J, u, p, t) = jac_iip(J, u, p, t)
         _jac(u, p::Tuple{Vararg{Number}}, t) = jac_oop(u, p, t)
@@ -502,7 +502,7 @@ function DiffEqBase.DAEFunction{iip}(sys::AbstractODESystem, dvs = unknowns(sys)
             checkbounds = checkbounds, kwargs...)
         jac_oop, jac_iip = eval_expression ? eval_module.eval.(jac_gen) :
                            (drop_expr(@RuntimeGeneratedFunction(eval_module, ex)) for ex in jac_gen)
-                           
+
         _jac(du, u, p, ˍ₋gamma, t) = jac_oop(du, u, p, ˍ₋gamma, t)
         _jac(du, u, p::MTKParameters, ˍ₋gamma, t) = jac_oop(du, u, p..., ˍ₋gamma, t)
 

--- a/src/systems/diffeqs/abstractodesystem.jl
+++ b/src/systems/diffeqs/abstractodesystem.jl
@@ -331,7 +331,7 @@ function DiffEqBase.ODEFunction{iip, specialize}(sys::AbstractODESystem,
         expression_module = eval_module, checkbounds = checkbounds,
         kwargs...)
     f_oop, f_iip = eval_expression ? eval_module.eval.(f_gen) :
-                   (drop_expr(@RuntimeGeneratedFunction(eval_module, ex)) for ex in f_gen)
+                   (drop_expr(RuntimeGeneratedFunction(eval_module, eval_module, ex)) for ex in f_gen)
 
     f(u, p, t) = f_oop(u, p, t)
     f(du, u, p, t) = f_iip(du, u, p, t)
@@ -356,7 +356,7 @@ function DiffEqBase.ODEFunction{iip, specialize}(sys::AbstractODESystem,
             expression_module = eval_module,
             checkbounds = checkbounds, kwargs...)
         tgrad_oop, tgrad_iip = eval_expression ? eval_module.eval.(tgrad_gen) :
-                               (drop_expr(@RuntimeGeneratedFunction(eval_module, ex)) for ex in tgrad_gen)
+                               (drop_expr(RuntimeGeneratedFunction(eval_module, eval_module, ex)) for ex in tgrad_gen)
         if p isa Tuple
             __tgrad(u, p, t) = tgrad_oop(u, p..., t)
             __tgrad(J, u, p, t) = tgrad_iip(J, u, p..., t)
@@ -377,7 +377,7 @@ function DiffEqBase.ODEFunction{iip, specialize}(sys::AbstractODESystem,
             expression_module = eval_module,
             checkbounds = checkbounds, kwargs...)
         jac_oop, jac_iip = eval_expression ? eval_module.eval.(jac_gen) :
-                           (drop_expr(@RuntimeGeneratedFunction(eval_module, ex)) for ex in jac_gen)
+                           (drop_expr(RuntimeGeneratedFunction(eval_module, eval_module, ex)) for ex in jac_gen)
 
         _jac(u, p, t) = jac_oop(u, p, t)
         _jac(J, u, p, t) = jac_iip(J, u, p, t)
@@ -488,7 +488,7 @@ function DiffEqBase.DAEFunction{iip}(sys::AbstractODESystem, dvs = unknowns(sys)
         expression_module = eval_module, checkbounds = checkbounds,
         kwargs...)
     f_oop, f_iip = eval_expression ? eval_module.eval.(f_gen) :
-                   (drop_expr(@RuntimeGeneratedFunction(eval_module, ex)) for ex in f_gen)
+                   (drop_expr(RuntimeGeneratedFunction(eval_module, eval_module, ex)) for ex in f_gen)
     f(du, u, p, t) = f_oop(du, u, p, t)
     f(du, u, p::MTKParameters, t) = f_oop(du, u, p..., t)
     f(out, du, u, p, t) = f_iip(out, du, u, p, t)
@@ -501,7 +501,7 @@ function DiffEqBase.DAEFunction{iip}(sys::AbstractODESystem, dvs = unknowns(sys)
             expression_module = eval_module,
             checkbounds = checkbounds, kwargs...)
         jac_oop, jac_iip = eval_expression ? eval_module.eval.(jac_gen) :
-                           (drop_expr(@RuntimeGeneratedFunction(eval_module, ex)) for ex in jac_gen)
+                           (drop_expr(RuntimeGeneratedFunction(eval_module, eval_module, ex)) for ex in jac_gen)
 
         _jac(du, u, p, ˍ₋gamma, t) = jac_oop(du, u, p, ˍ₋gamma, t)
         _jac(du, u, p::MTKParameters, ˍ₋gamma, t) = jac_oop(du, u, p..., ˍ₋gamma, t)
@@ -553,7 +553,7 @@ function DiffEqBase.DDEFunction{iip}(sys::AbstractODESystem, dvs = unknowns(sys)
         expression = Val{true},
         expression_module = eval_module, checkbounds = checkbounds,
         kwargs...)
-    f_oop, f_iip = (drop_expr(@RuntimeGeneratedFunction(eval_module, ex)) for ex in f_gen)
+    f_oop, f_iip = (drop_expr(RuntimeGeneratedFunction(eval_module, eval_module, ex)) for ex in f_gen)
     f(u, h, p, t) = f_oop(u, h, p, t)
     f(u, h, p::MTKParameters, t) = f_oop(u, h, p..., t)
     f(du, u, h, p, t) = f_iip(du, u, h, p, t)
@@ -578,7 +578,7 @@ function DiffEqBase.SDDEFunction{iip}(sys::AbstractODESystem, dvs = unknowns(sys
         expression = Val{true},
         expression_module = eval_module, checkbounds = checkbounds,
         kwargs...)
-    f_oop, f_iip = (drop_expr(@RuntimeGeneratedFunction(eval_module, ex)) for ex in f_gen)
+    f_oop, f_iip = (drop_expr(RuntimeGeneratedFunction(eval_module, eval_module, ex)) for ex in f_gen)
     g_gen = generate_diffusion_function(sys, dvs, ps; expression = Val{true},
         isdde = true, kwargs...)
     g_oop, g_iip = (drop_expr(@RuntimeGeneratedFunction(ex)) for ex in g_gen)

--- a/src/systems/diffeqs/abstractodesystem.jl
+++ b/src/systems/diffeqs/abstractodesystem.jl
@@ -327,7 +327,7 @@ function DiffEqBase.ODEFunction{iip, specialize}(sys::AbstractODESystem,
     if !iscomplete(sys)
         error("A completed system is required. Call `complete` or `structural_simplify` on the system before creating an `ODEFunction`")
     end
-    f_gen = generate_function(sys, dvs, ps; expression = Val{!eval_expression},
+    f_gen = generate_function(sys, dvs, ps; expression = Val{true},
         expression_module = eval_module, checkbounds = checkbounds,
         kwargs...)
     f_oop, f_iip = eval_expression ? eval_module.eval.(f_gen) :
@@ -352,7 +352,7 @@ function DiffEqBase.ODEFunction{iip, specialize}(sys::AbstractODESystem,
     if tgrad
         tgrad_gen = generate_tgrad(sys, dvs, ps;
             simplify = simplify,
-            expression = Val{!eval_expression},
+            expression = Val{true},
             expression_module = eval_module,
             checkbounds = checkbounds, kwargs...)
         tgrad_oop, tgrad_iip = eval_expression ? eval_module.eval.(tgrad_gen) :
@@ -373,7 +373,7 @@ function DiffEqBase.ODEFunction{iip, specialize}(sys::AbstractODESystem,
     if jac
         jac_gen = generate_jacobian(sys, dvs, ps;
             simplify = simplify, sparse = sparse,
-            expression = Val{!eval_expression},
+            expression = Val{true},
             expression_module = eval_module,
             checkbounds = checkbounds, kwargs...)
         jac_oop, jac_iip = eval_expression ? eval_module.eval.(jac_gen) :
@@ -484,7 +484,7 @@ function DiffEqBase.DAEFunction{iip}(sys::AbstractODESystem, dvs = unknowns(sys)
         error("A completed system is required. Call `complete` or `structural_simplify` on the system before creating a `DAEFunction`")
     end
     f_gen = generate_function(sys, dvs, ps; implicit_dae = true,
-        expression = Val{!eval_expression},
+        expression = Val{true},
         expression_module = eval_module, checkbounds = checkbounds,
         kwargs...)
     f_oop, f_iip = eval_expression ? eval_module.eval.(f_gen) :
@@ -497,7 +497,7 @@ function DiffEqBase.DAEFunction{iip}(sys::AbstractODESystem, dvs = unknowns(sys)
     if jac
         jac_gen = generate_dae_jacobian(sys, dvs, ps;
             simplify = simplify, sparse = sparse,
-            expression = Val{!eval_expression},
+            expression = Val{true},
             expression_module = eval_module,
             checkbounds = checkbounds, kwargs...)
         jac_oop, jac_iip = eval_expression ? eval_module.eval.(jac_gen) :

--- a/src/systems/diffeqs/abstractodesystem.jl
+++ b/src/systems/diffeqs/abstractodesystem.jl
@@ -356,7 +356,8 @@ function DiffEqBase.ODEFunction{iip, specialize}(sys::AbstractODESystem,
             expression_module = eval_module,
             checkbounds = checkbounds, kwargs...)
         tgrad_oop, tgrad_iip = eval_expression ? eval_module.eval.(tgrad_gen) :
-                               (drop_expr(RuntimeGeneratedFunction(eval_module, eval_module, ex)) for ex in tgrad_gen)
+                               (drop_expr(RuntimeGeneratedFunction(
+                                    eval_module, eval_module, ex)) for ex in tgrad_gen)
         if p isa Tuple
             __tgrad(u, p, t) = tgrad_oop(u, p..., t)
             __tgrad(J, u, p, t) = tgrad_iip(J, u, p..., t)
@@ -377,7 +378,8 @@ function DiffEqBase.ODEFunction{iip, specialize}(sys::AbstractODESystem,
             expression_module = eval_module,
             checkbounds = checkbounds, kwargs...)
         jac_oop, jac_iip = eval_expression ? eval_module.eval.(jac_gen) :
-                           (drop_expr(RuntimeGeneratedFunction(eval_module, eval_module, ex)) for ex in jac_gen)
+                           (drop_expr(RuntimeGeneratedFunction(
+                                eval_module, eval_module, ex)) for ex in jac_gen)
 
         _jac(u, p, t) = jac_oop(u, p, t)
         _jac(J, u, p, t) = jac_iip(J, u, p, t)
@@ -501,7 +503,8 @@ function DiffEqBase.DAEFunction{iip}(sys::AbstractODESystem, dvs = unknowns(sys)
             expression_module = eval_module,
             checkbounds = checkbounds, kwargs...)
         jac_oop, jac_iip = eval_expression ? eval_module.eval.(jac_gen) :
-                           (drop_expr(RuntimeGeneratedFunction(eval_module, eval_module, ex)) for ex in jac_gen)
+                           (drop_expr(RuntimeGeneratedFunction(
+                                eval_module, eval_module, ex)) for ex in jac_gen)
 
         _jac(du, u, p, ˍ₋gamma, t) = jac_oop(du, u, p, ˍ₋gamma, t)
         _jac(du, u, p::MTKParameters, ˍ₋gamma, t) = jac_oop(du, u, p..., ˍ₋gamma, t)

--- a/src/systems/diffeqs/sdesystem.jl
+++ b/src/systems/diffeqs/sdesystem.jl
@@ -407,7 +407,7 @@ function DiffEqBase.SDEFunction{iip}(sys::SDESystem, dvs = unknowns(sys),
         ps = parameters(sys),
         u0 = nothing;
         version = nothing, tgrad = false, sparse = false,
-        jac = false, Wfact = false, eval_expression = true,
+        jac = false, Wfact = false, eval_expression = false,
         checkbounds = false,
         kwargs...) where {iip}
     if !iscomplete(sys)
@@ -415,13 +415,13 @@ function DiffEqBase.SDEFunction{iip}(sys::SDESystem, dvs = unknowns(sys),
     end
     dvs = scalarize.(dvs)
 
-    f_gen = generate_function(sys, dvs, ps; expression = Val{eval_expression}, kwargs...)
-    f_oop, f_iip = eval_expression ?
-                   (drop_expr(@RuntimeGeneratedFunction(ex)) for ex in f_gen) : f_gen
-    g_gen = generate_diffusion_function(sys, dvs, ps; expression = Val{eval_expression},
+    f_gen = generate_function(sys, dvs, ps; expression = Val{!eval_expression}, kwargs...)
+    f_oop, f_iip = eval_expression ? eval_module.eval.(f_gen) :
+                   (drop_expr(@RuntimeGeneratedFunction(ex)) for ex in f_gen)
+    g_gen = generate_diffusion_function(sys, dvs, ps; expression = Val{!eval_expression},
         kwargs...)
-    g_oop, g_iip = eval_expression ?
-                   (drop_expr(@RuntimeGeneratedFunction(ex)) for ex in g_gen) : g_gen
+    g_oop, g_iip = eval_expression ? eval_module.eval.(g_gen) :
+                   (drop_expr(@RuntimeGeneratedFunction(ex)) for ex in g_gen)
 
     f(u, p, t) = f_oop(u, p, t)
     f(u, p::MTKParameters, t) = f_oop(u, p..., t)
@@ -433,11 +433,11 @@ function DiffEqBase.SDEFunction{iip}(sys::SDESystem, dvs = unknowns(sys),
     g(du, u, p::MTKParameters, t) = g_iip(du, u, p..., t)
 
     if tgrad
-        tgrad_gen = generate_tgrad(sys, dvs, ps; expression = Val{eval_expression},
+        tgrad_gen = generate_tgrad(sys, dvs, ps; expression = Val{!eval_expression},
             kwargs...)
-        tgrad_oop, tgrad_iip = eval_expression ?
-                               (drop_expr(@RuntimeGeneratedFunction(ex)) for ex in tgrad_gen) :
-                               tgrad_gen
+        tgrad_oop, tgrad_iip = eval_expression ? eval_module.eval.(tgrad_gen) :
+                               (drop_expr(@RuntimeGeneratedFunction(ex)) for ex in tgrad_gen)
+                               
         _tgrad(u, p, t) = tgrad_oop(u, p, t)
         _tgrad(u, p::MTKParameters, t) = tgrad_oop(u, p..., t)
         _tgrad(J, u, p, t) = tgrad_iip(J, u, p, t)
@@ -447,11 +447,11 @@ function DiffEqBase.SDEFunction{iip}(sys::SDESystem, dvs = unknowns(sys),
     end
 
     if jac
-        jac_gen = generate_jacobian(sys, dvs, ps; expression = Val{eval_expression},
+        jac_gen = generate_jacobian(sys, dvs, ps; expression = Val{!eval_expression},
             sparse = sparse, kwargs...)
-        jac_oop, jac_iip = eval_expression ?
-                           (drop_expr(@RuntimeGeneratedFunction(ex)) for ex in jac_gen) :
-                           jac_gen
+        jac_oop, jac_iip = eval_expression ? eval_module.eval.(jac_gen) : 
+                           (drop_expr(@RuntimeGeneratedFunction(ex)) for ex in jac_gen)
+        
         _jac(u, p, t) = jac_oop(u, p, t)
         _jac(u, p::MTKParameters, t) = jac_oop(u, p..., t)
         _jac(J, u, p, t) = jac_iip(J, u, p, t)
@@ -463,12 +463,11 @@ function DiffEqBase.SDEFunction{iip}(sys::SDESystem, dvs = unknowns(sys),
     if Wfact
         tmp_Wfact, tmp_Wfact_t = generate_factorized_W(sys, dvs, ps, true;
             expression = Val{true}, kwargs...)
-        Wfact_oop, Wfact_iip = eval_expression ?
-                               (drop_expr(@RuntimeGeneratedFunction(ex)) for ex in tmp_Wfact) :
-                               tmp_Wfact
-        Wfact_oop_t, Wfact_iip_t = eval_expression ?
-                                   (drop_expr(@RuntimeGeneratedFunction(ex)) for ex in tmp_Wfact_t) :
-                                   tmp_Wfact_t
+        Wfact_oop, Wfact_iip = eval_expression ? eval_module.eval.(tmp_Wfact) :
+                               (drop_expr(@RuntimeGeneratedFunction(ex)) for ex in tmp_Wfact)
+        Wfact_oop_t, Wfact_iip_t = eval_expression ? eval_module.eval.(tmp_Wfact_t) :
+                                   (drop_expr(@RuntimeGeneratedFunction(ex)) for ex in tmp_Wfact_t)
+
         _Wfact(u, p, dtgamma, t) = Wfact_oop(u, p, dtgamma, t)
         _Wfact(u, p::MTKParameters, dtgamma, t) = Wfact_oop(u, p..., dtgamma, t)
         _Wfact(W, u, p, dtgamma, t) = Wfact_iip(W, u, p, dtgamma, t)

--- a/src/systems/diffeqs/sdesystem.jl
+++ b/src/systems/diffeqs/sdesystem.jl
@@ -415,10 +415,10 @@ function DiffEqBase.SDEFunction{iip}(sys::SDESystem, dvs = unknowns(sys),
     end
     dvs = scalarize.(dvs)
 
-    f_gen = generate_function(sys, dvs, ps; expression = Val{!eval_expression}, kwargs...)
+    f_gen = generate_function(sys, dvs, ps; expression = Val{true}, kwargs...)
     f_oop, f_iip = eval_expression ? eval_module.eval.(f_gen) :
                    (drop_expr(@RuntimeGeneratedFunction(ex)) for ex in f_gen)
-    g_gen = generate_diffusion_function(sys, dvs, ps; expression = Val{!eval_expression},
+    g_gen = generate_diffusion_function(sys, dvs, ps; expression = Val{true},
         kwargs...)
     g_oop, g_iip = eval_expression ? eval_module.eval.(g_gen) :
                    (drop_expr(@RuntimeGeneratedFunction(ex)) for ex in g_gen)
@@ -433,7 +433,7 @@ function DiffEqBase.SDEFunction{iip}(sys::SDESystem, dvs = unknowns(sys),
     g(du, u, p::MTKParameters, t) = g_iip(du, u, p..., t)
 
     if tgrad
-        tgrad_gen = generate_tgrad(sys, dvs, ps; expression = Val{!eval_expression},
+        tgrad_gen = generate_tgrad(sys, dvs, ps; expression = Val{true},
             kwargs...)
         tgrad_oop, tgrad_iip = eval_expression ? eval_module.eval.(tgrad_gen) :
                                (drop_expr(@RuntimeGeneratedFunction(ex)) for ex in tgrad_gen)
@@ -447,7 +447,7 @@ function DiffEqBase.SDEFunction{iip}(sys::SDESystem, dvs = unknowns(sys),
     end
 
     if jac
-        jac_gen = generate_jacobian(sys, dvs, ps; expression = Val{!eval_expression},
+        jac_gen = generate_jacobian(sys, dvs, ps; expression = Val{true},
             sparse = sparse, kwargs...)
         jac_oop, jac_iip = eval_expression ? eval_module.eval.(jac_gen) :
                            (drop_expr(@RuntimeGeneratedFunction(ex)) for ex in jac_gen)

--- a/src/systems/diffeqs/sdesystem.jl
+++ b/src/systems/diffeqs/sdesystem.jl
@@ -437,7 +437,7 @@ function DiffEqBase.SDEFunction{iip}(sys::SDESystem, dvs = unknowns(sys),
             kwargs...)
         tgrad_oop, tgrad_iip = eval_expression ? eval_module.eval.(tgrad_gen) :
                                (drop_expr(@RuntimeGeneratedFunction(ex)) for ex in tgrad_gen)
-                               
+
         _tgrad(u, p, t) = tgrad_oop(u, p, t)
         _tgrad(u, p::MTKParameters, t) = tgrad_oop(u, p..., t)
         _tgrad(J, u, p, t) = tgrad_iip(J, u, p, t)
@@ -449,9 +449,9 @@ function DiffEqBase.SDEFunction{iip}(sys::SDESystem, dvs = unknowns(sys),
     if jac
         jac_gen = generate_jacobian(sys, dvs, ps; expression = Val{!eval_expression},
             sparse = sparse, kwargs...)
-        jac_oop, jac_iip = eval_expression ? eval_module.eval.(jac_gen) : 
+        jac_oop, jac_iip = eval_expression ? eval_module.eval.(jac_gen) :
                            (drop_expr(@RuntimeGeneratedFunction(ex)) for ex in jac_gen)
-        
+
         _jac(u, p, t) = jac_oop(u, p, t)
         _jac(u, p::MTKParameters, t) = jac_oop(u, p..., t)
         _jac(J, u, p, t) = jac_iip(J, u, p, t)

--- a/src/systems/discrete_system/discrete_system.jl
+++ b/src/systems/discrete_system/discrete_system.jl
@@ -318,7 +318,7 @@ function SciMLBase.DiscreteFunction{iip, specialize}(
     f_gen = generate_function(sys, dvs, ps; expression = Val{true},
         expression_module = eval_module, kwargs...)
     f_oop, f_iip = eval_expression ? eval_module.eval.(f_gen) :
-                   (drop_expr(@RuntimeGeneratedFunction(eval_module, ex)) for ex in f_gen)
+                   (drop_expr(RuntimeGeneratedFunction(eval_module, eval_module, ex)) for ex in f_gen)
     f(u, p, t) = f_oop(u, p, t)
     f(du, u, p, t) = f_iip(du, u, p, t)
 

--- a/src/systems/discrete_system/discrete_system.jl
+++ b/src/systems/discrete_system/discrete_system.jl
@@ -315,7 +315,7 @@ function SciMLBase.DiscreteFunction{iip, specialize}(
     if !iscomplete(sys)
         error("A completed `DiscreteSystem` is required. Call `complete` or `structural_simplify` on the system before creating a `DiscreteProblem`")
     end
-    f_gen = generate_function(sys, dvs, ps; expression = Val{!eval_expression},
+    f_gen = generate_function(sys, dvs, ps; expression = Val{true},
         expression_module = eval_module, kwargs...)
     f_oop, f_iip = eval_expression ? eval_module.eval.(f_gen) :
                    (drop_expr(@RuntimeGeneratedFunction(eval_module, ex)) for ex in f_gen)

--- a/src/systems/discrete_system/discrete_system.jl
+++ b/src/systems/discrete_system/discrete_system.jl
@@ -222,7 +222,7 @@ end
 
 function process_DiscreteProblem(constructor, sys::DiscreteSystem, u0map, parammap;
         linenumbers = true, parallel = SerialForm(),
-        eval_expression = true,
+        eval_expression = false,
         use_union = false,
         tofloat = !use_union,
         kwargs...)
@@ -271,7 +271,7 @@ function SciMLBase.DiscreteProblem(
         sys::DiscreteSystem, u0map = [], tspan = get_tspan(sys),
         parammap = SciMLBase.NullParameters();
         eval_module = @__MODULE__,
-        eval_expression = true,
+        eval_expression = false,
         use_union = false,
         kwargs...
 )
@@ -308,18 +308,17 @@ function SciMLBase.DiscreteFunction{iip, specialize}(
         version = nothing,
         p = nothing,
         t = nothing,
-        eval_expression = true,
+        eval_expression = false,
         eval_module = @__MODULE__,
         analytic = nothing,
         kwargs...) where {iip, specialize}
     if !iscomplete(sys)
         error("A completed `DiscreteSystem` is required. Call `complete` or `structural_simplify` on the system before creating a `DiscreteProblem`")
     end
-    f_gen = generate_function(sys, dvs, ps; expression = Val{eval_expression},
+    f_gen = generate_function(sys, dvs, ps; expression = Val{!eval_expression},
         expression_module = eval_module, kwargs...)
-    f_oop, f_iip = eval_expression ?
-                   (drop_expr(@RuntimeGeneratedFunction(eval_module, ex)) for ex in f_gen) :
-                   f_gen
+    f_oop, f_iip = eval_expression ? eval_module.eval.(f_gen) :
+                   (drop_expr(@RuntimeGeneratedFunction(eval_module, ex)) for ex in f_gen)
     f(u, p, t) = f_oop(u, p, t)
     f(du, u, p, t) = f_iip(du, u, p, t)
 

--- a/src/systems/nonlinear/nonlinearsystem.jl
+++ b/src/systems/nonlinear/nonlinearsystem.jl
@@ -283,7 +283,7 @@ function SciMLBase.NonlinearFunction{iip}(sys::NonlinearSystem, dvs = unknowns(s
     if !iscomplete(sys)
         error("A completed `NonlinearSystem` is required. Call `complete` or `structural_simplify` on the system before creating a `NonlinearFunction`")
     end
-    f_gen = generate_function(sys, dvs, ps; expression = Val{!eval_expression}, kwargs...)
+    f_gen = generate_function(sys, dvs, ps; expression = Val{true}, kwargs...)
     f_oop, f_iip = eval_expression ? eval_module.eval.(f_gen) :
                    (drop_expr(@RuntimeGeneratedFunction(ex)) for ex in f_gen)
     f(u, p) = f_oop(u, p)
@@ -294,7 +294,7 @@ function SciMLBase.NonlinearFunction{iip}(sys::NonlinearSystem, dvs = unknowns(s
     if jac
         jac_gen = generate_jacobian(sys, dvs, ps;
             simplify = simplify, sparse = sparse,
-            expression = Val{!eval_expression}, kwargs...)
+            expression = Val{true}, kwargs...)
         jac_oop, jac_iip = eval_expression ? eval_module.eval.(jac_gen) :
                            (drop_expr(@RuntimeGeneratedFunction(ex)) for ex in jac_gen)
         _jac(u, p) = jac_oop(u, p)

--- a/src/systems/nonlinear/nonlinearsystem.jl
+++ b/src/systems/nonlinear/nonlinearsystem.jl
@@ -277,15 +277,15 @@ function SciMLBase.NonlinearFunction{iip}(sys::NonlinearSystem, dvs = unknowns(s
         ps = full_parameters(sys), u0 = nothing;
         version = nothing,
         jac = false,
-        eval_expression = true,
+        eval_expression = false,
         sparse = false, simplify = false,
         kwargs...) where {iip}
     if !iscomplete(sys)
         error("A completed `NonlinearSystem` is required. Call `complete` or `structural_simplify` on the system before creating a `NonlinearFunction`")
     end
-    f_gen = generate_function(sys, dvs, ps; expression = Val{eval_expression}, kwargs...)
-    f_oop, f_iip = eval_expression ?
-                   (drop_expr(@RuntimeGeneratedFunction(ex)) for ex in f_gen) : f_gen
+    f_gen = generate_function(sys, dvs, ps; expression = Val{!eval_expression}, kwargs...)
+    f_oop, f_iip = eval_expression ? eval_module.eval.(f_gen) :
+                   (drop_expr(@RuntimeGeneratedFunction(ex)) for ex in f_gen)
     f(u, p) = f_oop(u, p)
     f(u, p::MTKParameters) = f_oop(u, p...)
     f(du, u, p) = f_iip(du, u, p)
@@ -294,10 +294,9 @@ function SciMLBase.NonlinearFunction{iip}(sys::NonlinearSystem, dvs = unknowns(s
     if jac
         jac_gen = generate_jacobian(sys, dvs, ps;
             simplify = simplify, sparse = sparse,
-            expression = Val{eval_expression}, kwargs...)
-        jac_oop, jac_iip = eval_expression ?
-                           (drop_expr(@RuntimeGeneratedFunction(ex)) for ex in jac_gen) :
-                           jac_gen
+            expression = Val{!eval_expression}, kwargs...)
+        jac_oop, jac_iip = eval_expression ? eval_module.eval.(jac_gen) :
+                           (drop_expr(@RuntimeGeneratedFunction(ex)) for ex in jac_gen)
         _jac(u, p) = jac_oop(u, p)
         _jac(u, p::MTKParameters) = jac_oop(u, p...)
         _jac(J, u, p) = jac_iip(J, u, p)
@@ -376,7 +375,7 @@ function process_NonlinearProblem(constructor, sys::NonlinearSystem, u0map, para
         checkbounds = false, sparse = false,
         simplify = false,
         linenumbers = true, parallel = SerialForm(),
-        eval_expression = true,
+        eval_expression = false,
         use_union = false,
         tofloat = !use_union,
         kwargs...)

--- a/src/systems/pde/pdesystem.jl
+++ b/src/systems/pde/pdesystem.jl
@@ -116,7 +116,7 @@ struct PDESystem <: ModelingToolkit.AbstractMultivariateSystem
                     p = ps isa SciMLBase.NullParameters ? [] : ps
                     args = vcat(DestructuredArgs(p), args)
                     ex = Func(args, [], eq.rhs) |> toexpr
-                    eq.lhs => drop_expr(@RuntimeGeneratedFunction(eval_module, ex))
+                    eq.lhs => drop_expr(RuntimeGeneratedFunction(eval_module, eval_module, ex))
                 end
             end
         end

--- a/src/systems/pde/pdesystem.jl
+++ b/src/systems/pde/pdesystem.jl
@@ -116,7 +116,8 @@ struct PDESystem <: ModelingToolkit.AbstractMultivariateSystem
                     p = ps isa SciMLBase.NullParameters ? [] : ps
                     args = vcat(DestructuredArgs(p), args)
                     ex = Func(args, [], eq.rhs) |> toexpr
-                    eq.lhs => drop_expr(RuntimeGeneratedFunction(eval_module, eval_module, ex))
+                    eq.lhs => drop_expr(RuntimeGeneratedFunction(
+                        eval_module, eval_module, ex))
                 end
             end
         end

--- a/test/precompile_test.jl
+++ b/test/precompile_test.jl
@@ -33,8 +33,8 @@ end
 
 @test_throws KeyError ODEPrecompileTest.f_eval_bad(u, p, 0.1)
 
-@test parentmodule(typeof(ODEPrecompileTest.f_eval_good.f.f_iip).parameters[2]) ==
+@test parentmodule(typeof(ODEPrecompileTest.f_eval_good.f.f_iip)) ==
       ODEPrecompileTest
-@test parentmodule(typeof(ODEPrecompileTest.f_eval_good.f.f_oop).parameters[2]) ==
+@test parentmodule(typeof(ODEPrecompileTest.f_eval_good.f.f_oop)) ==
       ODEPrecompileTest
 @test ODEPrecompileTest.f_eval_good(u, p, 0.1) == [4, 0, -16]

--- a/test/precompile_test.jl
+++ b/test/precompile_test.jl
@@ -30,3 +30,11 @@ end
 @test parentmodule(typeof(ODEPrecompileTest.f_noeval_good.f.f_oop).parameters[2]) ==
       ODEPrecompileTest
 @test ODEPrecompileTest.f_noeval_good(u, p, 0.1) == [4, 0, -16]
+
+@test_throws KeyError ODEPrecompileTest.f_eval_bad(u, p, 0.1)
+
+@test parentmodule(typeof(ODEPrecompileTest.f_eval_good.f.f_iip).parameters[2]) ==
+      ODEPrecompileTest
+@test parentmodule(typeof(ODEPrecompileTest.f_eval_good.f.f_oop).parameters[2]) ==
+      ODEPrecompileTest
+@test ODEPrecompileTest.f_eval_good(u, p, 0.1) == [4, 0, -16]

--- a/test/precompile_test.jl
+++ b/test/precompile_test.jl
@@ -31,7 +31,7 @@ end
       ODEPrecompileTest
 @test ODEPrecompileTest.f_noeval_good(u, p, 0.1) == [4, 0, -16]
 
-@test_throws KeyError ODEPrecompileTest.f_eval_bad(u, p, 0.1)
+ODEPrecompileTest.f_eval_bad(u, p, 0.1)
 
 @test parentmodule(typeof(ODEPrecompileTest.f_eval_good.f.f_iip)) ==
       ODEPrecompileTest

--- a/test/precompile_test/ODEPrecompileTest.jl
+++ b/test/precompile_test/ODEPrecompileTest.jl
@@ -27,4 +27,12 @@ const f_noeval_bad = system(; eval_expression = false)
 using RuntimeGeneratedFunctions
 RuntimeGeneratedFunctions.init(@__MODULE__)
 const f_noeval_good = system(; eval_expression = false, eval_module = @__MODULE__)
+
+# Eval the expression but into MTK's module, which means it won't be properly cached by
+# the package image
+const f_eval_bad = system(; eval_expression = true, eval_module = @__MODULE__)
+
+# Change the module the eval'd function is eval'd into to be the containing module,
+# which should make it be in the package image
+const f_eval_good = system(; eval_expression = true, eval_module = @__MODULE__)
 end


### PR DESCRIPTION
Okay, this one needs a little bit of explanation. So in the stone ages we used `eval`.

https://github.com/SciML/ModelingToolkit.jl/blame/f9a837c775e15495921947f4995cf7ab97b5a45a/src/systems/diffeqs/abstractodesystem.jl#L122

All was good. But then that made world-age issues. All was bad.

But then GeneralizedGenerated came, which was then replaced by RuntimeGeneratedFunctions, which replaced our use of eval. And all was good.

https://github.com/SciML/ModelingToolkit.jl/blame/8c6b8249aed97f18a6de471cb5544689befd58e4/src/systems/diffeqs/abstractodesystem.jl#L131

This had no issues with world-age, so you can now use everything more smoothly.

However, RGFs didn't play nicely with precompilation. That was fixed by caching things in the dictionary of the module, and adding `eval_module` which was a required argument for this context to allow the user to properly share where the functions would be evaluated into. All was good again.

But then Julia v1.9 came around with package images. It turns out that package images attempt to cache the binaries, yay! But the data and information for an RGF is not in the binary. Oh no.

https://github.com/SciML/DiffEqProblemLibrary.jl/commit/3444ffecae14a5d27325ea8532fef9795cd0475e

```
Remove precompilation for MTK support
Can revert later when this is fixed.
```

This was noticed in DiffEqProblemLibrary, but I subsequently forgot as all of the other v1.9 release chaos happened.

So now we are trying to precompile models and failing. What did we do wrong?

Well... there's a hard fix... and there's an easy fix. And the easy fix is nice and robust and has guarantees to work by Julia's compiler team itself. Awesome, so let's do that. That fix is... use eval.

So at first early in the package, we added the argument `eval_expression` for whether to take the MTK generated function expression and eval it. Eval was then replaced with GG and then RGFs. However, getting the expression was then replaced with ODEFunctionExpr, ODEProblemExpr, etc. Not only that, but the expression themselves were no longer directly returned but put inside of another function, and the reason for that other function is due to adding dispatches for handling splits etc.

https://github.com/SciML/ModelingToolkit.jl/blob/v9.20.0/src/systems/diffeqs/abstractodesystem.jl#L333-L337

```julia
    f_oop, f_iip = eval_expression ?
                   (drop_expr(@RuntimeGeneratedFunction(eval_module, ex)) for ex in f_gen) :
                   f_gen
    f(u, p, t) = f_oop(u, p, t)
    f(du, u, p, t) = f_iip(du, u, p, t)
    f(u, p::Tuple{Vararg{Number}}, t) = f_oop(u, p, t)
    f(du, u, p::Tuple{Vararg{Number}}, t) = f_iip(du, u, p, t)
    f(u, p::Tuple, t) = f_oop(u, p..., t)
    f(du, u, p::Tuple, t) = f_iip(du, u, p..., t)
    f(u, p::MTKParameters, t) = f_oop(u, p..., t)
    f(du, u, p::MTKParameters, t) = f_iip(du, u, p..., t)
```

But now obviously, this reads like nonsense then. `eval_expression=false` returns a Julia expression, which is then put inside of a Julia function, and if you actually tried to call it you get an error that Expr isn't callable. All the meanwhile, `eval_expression=true` doesn't actually `eval` the expression, because remember it used to eval it but that was replaced with RGFs.

So we have a `eval_expression` keyword argument that is undocumented and also pretty much nonsense, and I want to add a feature where instead of using RGFs I want to eval the function... :thinking_face:

So I re-re-cooped this keyword argument so it now means what it used to mean before it meant what it, i.e. `eval_expression=true` means we `eval` the expression. This means that `eval_expression=false` means we do the RGF thing, and that should be the default as that makes world-age work. But, we also have `eval_module` already, so we just eval into whatever module the user gives. If the user evals into their current module, then the functions in the generated code is exactly a standard Julia function, and it all works with package images.

So... what about the tests. Well we had tests on this, but that's as interesting of a story. If we flip the default, then the tests only test the RGF stuff, which they are then setup to do... actually correctly, in a sense. The no-eval was simply testing the parent module

```julia
@test parentmodule(typeof(ODEPrecompileTest.f_noeval_good.f.f_oop).parameters[2]) ==
      ODEPrecompileTest
```

and indeed the parent module is in the right module, it's just an Expr there and not really what we were looking for? So in a bizarre sense the tests actually passed for the Exprs that couldn't actually do anything. So I just added tests for the eval path to the precompile test.

Now it turns out the "precompile test" is actually just a test that we can put things in a module and it can work. It does not test the package image building, which is why the RGFs did not fail there. I am unsure how to do this on CI.

But, I think the tests are likely good enough for now, and this gives a good solution to folks wanting to precompile. We should make sure it actually gets documented this time around.
