### PR TITLE
fix: fix missing `MTKParameters` handling in `linearize`

### DIFF
--- a/test/downstream/linearize.jl
+++ b/test/downstream/linearize.jl
@@ -306,3 +306,13 @@ linfun, _ = linearization_function(sys, [u], []; op = Dict(x => 2.0))
 matrices = linfun([1.0], Dict(p => 3.0), 1.0)
 # this would be 1 if the parameter value isn't respected
 @test matrices.f_u[] == 3.0
+
+@testset "Issue #2941" begin
+    @variables x(t) y(t)
+    @parameters p
+    eqs = [0 ~ x * log(y) - p]
+    @named sys = ODESystem(eqs, t; defaults = [p => 1.0])
+    sys = complete(sys)
+    @test_nowarn linearize(
+        sys, [x], []; op = Dict(x => 1.0), allow_input_derivatives = true)
+end


### PR DESCRIPTION
Close #2941

## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
