### PR TITLE
Detect cases where there's fewer brownians than equations, but noise still 'diagonal'

### DIFF
--- a/src/systems/diffeqs/sdesystem.jl
+++ b/src/systems/diffeqs/sdesystem.jl
@@ -245,11 +245,11 @@ function Base.:(==)(sys1::SDESystem, sys2::SDESystem)
         all(s1 == s2 for (s1, s2) in zip(get_systems(sys1), get_systems(sys2)))
 end
 
-function __num_isdiag(mat)
-    for i in axes(mat, 1), j in axes(mat, 2)
-        i == j || isequal(mat[i, j], 0) || return false
-    end
-    return true
+function __num_isdiag_noise(mat)
+    all(col -> count(!iszero, col) <= 1, eachcol(mat))
+end
+function __get_num_diag_noise(mat)
+    vec(sum(mat; dims = 2))
 end
 
 function generate_diffusion_function(sys::SDESystem, dvs = unknowns(sys),
@@ -258,7 +258,7 @@ function generate_diffusion_function(sys::SDESystem, dvs = unknowns(sys),
     if isdde
         eqs = delay_to_function(sys, eqs)
     end
-    if eqs isa AbstractMatrix && __num_isdiag(eqs)
+    if eqs isa AbstractMatrix && __num_isdiag_noise(eqs)
         eqs = diag(eqs)
     end
     u = map(x -> time_varying_as_func(value(x), sys), dvs)

--- a/src/systems/diffeqs/sdesystem.jl
+++ b/src/systems/diffeqs/sdesystem.jl
@@ -261,7 +261,7 @@ function __num_isdiag_noise(mat)
 end
 function __get_num_diag_noise(mat)
     map(axes(mat, 2)) do j
-        for i ∈ axes(mat, 1)
+        for i in axes(mat, 1)
             if !isequal(mat[i, j], 0)
                 return mat[i, j]
             end

--- a/src/systems/diffeqs/sdesystem.jl
+++ b/src/systems/diffeqs/sdesystem.jl
@@ -246,7 +246,18 @@ function Base.:(==)(sys1::SDESystem, sys2::SDESystem)
 end
 
 function __num_isdiag_noise(mat)
-    all(col -> count(!iszero, col) <= 1, eachcol(mat))
+    for j in axes(mat, 2)
+        nnz = 0
+        for i in axes(mat, 1)
+            if !isequal(mat[i, j], 0)
+                nnz += 1
+            end
+        end
+        if nnz > 1
+            return false
+        end
+    end
+    true
 end
 function __get_num_diag_noise(mat)
     vec(sum(mat; dims = 2))

--- a/src/systems/diffeqs/sdesystem.jl
+++ b/src/systems/diffeqs/sdesystem.jl
@@ -277,9 +277,6 @@ function generate_diffusion_function(sys::SDESystem, dvs = unknowns(sys),
     if isdde
         eqs = delay_to_function(sys, eqs)
     end
-    if eqs isa AbstractMatrix && __num_isdiag_noise(eqs)
-        eqs = __get_num_diag_noise(eqs)
-    end
     u = map(x -> time_varying_as_func(value(x), sys), dvs)
     p = if has_index_cache(sys) && get_index_cache(sys) !== nothing
         reorder_parameters(get_index_cache(sys), ps)

--- a/src/systems/diffeqs/sdesystem.jl
+++ b/src/systems/diffeqs/sdesystem.jl
@@ -246,29 +246,55 @@ function Base.:(==)(sys1::SDESystem, sys2::SDESystem)
 end
 
 function __num_isdiag_noise(mat)
-    for j in axes(mat, 2)
+    for i in axes(mat, 1)
         nnz = 0
-        for i in axes(mat, 1)
+        for j in axes(mat, 2)
             if !isequal(mat[i, j], 0)
                 nnz += 1
             end
         end
         if nnz > 1
-            return false
+            return (false)
         end
     end
     true
 end
 function __get_num_diag_noise(mat)
-    map(axes(mat, 2)) do j
-        for i in axes(mat, 1)
-            if !isequal(mat[i, j], 0)
-                return mat[i, j]
+    map(axes(mat, 1)) do i
+        for j in axes(mat, 2)
+            mij = mat[i, j]
+            if !isequal(mij, 0)
+                return mij
             end
         end
         0
     end
 end
+
+# function __num_isdiag_noise(mat)
+#     for j in axes(mat, 2)
+#         nnz = 0
+#         for i in axes(mat, 1)
+#             if !isequal(mat[i, j], 0)
+#                 nnz += 1
+#             end
+#         end
+#         if nnz > 1
+#             return false
+#         end
+#     end
+#     true
+# end
+# function __get_num_diag_noise(mat)
+#     map(axes(mat, 2)) do j
+#         for i in axes(mat, 1)
+#             if !isequal(mat[i, j], 0)
+#                 return mat[i, j]
+#             end
+#         end
+#         0
+#     end
+# end
 
 function generate_diffusion_function(sys::SDESystem, dvs = unknowns(sys),
         ps = full_parameters(sys); isdde = false, kwargs...)

--- a/src/systems/diffeqs/sdesystem.jl
+++ b/src/systems/diffeqs/sdesystem.jl
@@ -260,7 +260,14 @@ function __num_isdiag_noise(mat)
     true
 end
 function __get_num_diag_noise(mat)
-    vec(sum(mat; dims = 2))
+    map(axes(mat, 2)) do j
+        for i ∈ axes(mat, 1)
+            if !isequal(mat[i, j], 0)
+                return mat[i, j]
+            end
+        end
+        0
+    end
 end
 
 function generate_diffusion_function(sys::SDESystem, dvs = unknowns(sys),

--- a/src/systems/diffeqs/sdesystem.jl
+++ b/src/systems/diffeqs/sdesystem.jl
@@ -259,7 +259,7 @@ function generate_diffusion_function(sys::SDESystem, dvs = unknowns(sys),
         eqs = delay_to_function(sys, eqs)
     end
     if eqs isa AbstractMatrix && __num_isdiag_noise(eqs)
-        eqs = diag(eqs)
+        eqs = __get_num_diag_noise(eqs)
     end
     u = map(x -> time_varying_as_func(value(x), sys), dvs)
     p = if has_index_cache(sys) && get_index_cache(sys) !== nothing

--- a/src/systems/diffeqs/sdesystem.jl
+++ b/src/systems/diffeqs/sdesystem.jl
@@ -271,31 +271,6 @@ function __get_num_diag_noise(mat)
     end
 end
 
-# function __num_isdiag_noise(mat)
-#     for j in axes(mat, 2)
-#         nnz = 0
-#         for i in axes(mat, 1)
-#             if !isequal(mat[i, j], 0)
-#                 nnz += 1
-#             end
-#         end
-#         if nnz > 1
-#             return false
-#         end
-#     end
-#     true
-# end
-# function __get_num_diag_noise(mat)
-#     map(axes(mat, 2)) do j
-#         for i in axes(mat, 1)
-#             if !isequal(mat[i, j], 0)
-#                 return mat[i, j]
-#             end
-#         end
-#         0
-#     end
-# end
-
 function generate_diffusion_function(sys::SDESystem, dvs = unknowns(sys),
         ps = full_parameters(sys); isdde = false, kwargs...)
     eqs = get_noiseeqs(sys)

--- a/src/systems/systems.jl
+++ b/src/systems/systems.jl
@@ -133,10 +133,11 @@ function __structural_simplify(sys::AbstractSystem, io = nothing; simplify = fal
             # we get a Nx1 matrix of noise equations, which is a special case known as scalar noise
             noise_eqs = sorted_g_rows[:, 1]
             is_scalar_noise = true
-        elseif isdiag(sorted_g_rows)
-            # If the noise matrix is diagonal, then the solver just takes a vector column of equations
-            # and it interprets that as diagonal noise.
-            noise_eqs = diag(sorted_g_rows)
+        elseif __num_isdiag_noise(sorted_g_rows)
+            # If each column of the noise matrix has either 0 or 1 non-zero entry, then this is "diagonal noise".
+            # In this case, the solver just takes a vector column of equations and it interprets that to
+            # mean that each noise process is independant
+            noise_eqs = __get_num_diag_noise(sorted_g_rows)
             is_scalar_noise = false
         else
             noise_eqs = sorted_g_rows

--- a/src/systems/systems.jl
+++ b/src/systems/systems.jl
@@ -136,7 +136,7 @@ function __structural_simplify(sys::AbstractSystem, io = nothing; simplify = fal
         elseif __num_isdiag_noise(sorted_g_rows)
             # If each column of the noise matrix has either 0 or 1 non-zero entry, then this is "diagonal noise".
             # In this case, the solver just takes a vector column of equations and it interprets that to
-            # mean that each noise process is independant
+            # mean that each noise process is independent
             noise_eqs = __get_num_diag_noise(sorted_g_rows)
             is_scalar_noise = false
         else

--- a/test/sdesystem.jl
+++ b/test/sdesystem.jl
@@ -747,7 +747,7 @@ end
     prob = SDEProblem(de, u0map, (0.0, 100.0), parammap)
     # SOSRI only works for diagonal and scalar noise
     @test_throws ErrorException solve(prob, SOSRI()).retcode==ReturnCode.Success
-    # ImplictEM does work for non-diagonal noise
+    # ImplicitEM does work for non-diagonal noise
     @test solve(prob, ImplicitEM()).retcode == ReturnCode.Success
 end
 

--- a/test/sdesystem.jl
+++ b/test/sdesystem.jl
@@ -726,10 +726,10 @@ end
 @testset "Non-diagonal noise check" begin
     @parameters σ ρ β
     @variables x(tt) y(tt) z(tt)
-    @brownian a b c
-    eqs = [D(x) ~ σ * (y - x) + 0.1a * x + 0.1b * y,
-        D(y) ~ x * (ρ - z) - y + 0.1b * y,
-        D(z) ~ x * y - β * z + 0.1c * z]
+    @brownian a b c d e f
+    eqs = [D(x) ~ σ * (y - x) + 0.1a * x + d,
+        D(y) ~ x * (ρ - z) - y + 0.1b * y + e,
+        D(z) ~ x * y - β * z + 0.1c * z + f]
     @mtkbuild de = System(eqs, tt)
 
     u0map = [
@@ -749,6 +749,7 @@ end
     @test_throws ErrorException solve(prob, SOSRI()).retcode==ReturnCode.Success
     # ImplicitEM does work for non-diagonal noise
     @test solve(prob, ImplicitEM()).retcode == ReturnCode.Success
+    @test size(ModelingToolkit.get_noiseeqs(de)) == (3, 6)
 end
 
 @testset "Diagonal noise, less brownians than equations" begin


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

Followup to #2882 and #2886 
