### PR TITLE
support JumpProblems over ODEProblems

### DIFF
--- a/src/systems/dependency_graphs.jl
+++ b/src/systems/dependency_graphs.jl
@@ -143,7 +143,6 @@ variable_dependencies(jumpsys)
 """
 function variable_dependencies(sys::AbstractSystem; variables = unknowns(sys),
         variablestoids = nothing, eqs = equations(sys))
-
     vtois = isnothing(variablestoids) ? Dict(v => i for (i, v) in enumerate(variables)) :
             variablestoids
 

--- a/src/systems/dependency_graphs.jl
+++ b/src/systems/dependency_graphs.jl
@@ -36,8 +36,8 @@ equation_dependencies(jumpsys)
 equation_dependencies(jumpsys, variables = parameters(jumpsys))
 ```
 """
-function equation_dependencies(sys::AbstractSystem; variables = unknowns(sys))
-    eqs = equations(sys)
+function equation_dependencies(sys::AbstractSystem; variables = unknowns(sys),
+        eqs = equations(sys))
     deps = Set()
     depeqs_to_vars = Vector{Vector}(undef, length(eqs))
 
@@ -114,8 +114,9 @@ digr = asgraph(jumpsys)
 ```
 """
 function asgraph(sys::AbstractSystem; variables = unknowns(sys),
-        variablestoids = Dict(v => i for (i, v) in enumerate(variables)))
-    asgraph(equation_dependencies(sys, variables = variables), variablestoids)
+        variablestoids = Dict(v => i for (i, v) in enumerate(variables)),
+        eqs = equations(sys))
+    asgraph(equation_dependencies(sys; variables, eqs), variablestoids)
 end
 
 """
@@ -141,8 +142,8 @@ variable_dependencies(jumpsys)
 ```
 """
 function variable_dependencies(sys::AbstractSystem; variables = unknowns(sys),
-        variablestoids = nothing)
-    eqs = equations(sys)
+        variablestoids = nothing, eqs = equations(sys))
+
     vtois = isnothing(variablestoids) ? Dict(v => i for (i, v) in enumerate(variables)) :
             variablestoids
 
@@ -193,8 +194,8 @@ dg = asdigraph(digr, jumpsys)
 ```
 """
 function asdigraph(g::BipartiteGraph, sys::AbstractSystem; variables = unknowns(sys),
-        equationsfirst = true)
-    neqs = length(equations(sys))
+        equationsfirst = true, eqs = equations(sys))
+    neqs = length(eqs)
     nvars = length(variables)
     fadjlist = deepcopy(g.fadjlist)
     badjlist = deepcopy(g.badjlist)

--- a/src/systems/jumps/jumpsystem.jl
+++ b/src/systems/jumps/jumpsystem.jl
@@ -194,6 +194,10 @@ function JumpSystem(eqs, iv, unknowns, ps;
         metadata, gui_metadata, checks = checks)
 end
 
+has_massactionjumps(js::JumpSystem) = !isempty(equations(js).x[1])
+has_constantratejumps(js::JumpSystem) = !isempty(equations(js).x[2])
+has_variableratejumps(js::JumpSystem) = !isempty(equations(js).x[3])
+
 function generate_rate_function(js::JumpSystem, rate)
     consts = collect_constants(rate)
     if !isempty(consts) # The SymbolicUtils._build_function method of this case doesn't support postprocess_fbody

