### PR TITLE
Detect diagonal noise in `SDESystem`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -56,10 +56,12 @@ Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 [weakdeps]
 BifurcationKit = "0f109fa4-8a5d-4b75-95aa-f515264e7665"
 DeepDiffs = "ab62b9b5-e342-54a8-a765-a90f495de1a6"
+DiffEqNoiseProcess = "77a26b50-5914-5dd7-bc55-306e6241c503"
 
 [extensions]
 MTKBifurcationKitExt = "BifurcationKit"
 MTKDeepDiffsExt = "DeepDiffs"
+MTKDiffEqNoiseProcess = "DiffEqNoiseProcess"
 
 [compat]
 AbstractTrees = "0.3, 0.4"

--- a/Project.toml
+++ b/Project.toml
@@ -12,6 +12,7 @@ ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
 DiffEqCallbacks = "459566f4-90b8-5000-8ac3-15dfb0a30def"
+DiffEqNoiseProcess = "77a26b50-5914-5dd7-bc55-306e6241c503"
 DiffRules = "b552c78f-8df3-52c6-915a-8e097449b14b"
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
@@ -56,12 +57,10 @@ Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 [weakdeps]
 BifurcationKit = "0f109fa4-8a5d-4b75-95aa-f515264e7665"
 DeepDiffs = "ab62b9b5-e342-54a8-a765-a90f495de1a6"
-DiffEqNoiseProcess = "77a26b50-5914-5dd7-bc55-306e6241c503"
 
 [extensions]
 MTKBifurcationKitExt = "BifurcationKit"
 MTKDeepDiffsExt = "DeepDiffs"
-MTKDiffEqNoiseProcess = "DiffEqNoiseProcess"
 
 [compat]
 AbstractTrees = "0.3, 0.4"
@@ -74,6 +73,7 @@ DataStructures = "0.17, 0.18"
 DeepDiffs = "1"
 DiffEqBase = "6.103.0"
 DiffEqCallbacks = "2.16, 3"
+DiffEqNoiseProcess = "5"
 DiffRules = "0.1, 1.0"
 Distributed = "1"
 Distributions = "0.23, 0.24, 0.25"

--- a/ext/MTKDiffEqNoiseProcess.jl
+++ b/ext/MTKDiffEqNoiseProcess.jl
@@ -1,8 +1,0 @@
-module MTKDiffEqNoiseProcess
-
-using ModelingToolkit: ModelingToolkit
-using DiffEqNoiseProcess: WienerProcess
-
-ModelingToolkit.scalar_noise() = WienerProcess(0.0, 0.0, 0.0)
-
-end

--- a/ext/MTKDiffEqNoiseProcess.jl
+++ b/ext/MTKDiffEqNoiseProcess.jl
@@ -1,0 +1,8 @@
+module MTKDiffEqNoiseProcess
+
+using ModelingToolkit: ModelingToolkit
+using DiffEqNoiseProcess: WienerProcess
+
+ModelingToolkit.scalar_noise() = WienerProcess(0.0, 0.0, 0.0)
+
+end

--- a/src/ModelingToolkit.jl
+++ b/src/ModelingToolkit.jl
@@ -22,6 +22,7 @@ using DiffEqCallbacks
 using Graphs
 import ExprTools: splitdef, combinedef
 import OrderedCollections
+using DiffEqNoiseProcess: DiffEqNoiseProcess, WienerProcess
 
 using SymbolicIndexingInterface
 using LinearAlgebra, SparseArrays, LabelledArrays

--- a/src/systems/abstractsystem.jl
+++ b/src/systems/abstractsystem.jl
@@ -655,7 +655,8 @@ for prop in [:eqs
              :solved_unknowns
              :split_idxs
              :parent
-             :index_cache]
+             :index_cache
+             :is_scalar_noise]
     fname_get = Symbol(:get_, prop)
     fname_has = Symbol(:has_, prop)
     @eval begin

