### PR TITLE
Getting started doc rewrite

### DIFF
--- a/docs/src/tutorials/ode_modeling.md
+++ b/docs/src/tutorials/ode_modeling.md
@@ -1,4 +1,4 @@
-# Getting Started with ModelingToolkit.jl
+# [Getting Started with ModelingToolkit.jl](@id getting_started)
 
 This is an introductory tutorial for ModelingToolkit (MTK). We will demonstrate
 the basics of the package by demonstrating how to define and simulate simple
@@ -96,6 +96,33 @@ plot(solve(prob))
 
 The parameter values are determined using the right hand side of the expressions in the `@parameters` block,
 and similarly initial conditions are determined using the right hand side of the expressions in the `@variables` block.
+
+## Using different values for parameters and initial conditions
+
+If you want to simulate the same model,
+but with different values for the parameters and initial conditions than the default values,
+you likely do not want to write an entirely new `@mtkmodel`.
+ModelingToolkit supports overwriting the default values:
+
+```@example ode2
+@mtkbuild fol_different_values = FOL(; τ = 1 / 3, x = 0.5)
+prob = ODEProblem(fol_different_values, [], (0.0, 10.0), [])
+plot(solve(prob))
+```
+
+Alternatively, this overwriting could also have occurred at the `ODEProblem` level.
+
+```@example ode2
+prob = ODEProblem(fol, [fol.τ => 1 / 3], (0.0, 10.0), [fol.x => 0.5])
+plot(solve(prob))
+```
+
+Here, the second argument of `ODEProblem` is an array of `Pairs`.
+The left hand side of each Pair is the parameter you want to overwrite,
+and the right hand side is the value to overwrite it with.
+Similarly, the initial conditions are overwritten in the fourth argument.
+One important difference with the previous method is
+that the parameter has to be referred to as `fol.τ` instead of just `τ`.
 
 ## Algebraic relations and structural simplification
 


### PR DESCRIPTION
The getting started documentation is currently a confusing combination of sometimes using the `mtkmodel` macro, and sometimes not. This PR puts as much functionality as possible into said macro, and removes all sidetracking explanations of the more manual definitions of `ODESystems` and `ODEProblem`.

I'll also take the opportunity to note the sentences in the tutorial I did not fully understand:

> And the independent variable t is automatically added by @mtkmodel.

Added where exactly?

> Vector-valued parameters and variables are possible. A cleaner, more
> consistent treatment of these is still a work in progress, however. Once finished,
> this introductory tutorial will also cover this feature.

Is this ready by now?

> Observed equations are variables which can be computed on-demand but are not necessary for the solution of the system.

Calculating RHS is definitely needed for solving the system (you can see this by inspecting `prob.f.f.f_oop`, it is just not a state of the dynamic system? I don't know how to succinctly rewrite this.
