### PR TITLE
Fix Latex tests to use new upstream equation equality aligning

### DIFF
--- a/docs/src/examples/modelingtoolkitize_index_reduction.md
+++ b/docs/src/examples/modelingtoolkitize_index_reduction.md
@@ -119,11 +119,11 @@ you can arrive at the following set of equations](https://people.math.wisc.edu/%
 
 ```math
 \begin{aligned}
-x^\prime =& v_x \\
-v_x^\prime =& x T \\
-y^\prime =& v_y \\
-v_y^\prime =& y T - g \\
-0 =& 2 \left(v_x^{2} + v_y^{2} + y ( y T - g ) + T x^2 \right)
+x^\prime &= v_x \\
+v_x^\prime &= x T \\
+y^\prime &= v_y \\
+v_y^\prime &= y T - g \\
+0 &= 2 \left(v_x^{2} + v_y^{2} + y ( y T - g ) + T x^2 \right)
 \end{aligned}
 ```
 

--- a/test/latexify/10.tex
+++ b/test/latexify/10.tex
@@ -1,5 +1,5 @@
 \begin{align}
-\frac{\mathrm{d} x\left( t \right)}{\mathrm{d}t} =& \frac{\left(  - x\left( t \right) + y\left( t \right) \right) \frac{\mathrm{d}}{\mathrm{d}t} \left( x\left( t \right) - y\left( t \right) \right) \sigma}{\frac{\mathrm{d} z\left( t \right)}{\mathrm{d}t}} \\
-0 =&  - y\left( t \right) + \frac{1}{10} x\left( t \right) \left(  - z\left( t \right) + \rho \right) \sigma \\
-\frac{\mathrm{d} z\left( t \right)}{\mathrm{d}t} =& \left( y\left( t \right) \right)^{\frac{2}{3}} x\left( t \right) - z\left( t \right) \beta
+\frac{\mathrm{d} x\left( t \right)}{\mathrm{d}t} &= \frac{\left(  - x\left( t \right) + y\left( t \right) \right) \frac{\mathrm{d}}{\mathrm{d}t} \left( x\left( t \right) - y\left( t \right) \right) \sigma}{\frac{\mathrm{d} z\left( t \right)}{\mathrm{d}t}} \\
+0 &=  - y\left( t \right) + \frac{1}{10} x\left( t \right) \left(  - z\left( t \right) + \rho \right) \sigma \\
+\frac{\mathrm{d} z\left( t \right)}{\mathrm{d}t} &= \left( y\left( t \right) \right)^{\frac{2}{3}} x\left( t \right) - z\left( t \right) \beta
 \end{align}

--- a/test/latexify/20.tex
+++ b/test/latexify/20.tex
@@ -1,5 +1,5 @@
 \begin{align}
-\frac{\mathrm{d} u\left( t \right)_{1}}{\mathrm{d}t} =& p_{3} \left(  - u\left( t \right)_{1} + u\left( t \right)_{2} \right) \\
-0 =&  - u\left( t \right)_{2} + \frac{1}{10} \left( p_{1} - u\left( t \right)_{1} \right) p_{2} p_{3} u\left( t \right)_{1} \\
-\frac{\mathrm{d} u\left( t \right)_{3}}{\mathrm{d}t} =& u\left( t \right)_{2}^{\frac{2}{3}} u\left( t \right)_{1} - p_{3} u\left( t \right)_{3}
+\frac{\mathrm{d} u\left( t \right)_{1}}{\mathrm{d}t} &= p_{3} \left(  - u\left( t \right)_{1} + u\left( t \right)_{2} \right) \\
+0 &=  - u\left( t \right)_{2} + \frac{1}{10} \left( p_{1} - u\left( t \right)_{1} \right) p_{2} p_{3} u\left( t \right)_{1} \\
+\frac{\mathrm{d} u\left( t \right)_{3}}{\mathrm{d}t} &= u\left( t \right)_{2}^{\frac{2}{3}} u\left( t \right)_{1} - p_{3} u\left( t \right)_{3}
 \end{align}

--- a/test/latexify/30.tex
+++ b/test/latexify/30.tex
@@ -1,5 +1,5 @@
 \begin{align}
-\frac{\mathrm{d} u\left( t \right)_{1}}{\mathrm{d}t} =& p_{3} \left(  - u\left( t \right)_{1} + u\left( t \right)_{2} \right) \\
-\frac{\mathrm{d} u\left( t \right)_{2}}{\mathrm{d}t} =&  - u\left( t \right)_{2} + \frac{1}{10} \left( p_{1} - u\left( t \right)_{1} \right) p_{2} p_{3} u\left( t \right)_{1} \\
-\frac{\mathrm{d} u\left( t \right)_{3}}{\mathrm{d}t} =& u\left( t \right)_{2}^{\frac{2}{3}} u\left( t \right)_{1} - p_{3} u\left( t \right)_{3}
+\frac{\mathrm{d} u\left( t \right)_{1}}{\mathrm{d}t} &= p_{3} \left(  - u\left( t \right)_{1} + u\left( t \right)_{2} \right) \\
+\frac{\mathrm{d} u\left( t \right)_{2}}{\mathrm{d}t} &=  - u\left( t \right)_{2} + \frac{1}{10} \left( p_{1} - u\left( t \right)_{1} \right) p_{2} p_{3} u\left( t \right)_{1} \\
+\frac{\mathrm{d} u\left( t \right)_{3}}{\mathrm{d}t} &= u\left( t \right)_{2}^{\frac{2}{3}} u\left( t \right)_{1} - p_{3} u\left( t \right)_{3}
 \end{align}

--- a/test/latexify/40.tex
+++ b/test/latexify/40.tex
@@ -1,3 +1,3 @@
 \begin{align}
-\frac{\mathrm{d} x\left( t \right)}{\mathrm{d}t} =& \frac{1 + \cos\left( t \right)}{1 + 2 x\left( t \right)}
+\frac{\mathrm{d} x\left( t \right)}{\mathrm{d}t} &= \frac{1 + \cos\left( t \right)}{1 + 2 x\left( t \right)}
 \end{align}


### PR DESCRIPTION
https://github.com/korsbo/Latexify.jl/pull/300 was merged, so I think this will be needed to fix tests?
All this should close https://github.com/SciML/ModelingToolkit.jl/issues/2894.
This is just a search-and-replace `=&` to `&=`.