### PR TITLE
Fix an exception during documentation build

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,4 +1,5 @@
 using Documenter, ModelingToolkit
+using ModelingToolkit: SciMLBase
 
 # Make sure that plots don't throw a bunch of warnings / errors!
 ENV["GKSwstype"] = "100"

--- a/docs/src/internals.md
+++ b/docs/src/internals.md
@@ -27,7 +27,7 @@ The procedure for variable elimination inside [`structural_simplify`](@ref) is
 
 ## Preparing a system for simulation
 
-Before a simulation or optimization can be performed, the symbolic equations stored in an [`AbstractSystem`](@ref) must be converted into executable code. This step typically occurs after the simplification explained above, and is performed when an instance of a [`SciMLBase.SciMLProblem`](@ref), such as a [`ODEProblem`](@ref), is constructed.
+Before a simulation or optimization can be performed, the symbolic equations stored in an [`AbstractSystem`](@ref) must be converted into executable code. This step typically occurs after the simplification explained above, and is performed when an instance of a [`SciMLBase.AbstractSciMLProblem`](@ref), such as a [`ODEProblem`](@ref), is constructed.
 The call chain typically looks like this, with the function names in the case of an `ODESystem` indicated in parentheses
 
  1. Problem constructor ([`ODEProblem`](@ref))


### PR DESCRIPTION
Referencing the non-existent `SciMLBase.SciMLProblem` causes an exception during documentation build because `SiMLBase` is not in scope. This exception is caught and doesn't break the build, but it does result in a missing link in the documentation. Adding an import for `SCIMLBase` and referencing the correct `SciMLBase.AbstractSciMLProblem` fixes the error.

## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
