### PR TITLE
Pass down documented kwargs in structural_simplifiy

### DIFF
--- a/src/systems/systems.jl
+++ b/src/systems/systems.jl
@@ -22,7 +22,7 @@ function structural_simplify(
         allow_symbolic = true, allow_parameter = true, conservative = false, fully_determined = true,
         kwargs...)
     newsys′ = __structural_simplify(sys, io; simplify,
-        allow_symbolic = true, allow_parameter = true, conservative = false, fully_determined = true,
+        allow_symbolic, allow_parameter, conservative, fully_determined,
         kwargs...)
     if newsys′ isa Tuple
         @assert length(newsys′) == 2

--- a/src/systems/systems.jl
+++ b/src/systems/systems.jl
@@ -19,7 +19,7 @@ topological sort of the observed equations in `sys`.
 """
 function structural_simplify(
         sys::AbstractSystem, io = nothing; simplify = false, split = true,
-        allow_symbolic = true, allow_parameter = true, conservative = false, fully_determined = true,
+        allow_symbolic = false, allow_parameter = true, conservative = false, fully_determined = true,
         kwargs...)
     newsys′ = __structural_simplify(sys, io; simplify,
         allow_symbolic, allow_parameter, conservative, fully_determined,

--- a/src/systems/systems.jl
+++ b/src/systems/systems.jl
@@ -21,7 +21,9 @@ function structural_simplify(
         sys::AbstractSystem, io = nothing; simplify = false, split = true,
         allow_symbolic = true, allow_parameter = true, conservative = false, fully_determined = true,
         kwargs...)
-    newsys′ = __structural_simplify(sys, io; simplify, kwargs...)
+    newsys′ = __structural_simplify(sys, io; simplify, 
+                allow_symbolic = true, allow_parameter = true, conservative = false, fully_determined = true,
+                kwargs...)
     if newsys′ isa Tuple
         @assert length(newsys′) == 2
         newsys = newsys′[1]

--- a/src/systems/systems.jl
+++ b/src/systems/systems.jl
@@ -21,9 +21,9 @@ function structural_simplify(
         sys::AbstractSystem, io = nothing; simplify = false, split = true,
         allow_symbolic = true, allow_parameter = true, conservative = false, fully_determined = true,
         kwargs...)
-    newsys′ = __structural_simplify(sys, io; simplify, 
-                allow_symbolic = true, allow_parameter = true, conservative = false, fully_determined = true,
-                kwargs...)
+    newsys′ = __structural_simplify(sys, io; simplify,
+        allow_symbolic = true, allow_parameter = true, conservative = false, fully_determined = true,
+        kwargs...)
     if newsys′ isa Tuple
         @assert length(newsys′) == 2
         newsys = newsys′[1]


### PR DESCRIPTION
I didn't let the tests run because I thought it was a harmless doc change, I missed that these kwargs were pulled out. But at least the failure wasn't released.