### PR TITLE
Fix typo in get_unit for ops

### DIFF
--- a/src/systems/unit_check.jl
+++ b/src/systems/unit_check.jl
@@ -78,7 +78,7 @@ get_unit(op::typeof(instream), args) = get_unit(args[1])
 function get_unit(op, args) # Fallback
     result = op(get_unit.(args)...)
     try
-        result
+        get_unit(result)
     catch
         throw(ValidationError("Unable to get unit for operation $op with arguments $args."))
     end

--- a/test/units.jl
+++ b/test/units.jl
@@ -220,3 +220,6 @@ end
 
 @named sys = ArrayParamTest(a = [1.0, 3.0]u"cm")
 @test ModelingToolkit.getdefault(sys.a) ≈ [0.01, 0.03]
+
+@variables x(t)
+@test ModelingToolkit.get_unit(sin(x)) == ModelingToolkit.unitless


### PR DESCRIPTION
I'm almost sure this is a typo since otherwise the try/catch block doesn't makes sense and fixing this fixes an error during documentation build.

## Checklist

- [X] Appropriate tests were added
- [X] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [X] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