--- a/src/systems/diffeqs/sdesystem.jl
+++ b/src/systems/diffeqs/sdesystem.jl
@@ -133,13 +133,13 @@ struct SDESystem <: AbstractODESystem
     be `true` when `noiseeqs isa Vector`. 
     """
     is_scalar_noise::Bool
-    
+
     function SDESystem(tag, deqs, neqs, iv, dvs, ps, tspan, var_to_name, ctrls, observed,
             tgrad,
             jac,
             ctrl_jac, Wfact, Wfact_t, name, systems, defaults, connector_type,
             cevents, devents, parameter_dependencies, metadata = nothing, gui_metadata = nothing,
-            complete = false, index_cache = nothing, parent = nothing, is_scalar_noise=false;
+            complete = false, index_cache = nothing, parent = nothing, is_scalar_noise = false;
             checks::Union{Bool, Int} = true)
         if checks == true || (checks & CheckComponents) > 0
             check_independent_variables([iv])
@@ -181,11 +181,11 @@ function SDESystem(deqs::AbstractVector{<:Equation}, neqs::AbstractArray, iv, dv
         discrete_events = nothing,
         parameter_dependencies = nothing,
         metadata = nothing,
-                   gui_metadata = nothing,
-                   complete = false,
-                   index_cache = nothing,
-                   parent = nothing,
-                   is_scalar_noise=false)
+        gui_metadata = nothing,
+        complete = false,
+        index_cache = nothing,
+        parent = nothing,
+        is_scalar_noise = false)
     name === nothing &&
         throw(ArgumentError("The `name` keyword must be provided. Please consider using the `@named` macro"))
     iv′ = value(iv)
@@ -220,10 +220,10 @@ function SDESystem(deqs::AbstractVector{<:Equation}, neqs::AbstractArray, iv, dv
     parameter_dependencies, ps′ = process_parameter_dependencies(
         parameter_dependencies, ps′)
     SDESystem(Threads.atomic_add!(SYSTEM_COUNT, UInt(1)),
-              deqs, neqs, iv′, dvs′, ps′, tspan, var_to_name, ctrl′, observed, tgrad, jac,
-              ctrl_jac, Wfact, Wfact_t, name, systems, defaults, connector_type,
-              cont_callbacks, disc_callbacks, parameter_dependencies, metadata, gui_metadata,
-              complete, index_cache, parent, is_scalar_noise; checks = checks)
+        deqs, neqs, iv′, dvs′, ps′, tspan, var_to_name, ctrl′, observed, tgrad, jac,
+        ctrl_jac, Wfact, Wfact_t, name, systems, defaults, connector_type,
+        cont_callbacks, disc_callbacks, parameter_dependencies, metadata, gui_metadata,
+        complete, index_cache, parent, is_scalar_noise; checks = checks)
 end
 
 function SDESystem(sys::ODESystem, neqs; kwargs...)
@@ -615,7 +615,6 @@ function SDEFunctionExpr(sys::SDESystem, args...; kwargs...)
     SDEFunctionExpr{true}(sys, args...; kwargs...)
 end
 
-
 function scalar_noise end # defined in ../ext/MTKDiffEqNoiseProcess.jl
 
 function DiffEqBase.SDEProblem{iip, specialize}(
@@ -738,7 +737,8 @@ function SDEProblemExpr{iip}(sys::SDESystem, u0map, tspan,
         p = $p
         noise_rate_prototype = $noise_rate_prototype
         noise = $noise
-        SDEProblem(f, u0, tspan, p; noise_rate_prototype = noise_rate_prototype, noise = noise,
+        SDEProblem(
+            f, u0, tspan, p; noise_rate_prototype = noise_rate_prototype, noise = noise,
             $(kwargs...))
     end
     !linenumbers ? Base.remove_linenums!(ex) : ex

--- a/src/systems/diffeqs/sdesystem.jl
+++ b/src/systems/diffeqs/sdesystem.jl
@@ -152,7 +152,7 @@ struct SDESystem <: AbstractODESystem
             end
             check_equations(equations(cevents), iv)
             if is_scalar_noise && neqs isa AbstractMatrix
-                throw(ArgumentError("Noise equations ill-formed. Recieved a matrix of noise equations of size $(size(neqs)), but `is_scalar_noise` was set to `true`. Scalar noise is only compatible with an `AbstractVector` of noise equations."))
+                throw(ArgumentError("Noise equations ill-formed. Received a matrix of noise equations of size $(size(neqs)), but `is_scalar_noise` was set to `true`. Scalar noise is only compatible with an `AbstractVector` of noise equations."))
             end
         end
         if checks == true || (checks & CheckUnits) > 0

--- a/src/systems/diffeqs/sdesystem.jl
+++ b/src/systems/diffeqs/sdesystem.jl
@@ -128,13 +128,18 @@ struct SDESystem <: AbstractODESystem
     The hierarchical parent system before simplification.
     """
     parent::Any
