### PR TITLE
Use `subs_constants` in `generate_control_function`

### DIFF
--- a/src/inputoutput.jl
+++ b/src/inputoutput.jl
@@ -218,6 +218,7 @@ function generate_control_function(sys::AbstractODESystem, inputs = unbound_inpu
     inputs = map(x -> time_varying_as_func(value(x), sys), inputs)
 
     eqs = [eq for eq in full_equations(sys)]
+    eqs = map(subs_constants, eqs)
     if disturbance_inputs !== nothing
         # Set all disturbance *inputs* to zero (we just want to keep the disturbance state)
         subs = Dict(disturbance_inputs .=> 0)

--- a/test/input_output_handling.jl
+++ b/test/input_output_handling.jl
@@ -171,16 +171,6 @@ x = [rand()]
 u = [rand()]
 @test f[1](x, u, p, 1) == -x + u
 
-@testset "Constants substitution" begin
-    @constants c = 2.0
-    @variables x(t)
-    eqs = [D(x) ~ c * x]
-    @named sys = ODESystem(eqs, t, [x], [])
-
-    f, dvs, ps = ModelingToolkit.generate_control_function(sys, simplify = true)
-    @test f[1]([0.5], nothing, nothing, 0.0) == [1.0]
-end
-
 # more complicated system
 
 @variables u(t) [input = true]
@@ -400,4 +390,15 @@ matrices, ssys = linearize(augmented_sys,
     obsfn = ModelingToolkit.build_explicit_observed_function(
         io_sys, [x + u * t]; inputs = [u])
     @test obsfn([1.0], [2.0], nothing, 3.0) == [7.0]
+end
+
+# https://github.com/SciML/ModelingToolkit.jl/issues/2896
+@testset "Constants substitution" begin
+    @constants c = 2.0
+    @variables x(t)
+    eqs = [D(x) ~ c * x]
+    @named sys = ODESystem(eqs, t, [x], [])
+
+    f, dvs, ps = ModelingToolkit.generate_control_function(sys, simplify = true)
+    @test f[1]([0.5], nothing, nothing, 0.0) == [1.0]
 end

--- a/test/input_output_handling.jl
+++ b/test/input_output_handling.jl
@@ -171,6 +171,16 @@ x = [rand()]
 u = [rand()]
 @test f[1](x, u, p, 1) == -x + u
 
+@testset "Constants substitution" begin
+    @constants c = 2.0
+    @variables x(t)
+    eqs = [D(x) ~ c * x]
+    @named sys = ODESystem(eqs, t, [x], [])
+
+    f, dvs, ps = ModelingToolkit.generate_control_function(sys, simplify = true)
+    @test f[1]([0.5], nothing, nothing, 0.0) == [1.0]
+end
+
 # more complicated system
 
 @variables u(t) [input = true]


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

In response to issue [2896](https://github.com/SciML/ModelingToolkit.jl/issues/2896)

Adds a line to call `subs_constants` for each `eq` from `full_equations`. Test was added to verify it would fail before fix, and pass after.
