### PR TITLE
Transform systems robustly by remaking systems

### DIFF
--- a/src/systems/abstractsystem.jl
+++ b/src/systems/abstractsystem.jl
@@ -741,7 +741,9 @@ WARNING: intended for internal use; does not perform any sanity checks.
 """
 # TODO: optionally re-call constructor to sanity check?
 # TODO: use SciMLBase's generic remake()? doesn't work out of the box, though
-function remake(sys::AbstractSystem; skip_nonexisting = false, kwargs...)
+# TODO: should register new tag? move Threads.atomic_add!(SYSTEM_COUNT, ...) to a separate function?
+# TODO: recreate the struct once with all new fields, instead of once for every field
+function remake(sys::AbstractSystem; kwargs...)
     for (field, value) in kwargs
         # like `Setfield.@set! sys.field = value`, but with `field` replaced by an arbitrarily named symbol
         # (e.g. https://discourse.julialang.org/t/accessing-struct-via-symbol/58809/4)

--- a/src/systems/abstractsystem.jl
+++ b/src/systems/abstractsystem.jl
@@ -2658,10 +2658,9 @@ system's name.
 See also [`extend`](@ref).
 """
 function compose(sys::AbstractSystem, systems::AbstractArray; name = nameof(sys))
-    nsys = length(systems)
-    nsys == 0 && return sys
-    @set! sys.name = name
-    @set! sys.systems = [get_systems(sys); systems]
+    if !isempty(systems)
+        sys = remake(sys; name = name, systems = [get_systems(sys); systems])
+    end
     return sys
 end
 function compose(syss...; name = nameof(first(syss)))

--- a/src/systems/abstractsystem.jl
+++ b/src/systems/abstractsystem.jl
@@ -726,6 +726,30 @@ end
     end
 end
 
+"""
+$(TYPEDSIGNATURES)
+
+Remake the system `sys` with every field replaced by the value in `kwargs`.
+
+```julia
+@variables x(t) y(t)
+@named sysx = ODESystem([x ~ 0], t)
+sysy = remake(sysx, eqs = [y ~ 0])
+```
+
+WARNING: intended for internal use; does not perform any sanity checks.
+"""
+# TODO: optionally re-call constructor to sanity check?
+# TODO: use SciMLBase's generic remake()? doesn't work out of the box, though
+function remake(sys::AbstractSystem; kwargs...)
+    for (field, value) in kwargs
+        # like `Setfield.@set! sys.field = value`, but with `field` replaced by an arbitrarily named symbol
+        # (e.g. https://discourse.julialang.org/t/accessing-struct-via-symbol/58809/4)
+        sys = Setfield.set(sys, Setfield.PropertyLens{field}(), value)
+    end
+    return sys
+end
+
 rename(x, name) = @set x.name = name
 
 function Base.propertynames(sys::AbstractSystem; private = false)

--- a/src/systems/alias_elimination.jl
+++ b/src/systems/alias_elimination.jl
@@ -135,8 +135,7 @@ function alias_elimination!(state::TearingState; kwargs...)
     state.structure.eq_to_diff = new_eq_to_diff
     state.structure.var_to_diff = new_var_to_diff
 
-    sys = state.sys
-    @set! sys.eqs = eqs
+    sys = remake(state.sys; eqs)
     state.sys = sys
     return invalidate_cache!(sys), mm
 end

--- a/src/systems/connectors.jl
+++ b/src/systems/connectors.jl
@@ -485,9 +485,8 @@ function expand_connections(sys::AbstractSystem, find = nothing, replace = nothi
     ceqs, instream_csets = generate_connection_equations_and_stream_connections(csets)
     _sys = expand_instream(instream_csets, sys; debug = debug, tol = tol)
     sys = flatten(sys, true)
-    @set! sys.eqs = [equations(_sys); ceqs]
     d_defs = domain_defaults(sys, domain_csets)
-    @set! sys.defaults = merge(get_defaults(sys), d_defs)
+    remake(sys; eqs = [equations(_sys); ceqs], defaults = merge(get_defaults(sys), d_defs))
 end
 
 function unnamespace(root, namespace)

--- a/src/systems/diffeqs/first_order_transform.jl
+++ b/src/systems/diffeqs/first_order_transform.jl
@@ -7,9 +7,7 @@ form by defining new variables which represent the N-1 derivatives.
 function ode_order_lowering(sys::ODESystem)
     iv = get_iv(sys)
     eqs_lowered, new_vars = ode_order_lowering(equations(sys), iv, unknowns(sys))
-    @set! sys.eqs = eqs_lowered
-    @set! sys.unknowns = new_vars
-    return sys
+    return remake(sys; eqs = eqs_lowered, unknowns = new_vars)
 end
 
 function dae_order_lowering(sys::ODESystem)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,14 +1,3 @@
-"""
-    union_nothing(x::Union{T1, Nothing}, y::Union{T2, Nothing}) where {T1, T2}
-
-Unite x and y gracefully when they could be nothing. If neither is nothing, x and y are united normally. If one is nothing, the other is returned unmodified. If both are nothing, nothing is returned.
-"""
-function union_nothing(x::Union{T1, Nothing}, y::Union{T2, Nothing}) where {T1, T2}
-    isnothing(x) && return y # y can be nothing or something
-    isnothing(y) && return x # x can be nothing or something
-    return union(x, y) # both x and y are something and can be united normally
-end
-
 get_iv(D::Differential) = D.x
 
 function make_operation(@nospecialize(op), args)


### PR DESCRIPTION
This is an attempt to strengthen the robustness of system transformations (i.e. processes that turn one system into another).

Internally, as pointed out in #1710 and #1752, there is inconsistency between

1. transformations that re-calls the system constructor with the modified fields (dropping unspecified fields, but redoing checks),
2. transformations that uses `@set! sys.field = value` from Setfield.jl (keeping unspecified fields, but skipping checks).

Field dropping has spawned bugs like #2845 and #2502, which usually gets "duct tape patched" by adding that single field for one particular system type. Transforming systems in a uniform way could prevent such bugs in the future, and maybe simplify some internal machinery. Maybe it would also be more efficient to "batch remake" several modified fields with a single new constructor call, rather than `@set! sys.field1 = value1; @set! sys.field2 = value2; ...` which I think calls the constructor several times.

Externally, I "envision" that a simple and robust interface could facilitate users making their own custom transformations. Maybe another package using ModelingToolkit would like to build models in a way that requires some simple application-dependent transformation of the system. Every user shouldn't have to reinvent a machinery for doing this themselves.

This is a draft for now. I would really appreciate thoughts and suggestions, or to know if you think this is not a good idea.

## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API