### PR TITLE
feat: allow users to set array length via args in `@mtkmodel`

### DIFF
--- a/docs/src/basics/MTKLanguage.md
+++ b/docs/src/basics/MTKLanguage.md
@@ -63,13 +63,14 @@ end
     @structural_parameters begin
         f = sin
         N = 2
+        M = 3
     end
     begin
         v_var = 1.0
     end
     @variables begin
         v(t) = v_var
-        v_array(t)[1:2, 1:3]
+        v_array(t)[1:N, 1:M]
         v_for_defaults(t)
     end
     @extend ModelB(; p1)
@@ -310,10 +311,10 @@ end
   - `:defaults`: Dictionary of variables and default values specified in the `@defaults`.
   - `:extend`: The list of extended unknowns, name given to the base system, and name of the base system.
   - `:structural_parameters`: Dictionary of structural parameters mapped to their metadata.
-  - `:parameters`: Dictionary of symbolic parameters mapped to their metadata. For
-    parameter arrays, length is added to the metadata as `:size`.
-  - `:variables`: Dictionary of symbolic variables mapped to their metadata. For
-    variable arrays, length is added to the metadata as `:size`.
+  - `:parameters`: Dictionary of symbolic parameters mapped to their metadata. Metadata of
+    the parameter arrays is, for now, omitted.
+  - `:variables`: Dictionary of symbolic variables mapped to their metadata. Metadata of
+    the variable arrays is, for now, omitted.
   - `:kwargs`: Dictionary of keyword arguments mapped to their metadata.
   - `:independent_variable`: Independent variable, which is added while generating the Model.
   - `:equations`: List of equations (represented as strings).
@@ -324,10 +325,10 @@ For example, the structure of `ModelC` is:
 julia> ModelC.structure
 Dict{Symbol, Any} with 10 entries:
   :components            => Any[Union{Expr, Symbol}[:model_a, :ModelA], Union{Expr, Symbol}[:model_array_a, :ModelA, :(1:N)], Union{Expr, Symbol}[:model_array_b, :ModelA, :(1:N)]]
-  :variables             => Dict{Symbol, Dict{Symbol, Any}}(:v=>Dict(:default=>:v_var, :type=>Real), :v_array=>Dict(:type=>Real, :size=>(2, 3)), :v_for_defaults=>Dict(:type=>Real))
+  :variables             => Dict{Symbol, Dict{Symbol, Any}}(:v=>Dict(:default=>:v_var, :type=>Real), :v_for_defaults=>Dict(:type=>Real))
   :icon                  => URI("https://github.com/SciML/SciMLDocs/blob/main/docs/src/assets/logo.png")
-  :kwargs                => Dict{Symbol, Dict}(:f=>Dict(:value=>:sin), :N=>Dict(:value=>2), :v=>Dict{Symbol, Any}(:value=>:v_var, :type=>Real), :v_array=>Dict{Symbol, Union{Nothing, UnionAll}}(:value=>nothing, :type=>AbstractArray{Real}), :v_for_defaults=>Dict{Symbol, Union{Nothing, DataType}}(:value=>nothing, :type=>Real), :p1=>Dict(:value=>nothing))
-  :structural_parameters => Dict{Symbol, Dict}(:f=>Dict(:value=>:sin), :N=>Dict(:value=>2))
+  :kwargs                => Dict{Symbol, Dict}(:f => Dict(:value => :sin), :N => Dict(:value => 2), :M => Dict(:value => 3), :v => Dict{Symbol, Any}(:value => :v_var, :type => Real), :v_for_defaults => Dict{Symbol, Union{Nothing, DataType}}(:value => nothing, :type => Real), :p1 => Dict(:value => nothing)),
+  :structural_parameters => Dict{Symbol, Dict}(:f => Dict(:value => :sin), :N => Dict(:value => 2), :M => Dict(:value => 3))
   :independent_variable  => t
   :constants             => Dict{Symbol, Dict}(:c=>Dict{Symbol, Any}(:value=>1, :type=>Int64, :description=>"Example constant."))
   :extend                => Any[[:p2, :p1], Symbol("#mtkmodel__anonymous__ModelB"), :ModelB]

