### PR TITLE
Support SymbolicUtils 1.7.0 and 1.7.1 in MTK v8

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ModelingToolkit"
 uuid = "961ee093-0014-501f-94e3-6117800e7a78"
 authors = ["Yingbo Ma <mayingbo5@gmail.com>", "Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
-version = "8.76.0"
+version = "8.77.0"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
@@ -99,7 +99,7 @@ SparseArrays = "1"
 SpecialFunctions = "0.7, 0.8, 0.9, 0.10, 1.0, 2"
 StaticArrays = "0.10, 0.11, 0.12, 1.0"
 SymbolicIndexingInterface = "0.3.1"
-SymbolicUtils = "1.0 - 1.5.1"
+SymbolicUtils = "1.0 - 1.5.1, 1.7"
 Symbolics = "5.7"
 URIs = "1"
 UnPack = "0.1, 1.0"


### PR DESCRIPTION
This PR adds support for SymbolicUtils 1.7.1 for MTK v8 in a backport to make the bugfix for the ConstructionBase/SymbolicUtils issue available for people stuck on MTK v8. Compatibility with SymbolicUtils was previously limited to <= 1.5.1 due to an incompatibility in 1.6.0 which was later reverted in 1.7.0: https://github.com/SciML/ModelingToolkit.jl/pull/2726