--- a/src/systems/jumps/jumpsystem.jl
+++ b/src/systems/jumps/jumpsystem.jl
@@ -465,7 +465,6 @@ function DiffEqBase.ODEProblem(sys::JumpSystem, u0map, tspan::Union{Tuple, Nothi
     ODEProblem(df, u0, tspan, p; kwargs...)
 end
 
-
 """
 ```julia
 DiffEqBase.JumpProblem(js::JumpSystem, prob, aggregator; kwargs...)

--- a/src/systems/jumps/jumpsystem.jl
+++ b/src/systems/jumps/jumpsystem.jl
@@ -461,7 +461,7 @@ function DiffEqBase.ODEProblem(sys::JumpSystem, u0map, tspan::Union{Tuple, Nothi
     observedfun = ObservedFunctionCache(sys; eval_expression, eval_module)
 
     f = (du, u, p, t) -> (du .= 0; nothing)
-    df = ODEFunction(f; sys = sys, observed = observedfun)
+    df = ODEFunction(f; sys, observed = observedfun)
     ODEProblem(df, u0, tspan, p; kwargs...)
 end
 

--- a/src/systems/jumps/jumpsystem.jl
+++ b/src/systems/jumps/jumpsystem.jl
@@ -502,10 +502,12 @@ function JumpProcesses.JumpProblem(js::JumpSystem, prob,
         error("Use continuous problems such as an ODEProblem or a SDEProblem with VariableRateJumps")
     jset = JumpSet(Tuple(vrjs), Tuple(crjs), nothing, majs)
 
+    # dep graphs are only for constant rate jumps
+    nonvrjs = ArrayPartition(eqs.x[1], eqs.x[2])
     if needs_vartojumps_map(aggregator) || needs_depgraph(aggregator) ||
        (aggregator isa JumpProcesses.NullAggregator)
-        jdeps = asgraph(js)
-        vdeps = variable_dependencies(js)
+        jdeps = asgraph(js; eqs = nonvrjs)
+        vdeps = variable_dependencies(js; eqs = nonvrjs)
         vtoj = jdeps.badjlist
         jtov = vdeps.badjlist
         jtoj = needs_depgraph(aggregator) ? eqeq_dependencies(jdeps, vdeps).fadjlist :

--- a/test/dep_graphs.jl
+++ b/test/dep_graphs.jl
@@ -1,5 +1,5 @@
 using Test
-using ModelingToolkit, Graphs, JumpProcesses
+using ModelingToolkit, Graphs, JumpProcesses, RecursiveArrayTools
 using ModelingToolkit: t_nounits as t, D_nounits as D
 import ModelingToolkit: value
 
@@ -71,6 +71,80 @@ for (vidx, vdeps) in enumerate(var_vardeps)
 end
 dg4 = varvar_dependencies(depsbg, deps2)
 @test dg == dg4
+
+# testing when ignoring VariableRateJumps
+let
+    @parameters k1 k2
+    @variables S(t) I(t) R(t)
+    j₁ = MassActionJump(k1, [0 => 1], [S => 1])
+    j₂ = MassActionJump(k1, [S => 1], [S => -1])
+    j₃ = MassActionJump(k2, [S => 1, I => 1], [S => -1, I => 1])
+    j₄ = MassActionJump(k2, [S => 2, R => 1], [R => -1])
+    j₅ = ConstantRateJump(k1 * I, [R ~ R + 1])
+    j₆ = VariableRateJump(k1 * k2 / (1 + t) * S, [S ~ S - 1, R ~ R + 1])
+    eqs = [j₁, j₂, j₃, j₄, j₅, j₆]
+    @named js = JumpSystem(eqs, t, [S, I, R], [k1, k2])
+    S = value(S);
+    I = value(I);
+    R = value(R);
+    k1 = value(k1);
+    k2 = value(k2);
+    # eq to vars they depend on
+    eq_sdeps = [Variable[], [S], [S, I], [S, R], [I]]
+    eq_sidepsf = [Int[], [1], [1, 2], [1, 3], [2]]
+    eq_sidepsb = [[2, 3, 4], [3, 5], [4]]
+
+    # filter out vrjs in making graphs
+    eqs = ArrayPartition(equations(js).x[1], equations(js).x[2])
+    deps = equation_dependencies(js; eqs)
+    @test length(deps) == length(eq_sdeps)
+    @test all(i -> isequal(Set(eq_sdeps[i]), Set(deps[i])), 1:length(eqs))
+    depsbg = asgraph(js; eqs)
+    @test depsbg.fadjlist == eq_sidepsf
+    @test depsbg.badjlist == eq_sidepsb
+
+    # eq to params they depend on
+    eq_pdeps = [[k1], [k1], [k2], [k2], [k1]]
+    eq_pidepsf = [[1], [1], [2], [2], [1]]
+    eq_pidepsb = [[1, 2, 5], [3, 4]]
+    deps = equation_dependencies(js; variables = parameters(js), eqs)
+    @test length(deps) == length(eq_pdeps)
+    @test all(i -> isequal(Set(eq_pdeps[i]), Set(deps[i])), 1:length(eqs))
+    depsbg2 = asgraph(js; variables = parameters(js), eqs)
+    @test depsbg2.fadjlist == eq_pidepsf
+    @test depsbg2.badjlist == eq_pidepsb
+
+    # var to eqs that modify them
+    s_eqdepsf = [[1, 2, 3], [3], [4, 5]]
+    s_eqdepsb = [[1], [1], [1, 2], [3], [3]]
+    ne = 6
+    bg = BipartiteGraph(ne, s_eqdepsf, s_eqdepsb)
+    deps2 = variable_dependencies(js; eqs)
+    @test isequal(bg, deps2)
+
+    # eq to eqs that depend on them
+    eq_eqdeps = [[2, 3, 4], [2, 3, 4], [2, 3, 4, 5], [4], [4], [2, 3, 4]]
+    dg = SimpleDiGraph(5)
+    for (eqidx, eqdeps) in enumerate(eq_eqdeps)
+        for eqdepidx in eqdeps
+            add_edge!(dg, eqidx, eqdepidx)
+        end
+    end
+    dg3 = eqeq_dependencies(depsbg, deps2)
+    @test dg == dg3
+
+    # var to vars that depend on them
+    var_vardeps = [[1, 2, 3], [1, 2, 3], [3]]
+    ne = 7
+    dg = SimpleDiGraph(3)
+    for (vidx, vdeps) in enumerate(var_vardeps)
+        for vdepidx in vdeps
+            add_edge!(dg, vidx, vdepidx)
+        end
+    end
+    dg4 = varvar_dependencies(depsbg, deps2)
+    @test dg == dg4
+end
 
 #####################################
 #       testing for ODE/SDEs

--- a/test/dep_graphs.jl
+++ b/test/dep_graphs.jl
@@ -16,11 +16,11 @@ j₅ = ConstantRateJump(k1 * I, [R ~ R + 1])
 j₆ = VariableRateJump(k1 * k2 / (1 + t) * S, [S ~ S - 1, R ~ R + 1])
 eqs = [j₁, j₂, j₃, j₄, j₅, j₆]
 @named js = JumpSystem(eqs, t, [S, I, R], [k1, k2])
-S = value(S);
-I = value(I);
-R = value(R);
-k1 = value(k1);
-k2 = value(k2);
+S = value(S)
+I = value(I)
+R = value(R)
+k1 = value(k1)
+k2 = value(k2)
 # eq to vars they depend on
 eq_sdeps = [Variable[], [S], [S, I], [S, R], [I], [S]]
 eq_sidepsf = [Int[], [1], [1, 2], [1, 3], [2], [1]]
@@ -84,11 +84,11 @@ let
     j₆ = VariableRateJump(k1 * k2 / (1 + t) * S, [S ~ S - 1, R ~ R + 1])
     eqs = [j₁, j₂, j₃, j₄, j₅, j₆]
     @named js = JumpSystem(eqs, t, [S, I, R], [k1, k2])
-    S = value(S);
-    I = value(I);
-    R = value(R);
-    k1 = value(k1);
-    k2 = value(k2);
+    S = value(S)
+    I = value(I)
+    R = value(R)
+    k1 = value(k1)
+    k2 = value(k2)
     # eq to vars they depend on
     eq_sdeps = [Variable[], [S], [S, I], [S, R], [I]]
     eq_sidepsf = [Int[], [1], [1, 2], [1, 3], [2]]

--- a/test/jumpsystem.jl
+++ b/test/jumpsystem.jl
@@ -67,7 +67,7 @@ tspan = (0.0, 250.0);
 u₀map = [S => 999, I => 1, R => 0]
 parammap = [β => 0.1 / 1000, γ => 0.01]
 dprob = DiscreteProblem(js2, u₀map, tspan, parammap)
-jprob = JumpProblem(js2, dprob, Direct(), save_positions = (false, false), rng = rng)
+jprob = JumpProblem(js2, dprob, Direct(), save_positions = (false, false), rng)
 Nsims = 30000
 function getmean(jprob, Nsims; use_stepper = true)
     m = 0.0
@@ -89,12 +89,12 @@ obs = [S2 ~ 2 * S]
 @named js2b = JumpSystem([j₁, j₃], t, [S, I, R], [β, γ], observed = obs)
 js2b = complete(js2b)
 dprob = DiscreteProblem(js2b, u₀map, tspan, parammap)
-jprob = JumpProblem(js2b, dprob, Direct(), save_positions = (false, false), rng = rng)
+jprob = JumpProblem(js2b, dprob, Direct(), save_positions = (false, false), rng)
 sol = solve(jprob, SSAStepper(), saveat = tspan[2] / 10)
 @test all(2 .* sol[S] .== sol[S2])
 
 # test save_positions is working
-jprob = JumpProblem(js2, dprob, Direct(), save_positions = (false, false), rng = rng)
+jprob = JumpProblem(js2, dprob, Direct(), save_positions = (false, false), rng)
 sol = solve(jprob, SSAStepper(), saveat = 1.0)
 @test all((sol.t) .== collect(0.0:tspan[2]))
 
@@ -129,7 +129,7 @@ function a2!(integrator)
 end
 j2 = ConstantRateJump(r2, a2!)
 jset = JumpSet((), (j1, j2), nothing, nothing)
-jprob = JumpProblem(prob, Direct(), jset, save_positions = (false, false), rng = rng)
+jprob = JumpProblem(prob, Direct(), jset, save_positions = (false, false), rng)
 m2 = getmean(jprob, Nsims)
 
 # test JumpSystem solution agrees with direct version
@@ -141,17 +141,17 @@ maj2 = MassActionJump(γ, [I => 1], [I => -1, R => 1])
 @named js3 = JumpSystem([maj1, maj2], t, [S, I, R], [β, γ])
 js3 = complete(js3)
 dprob = DiscreteProblem(js3, u₀map, tspan, parammap)
-jprob = JumpProblem(js3, dprob, Direct(), rng = rng)
+jprob = JumpProblem(js3, dprob, Direct(), rng)
 m3 = getmean(jprob, Nsims)
 @test abs(m - m3) / m < 0.01
 
 # maj jump test with various dep graphs
 @named js3b = JumpSystem([maj1, maj2], t, [S, I, R], [β, γ])
 js3b = complete(js3b)
-jprobb = JumpProblem(js3b, dprob, NRM(), rng = rng)
+jprobb = JumpProblem(js3b, dprob, NRM(), rng)
 m4 = getmean(jprobb, Nsims)
 @test abs(m - m4) / m < 0.01
-jprobc = JumpProblem(js3b, dprob, RSSA(), rng = rng)
+jprobc = JumpProblem(js3b, dprob, RSSA(), rng)
 m4 = getmean(jprobc, Nsims)
 @test abs(m - m4) / m < 0.01
 
@@ -161,7 +161,7 @@ maj2 = MassActionJump(γ, [S => 1], [S => -1])
 @named js4 = JumpSystem([maj1, maj2], t, [S], [β, γ])
 js4 = complete(js4)
 dprob = DiscreteProblem(js4, [S => 999], (0, 1000.0), [β => 100.0, γ => 0.01])
-jprob = JumpProblem(js4, dprob, Direct(), rng = rng)
+jprob = JumpProblem(js4, dprob, Direct(), rng)
 m4 = getmean(jprob, Nsims)
 @test abs(m4 - 2.0 / 0.01) * 0.01 / 2.0 < 0.01
 
@@ -171,7 +171,7 @@ maj2 = MassActionJump(γ, [S => 2], [S => -1])
 @named js4 = JumpSystem([maj1, maj2], t, [S], [β, γ])
 js4 = complete(js4)
 dprob = DiscreteProblem(js4, [S => 999], (0, 1000.0), [β => 100.0, γ => 0.01])
-jprob = JumpProblem(js4, dprob, Direct(), rng = rng)
+jprob = JumpProblem(js4, dprob, Direct(), rng)
 sol = solve(jprob, SSAStepper());
 
 # issue #819
@@ -183,28 +183,30 @@ sol = solve(jprob, SSAStepper());
 end
 
 # test if param mapper is setup correctly for callbacks
-@parameters k1 k2 k3
-@variables A(t) B(t)
-maj1 = MassActionJump(k1 * k3, [0 => 1], [A => -1, B => 1])
-maj2 = MassActionJump(k2, [B => 1], [A => 1, B => -1])
-@named js5 = JumpSystem([maj1, maj2], t, [A, B], [k1, k2, k3])
-js5 = complete(js5)
-p = [k1 => 2.0, k2 => 0.0, k3 => 0.5]
-u₀ = [A => 100, B => 0]
-tspan = (0.0, 2000.0)
-dprob = DiscreteProblem(js5, u₀, tspan, p)
-jprob = JumpProblem(js5, dprob, Direct(), save_positions = (false, false), rng = rng)
-@test all(jprob.massaction_jump.scaled_rates .== [1.0, 0.0])
+let
+    @parameters k1 k2 k3
+    @variables A(t) B(t)
+    maj1 = MassActionJump(k1 * k3, [0 => 1], [A => -1, B => 1])
+    maj2 = MassActionJump(k2, [B => 1], [A => 1, B => -1])
+    @named js5 = JumpSystem([maj1, maj2], t, [A, B], [k1, k2, k3])
+    js5 = complete(js5)
+    p = [k1 => 2.0, k2 => 0.0, k3 => 0.5]
+    u₀ = [A => 100, B => 0]
+    tspan = (0.0, 2000.0)
+    dprob = DiscreteProblem(js5, u₀, tspan, p)
+    jprob = JumpProblem(js5, dprob, Direct(); save_positions = (false, false), rng)
+    @test all(jprob.massaction_jump.scaled_rates .== [1.0, 0.0])
 
-pcondit(u, t, integrator) = t == 1000.0
-function paffect!(integrator)
-    integrator.ps[k1] = 0.0
-    integrator.ps[k2] = 1.0
-    reset_aggregated_jumps!(integrator)
+    pcondit(u, t, integrator) = t == 1000.0
+    function paffect!(integrator)
+        integrator.ps[k1] = 0.0
+        integrator.ps[k2] = 1.0
+        reset_aggregated_jumps!(integrator)
+    end
+    cb = DiscreteCallback(pcondit, paffect!)
+    sol = solve(jprob, SSAStepper(); tstops = [1000.0], callback = cb)
+    @test sol.u[end][1] == 100
 end
-sol = solve(jprob, SSAStepper(), tstops = [1000.0],
-    callback = DiscreteCallback(pcondit, paffect!))
-@test_skip sol.u[end][1] == 100 # TODO: Fix mass-action jumps in JumpProcesses
 
 # observed variable handling
 @variables OBS(t)

--- a/test/jumpsystem.jl
+++ b/test/jumpsystem.jl
@@ -305,7 +305,7 @@ let
     @variables A(t) B(t) C(t)
     @parameters k
     vrj = VariableRateJump(k * (sin(t) + 1), [A ~ A + 1, C ~ C + 2])
-    js = complete(JumpSystem([vrj], t, [A,C], [k]; name = :js, observed = [B ~ C*A]))
+    js = complete(JumpSystem([vrj], t, [A, C], [k]; name = :js, observed = [B ~ C * A]))
     oprob = ODEProblem(js, [A => 0, C => 0], (0.0, 10.0), [k => 1.0])
     jprob = JumpProblem(js, oprob, Direct(); rng)
     sol = solve(jprob, Tsit5())
@@ -329,7 +329,7 @@ let
         nothing
     end
     vrj2 = VariableRateJump(vrjrate, vrjaffect!)
-    oprob2 = ODEProblem((du,u,p,t) -> (du .= 0; nothing), [0, 0], (0.0, 10.0), (1.0,))
+    oprob2 = ODEProblem((du, u, p, t) -> (du .= 0; nothing), [0, 0], (0.0, 10.0), (1.0,))
     jprob2 = JumpProblem(oprob2, Direct(), vrj2; rng)
     cmean2 = zeros(11)
     for n in 1:N
@@ -338,5 +338,5 @@ let
     end
     cmean2 ./= N
 
-    @test all( abs.(cmean .- cmean2) .<= .05 .* cmean)
+    @test all(abs.(cmean .- cmean2) .<= 0.05 .* cmean)
 end


### PR DESCRIPTION
To enable more automatic VariableRateJump handling.

~~@AayushSabharwal this is supposed to allow JumpProblems over ODEProblems, but symbolic indexing of solutions and plotting / plot legends are not working. I just copied how we did JumpProblems over DiscreteProblems, but that doesn't seem to work? Can you let me know how to update the dummy ODEProblem(::JumpSystem,...) here to get it working? Thanks!~~ 

TODO:
- ~~Fix dependency graph generation to ignore `VariableRateJump`s and add tests.~~
- ~~Get symbolic indexing working for the resulting solutions~~

Basic `plot(sol)` is currently broken but that is more of a SciMLBase / JumpProcesses issue from the ExtendedJumpArrays. Plotting works with explicit specification of indexes to plot.

Edit: Needs [JumpProcesses 438](https://github.com/SciML/JumpProcesses.jl/pull/438) and a JumpProcesses release. 