### PR TITLE
fix: allow vector defaults in `@mtkmodel`

### DIFF
--- a/src/systems/model_parsing.jl
+++ b/src/systems/model_parsing.jl
@@ -340,6 +340,9 @@ function parse_default(mod, a)
             (expr, nothing)
         end
         Expr(:if, condition, x, y) => (a, nothing)
+        Expr(:vect, x...) => begin
+            (a, nothing)
+        end
         _ => error("Cannot parse default $a $(typeof(a))")
     end
 end

--- a/test/model_parsing.jl
+++ b/test/model_parsing.jl
@@ -817,3 +817,38 @@ end
     @test defs[ordermodel.c] == 2
     @test defs[ordermodel.d] == 1
 end
+
+@testset "Vector defaults" begin
+    @mtkmodel VectorDefaultWithMetadata begin
+        @parameters begin
+            n[1:3] = [1, 2, 3], [description = "Vector defaults"]
+        end
+    end
+
+    @named vec = VectorDefaultWithMetadata()
+    for i in 1:3
+        @test getdefault(vec.n[i]) == i
+    end
+
+    @mtkmodel VectorConditionalDefault begin
+        @structural_parameters begin
+            flag = true
+        end
+        @parameters begin
+            n[1:3] = if flag
+                [2, 2, 2]
+            else
+                1
+            end
+        end
+    end
+
+    @named vec_true = VectorConditionalDefault()
+    for i in 1:3
+        @test getdefault(vec_true.n[i]) == 2
+    end
+    @named vec_false = VectorConditionalDefault(flag = false)
+    for i in 1:3
+        @test getdefault(vec_false.n[i]) == 1
+    end
+end


### PR DESCRIPTION
Closes #2810

These work now:
```julia
   @mtkmodel VectorDefaultWithMetadata begin
        @parameters begin
            n[1:3] = [1, 2, 3], [description = "Vector defaults"]
        end
    end

   @mtkmodel VectorConditionalDefault begin
        @structural_parameters begin
           flag = true
        end
        @parameters begin
            n[1:3] = if flag
                [2, 2, 2]
            else
               1
            end
        end
    end
```

## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API

