### PR TITLE
fix: appropriate error msg for invalid `@defaults`

### DIFF
--- a/src/systems/model_parsing.jl
+++ b/src/systems/model_parsing.jl
@@ -509,7 +509,7 @@ function parse_system_defaults!(exprs, defaults_body, dict)
                 push!(exprs, :(defaults[$a] = $b))
                 push_additional_defaults!(dict, a, b)
             end
-            _ => error("Invalid `defaults` entry $default_arg $(typeof(a)) $(typeof(b))")
+            _ => error("Invalid `@defaults` entry: `$default_arg`")
         end
     end
 end


### PR DESCRIPTION
Fixes
- #3011
## Checklist

~- [ ] Appropriate tests were added~ This is a simple bugfix of an error message; this doesn't need a test
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
