### PR TITLE
Error missing defaults

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -217,7 +217,7 @@ function iv_from_nested_derivative(x, op = Differential)
 end
 
 hasdefault(v) = hasmetadata(v, Symbolics.VariableDefaultValue)
-getdefault(v) = value(getmetadata(v, Symbolics.VariableDefaultValue))
+getdefault(v) = value(Symbolics.getdefaultval(v))
 function getdefaulttype(v)
     def = value(getmetadata(unwrap(v), Symbolics.VariableDefaultValue, nothing))
     def === nothing ? Float64 : typeof(def)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -171,7 +171,7 @@ end
 """
     check_equations(eqs, iv)
 
-Assert that equations are well-formed when building ODE, i.e., only containing a single independent variable.
+Assert that ODE equations are well-formed.
 """
 function check_equations(eqs, iv)
     ivs = collect_ivs(eqs)
@@ -182,6 +182,17 @@ function check_equations(eqs, iv)
         single_iv = pop!(ivs)
         isequal(single_iv, iv) ||
             throw(ArgumentError("Differential w.r.t. variable ($single_iv) other than the independent variable ($iv) are not allowed."))
+    end
+
+    for eq in eqs
+        vars, pars = collect_vars(eq, iv)
+        if isempty(vars)
+            if isempty(pars)
+                throw(ArgumentError("Equation $eq contains no variables or parameters."))
+            else
+                throw(ArgumentError("Equation $eq contains only parameters, but relationships between parameters should be specified with defaults or parameter_dependencies."))
+            end
+        end
     end
 end
 """
@@ -437,6 +448,12 @@ function find_derivatives!(vars, expr, f)
         vars!(vars, arg)
     end
     return vars
+end
+
+function collect_vars(args...; kwargs...)
+    unknowns, parameters = [], []
+    collect_vars!(unknowns, parameters, args...; kwargs...)
+    return unknowns, parameters
 end
 
 function collect_vars!(unknowns, parameters, expr, iv; op = Differential)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -171,7 +171,7 @@ end
 """
     check_equations(eqs, iv)
 
-Assert that ODE equations are well-formed.
+Assert that equations are well-formed when building ODE, i.e., only containing a single independent variable.
 """
 function check_equations(eqs, iv)
     ivs = collect_ivs(eqs)
@@ -182,17 +182,6 @@ function check_equations(eqs, iv)
         single_iv = pop!(ivs)
         isequal(single_iv, iv) ||
             throw(ArgumentError("Differential w.r.t. variable ($single_iv) other than the independent variable ($iv) are not allowed."))
-    end
-
-    for eq in eqs
-        vars, pars = collect_vars(eq, iv)
-        if isempty(vars)
-            if isempty(pars)
-                throw(ArgumentError("Equation $eq contains no variables or parameters."))
-            else
-                throw(ArgumentError("Equation $eq contains only parameters, but relationships between parameters should be specified with defaults or parameter_dependencies."))
-            end
-        end
     end
 end
 """
@@ -448,12 +437,6 @@ function find_derivatives!(vars, expr, f)
         vars!(vars, arg)
     end
     return vars
-end
-
-function collect_vars(args...; kwargs...)
-    unknowns, parameters = [], []
-    collect_vars!(unknowns, parameters, args...; kwargs...)
-    return unknowns, parameters
 end
 
 function collect_vars!(unknowns, parameters, expr, iv; op = Differential)

--- a/test/model_parsing.jl
+++ b/test/model_parsing.jl
@@ -263,7 +263,7 @@ end
     @test getdefault(model.cval) == 1
     @test isequal(getdefault(model.c), model.cval + model.jval)
     @test getdefault(model.d) == 2
-    @test_throws KeyError getdefault(model.e)
+    @test_throws ErrorException getdefault(model.e)
     @test getdefault(model.f) == 3
     @test getdefault(model.i) == 4
     @test all(getdefault.(scalarize(model.b2)) .== [1, 3])

--- a/test/odesystem.jl
+++ b/test/odesystem.jl
@@ -420,7 +420,14 @@ der = Differential(w)
 eqs = [
     der(u1) ~ t
 ]
-@test_throws ArgumentError ModelingToolkit.ODESystem(eqs, t, vars, pars, name = :foo)
+@test_throws ArgumentError ODESystem(eqs, t, vars, pars, name = :foo)
+
+ # equations without variables are forbidden
+ # https://github.com/SciML/ModelingToolkit.jl/issues/2727
+@parameters p q
+@test_throws ArgumentError ODESystem([p ~ q], t; name = :foo)
+@test_throws ArgumentError ODESystem([p ~ 1], t; name = :foo)
+@test_throws ArgumentError ODESystem([1 ~ 2], t; name = :foo)
 
 @variables x(t)
 @parameters M b k

--- a/test/odesystem.jl
+++ b/test/odesystem.jl
@@ -420,14 +420,7 @@ der = Differential(w)
 eqs = [
     der(u1) ~ t
 ]
-@test_throws ArgumentError ODESystem(eqs, t, vars, pars, name = :foo)
-
- # equations without variables are forbidden
- # https://github.com/SciML/ModelingToolkit.jl/issues/2727
-@parameters p q
-@test_throws ArgumentError ODESystem([p ~ q], t; name = :foo)
-@test_throws ArgumentError ODESystem([p ~ 1], t; name = :foo)
-@test_throws ArgumentError ODESystem([1 ~ 2], t; name = :foo)
+@test_throws ArgumentError ModelingToolkit.ODESystem(eqs, t, vars, pars, name = :foo)
 
 @variables x(t)
 @parameters M b k

--- a/test/variable_parsing.jl
+++ b/test/variable_parsing.jl
@@ -104,6 +104,7 @@ end
     y = 2, [connect = Flow]
 end
 
+@test_throws ErrorException ModelingToolkit.getdefault(x)
 @test !hasmetadata(x, VariableDefaultValue)
 @test getmetadata(x, VariableConnectType) == Flow
 @test getmetadata(x, VariableUnit) == u
@@ -111,6 +112,7 @@ end
 @test getmetadata(y, VariableConnectType) == Flow
 
 a = rename(value(x), :a)
+@test_throws ErrorException ModelingToolkit.getdefault(x)
 @test !hasmetadata(x, VariableDefaultValue)
 @test getmetadata(x, VariableConnectType) == Flow
 @test getmetadata(x, VariableUnit) == u

--- a/test/variable_parsing.jl
+++ b/test/variable_parsing.jl
@@ -112,10 +112,10 @@ end
 @test getmetadata(y, VariableConnectType) == Flow
 
 a = rename(value(x), :a)
-@test_throws ErrorException ModelingToolkit.getdefault(x)
-@test !hasmetadata(x, VariableDefaultValue)
-@test getmetadata(x, VariableConnectType) == Flow
-@test getmetadata(x, VariableUnit) == u
+@test_throws ErrorException ModelingToolkit.getdefault(a)
+@test !hasmetadata(a, VariableDefaultValue)
+@test getmetadata(a, VariableConnectType) == Flow
+@test getmetadata(a, VariableUnit) == u
 
 @variables t x(t)=1 [connect = Flow, unit = u]
 


### PR DESCRIPTION
I suggest fixing/closing #2857 by forwarding `getdefault()` to Symbolics, which already errors if a variable has no defaults.

## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API