### PR TITLE
Fix unit conversion for expressions

### DIFF
--- a/src/systems/model_parsing.jl
+++ b/src/systems/model_parsing.jl
@@ -663,6 +663,14 @@ function convert_units(varunits::Unitful.FreeUnits, value::AbstractArray{T}) whe
     Unitful.ustrip.(varunits, value)
 end
 
+function convert_units(varunits::Unitful.FreeUnits, value::Num)
+    value
+end
+
+function convert_units(varunits::DynamicQuantities.Quantity, value::Num)
+    value
+end
+
 function parse_variable_arg(dict, mod, arg, varclass, kwargs, where_types)
     vv, def, metadata_with_exprs = parse_variable_def!(
         dict, mod, arg, varclass, kwargs, where_types)

--- a/test/units.jl
+++ b/test/units.jl
@@ -236,7 +236,7 @@ end
 
 @named sys = ExpressionParametersTest(; v = 2.0u"m/s", τ = 3.0u"s")
 sys = complete(sys)
-# TODO: Is there a way to evalute this expression and compare to 6.0?
+# TODO: Is there a way to evaluate this expression and compare to 6.0?
 @test isequal(ModelingToolkit.getdefault(sys.pt.a), sys.v * sys.τ)
 @test ModelingToolkit.getdefault(sys.v) ≈ 2.0
 @test ModelingToolkit.getdefault(sys.τ) ≈ 3.0

--- a/test/units.jl
+++ b/test/units.jl
@@ -223,3 +223,21 @@ end
 
 @variables x(t)
 @test ModelingToolkit.get_unit(sin(x)) == ModelingToolkit.unitless
+
+@mtkmodel ExpressionParametersTest begin
+    @parameters begin
+        v = 1.0, [unit = u"m/s"]
+        τ = 1.0, [unit = u"s"]
+    end
+    @components begin
+        pt = ParamTest(; a = v * τ)
+    end
+end
+
+@named sys = ExpressionParametersTest(; v = 2.0u"m/s", τ = 3.0u"s")
+sys = complete(sys)
+# TODO: Is there a way to evalute this expression and compare to 6.0?
+@test isequal(ModelingToolkit.getdefault(sys.pt.a), sys.v * sys.τ)
+@test ModelingToolkit.getdefault(sys.v) ≈ 2.0
+@test ModelingToolkit.getdefault(sys.τ) ≈ 3.0
+


### PR DESCRIPTION
When a parameter is specified in terms of other parameters, no unit conversion should be attempted until the full expression is evaluated.

## Checklist

- [X] Appropriate tests were added
- [X] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [X] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
