### PR TITLE
Dispatch for symbolic array units

### DIFF
--- a/src/systems/unit_check.jl
+++ b/src/systems/unit_check.jl
@@ -69,6 +69,7 @@ get_unit(x::Real) = unitless
 get_unit(x::DQ.AbstractQuantity) = screen_unit(x)
 get_unit(x::AbstractArray) = map(get_unit, x)
 get_unit(x::Num) = get_unit(unwrap(x))
+get_unit(x::Symbolics.Arr) = get_unit(unwrap(x))
 get_unit(op::Differential, args) = get_unit(args[1]) / get_unit(op.x)
 get_unit(op::Difference, args) = get_unit(args[1]) / get_unit(op.t)
 get_unit(op::typeof(getindex), args) = get_unit(args[1])

--- a/test/dq_units.jl
+++ b/test/dq_units.jl
@@ -239,3 +239,10 @@ let
     @test mm2units == MT.oneunit(mm2units)
     @test mmunits == mm2units
 end
+
+# test for array variable units https://github.com/SciML/ModelingToolkit.jl/issues/3009
+let
+    @variables x_vec(t)[1:3] [unit = u"1"] x_mat(t)[1:3, 1:3] [unit = u"1"]
+    @test MT.get_unit(x_vec) == u"1"
+    @test MT.get_unit(x_mat) == u"1"
+end


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

Adds an additional dispatch for `get_unit` on `Symbolics.Arr` to `unwrap` before passing back to `get_unit`
