### PR TITLE
Fix @mtkmodel independent variable generation

### DIFF
--- a/src/independent_variables.jl
+++ b/src/independent_variables.jl
@@ -9,3 +9,6 @@ Define one or more independent variables. For example:
 macro independent_variables(ts...)
     :(@parameters $(ts...)) |> esc # TODO: treat independent variables separately from variables and parameters
 end
+
+toiv(s::Symbolic) = setmetadata(s, MTKVariableTypeCtx, PARAMETER)
+toiv(s::Num) = Num(toiv(value(s)))

--- a/src/systems/model_parsing.jl
+++ b/src/systems/model_parsing.jl
@@ -284,6 +284,8 @@ function generate_var(a, varclass;
           first(@variables $a[indices...]::type)
     if varclass == :parameters
         var = toparam(var)
+    elseif varclass == :independent_variables
+        var = toiv(var)
     end
     var
 end
@@ -315,7 +317,7 @@ end
 function generate_var!(dict, a, b, varclass, mod;
         indices::Union{Vector{UnitRange{Int}}, Nothing} = nothing,
         type = Real)
-    iv = b == :t ? get_t(mod, b) : generate_var(b, :variables)
+    iv = b == :t ? get_t(mod, b) : generate_var(b, :independent_variables)
     prev_iv = get!(dict, :independent_variable) do
         iv
     end

--- a/test/odesystem.jl
+++ b/test/odesystem.jl
@@ -1202,6 +1202,18 @@ end
     @variables y(x)
     @test_nowarn @named sys = ODESystem([y ~ 0], x)
 
+    # the same, but with @mtkmodel
+    @independent_variables x
+    @mtkmodel MyModel begin
+        @variables begin
+            y(x)
+        end
+        @equations begin
+            y ~ 0
+        end
+    end
+    @test_nowarn @mtkbuild sys = MyModel()
+
     @variables x y(x)
     @test_logs (:warn,) @named sys = ODESystem([y ~ 0], x)
 


### PR DESCRIPTION
This should fix https://discourse.julialang.org/t/how-do-i-import-t-nounits-with-a-different-name-than-t-in-modelingtoolkit/118640.

The issue was that the `@mtkmodel` macro internally generates independent variables as "variables", and not "parameters" (which `@independent_variables` does). I have tried to fix this in a way which is consistent with the rest of the code.

## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API