### PR TITLE
Remove incidence matrix from system show

### DIFF
--- a/src/systems/abstractsystem.jl
+++ b/src/systems/abstractsystem.jl
@@ -876,8 +876,7 @@ end
 """
 $(TYPEDSIGNATURES)
 
-Mark a system as completed. A completed system is assumed to be a 
-If a system is complete, the system will no longer
+Mark a system as completed. If a system is complete, the system will no longer
 namespace its subsystems or variables, i.e. `isequal(complete(sys).v.i, v.i)`.
 """
 function complete(sys::AbstractSystem; split = true)

--- a/src/systems/abstractsystem.jl
+++ b/src/systems/abstractsystem.jl
@@ -876,7 +876,8 @@ end
 """
 $(TYPEDSIGNATURES)
 
-Mark a system as completed. If a system is complete, the system will no longer
+Mark a system as completed. A completed system is assumed to be a 
+If a system is complete, the system will no longer
 namespace its subsystems or variables, i.e. `isequal(complete(sys).v.i, v.i)`.
 """
 function complete(sys::AbstractSystem; split = true)
@@ -1859,17 +1860,16 @@ function Base.show(io::IO, mime::MIME"text/plain", sys::AbstractSystem)
         end
     end
     limited && print(io, "\n⋮")
-
-    if has_torn_matching(sys) && has_tearing_state(sys)
-        # If the system can take a torn matching, then we can initialize a tearing
-        # state on it. Do so and get show the structure.
-        state = get_tearing_state(sys)
-        if state !== nothing
-            Base.printstyled(io, "\nIncidence matrix:"; color = :magenta)
-            show(io, mime, incidence_matrix(state.structure.graph, Num(Sym{Real}(:×))))
-        end
-    end
     return nothing
+end
+
+function Graphs.incidence_matrix(sys)
+    if has_torn_matching(sys) && has_tearing_state(sys)
+        state = get_tearing_state(sys)
+        incidence_matrix(state.structure.graph, Num(Sym{Real}(:×)))
+    else
+        return nothing
+    end
 end
 
 function split_assign(expr)


### PR DESCRIPTION
Fixes https://github.com/SciML/ModelingToolkit.jl/issues/2178

>
The incidence matrix is actually not useful for humans. I am just showing it because it looks cool. We can just disable it if it's confusing.

I'm not even sure it's worth documenting, but who it's useful for is for the compiler writers since if structural simplification works, then you're good. Maybe it's useful for diagnosing singularities, but that should get a debugging page because someone would need to get introduced to what it is for it to be useful. So I keep it around as a `ModelingToolkit.incidence_matrix` function that can be easily queried, but it's removed from the default show.