--- a/src/systems/model_parsing.jl
+++ b/src/systems/model_parsing.jl
@@ -232,19 +232,21 @@ function parse_variable_def!(dict, mod, arg, varclass, kwargs, where_types;
                 varclass, where_types, meta)
             return var, def, Dict()
         end
-        Expr(:tuple, Expr(:ref, a, b...), y) => begin
+        Expr(:tuple, Expr(:ref, a, b...), y) || Expr(:tuple, Expr(:(::), Expr(:ref, a, b...), n), y) => begin
+            isdefined(mod, :n) || (n = Real)
             varname = Meta.isexpr(a, :call) ? a.args[1] : a
             push!(kwargs, Expr(:kw, varname, nothing))
             varval = unit_handled_variable_value(mod, y, varname)
             if varclass == :parameters
-                var = :($varname = $first(@parameters $a[$(b...)] = ($varval, $y)))
+                var = :($varname = $first(@parameters $a[$(b...)]::$n = ($varval, $y)))
             else
-                var = :($varname = $first(@variables $a[$(b...)] = ($varval, $y)))
+                var = :($varname = $first(@variables $a[$(b...)]::$n = ($varval, $y)))
             end
             #TODO: update `dict` aka `Model.structure` with the metadata
             (:($varname...), var), nothing, Dict()
         end
-        Expr(:(=), Expr(:ref, a, b...), y) => begin
+        Expr(:(=), Expr(:ref, a, b...), y) || Expr(:(=), Expr(:(::), Expr(:ref, a, b...), n), y) => begin
+            isdefined(mod, :n) || (n = Real)
             varname = Meta.isexpr(a, :call) ? a.args[1] : a
             if Meta.isexpr(y, :tuple)
                 varval = unit_handled_variable_value(mod, y, varname)