-
+    """
+    Signal for whether the noise equations should be treated as a scalar process. This should only
+    be `true` when `noiseeqs isa Vector`. 
+    """
+    is_scalar_noise::Bool
+    
     function SDESystem(tag, deqs, neqs, iv, dvs, ps, tspan, var_to_name, ctrls, observed,
             tgrad,
             jac,
             ctrl_jac, Wfact, Wfact_t, name, systems, defaults, connector_type,
             cevents, devents, parameter_dependencies, metadata = nothing, gui_metadata = nothing,
-            complete = false, index_cache = nothing, parent = nothing;
+            complete = false, index_cache = nothing, parent = nothing, is_scalar_noise=false;
             checks::Union{Bool, Int} = true)
         if checks == true || (checks & CheckComponents) > 0
             check_independent_variables([iv])
@@ -146,6 +151,9 @@ struct SDESystem <: AbstractODESystem
                 throw(ArgumentError("Noise equations ill-formed. Number of rows must match number of drift equations. size(neqs,1) = $(size(neqs,1)) != length(deqs) = $(length(deqs))"))
             end
             check_equations(equations(cevents), iv)
+            if is_scalar_noise && neqs isa AbstractMatrix
+                throw(ArgumentError("Noise equations ill-formed. Recieved a matrix of noise equations of size $(size(neqs)), but `is_scalar_noise` was set to `true`. Scalar noise is only compatible with an `AbstractVector` of noise equations."))
+            end
         end
         if checks == true || (checks & CheckUnits) > 0
             u = __get_unit_type(dvs, ps, iv)
@@ -154,7 +162,7 @@ struct SDESystem <: AbstractODESystem
         new(tag, deqs, neqs, iv, dvs, ps, tspan, var_to_name, ctrls, observed, tgrad, jac,
             ctrl_jac,
             Wfact, Wfact_t, name, systems, defaults, connector_type, cevents, devents,
-            parameter_dependencies, metadata, gui_metadata, complete, index_cache, parent)
+            parameter_dependencies, metadata, gui_metadata, complete, index_cache, parent, is_scalar_noise)
     end
 end
 
@@ -173,7 +181,11 @@ function SDESystem(deqs::AbstractVector{<:Equation}, neqs::AbstractArray, iv, dv
         discrete_events = nothing,
         parameter_dependencies = nothing,
         metadata = nothing,
-        gui_metadata = nothing)
+                   gui_metadata = nothing,
+                   complete = false,
+                   index_cache = nothing,
+                   parent = nothing,
+                   is_scalar_noise=false)
     name === nothing &&
         throw(ArgumentError("The `name` keyword must be provided. Please consider using the `@named` macro"))
     iv′ = value(iv)
@@ -208,9 +220,10 @@ function SDESystem(deqs::AbstractVector{<:Equation}, neqs::AbstractArray, iv, dv
     parameter_dependencies, ps′ = process_parameter_dependencies(
         parameter_dependencies, ps′)
     SDESystem(Threads.atomic_add!(SYSTEM_COUNT, UInt(1)),
-        deqs, neqs, iv′, dvs′, ps′, tspan, var_to_name, ctrl′, observed, tgrad, jac,
-        ctrl_jac, Wfact, Wfact_t, name, systems, defaults, connector_type,
-        cont_callbacks, disc_callbacks, parameter_dependencies, metadata, gui_metadata; checks = checks)
+              deqs, neqs, iv′, dvs′, ps′, tspan, var_to_name, ctrl′, observed, tgrad, jac,
+              ctrl_jac, Wfact, Wfact_t, name, systems, defaults, connector_type,
+              cont_callbacks, disc_callbacks, parameter_dependencies, metadata, gui_metadata,
+              complete, index_cache, parent, is_scalar_noise; checks = checks)
 end
 
 function SDESystem(sys::ODESystem, neqs; kwargs...)
@@ -225,6 +238,7 @@ function Base.:(==)(sys1::SDESystem, sys2::SDESystem)
         isequal(nameof(sys1), nameof(sys2)) &&
         isequal(get_eqs(sys1), get_eqs(sys2)) &&
         isequal(get_noiseeqs(sys1), get_noiseeqs(sys2)) &&
+        isequal(get_is_scalar_noise(sys1), get_is_scalar_noise(sys2)) &&
         _eq_unordered(get_unknowns(sys1), get_unknowns(sys2)) &&
         _eq_unordered(get_ps(sys1), get_ps(sys2)) &&
         all(s1 == s2 for (s1, s2) in zip(get_systems(sys1), get_systems(sys2)))
@@ -601,6 +615,9 @@ function SDEFunctionExpr(sys::SDESystem, args...; kwargs...)
     SDEFunctionExpr{true}(sys, args...; kwargs...)
 end
 
