### PR TITLE
normalize operating point user input

### DIFF
--- a/src/systems/abstractsystem.jl
+++ b/src/systems/abstractsystem.jl
@@ -2196,6 +2196,7 @@ function linearization_function(sys::AbstractSystem, inputs,
         eval_expression = false, eval_module = @__MODULE__,
         warn_initialize_determined = true,
         kwargs...)
+    op = Dict(op)
     inputs isa AbstractVector || (inputs = [inputs])
     outputs isa AbstractVector || (outputs = [outputs])
     ssys, diff_idxs, alge_idxs, input_idxs = io_preprocessing(sys, inputs, outputs;


### PR DESCRIPTION
In case the user passes a vector of pairs, the `merge` below will fail.