### PR TITLE
Make screen_units work with Unitful

### DIFF
--- a/src/systems/unit_check.jl
+++ b/src/systems/unit_check.jl
@@ -57,6 +57,8 @@ function screen_unit(result)
         else
             throw(ValidationError("$result doesn't use SI unit, please use `u\"m\"` to instantiate SI unit only."))
         end
+    elseif result isa Unitful.FreeUnits
+        return result
     else
         throw(ValidationError("$result doesn't have any unit."))
     end


### PR DESCRIPTION
Currently, constructing a model using Unitful results in many spurious warnings about missing units. This adds a check for any `Unitful.FreeUnits` and considers that a success.

I'm not sure what the intent of this function is, and even for DynamicQuantities it seems too restrictive. One nice way to use units is to select a consistent set of units that scale the problem nicely, these may not be base SI units depending on the problem. The system should still be able to verify consistency over that nicely-scaled set of units. Why does this function reject anything but base SI units?