### PR TITLE
Left-to-right expand observed equations into defaults during initialization

### DIFF
--- a/src/systems/diffeqs/abstractodesystem.jl
+++ b/src/systems/diffeqs/abstractodesystem.jl
@@ -730,7 +730,7 @@ function get_u0(
     # if "lhs" is known by other means (parameter, another default, ...)
     # TODO: Is there a better way to determine which equations to flip?
     obs = map(x -> x.lhs => x.rhs, observed(sys))
-    obs = map(x -> isparameter(x[1]) || x[1] in keys(defs) ? reverse(x) : x, obs)
+    obs = map(x -> x[1] in keys(defs) ? reverse(x) : x, obs)
     obs = filter!(x -> !(x[1] isa Number), obs) # exclude e.g. "0 => x^2 + y^2 - 25"
     obsmap = isempty(obs) ? Dict() : todict(obs)
 

--- a/src/systems/diffeqs/abstractodesystem.jl
+++ b/src/systems/diffeqs/abstractodesystem.jl
@@ -725,10 +725,16 @@ function get_u0(
         defs = mergedefaults(defs, parammap, ps)
     end
 
-    obs = filter!(x -> !(x[1] isa Number),
-        map(x -> isparameter(x.rhs) ? x.lhs => x.rhs : x.rhs => x.lhs, observed(sys)))
-    observedmap = isempty(obs) ? Dict() : todict(obs)
-    defs = mergedefaults(defs, observedmap, u0map, dvs)
+    # Convert observed equations "lhs ~ rhs" into defaults.
+    # Use the order "lhs => rhs" by default, but flip it to "rhs => lhs"
+    # if "lhs" is known by other means (parameter, another default, ...)
+    # TODO: Is there a better way to determine which equations to flip?
+    obs = map(x -> x.lhs => x.rhs, observed(sys))
+    obs = map(x -> isparameter(x[1]) || x[1] in keys(defs) ? reverse(x) : x, obs)
+    obs = filter!(x -> !(x[1] isa Number), obs) # exclude e.g. "0 => x^2 + y^2 - 25"
+    obsmap = isempty(obs) ? Dict() : todict(obs)
+
+    defs = mergedefaults(defs, obsmap, u0map, dvs)
     if symbolic_u0
         u0 = varmap_to_vars(
             u0map, dvs; defaults = defs, tofloat = false, use_union = false, toterm)

--- a/test/guess_propagation.jl
+++ b/test/guess_propagation.jl
@@ -90,21 +90,21 @@ prob = ODEProblem(sys, [], (0.0, 1.0), [x0 => 1.0])
 @variables y(t) = x0
 @mtkbuild sys = ODESystem([x ~ x0, D(y) ~ x], t)
 prob = ODEProblem(sys, [], (0.0, 1.0), [x0 => 1.0])
-prob[x] == 1.0
-prob[y] == 1.0
+@test prob[x] == 1.0
+@test prob[y] == 1.0
 
 @parameters x0
 @variables x(t)
 @variables y(t) = x0
 @mtkbuild sys = ODESystem([x ~ y, D(y) ~ x], t)
 prob = ODEProblem(sys, [], (0.0, 1.0), [x0 => 1.0])
-prob[x] == 1.0
-prob[y] == 1.0
+@test prob[x] == 1.0
+@test prob[y] == 1.0
 
 @parameters x0
 @variables x(t) = x0
 @variables y(t) = x
 @mtkbuild sys = ODESystem([x ~ y, D(y) ~ x], t)
 prob = ODEProblem(sys, [], (0.0, 1.0), [x0 => 1.0])
-prob[x] == 1.0
-prob[y] == 1.0
+@test prob[x] == 1.0
+@test prob[y] == 1.0

--- a/test/odesystem.jl
+++ b/test/odesystem.jl
@@ -1194,3 +1194,23 @@ end
     @test_nowarn obsfn(buffer, [1.0], ps..., 3.0)
     @test buffer ≈ [2.0, 3.0, 4.0]
 end
+
+# https://github.com/SciML/ModelingToolkit.jl/issues/2859
+@testset "Initialization with defaults from observed equations (edge case)" begin
+    @variables x(t) y(t) z(t)
+    eqs = [D(x) ~ 0, y ~ x, D(z) ~ 0]
+    defaults = [x => 1, z => y]
+    @named sys = ODESystem(eqs, t; defaults)
+    ssys = structural_simplify(sys)
+    prob = ODEProblem(ssys, [], (0.0, 1.0), [])
+    @test prob[x] == prob[y] == prob[z] == 1.0
+
+    @parameters y0
+    @variables x(t) y(t) z(t)
+    eqs = [D(x) ~ 0, y ~ y0 / x, D(z) ~ y]
+    defaults = [y0 => 1, x => 1, z => y]
+    @named sys = ODESystem(eqs, t; defaults)
+    ssys = structural_simplify(sys)
+    prob = ODEProblem(ssys, [], (0.0, 1.0), [])
+    @test prob[x] == prob[y] == prob[z] == 1.0
+end


### PR DESCRIPTION
Fixes #2859.

This slightly changes how observed equations are expanded into a map of defaults when an ODE is initialized with defaults. Before this process took `rhs => lhs` by default, but flipped it to `lhs => rhs` if `rhs` was a parameter (my interpretation: "if `rhs` is something known").

Now it instead takes `lhs => rhs` by default, and flips if `lhs` is something known. I think this makes more sense, because unlike the arbitrarily complicated `rhs`, `lhs` of an observed equation (in a simplified system) is guaranteed (?) to be something simple (e.g. `0 ~ rhs` or `x ~ rhs`). It is therefore better to decide whether to flip based on `lhs`.

I am not sure I have thought of everything. But it looks like all MTK tests are passing on my computer.

## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API