### PR TITLE
sub constants in `generate_function`

### DIFF
--- a/src/systems/diffeqs/abstractodesystem.jl
+++ b/src/systems/diffeqs/abstractodesystem.jl
@@ -174,6 +174,10 @@ function generate_function(sys::AbstractODESystem, dvs = unknowns(sys),
         check_operator_variables(eqs, Differential)
         check_lhs(eqs, Differential, Set(dvs))
     end
+
+    # substitute constants in
+    eqs = map(subs_constants, eqs)
+
     # substitute x(t) by just x
     rhss = implicit_dae ? [_iszero(eq.lhs) ? eq.rhs : eq.rhs - eq.lhs for eq in eqs] :
            [eq.rhs for eq in eqs]


### PR DESCRIPTION
In the case of nested systems, `@constants` in the nested systems were not being substituted. See [2969](https://github.com/SciML/ModelingToolkit.jl/issues/2969)

Similar to [2904](https://github.com/SciML/ModelingToolkit.jl/pull/2904), we simply call `subs_constants` on the equations before using them.

Included test fails before fix, passes after.

Thanks!

## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
