### PR TITLE
Bifurcationkit_ext observable fix

### DIFF
--- a/ext/MTKBifurcationKitExt.jl
+++ b/ext/MTKBifurcationKitExt.jl
@@ -144,7 +144,7 @@ function BifurcationKit.BifurcationProblem(osys::ODESystem, args...; kwargs...)
     if !ModelingToolkit.iscomplete(osys)
         error("A completed `ODESystem` is required. Call `complete` or `structural_simplify` on the system before creating a `BifurcationProblem`")
     end
-    nsys = NonlinearSystem([0 ~ eq.rhs for eq in equations(osys)],
+    nsys = NonlinearSystem([0 ~ eq.rhs for eq in full_equations(osys)],
         unknowns(osys),
         parameters(osys);
         name = nameof(osys))

--- a/ext/MTKBifurcationKitExt.jl
+++ b/ext/MTKBifurcationKitExt.jl
@@ -147,6 +147,7 @@ function BifurcationKit.BifurcationProblem(osys::ODESystem, args...; kwargs...)
     nsys = NonlinearSystem([0 ~ eq.rhs for eq in full_equations(osys)],
         unknowns(osys),
         parameters(osys);
+        observed = observed(osys),
         name = nameof(osys))
     return BifurcationKit.BifurcationProblem(complete(nsys), args...; kwargs...)
 end

--- a/test/extensions/bifurcationkit.jl
+++ b/test/extensions/bifurcationkit.jl
@@ -160,7 +160,7 @@ let
     bp = BifurcationProblem(fol, u0, par, bif_par)
     opts_br = ContinuationPar(p_min = -1.0,
         p_max = 1.0)
-    bf = bifurcationdiagram(bp, PALC(), 2, opts_br).γ.specialpoint[1] ≈ 0.1
+    bf = bifurcationdiagram(bp, PALC(), 2, opts_br)
 
     @test bf.γ.specialpoint[1].param≈0.1 atol=1e-4 rtol=1e-4
 

--- a/test/extensions/bifurcationkit.jl
+++ b/test/extensions/bifurcationkit.jl
@@ -134,8 +134,7 @@ let
     @test fold_points ≈ [-1.1851851706940317, -5.6734983580551894e-6] # test that they occur at the correct parameter values).
 end
 
-let 
-
+let
     @mtkmodel FOL begin
         @parameters begin
             τ # parameters
@@ -163,5 +162,4 @@ let
     bf = bifurcationdiagram(bp, PALC(), 2, opts_br)
 
     @test bf.γ.specialpoint[1].param≈0.1 atol=1e-4 rtol=1e-4
-
 end

--- a/test/extensions/bifurcationkit.jl
+++ b/test/extensions/bifurcationkit.jl
@@ -133,3 +133,35 @@ let
     @test length(fold_points) == 2
     @test fold_points ≈ [-1.1851851706940317, -5.6734983580551894e-6] # test that they occur at the correct parameter values).
 end
+
+let 
+
+    @mtkmodel FOL begin
+        @parameters begin
+            τ # parameters
+        end
+        @variables begin
+            x(t) # dependent variables
+            RHS(t)
+        end
+        @equations begin
+            RHS ~ τ + x^2 - 0.1
+            D(x) ~ RHS
+        end
+    end
+
+    @mtkbuild fol = FOL()
+
+    par = [fol.τ => 0.0]
+    u0 = [fol.x => -1.0]
+    #prob = ODEProblem(fol, u0, (0.0, 1.), par)
+
+    bif_par = fol.τ
+    bp = BifurcationProblem(fol, u0, par, bif_par)
+    opts_br = ContinuationPar(p_min = -1.0,
+        p_max = 1.0)
+    bf = bifurcationdiagram(bp, PALC(), 2, opts_br).γ.specialpoint[1] ≈ 0.1
+
+    @test bf.γ.specialpoint[1].param≈0.1 atol=1e-4 rtol=1e-4
+
+end


### PR DESCRIPTION
## Checklist

- [ x] Appropriate tests were added
- [x ] Any code changes were done in a way that does not break public API
- [ x] All documentation related to code changes were updated
- [ x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x ] Any new documentation only uses public API
  
## Additional context
This fixes the error in https://github.com/SciML/ModelingToolkit.jl/issues/2889, but I'm not sure if it's completely correct. e.g. I don't think this would work if the Bifurcation parameter was an observable. 
