### PR TITLE
refactor: avoid substitute warning when not needed

### DIFF
--- a/src/systems/abstractsystem.jl
+++ b/src/systems/abstractsystem.jl
@@ -2600,8 +2600,10 @@ end
 
 keytype(::Type{<:Pair{T, V}}) where {T, V} = T
 function Symbolics.substitute(sys::AbstractSystem, rules::Union{Vector{<:Pair}, Dict})
-    if has_continuous_domain(sys) && get_continuous_events(sys) !== nothing ||
-       has_discrete_events(sys) && get_discrete_events(sys) !== nothing
+    if has_continuous_domain(sys) && get_continuous_events(sys) !== nothing &&
+       !isempty(get_continuous_events(sys)) ||
+       has_discrete_events(sys) && get_discrete_events(sys) !== nothing &&
+       !isempty(get_discrete_events(sys))
         @warn "`substitute` only supports performing substitutions in equations. This system has events, which will not be updated."
     end
     if keytype(eltype(rules)) <: Symbol

--- a/test/odesystem.jl
+++ b/test/odesystem.jl
@@ -972,7 +972,8 @@ vars_sub2 = @variables s2(t)
 @named partial_sub = ODESystem(Equation[], t, vars_sub2, [])
 @named sub = extend(partial_sub, sub)
 
-new_sys2 = complete(substitute(sys2, Dict(:sub => sub)))
+# no warnings for systems without events
+new_sys2 = @test_nowarn complete(substitute(sys2, Dict(:sub => sub)))
 Set(unknowns(new_sys2)) == Set([new_sys2.x1, new_sys2.sys1.x1,
     new_sys2.sys1.sub.s1, new_sys2.sys1.sub.s2,
     new_sys2.sub.s1, new_sys2.sub.s2])


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

940d637f0e7765af54e5b8c607cd9f0812a3c7fe added a warning for `substitute` in the case where the system has events, but the condition is too broad and the warning appears even if there are no events in the system. This PR adds additional checks to make sure that the warning only shows up only if the number of events is > 0.