### PR TITLE
kwarg to disable unit checking in `InitializationProblem`

### DIFF
--- a/src/systems/nonlinear/initializesystem.jl
+++ b/src/systems/nonlinear/initializesystem.jl
@@ -10,6 +10,7 @@ function generate_initializesystem(sys::ODESystem;
         default_dd_value = 0.0,
         algebraic_only = false,
         initialization_eqs = [],
+        check_units = true,
         kwargs...)
     sts, eqs = unknowns(sys), equations(sys)
     idxs_diff = isdiffeq.(eqs)
@@ -102,6 +103,7 @@ function generate_initializesystem(sys::ODESystem;
         pars;
         defaults = merge(ModelingToolkit.defaults(sys), todict(u0), dd_guess),
         parameter_dependencies = parameter_dependencies(sys),
+        checks = check_units,
         name,
         kwargs...)
 

--- a/test/dq_units.jl
+++ b/test/dq_units.jl
@@ -185,3 +185,27 @@ end
 
 @named sys = ArrayParamTest(a = [1.0, 3.0]u"cm")
 @test ModelingToolkit.getdefault(sys.a) ≈ [0.01, 0.03]
+
+@testset "Initialization checks" begin
+    @mtkmodel PendulumUnits begin
+        @parameters begin
+            g, [unit = u"m/s^2"]
+            L, [unit = u"m"]
+        end
+        @variables begin
+            x(t), [unit = u"m"]
+            y(t), [state_priority = 10, unit = u"m"]
+            λ(t), [unit = u"s^-2"]
+        end
+        @equations begin
+            D(D(x)) ~ λ * x
+            D(D(y)) ~ λ * y - g
+            x^2 + y^2 ~ L^2
+        end
+    end
+    @mtkbuild pend = PendulumUnits()
+    u0 = [pend.x => 1.0, pend.y => 0.0]
+    p = [pend.g => 1.0, pend.L => 1.0]
+    guess = [pend.λ => 0.0]
+    @test_broken prob = ODEProblem(pend, u0, (0.0, 1.0), p; guesses = guess)
+end

--- a/test/dq_units.jl
+++ b/test/dq_units.jl
@@ -207,5 +207,6 @@ end
     u0 = [pend.x => 1.0, pend.y => 0.0]
     p = [pend.g => 1.0, pend.L => 1.0]
     guess = [pend.λ => 0.0]
-    @test_broken prob = ODEProblem(pend, u0, (0.0, 1.0), p; guesses = guess)
+    @test prob = ODEProblem(
+        pend, u0, (0.0, 1.0), p; guesses = guess, check_units = false) isa Any
 end


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

It seems that for systems requiring an initialization problem be solved, and containing units, the `NonlinearSystem` that is used when creating an `ODEProblem` from the system fails its unit checking step (even when the top-level system is validated). 

Similar to `fully_determined` (I think...) this PR introduces a `check_units` kwarg that propagates  down to the `NonlinearSystem` `check` kwarg to disable unit checking.

The included test failed before the fix, and passes after.

Things to note:
* from a brief investigation, it seems like the `structural_simplify`/dummy variable process does not handle units correctly
* as such, this is a band aid...if this isn't desired, no worries please just let me know
* it didn't seem like any changes needed doc changes, but if so just let me know

thanks!
