### PR TITLE
Make default value units consistent

### DIFF
--- a/src/systems/model_parsing.jl
+++ b/src/systems/model_parsing.jl
@@ -628,7 +628,8 @@ function convert_units(varunits::DynamicQuantities.Quantity, value)
         DynamicQuantities.SymbolicUnits.as_quantity(varunits), value))
 end
 
-function convert_units(varunits::DynamicQuantities.Quantity, value::AbstractArray{T}) where T
+function convert_units(
+        varunits::DynamicQuantities.Quantity, value::AbstractArray{T}) where {T}
     DynamicQuantities.ustrip.(DynamicQuantities.uconvert.(
         DynamicQuantities.SymbolicUnits.as_quantity(varunits), value))
 end
@@ -637,10 +638,9 @@ function convert_units(varunits::Unitful.FreeUnits, value)
     Unitful.ustrip(varunits, value)
 end
 
-function convert_units(varunits::Unitful.FreeUnits, value::AbstractArray{T}) where T
+function convert_units(varunits::Unitful.FreeUnits, value::AbstractArray{T}) where {T}
     Unitful.ustrip.(varunits, value)
 end
-
 
 function parse_variable_arg(dict, mod, arg, varclass, kwargs, where_types)
     vv, def, metadata_with_exprs = parse_variable_def!(

--- a/src/systems/model_parsing.jl
+++ b/src/systems/model_parsing.jl
@@ -239,7 +239,7 @@ function parse_variable_def!(dict, mod, arg, varclass, kwargs, where_types;
         Expr(:tuple, a, b) => begin
             meta = parse_metadata(mod, b)
             var, def, _ = parse_variable_def!(
-                dict, mod, a, varclass, kwargs, where_types, meta; type, meta)
+                dict, mod, a, varclass, kwargs, where_types; type, meta)
             if meta !== nothing
                 for (type, key) in metatypes
                     if (mt = get(meta, key, nothing)) !== nothing

--- a/src/systems/model_parsing.jl
+++ b/src/systems/model_parsing.jl
@@ -197,12 +197,14 @@ function parse_variable_def!(dict, mod, arg, varclass, kwargs, where_types;
         end
         Expr(:(::), a, type) => begin
             type = getfield(mod, type)
-            parse_variable_def!(dict, mod, a, varclass, kwargs, where_types; def, type, meta)
+            parse_variable_def!(
+                dict, mod, a, varclass, kwargs, where_types; def, type, meta)
         end
         Expr(:(::), Expr(:call, a, b), type) => begin
             type = getfield(mod, type)
             def = _type_check!(def, a, type, varclass)
-            parse_variable_def!(dict, mod, a, varclass, kwargs, where_types; def, type, meta)
+            parse_variable_def!(
+                dict, mod, a, varclass, kwargs, where_types; def, type, meta)
         end
         Expr(:call, a, b) => begin
             var = generate_var!(dict, a, b, varclass, mod; indices, type)
@@ -618,7 +620,8 @@ function parse_variable_arg!(exprs, vs, dict, mod, arg, varclass, kwargs, where_
 end
 
 function convert_units(varunits::DynamicQuantities.Quantity, value)
-    DynamicQuantities.ustrip(DynamicQuantities.uconvert(DynamicQuantities.SymbolicUnits.as_quantity(varunits), value))
+    DynamicQuantities.ustrip(DynamicQuantities.uconvert(
+        DynamicQuantities.SymbolicUnits.as_quantity(varunits), value))
 end
 
 function convert_units(varunits::Unitful.FreeUnits, value)
@@ -639,10 +642,12 @@ function parse_variable_arg(dict, mod, arg, varclass, kwargs, where_types)
                 try
                     $setdefault($vv, $convert_units($unit, $name))
                 catch e
-                    if isa(e, $(DynamicQuantities.DimensionError)) || isa(e, $(Unitful.DimensionError))
-                        error("Unable to convert units for \'"*string(:($$vv))*"\'")
+                    if isa(e, $(DynamicQuantities.DimensionError)) ||
+                       isa(e, $(Unitful.DimensionError))
+                        error("Unable to convert units for \'" * string(:($$vv)) * "\'")
                     elseif isa(e, MethodError)
-                        error("No or invalid units provided for \'"*string(:($$vv))*"\'")
+                        error("No or invalid units provided for \'" * string(:($$vv)) *
+                              "\'")
                     else
                         rethrow(e)
                     end

--- a/src/systems/model_parsing.jl
+++ b/src/systems/model_parsing.jl
@@ -639,8 +639,10 @@ function parse_variable_arg(dict, mod, arg, varclass, kwargs, where_types)
                 try
                     $setdefault($vv, $convert_units($unit, $name))
                 catch e
-                    if isa(e, DynamicQuantities.DimensionError) || isa(e, Unitful.DimensionError)
+                    if isa(e, $(DynamicQuantities.DimensionError)) || isa(e, $(Unitful.DimensionError))
                         error("Unable to convert units for \'"*string(:($$vv))*"\'")
+                    elseif isa(e, MethodError)
+                        error("No or invalid units provided for \'"*string(:($$vv))*"\'")
                     else
                         rethrow(e)
                     end

--- a/test/dq_units.jl
+++ b/test/dq_units.jl
@@ -174,3 +174,14 @@ end
 
 @test_throws ErrorException ParamTest(; name = :t, a = 1.0)
 @test_throws ErrorException ParamTest(; name = :t, a = 1.0u"s")
+
+@mtkmodel ArrayParamTest begin
+    @parameters begin
+        a[1:2], [unit = u"m"]
+    end
+end
+
+@named sys = ArrayParamTest()
+
+@named sys = ArrayParamTest(a = [1.0, 3.0]u"cm")
+@test ModelingToolkit.getdefault(sys.a) ≈ [0.01, 0.03]

--- a/test/dq_units.jl
+++ b/test/dq_units.jl
@@ -160,17 +160,17 @@ maj2 = MassActionJump(γ, [S => 1], [S => -1])
 
 @mtkmodel ParamTest begin
     @parameters begin
-        a, [unit=u"m"]
+        a, [unit = u"m"]
     end
     @variables begin
-        b(t), [unit=u"kg"]
+        b(t), [unit = u"kg"]
     end
 end
 
 @named sys = ParamTest()
 
-@named sys = ParamTest(a=3.0u"cm")
+@named sys = ParamTest(a = 3.0u"cm")
 @test ModelingToolkit.getdefault(sys.a) ≈ 0.03
 
-@test_throws ErrorException ParamTest(;name=:t, a=1.0)
-@test_throws ErrorException ParamTest(;name=:t, a=1.0u"s")
+@test_throws ErrorException ParamTest(; name = :t, a = 1.0)
+@test_throws ErrorException ParamTest(; name = :t, a = 1.0u"s")

--- a/test/dq_units.jl
+++ b/test/dq_units.jl
@@ -157,3 +157,20 @@ maj2 = MassActionJump(γ, [I => 1], [I => -1, R => 1])
 maj1 = MassActionJump(2.0, [0 => 1], [S => 1])
 maj2 = MassActionJump(γ, [S => 1], [S => -1])
 @named js4 = JumpSystem([maj1, maj2], ModelingToolkit.t_nounits, [S], [β, γ])
+
+@mtkmodel ParamTest begin
+    @parameters begin
+        a, [unit=u"m"]
+    end
+    @variables begin
+        b(t), [unit=u"kg"]
+    end
+end
+
+@named sys = ParamTest()
+
+@named sys = ParamTest(a=3.0u"cm")
+@test ModelingToolkit.getdefault(sys.a) ≈ 0.03
+
+@test_throws ErrorException ParamTest(;name=:t, a=1.0)
+@test_throws ErrorException ParamTest(;name=:t, a=1.0u"s")

--- a/test/model_parsing.jl
+++ b/test/model_parsing.jl
@@ -53,8 +53,9 @@ end
     end
 end
 
-@named p = Pin(; v = π)
-@test getdefault(p.v) == π
+@named p = Pin(; v = π * u"V")
+
+@test getdefault(p.v) ≈ π
 @test Pin.isconnector == true
 
 @mtkmodel OnePort begin

--- a/test/model_parsing.jl
+++ b/test/model_parsing.jl
@@ -165,7 +165,8 @@ resistor = getproperty(rc, :resistor; namespace = false)
 # Test that `C_val` passed via argument is set as default of C.
 @test getdefault(rc.capacitor.C) * get_unit(rc.capacitor.C) == C_val
 # Test that `k`'s default value is unchanged.
-@test getdefault(rc.constant.k) * get_unit(rc.constant.k) == eval(RC.structure[:kwargs][:k_val][:value])
+@test getdefault(rc.constant.k) * get_unit(rc.constant.k) ==
+      eval(RC.structure[:kwargs][:k_val][:value])
 @test getdefault(rc.capacitor.v) == 0.0
 
 @test get_gui_metadata(rc.resistor).layout == Resistor.structure[:icon] ==

--- a/test/model_parsing.jl
+++ b/test/model_parsing.jl
@@ -1,7 +1,8 @@
 using ModelingToolkit, Test
 using ModelingToolkit: get_connector_type, get_defaults, get_gui_metadata,
                        get_systems, get_ps, getdefault, getname, readable_code,
-                       scalarize, symtype, VariableDescription, RegularConnector
+                       scalarize, symtype, VariableDescription, RegularConnector,
+                       get_unit
 using URIs: URI
 using Distributions
 using DynamicQuantities, OrdinaryDiffEq
@@ -106,14 +107,14 @@ end
     @parameters begin
         C, [unit = u"F"]
     end
-    @extend OnePort(; v = 0.0)
+    @extend OnePort(; v = 0.0u"V")
     @icon "https://upload.wikimedia.org/wikipedia/commons/7/78/Capacitor_symbol.svg"
     @equations begin
         D(v) ~ i / C
     end
 end
 
-@named capacitor = Capacitor(C = 10, v = 10.0)
+@named capacitor = Capacitor(C = 10u"F", v = 10.0u"V")
 @test getdefault(capacitor.v) == 10.0
 
 @mtkmodel Voltage begin
@@ -128,9 +129,9 @@ end
 
 @mtkmodel RC begin
     @structural_parameters begin
-        R_val = 10
-        C_val = 10
-        k_val = 10
+        R_val = 10u"Ω"
+        C_val = 10u"F"
+        k_val = 10u"V"
     end
     @components begin
         resistor = Resistor(; R = R_val)
@@ -148,9 +149,9 @@ end
     end
 end
 
-C_val = 20
-R_val = 20
-res__R = 100
+C_val = 20u"F"
+R_val = 20u"Ω"
+res__R = 100u"Ω"
 @mtkbuild rc = RC(; C_val, R_val, resistor.R = res__R)
 prob = ODEProblem(rc, [], (0, 1e9))
 sol = solve(prob, Rodas5P())
@@ -161,11 +162,11 @@ resistor = getproperty(rc, :resistor; namespace = false)
 @test getname(rc.resistor.R) === getname(resistor.R)
 @test getname(rc.resistor.v) === getname(resistor.v)
 # Test that `resistor.R` overrides `R_val` in the argument.
-@test getdefault(rc.resistor.R) == res__R != R_val
+@test getdefault(rc.resistor.R) * get_unit(rc.resistor.R) == res__R != R_val
 # Test that `C_val` passed via argument is set as default of C.
-@test getdefault(rc.capacitor.C) == C_val
+@test getdefault(rc.capacitor.C) * get_unit(rc.capacitor.C) == C_val
 # Test that `k`'s default value is unchanged.
-@test getdefault(rc.constant.k) == RC.structure[:kwargs][:k_val][:value]
+@test getdefault(rc.constant.k) * get_unit(rc.constant.k) == eval(RC.structure[:kwargs][:k_val][:value])
 @test getdefault(rc.capacitor.v) == 0.0
 
 @test get_gui_metadata(rc.resistor).layout == Resistor.structure[:icon] ==

--- a/test/model_parsing.jl
+++ b/test/model_parsing.jl
@@ -78,7 +78,6 @@ end
 
 @test OnePort.isconnector == false
 
-resistor_log = "$(@__DIR__)/logo/resistor.svg"
 @mtkmodel Resistor begin
     @extend v, i = oneport = OnePort()
     @parameters begin

--- a/test/units.jl
+++ b/test/units.jl
@@ -195,17 +195,17 @@ maj2 = MassActionJump(γ, [S => 1], [S => -1])
 
 @mtkmodel ParamTest begin
     @parameters begin
-        a, [unit=u"m"]
+        a, [unit = u"m"]
     end
     @variables begin
-        b(t), [unit=u"kg"]
+        b(t), [unit = u"kg"]
     end
 end
 
 @named sys = ParamTest()
 
-@named sys = ParamTest(a=3.0u"cm")
+@named sys = ParamTest(a = 3.0u"cm")
 @test ModelingToolkit.getdefault(sys.a) ≈ 0.03
 
-@test_throws ErrorException ParamTest(;name=:t, a=1.0)
-@test_throws ErrorException ParamTest(;name=:t, a=1.0u"s")
+@test_throws ErrorException ParamTest(; name = :t, a = 1.0)
+@test_throws ErrorException ParamTest(; name = :t, a = 1.0u"s")

--- a/test/units.jl
+++ b/test/units.jl
@@ -209,3 +209,14 @@ end
 
 @test_throws ErrorException ParamTest(; name = :t, a = 1.0)
 @test_throws ErrorException ParamTest(; name = :t, a = 1.0u"s")
+
+@mtkmodel ArrayParamTest begin
+    @parameters begin
+        a[1:2], [unit = u"m"]
+    end
+end
+
+@named sys = ArrayParamTest()
+
+@named sys = ArrayParamTest(a = [1.0, 3.0]u"cm")
+@test ModelingToolkit.getdefault(sys.a) ≈ [0.01, 0.03]

--- a/test/units.jl
+++ b/test/units.jl
@@ -192,3 +192,20 @@ maj2 = MassActionJump(γ, [I => 1], [I => -1, R => 1])
 maj1 = MassActionJump(2.0, [0 => 1], [S => 1])
 maj2 = MassActionJump(γ, [S => 1], [S => -1])
 @named js4 = JumpSystem([maj1, maj2], t, [S], [β, γ])
+
+@mtkmodel ParamTest begin
+    @parameters begin
+        a, [unit=u"m"]
+    end
+    @variables begin
+        b(t), [unit=u"kg"]
+    end
+end
+
+@named sys = ParamTest()
+
+@named sys = ParamTest(a=3.0u"cm")
+@test ModelingToolkit.getdefault(sys.a) ≈ 0.03
+
+@test_throws ErrorException ParamTest(;name=:t, a=1.0)
+@test_throws ErrorException ParamTest(;name=:t, a=1.0u"s")


### PR DESCRIPTION
When using units in a component, it would be nice if those units could be checked on the default and initial values. With old ModelingToolkit, it was possible to do `@parameters p = ustrip(expected_unit, provided_value), [unit=expected_unit]`, but that is not longer possible. This PR is a draft of a way to restore that functionality. It only works with Unitful and only with scalar variables, but these could both be fixed if this is desirable.

The result is a component defined like this
```
julia> @mtkmodel ATest begin
       @parameters begin
       some=1.0, [description="Some", unit=u"kg"]
       more, [description="more", unit=u"L"]
       end
       end
ModelingToolkit.Model{typeof(__ATest__), Dict{Symbol, Any}}(__ATest__, Dict{Symbol, Any}(:kwargs => Dict{Symbol, Dict}(:some => Dict{Symbol, Any}(:value => 1.0, :type => Real), :more => Dict{Symbol, Union{Nothing, DataType}}(:value => nothing, :type => Real)), :independent_variable => t, :parameters => Dict{Symbol, Dict{Symbol, Any}}(:some => Dict(:default => 1.0, :unit => :(u"kg"), :type => Real, :description => "Some"), :more => Dict(:unit => :(u"L"), :type => Real, :description => "more"))), false)
```

can be instantiated like this

```
julia> ATest(;some=3.0u"g", name=:t)
Model t with 0 equations
Unknowns (0):
Parameters (2):
  some [defaults to 0.003]: Some
  more: more
```

And the units are converted correctly. Errors are given for incompatible or missing units.

Is this a desirable feature? If this PR were fleshed out to handle DynamicQuantities and array variables as well, is there a chance it could be merged?