+
+function scalar_noise end # defined in ../ext/MTKDiffEqNoiseProcess.jl
+
 function DiffEqBase.SDEProblem{iip, specialize}(
         sys::SDESystem, u0map = [], tspan = get_tspan(sys),
         parammap = DiffEqBase.NullParameters();
@@ -616,16 +633,24 @@ function DiffEqBase.SDEProblem{iip, specialize}(
     sparsenoise === nothing && (sparsenoise = get(kwargs, :sparse, false))
 
     noiseeqs = get_noiseeqs(sys)
+    is_scalar_noise = get_is_scalar_noise(sys)
     if noiseeqs isa AbstractVector
         noise_rate_prototype = nothing
+        if is_scalar_noise
+            noise = scalar_noise()
+        else
+            noise = nothing
+        end
     elseif sparsenoise
         I, J, V = findnz(SparseArrays.sparse(noiseeqs))
         noise_rate_prototype = SparseArrays.sparse(I, J, zero(eltype(u0)))
+        noise = nothing
     else
         noise_rate_prototype = zeros(eltype(u0), size(noiseeqs))
+        noise = nothing
     end
 
-    SDEProblem{iip}(f, u0, tspan, p; callback = cbs,
+    SDEProblem{iip}(f, u0, tspan, p; callback = cbs, noise,
         noise_rate_prototype = noise_rate_prototype, kwargs...)
 end
 
@@ -693,8 +718,12 @@ function SDEProblemExpr{iip}(sys::SDESystem, u0map, tspan,
     sparsenoise === nothing && (sparsenoise = get(kwargs, :sparse, false))
 
     noiseeqs = get_noiseeqs(sys)
+    is_scalar_noise = get_is_scalar_noise(sys)
     if noiseeqs isa AbstractVector
         noise_rate_prototype = nothing
+        if is_scalar_noise
+            noise = scalar_noise()
+        end
     elseif sparsenoise
         I, J, V = findnz(SparseArrays.sparse(noiseeqs))
         noise_rate_prototype = SparseArrays.sparse(I, J, zero(eltype(u0)))
@@ -708,7 +737,8 @@ function SDEProblemExpr{iip}(sys::SDESystem, u0map, tspan,
         tspan = $tspan
         p = $p
         noise_rate_prototype = $noise_rate_prototype
-        SDEProblem(f, u0, tspan, p; noise_rate_prototype = noise_rate_prototype,
+        noise = $noise
+        SDEProblem(f, u0, tspan, p; noise_rate_prototype = noise_rate_prototype, noise = noise,
             $(kwargs...))
     end
     !linenumbers ? Base.remove_linenums!(ex) : ex

--- a/src/systems/systems.jl
+++ b/src/systems/systems.jl
@@ -135,7 +135,7 @@ function __structural_simplify(sys::AbstractSystem, io = nothing; simplify = fal
         elseif sorted_g_rows isa AbstractMatrix && size(sorted_g_rows, 2) == 1
             ##-------------------------------------------------------------------------------
             ## TODO: re-enable this code once we add a way to signal that the noise is scalar
-            # sorted_g_rows[:, 1] # Take a vector slice so solver knows there's no mixing
+            # sorted_g_rows[:, 1] 
             ##-------------------------------------------------------------------------------
             sorted_g_rows
         else

--- a/src/systems/systems.jl
+++ b/src/systems/systems.jl
@@ -130,8 +130,10 @@ function __structural_simplify(sys::AbstractSystem, io = nothing; simplify = fal
         # Fix for https://github.com/SciML/ModelingToolkit.jl/issues/2490
         noise_eqs = if all(row -> count(!iszero, row) == 1, eachrow(sorted_g_rows)) # Does each row have only one non-zero entry?
             # then the noise is actually diagonal! make vector of non-zero entries.
-            # This happens when the user uses N different `@brownian`s for `N` equations
-            reduce(vcat, map(row -> filter(!iszero, row), eachrow(sorted_g_rows)))
+            # This happens when the user uses multiple `@brownian`s but never mixes them
+            map(eachrow(sorted_g_rows)) do row
+                only(filter(!iszero, row))
+            end
         elseif sorted_g_rows isa AbstractMatrix && size(sorted_g_rows, 2) == 1
             sorted_g_rows[:, 1] # Take a vector slice so solver knows there's no mixing
         else

--- a/src/systems/systems.jl
+++ b/src/systems/systems.jl
@@ -134,7 +134,7 @@ function __structural_simplify(sys::AbstractSystem, io = nothing; simplify = fal
             noise_eqs = diag(sorted_g_rows)
             is_scalar_noise = false
         elseif sorted_g_rows isa AbstractMatrix && size(sorted_g_rows, 2) == 1
-            noise_eqs = sorted_g_rows[:, 1] 
+            noise_eqs = sorted_g_rows[:, 1]
             is_scalar_noise = true
         else
             noise_eqs = sorted_g_rows

--- a/src/systems/systems.jl
+++ b/src/systems/systems.jl
@@ -128,21 +128,20 @@ function __structural_simplify(sys::AbstractSystem, io = nothing; simplify = fal
             @views copyto!(sorted_g_rows[i, :], g[g_row, :])
         end
         # Fix for https://github.com/SciML/ModelingToolkit.jl/issues/2490
-        noise_eqs = if isdiag(sorted_g_rows)
+        if isdiag(sorted_g_rows)
             # If the noise matrix is diagonal, then we just give solver just takes a vector column of equations
             # and it interprets that as diagonal noise.
-            diag(sorted_g_rows)
+            noise_eqs = diag(sorted_g_rows)
+            is_scalar_noise = false
         elseif sorted_g_rows isa AbstractMatrix && size(sorted_g_rows, 2) == 1
-            ##-------------------------------------------------------------------------------
-            ## TODO: re-enable this code once we add a way to signal that the noise is scalar
-            # sorted_g_rows[:, 1] 
-            ##-------------------------------------------------------------------------------
-            sorted_g_rows
+            noise_eqs = sorted_g_rows[:, 1] 
+            is_scalar_noise = true
         else
-            sorted_g_rows
+            noise_eqs = sorted_g_rows
+            is_scalar_noise = false
         end
         return SDESystem(full_equations(ode_sys), noise_eqs,
             get_iv(ode_sys), unknowns(ode_sys), parameters(ode_sys);
-            name = nameof(ode_sys))
+            name = nameof(ode_sys), is_scalar_noise)
     end
 end

--- a/test/dde.jl
+++ b/test/dde.jl
@@ -78,7 +78,7 @@ sol = solve(prob, RKMil())
 eqs = [D(x(t)) ~ a * x(t) + b * x(t - τ) + c + (α * x(t) + γ) * η]
 @mtkbuild sys = System(eqs, t)
 @test equations(sys) == [D(x(t)) ~ a * x(t) + b * x(t - τ) + c]
-@test isequal(ModelingToolkit.get_noiseeqs(sys), [α * x(t) + γ;;])
+@test isequal(ModelingToolkit.get_noiseeqs(sys), [α * x(t) + γ])
 prob_mtk = SDDEProblem(sys, [x(t) => 1.0 + t], tspan; constant_lags = (τ,));
 @test_nowarn sol_mtk = solve(prob_mtk, RKMil())
 

--- a/test/sdesystem.jl
+++ b/test/sdesystem.jl
@@ -657,3 +657,30 @@ ps = @SVector[p => 5.0, d => 0.5]
 sprob = SDEProblem(sys, u0, tspan, ps)
 @test sprob.f.g(sprob.u0, sprob.p, sprob.tspan[1]) isa SVector{2, Float64}
 @test_nowarn solve(sprob, ImplicitEM())
+
+# Define some variables
+let
+    @parameters σ ρ β
+    @variables x(t) y(t) z(t)
+    @brownian a
+    eqs = [D(x) ~ σ * (y - x) + 0.1a * x,
+        D(y) ~ x * (ρ - z) - y + 0.1a * y,
+        D(z) ~ x * y - β * z + 0.1a * z]
+
+    @mtkbuild de = System(eqs, t)
+
+    u0map = [
+        x => 1.0,
+        y => 0.0,
+        z => 0.0
+    ]
+
+    parammap = [
+        σ => 10.0,
+        β => 26.0,
+        ρ => 2.33
+    ]
+
+    prob = SDEProblem(de, u0map, (0.0, 100.0), parammap)
+    @test solve(prob, SOSRI()).retcode == ReturnCode.Success
+end

--- a/test/sdesystem.jl
+++ b/test/sdesystem.jl
@@ -679,18 +679,18 @@ let
         β => 26.0,
         ρ => 2.33
     ]
-
     prob = SDEProblem(de, u0map, (0.0, 100.0), parammap)
-    @test solve(prob, SOSRI()).retcode == ReturnCode.Success
+    # TODO: re-enable this when we support scalar noise
+    @test_broken solve(prob, SOSRI()).retcode == ReturnCode.Success
 end
 
 let
     @parameters σ ρ β
     @variables x(t) y(t) z(t)
-    @brownian a b
-    eqs = [D(x) ~ σ * (y - x) + 0.1b * x,
-        D(y) ~ x * (ρ - z) - y + 0.1a * y,
-        D(z) ~ x * y - β * z + 0.1b * z]
+    @brownian a b c
+    eqs = [D(x) ~ σ * (y - x)  + 0.1a * x,
+        D(y) ~ x * (ρ - z) - y + 0.1b * y,
+        D(z) ~ x * y - β * z   + 0.1c * z]
 
     @mtkbuild de = System(eqs, t)
 

--- a/test/sdesystem.jl
+++ b/test/sdesystem.jl
@@ -681,7 +681,7 @@ let
     ]
     prob = SDEProblem(de, u0map, (0.0, 100.0), parammap)
     # TODO: re-enable this when we support scalar noise
-    @test_broken solve(prob, SOSRI()).retcode == ReturnCode.Success
+    @test solve(prob, SOSRI()).retcode == ReturnCode.Success
 end
 
 let # test to make sure that scalar noise always recieve the same kicks
@@ -692,7 +692,7 @@ let # test to make sure that scalar noise always recieve the same kicks
 
     @mtkbuild de = System(eqs, t)
     prob = SDEProblem(de, [x => 0, y => 0], (0.0, 10.0), [])
-    sol = solve(prob, ImplicitEM())
+    sol = solve(prob, SOSRI())
     @test sol[end][1] == sol[end][2]
 end
 

--- a/test/sdesystem.jl
+++ b/test/sdesystem.jl
@@ -658,7 +658,6 @@ sprob = SDEProblem(sys, u0, tspan, ps)
 @test sprob.f.g(sprob.u0, sprob.p, sprob.tspan[1]) isa SVector{2, Float64}
 @test_nowarn solve(sprob, ImplicitEM())
 
-# Define some variables
 let
     @parameters σ ρ β
     @variables x(t) y(t) z(t)
@@ -666,6 +665,32 @@ let
     eqs = [D(x) ~ σ * (y - x) + 0.1a * x,
         D(y) ~ x * (ρ - z) - y + 0.1a * y,
         D(z) ~ x * y - β * z + 0.1a * z]
+
+    @mtkbuild de = System(eqs, t)
+
+    u0map = [
+        x => 1.0,
+        y => 0.0,
+        z => 0.0
+    ]
+
+    parammap = [
+        σ => 10.0,
+        β => 26.0,
+        ρ => 2.33
+    ]
+
+    prob = SDEProblem(de, u0map, (0.0, 100.0), parammap)
+    @test solve(prob, SOSRI()).retcode == ReturnCode.Success
+end
+
+let
+    @parameters σ ρ β
+    @variables x(t) y(t) z(t)
+    @brownian a b c
+    eqs = [D(x) ~ σ * (y - x) + 0.1c * x,
+        D(y) ~ x * (ρ - z) - y + 0.1a * y,
+        D(z) ~ x * y - β * z + 0.1b * z]
 
     @mtkbuild de = System(eqs, t)
 

--- a/test/sdesystem.jl
+++ b/test/sdesystem.jl
@@ -687,8 +687,8 @@ end
 let
     @parameters σ ρ β
     @variables x(t) y(t) z(t)
-    @brownian a b c
-    eqs = [D(x) ~ σ * (y - x) + 0.1c * x,
+    @brownian a b
+    eqs = [D(x) ~ σ * (y - x) + 0.1b * x,
         D(y) ~ x * (ρ - z) - y + 0.1a * y,
         D(z) ~ x * y - β * z + 0.1b * z]
 

--- a/test/sdesystem.jl
+++ b/test/sdesystem.jl
@@ -684,7 +684,7 @@ let
     @test solve(prob, SOSRI()).retcode == ReturnCode.Success
 end
 
-let # test to make sure that scalar noise always recieve the same kicks
+let # test to make sure that scalar noise always receive the same kicks
     @variables x(t) y(t)
     @brownian a
     eqs = [D(x) ~ a,
@@ -696,7 +696,7 @@ let # test to make sure that scalar noise always recieve the same kicks
     @test sol[end][1] == sol[end][2]
 end
 
-let # test that diagonal noise is corrently handled
+let # test that diagonal noise is correctly handled
     @parameters σ ρ β
     @variables x(t) y(t) z(t)
     @brownian a b c


### PR DESCRIPTION
Fixes https://github.com/SciML/ModelingToolkit.jl/issues/2490

see https://github.com/SciML/ModelingToolkit.jl/pull/2882#issuecomment-2241780144 for current state of PR 

## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

The idea here is that without this change, we were basically not communicating to the solver when the noise equations are either a diagonal matrix (using N independent `@brownian`s once), or a `Nx1` matrix (only one `@brownian` variable ~which also means diagonal noise rather confusingly~ which means scalar noise)


Example: 
```julia
using ModelingToolkit, StochasticDiffEq
using ModelingToolkit: t_nounits as t, D_nounits as D

# Define some variables
@parameters σ ρ β
@variables x(t) y(t) z(t)
@brownian a
eqs = [D(x) ~ σ * (y - x) + 0.1a * x,
    D(y) ~ x * (ρ - z) - y + 0.1a * y,
    D(z) ~ x * y - β * z + 0.1a * z]

@mtkbuild de = System(eqs, t)

u0map = [
    x => 1.0,
    y => 0.0,
    z => 0.0
]

parammap = [
    σ => 10.0,
    β => 26.0,
    ρ => 2.33
]

prob = SDEProblem(de, u0map, (0.0, 100.0), parammap)
sol = solve(prob, SOSRI())
```
Result before:
```
ERROR: The algorithm is not compatible with the chosen noise type. Please see the documentation on the solver methods
Stacktrace:
  [1] error(s::String)
    @ Base ./error.jl:35
  [2] __init(_prob::SDEProblem{…}, alg::SOSRI, timeseries_init::Vector{…}, ts_init::Vector{…}, ks_init::Type, recompile::Type{…}; saveat::Tuple{}, tstops::Tuple{}, d_discontinuities::Tuple{}, save_idxs::Nothing, save_everystep::Bool, save_noise::Bool, save_on::Bool, save_start::Bool, save_end::Nothing, callback::Nothing, dense::Bool, calck::Bool, dt::Float64, adaptive::Bool, gamma::Rational{…}, abstol::Nothing, reltol::Nothing, qmin::Rational{…}, qmax::Rational{…}, qsteady_min::Int64, qsteady_max::Int64, beta2::Nothing, beta1::Nothing, qoldinit::Rational{…}, controller::Nothing, fullnormalize::Bool, failfactor::Int64, delta::Rational{…}, maxiters::Int64, dtmax::Float64, dtmin::Float64, internalnorm::typeof(DiffEqBase.ODE_DEFAULT_NORM), isoutofdomain::typeof(DiffEqBase.ODE_DEFAULT_ISOUTOFDOMAIN), unstable_check::typeof(DiffEqBase.ODE_DEFAULT_UNSTABLE_CHECK), verbose::Bool, force_dtmin::Bool, timeseries_errors::Bool, dense_errors::Bool, advance_to_tstop::Bool, stop_at_next_tstop::Bool, initialize_save::Bool, progress::Bool, progress_steps::Int64, progress_name::String, progress_message::typeof(DiffEqBase.ODE_DEFAULT_PROG_MESSAGE), progress_id::Symbol, userdata::Nothing, initialize_integrator::Bool, seed::UInt64, alias_u0::Bool, alias_jumps::Bool, kwargs::@Kwargs{})
    @ StochasticDiffEq ~/.julia/packages/StochasticDiffEq/tdY4b/src/solve.jl:111
  [3] __solve(prob::SDEProblem{…}, alg::SOSRI, timeseries::Vector{…}, ts::Vector{…}, ks::Nothing, recompile::Type{…}; kwargs::@Kwargs{…})
    @ StochasticDiffEq ~/.julia/packages/StochasticDiffEq/tdY4b/src/solve.jl:6
  [4] solve_call(_prob::SDEProblem{…}, args::SOSRI; merge_callbacks::Bool, kwargshandle::Nothing, kwargs::@Kwargs{})
    @ DiffEqBase ~/.julia/packages/DiffEqBase/Sueu7/src/solve.jl:612
  [5] solve_call(_prob::SDEProblem{…}, args::SOSRI)
    @ DiffEqBase ~/.julia/packages/DiffEqBase/Sueu7/src/solve.jl:569
  [6] solve_up(prob::SDEProblem{…}, sensealg::Nothing, u0::Vector{…}, p::ModelingToolkit.MTKParameters{…}, args::SOSRI; kwargs::@Kwargs{})
    @ DiffEqBase ~/.julia/packages/DiffEqBase/Sueu7/src/solve.jl:1062
  [7] solve_up(prob::SDEProblem{…}, sensealg::Nothing, u0::Vector{…}, p::ModelingToolkit.MTKParameters{…}, args::SOSRI)
    @ DiffEqBase ~/.julia/packages/DiffEqBase/Sueu7/src/solve.jl:1048
  [8] solve(prob::SDEProblem{…}, args::SOSRI; sensealg::Nothing, u0::Nothing, p::Nothing, wrap::Val{…}, kwargs::@Kwargs{})
    @ DiffEqBase ~/.julia/packages/DiffEqBase/Sueu7/src/solve.jl:985
  [9] solve(prob::SDEProblem{…}, args::SOSRI)
    @ DiffEqBase ~/.julia/packages/DiffEqBase/Sueu7/src/solve.jl:975
 [10] top-level scope
    @ REPL[152]:1
```

Result after:
```
retcode: Success
Interpolation: 1st order linear
t: 18416-element Vector{Float64}:
   0.0
   0.0007146315987816352
   0.0008575579185379623
   0.0010183500282638302
   0.0011992411517054316
   0.0014027436655772332
   0.00163168399368301
   0.001888330123096511
   0.002169732452494152
   0.0024747179844340924
   0.002801083673034135
   0.0031467337392412443
   0.0035101593109016778
   0.0038893633340266673
   0.004282801251770871
   0.004689082950137011
   0.005106359961984013
   0.005534011073886903
   0.005970909411562779
   0.006416219161068274
   0.0068685852392637164
   ⋮
  99.86081178121842
  99.86691462888227
  99.87284456492715
  99.87822415992166
  99.88366393532804
  99.88978368266024
  99.89589654984118
  99.90277352541975
  99.90884369645995
  99.91567263888018
  99.92335519910294
  99.93199807935355
  99.93899925091941
  99.94687556893099
  99.95573642669403
  99.96333445262874
  99.9718822318053
  99.98149848337891
  99.9917836663466
 100.0
u: 18416-element Vector{Vector{Float64}}:
 [1.0, 0.0, 0.0]
 [0.9935723575521516, 0.0016623161802513916, 5.887476766870236e-7]
 [0.9931413985835341, 0.001996060215547187, 8.452725403365441e-7]
 [0.9897372191696431, 0.002364209074699878, 1.1910128901146396e-6]
 [0.9863754156964627, 0.0027870349754163344, 1.6442415456946722e-6]
 [0.9816453017746493, 0.0032485982077592327, 2.2360388646766377e-6]
 [0.9798823115339813, 0.00376419538431509, 3.002680985394169e-6]
 [0.9769627498611689, 0.004348290343345211, 3.994742748676605e-6]
 [0.9746752673052053, 0.005000608975232769, 5.2452143832247885e-6]
 [0.975561937347947, 0.005704683532084442, 6.780230831634797e-6]
 [0.9718800868550801, 0.006431432457643715, 8.644914220182036e-6]
 [0.9689080631202299, 0.007244604580622524, 1.0807603471826052e-5]
 [0.9652030007703591, 0.008079161111140092, 1.3371366562575522e-5]
 [0.9590883231049572, 0.008941237325611936, 1.6297379837288528e-5]
 [0.9587393808617176, 0.009811626838090969, 1.9656634680658225e-5]
 [0.9531404195509355, 0.010691604729587828, 2.342847672417148e-5]
 [0.9466340429697403, 0.011613839787154832, 2.7603782378153965e-5]
 [0.9387485145643154, 0.012547710361083157, 3.218172151733701e-5]
 [0.9366750081050457, 0.01348022317055927, 3.703196748463813e-5]
 [0.9342421952139918, 0.014485371063599746, 4.240227183615855e-5]
 [0.9292640616155787, 0.015474981880609914, 4.8194527448965316e-5]
 ⋮
 [5.897812975515105, 6.076645906038707, 1.3286115780193821]
 [5.880039741850383, 6.128572486802333, 1.3365183956845863]
 [5.903266999793311, 6.148150568928711, 1.3399252122262055]
 [5.891448398400042, 6.050028253586368, 1.347903994703874]
 [5.957592323941897, 6.084432178115382, 1.3654956169934376]
 [5.937188474950169, 6.0530838520784505, 1.3667764881070934]
 [5.974121750739623, 6.0357310672631845, 1.3496066140028748]
 [5.959039281116, 6.091080956514798, 1.3704623941006386]
 [6.002353668596953, 6.05426843580676, 1.3823165588516568]
 [6.032884184201906, 5.978308329753016, 1.3839087768390836]
 [6.054295488965005, 5.944376129570052, 1.398591650635967]
 [6.106997470914939, 5.940932286509221, 1.391178399422503]
 [6.045950238598028, 5.949308391126071, 1.3770320989414266]
 [5.997594101075954, 5.994909616470001, 1.355085339471976]
 [5.922569829217446, 6.061347469973805, 1.3627802914472535]
 [5.946840201546448, 6.023691890475072, 1.3700820457176575]
 [5.94821208242336, 5.964936071946218, 1.3800562379600143]
 [5.906584837349537, 5.962649759958491, 1.3818425027449064]
 [5.91918916372324, 6.058807477925927, 1.370347328607035]
 [6.060812868419076, 5.93461436780659, 1.3770640471338815]
```