@@ -252,59 +254,24 @@ function parse_variable_def!(dict, mod, arg, varclass, kwargs, where_types;
                 push!(kwargs, Expr(:kw, varname, nothing))
                 if varclass == :parameters
                     var = :($varname = $varname === nothing ? $val : $varname;
-                    $varname = $first(@parameters $a[$(b...)] = (
+                    $varname = $first(@parameters $a[$(b...)]::$n = (
                         $varval, $(y...))))
-                else
-                    var = :($varname = $varname === nothing ? $val : $varname;
-                    $varname = $first(@variables $a[$(b...)] = (
-                        $varval, $(y...))))
-                end
-            else
-                push!(kwargs, Expr(:kw, varname, nothing))
-                if varclass == :parameters
-                    var = :($varname = $varname === nothing ? $y : $varname; $varname = $first(@parameters $a[$(b...)] = $varname))
-                else
-                    var = :($varname = $varname === nothing ? $y : $varname; $varname = $first(@variables $a[$(b...)] = $varname))
-                end
-            end
-            #TODO: update `dict`` aka `Model.structure` with the metadata
-            (:($varname...), var), nothing, Dict()
-        end
-        Expr(:(=), Expr(:(::), Expr(:ref, a, b...), n), y) => begin
-            varname = Meta.isexpr(a, :call) ? a.args[1] : a
-            varval = unit_handled_variable_value(mod, y, varname)
-            if Meta.isexpr(y, :tuple)
-                val, y = (y.args[1], y.args[2:end])
-                push!(kwargs, Expr(:kw, varname, nothing))
-                if varclass == :parameters
-                    var = :($varname = $varname = $varname === nothing ? $val : $varname;
-                    $varname = $first(@parameters $a[$(b...)]::$n = ($varval, $(y...))))
                 else
                     var = :($varname = $varname === nothing ? $val : $varname;
                     $varname = $first(@variables $a[$(b...)]::$n = (
                         $varval, $(y...))))
                 end
             else
-                push!(kwargs, Expr(:kw, varname, y))
+                push!(kwargs, Expr(:kw, varname, nothing))
                 if varclass == :parameters
-                    var = :($varname = $first(@parameters $a[$(b...)]::$n = $varval))
+                    var = :($varname = $varname === nothing ? $y : $varname;
+                    $varname = $first(@parameters $a[$(b...)]::$n = $varname))
                 else
-                    var = :($varname = $first(@variables $a[$(b...)]::$n = $varval))
+                    var = :($varname = $varname === nothing ? $y : $varname;
+                    $varname = $first(@variables $a[$(b...)]::$n = $varname))
                 end
             end
             #TODO: update `dict`` aka `Model.structure` with the metadata
-            (:($varname...), var), nothing, Dict()
-        end
-        Expr(:tuple, Expr(:(::), Expr(:ref, a, b...), n), y) => begin
-            varname = Meta.isexpr(a, :call) ? a.args[1] : a
-            varval = unit_handled_variable_value(mod, y, varname)
-            push!(kwargs, Expr(:kw, varname, nothing))
-            if varclass == :parameters
-                var = :($varname = $first(@parameters $a[$(b...)]::$n = ($varval, $y)))
-            else
-                var = :($varname = $first(@variables $a[$(b...)]::$n = ($varval, $y)))
-            end
-            #TODO: update `dict` aka `Model.structure` with the metadata
             (:($varname...), var), nothing, Dict()
         end
         Expr(:ref, a, b...) => begin
@@ -478,7 +445,6 @@ function parse_default(mod, a)
 end
 
 function parse_metadata(mod, a::Expr)
-    @info a typeof(a)
     MLStyle.@match a begin
         Expr(:vect, b...) => Dict(parse_metadata(mod, m) for m in b)
         Expr(:tuple, a, b...) => parse_metadata(mod, b)

--- a/test/model_parsing.jl
+++ b/test/model_parsing.jl
@@ -303,9 +303,9 @@ end
     @test symtype(type_model.par2) == Int
     @test symtype(type_model.par3) == BigFloat
     @test symtype(type_model.par4) == Float64
-    @test_broken symtype(type_model.par5[1]) == BigFloat
-    @test_broken symtype(type_model.par6[1]) == BigFloat
-    @test_broken symtype(type_model.par7[1, 1]) == BigFloat
+    @test symtype(type_model.par5[1]) == BigFloat
+    @test symtype(type_model.par6[1]) == BigFloat
+    @test symtype(type_model.par7[1, 1]) == BigFloat
 
     @test_throws TypeError TypeModel(; name = :throws, flag = 1)
     @test_throws TypeError TypeModel(; name = :throws, par0 = 1)
@@ -317,7 +317,7 @@ end
 
     # Test that array types are correctly added.
     @named type_model2 = TypeModel(; par5 = rand(BigFloat, 3))
-    @test_broken symtype(type_model2.par5[1]) == BigFloat
+    @test symtype(type_model2.par5[1]) == BigFloat
 
     @named type_model3 = TypeModel(; par7 = rand(BigFloat, 3, 3))
     @test symtype(type_model3.par7[1, 1]) == BigFloat

--- a/test/model_parsing.jl
+++ b/test/model_parsing.jl
@@ -876,3 +876,26 @@ end
         end),
         false)
 end
+
+@testset "Array Length as an Input" begin
+    @mtkmodel VaryingLengthArray begin
+        @structural_parameters begin
+            N
+            M
+        end
+        @parameters begin
+            p1[1:N]
+            p2[1:N, 1:M]
+        end
+        @variables begin
+            v1(t)[1:N]
+            v2(t)[1:N, 1:M]
+        end
+    end
+    
+    @named model = VaryingLengthArray(N = 2, M = 3)
+    @test length(model.p1) == 2
+    @test size(model.p2) == (2, 3)
+    @test length(model.v1) == 2
+    @test size(model.v2) == (2, 3)
+end

--- a/test/model_parsing.jl
+++ b/test/model_parsing.jl
@@ -305,7 +305,7 @@ end
     @test symtype(type_model.par4) == Float64
     @test_broken symtype(type_model.par5[1]) == BigFloat
     @test_broken symtype(type_model.par6[1]) == BigFloat
-    @test symtype(type_model.par7[1, 1]) == BigFloat
+    @test_broken symtype(type_model.par7[1, 1]) == BigFloat
 
     @test_throws TypeError TypeModel(; name = :throws, flag = 1)
     @test_throws TypeError TypeModel(; name = :throws, par0 = 1)


### PR DESCRIPTION
- Arbitrary array length with/without defaults or metadata can now be specified in `@mtkmodel`
- This covers all cases of symbolic arrays in `@mtkmodel`.

## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  

## Additional Info:
- Model.structure isn't updated about these paramaters and variables. Related tests are marked as broken.
