### PR TITLE
Fix parameter dependencies across model hierarchy

### DIFF
--- a/src/systems/abstractsystem.jl
+++ b/src/systems/abstractsystem.jl
@@ -1240,7 +1240,7 @@ function namespace_equation(eq::Equation,
         ivs = independent_variables(sys))
     _lhs = namespace_expr(eq.lhs, sys, n; ivs)
     _rhs = namespace_expr(eq.rhs, sys, n; ivs)
-    _lhs ~ _rhs
+    (_lhs ~ _rhs)::Equation
 end
 
 function namespace_assignment(eq::Assignment, sys)

--- a/src/systems/abstractsystem.jl
+++ b/src/systems/abstractsystem.jl
@@ -1346,16 +1346,11 @@ function parameter_dependencies(sys::AbstractSystem)
     pdeps = get_parameter_dependencies(sys)
     systems = get_systems(sys)
     # put pdeps after those of subsystems to maintain topological sorted order
-    if isempty(systems)
-        return pdeps
-    else
-        return vcat(
-            reduce(vcat,
-                [map(eq -> namespace_equation(eq, s), parameter_dependencies(s))
-                 for s in systems]),
-            pdeps
-        )
-    end
+    namespaced_deps = mapreduce(
+        s -> map(eq -> namespace_equation(eq, s), parameter_dependencies(s)), vcat,
+        systems; init = Equation[])
+
+    return vcat(namespaced_deps, pdeps)
 end
 
 function full_parameters(sys::AbstractSystem)

--- a/test/parameter_dependencies.jl
+++ b/test/parameter_dependencies.jl
@@ -166,6 +166,10 @@ end
     sys1 = ODESystem(
         Equation[], t, [], [p1]; parameter_dependencies, name = :sys1, systems = [sys2])
 
+    # ensure that parameter_dependencies is type stable
+    # (https://github.com/SciML/ModelingToolkit.jl/pull/2978)
+    @inferred ModelingToolkit.parameter_dependencies(sys1)
+
     sys = structural_simplify(sys1)
 
     prob = ODEProblem(sys, [], (0.0, 1.0))

--- a/test/parameter_dependencies.jl
+++ b/test/parameter_dependencies.jl
@@ -153,6 +153,26 @@ end
     @test new_prob.ps[sys2.p2] == 3.0
 end
 
+@testset "parameter dependencies across model hierarchy" begin
+    sys2 = let name = :sys2
+        @parameters p2
+        @variables x(t) = 1.0
+        eqs = [D(x) ~ p2]
+        ODESystem(eqs, t, [x], [p2]; name)
+    end
+
+    @parameters p1 = 1.0
+    parameter_dependencies = [sys2.p2 ~ p1 * 2.0]
+    sys1 = ODESystem(
+        Equation[], t, [], [p1]; parameter_dependencies, name = :sys1, systems = [sys2])
+
+    sys = structural_simplify(sys1)
+
+    prob = ODEProblem(sys, [], (0.0, 1.0))
+    sol = solve(prob)
+    @test SciMLBase.successful_retcode(sol)
+end
+
 @testset "Clock system" begin
     dt = 0.1
     @variables x(t) y(t) u(t) yd(t) ud(t) r(t) z(t)


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

Parameter dependencies can get broken if `parameter_dependencies(sys::AbstractSystem)` returns `Vector{Any}`, as [`process_parameter_dependencies(pdeps, ps)`](https://github.com/SciML/ModelingToolkit.jl/blob/874985c8593de9ff7dfe7ace939ceedbe6d4b079/src/systems/abstractsystem.jl#L2945) checks the element type

https://github.com/SciML/ModelingToolkit.jl/blob/874985c8593de9ff7dfe7ace939ceedbe6d4b079/src/systems/abstractsystem.jl#L2951-L2953

This PR adds a type assert in equation namespaceing and makes `parameter_dependencies` infer better.

```
julia> @code_warntype ModelingToolkit.parameter_dependencies(sys1)
MethodInstance for ModelingToolkit.parameter_dependencies(::ODESystem)
  from parameter_dependencies(sys::ModelingToolkit.AbstractSystem) @ ModelingToolkit ~/.julia/dev/ModelingToolkit/src/systems/abstractsystem.jl:1342
Arguments
  #self#::Core.Const(ModelingToolkit.parameter_dependencies)
  sys::ODESystem
Locals
  #1409::ModelingToolkit.var"#1409#1411"
  namespaced_deps::Vector{Equation}
  systems::Vector{ODESystem}
  pdeps::Vector{Equation}
Body::Vector{Equation}
1 ─       Core.NewvarNode(:(#1409))
│         Core.NewvarNode(:(namespaced_deps))
│         Core.NewvarNode(:(systems))
│         Core.NewvarNode(:(pdeps))
│   %5  = ModelingToolkit.:!::Core.Const(!)
│   %6  = ModelingToolkit.has_parameter_dependencies(sys)::Core.Const(true)
│   %7  = (%5)(%6)::Core.Const(false)
└──       goto #3 if not %7
2 ─       Core.Const(:(Base.getindex(ModelingToolkit.Equation)))
└──       Core.Const(:(return %9))
3 ┄       (pdeps = ModelingToolkit.get_parameter_dependencies(sys))
│         (systems = ModelingToolkit.get_systems(sys))
│   %13 = ModelingToolkit.:(var"#1409#1411")::Core.Const(ModelingToolkit.var"#1409#1411")
│         (#1409 = %new(%13))
│   %15 = #1409::Core.Const(ModelingToolkit.var"#1409#1411"())
│   %16 = (:init,)::Core.Const((:init,))
│   %17 = Core.apply_type(Core.NamedTuple, %16)::Core.Const(NamedTuple{(:init,)})
│   %18 = Base.getindex(ModelingToolkit.Equation)::Vector{Equation}
│   %19 = Core.tuple(%18)::Tuple{Vector{Equation}}
│   %20 = (%17)(%19)::@NamedTuple{init::Vector{Equation}}
│   %21 = systems::Vector{ODESystem}
│         (namespaced_deps = Core.kwcall(%20, ModelingToolkit.mapreduce, %15, ModelingToolkit.vcat, %21))
│   %23 = namespaced_deps::Vector{Equation}
│   %24 = pdeps::Vector{Equation}
│   %25 = ModelingToolkit.vcat(%23, %24)::Vector{Equation}
└──       return %25
```

One case that shows this issue is having parameter dependencies that reference a subsystem (and this didn't have a test anyway, so I added that).

Note that while #2966 also made changes in this area, the test case that I am adding was not fixed by that. I had an initial version of this PR which would split off the empty case, but _after_ the recursion, but splitting that off should no longer be needed as type inference on mapping `namespace_equation` is better and we should always have `Vector{Equation}`.