### PR TITLE
feat: add `reorder_dimension_by_tunables!`, ensure `tunable_parameters` is correctly ordered

### DIFF
--- a/src/ModelingToolkit.jl
+++ b/src/ModelingToolkit.jl
@@ -278,6 +278,6 @@ export debug_system
 export Sample, Hold, Shift, ShiftIndex, sampletime, SampleTime
 export Clock, SolverStepClock, TimeDomain
 
-export MTKParameters
+export MTKParameters, reorder_dimension_by_tunables!, reorder_dimension_by_tunables
 
 end # module

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -381,7 +381,12 @@ Create a tunable parameter by
 @parameters u [tunable=true]
 ```
 
-See also [`getbounds`](@ref), [`istunable`](@ref)
+For systems created with `split = true` (the default) and `default = true` passed to this function, the order
+of parameters returned is the order in which they are stored in the tunables portion of `MTKParameters`. Note
+that array variables will not be scalarized. To obtain the flattened representation of the tunables portion,
+call `Symbolics.scalarize(tunable_parameters(sys))` and concatenate the resulting arrays.
+
+See also [`getbounds`](@ref), [`istunable`](@ref), [`MTKParameters`](@ref), [`complete`](@ref)
 """
 function tunable_parameters(sys, p = parameters(sys); default = true)
     filter(x -> istunable(x, default), p)

--- a/test/discrete_system.jl
+++ b/test/discrete_system.jl
@@ -42,7 +42,7 @@ for df in [
     # iip
     du = zeros(3)
     u = collect(1:3)
-    p = MTKParameters(syss, parameters(syss) .=> collect(1:5))
+    p = MTKParameters(syss, [c, nsteps, δt, β, γ] .=> collect(1:5))
     df.f(du, u, p, 0)
     @test du ≈ [0.01831563888873422, 0.9816849729159067, 4.999999388195359]
 

--- a/test/index_cache.jl
+++ b/test/index_cache.jl
@@ -63,3 +63,32 @@ ic = ModelingToolkit.get_index_cache(sys)
     end
 end
 
+@testset "reorder_dimension_by_tunables" begin
+    @parameters p q[1:3] r[1:2, 1:2] s [tunable = false]
+    @named sys = ODESystem(Equation[], t, [], [p, q, r, s])
+    src = ones(8)
+    dst = zeros(8)
+    # system must be complete...
+    @test_throws ArgumentError reorder_dimension_by_tunables!(dst, sys, src, [p, q, r])
+    @test_throws ArgumentError reorder_dimension_by_tunables(sys, src, [p, q, r])
+    sys = complete(sys; split = false)
+    # with split = true...
+    @test_throws ArgumentError reorder_dimension_by_tunables!(dst, sys, src, [p, q, r])
+    @test_throws ArgumentError reorder_dimension_by_tunables(sys, src, [p, q, r])
+    sys = complete(sys)
+    # and the arrays must have matching size
+    @test_throws ArgumentError reorder_dimension_by_tunables!(
+        zeros(2, 4), sys, src, [p, q, r])
+
+    ps = MTKParameters(sys, [p => 1.0, q => 3ones(3), r => 4ones(2, 2), s => 0.0])
+    src = ps.tunable
+    reorder_dimension_by_tunables!(dst, sys, src, [q, r, p])
+    @test dst ≈ vcat(3ones(3), 4ones(4), 1.0)
+    @test reorder_dimension_by_tunables(sys, src, [r, p, q]) ≈ vcat(4ones(4), 1.0, 3ones(3))
+    reorder_dimension_by_tunables!(dst, sys, src, [q[1], r[:, 1], q[2], r[:, 2], q[3], p])
+    @test dst ≈ vcat(3.0, 4ones(2), 3.0, 4ones(2), 3.0, 1.0)
+    src = stack([copy(ps.tunable) for i in 1:5]; dims = 1)
+    dst = zeros(size(src))
+    reorder_dimension_by_tunables!(dst, sys, src, [r, q, p]; dim = 2)
+    @test dst ≈ stack([vcat(4ones(4), 3ones(3), 1.0) for i in 1:5]; dims = 1)
+end

--- a/test/labelledarrays.jl
+++ b/test/labelledarrays.jl
@@ -87,5 +87,6 @@ u0 = @LArray [9998.0, 1.0, 1.0, 1.0] (:S, :I, :R, :C)
 problem = ODEProblem(SIR!, u0, tspan, p)
 sys = complete(modelingtoolkitize(problem))
 
-@test all(isequal.(parameters(sys), getproperty.(@variables(β, η, ω, φ, σ, μ), :val)))
+@test all(any(isequal(x), parameters(sys))
+for x in ModelingToolkit.unwrap.(@variables(β, η, ω, φ, σ, μ)))
 @test all(isequal.(Symbol.(unknowns(sys)), Symbol.(@variables(S(t), I(t), R(t), C(t)))))

--- a/test/model_parsing.jl
+++ b/test/model_parsing.jl
@@ -534,9 +534,9 @@ end
     @named else_in_sys = InsideTheBlock(flag = 3)
     else_in_sys = complete(else_in_sys)
 
-    @test getname.(parameters(if_in_sys)) == [:if_parameter, :eq]
-    @test getname.(parameters(elseif_in_sys)) == [:elseif_parameter, :eq]
-    @test getname.(parameters(else_in_sys)) == [:else_parameter, :eq]
+    @test sort(getname.(parameters(if_in_sys))) == [:eq, :if_parameter]
+    @test sort(getname.(parameters(elseif_in_sys))) == [:elseif_parameter, :eq]
+    @test sort(getname.(parameters(else_in_sys))) == [:else_parameter, :eq]
 
     @test getdefault(if_in_sys.if_parameter) == 100
     @test getdefault(elseif_in_sys.elseif_parameter) == 101

--- a/test/precompile_test.jl
+++ b/test/precompile_test.jl
@@ -10,7 +10,7 @@ using ODEPrecompileTest
 
 u = collect(1:3)
 p = ModelingToolkit.MTKParameters(ODEPrecompileTest.f_noeval_good.sys,
-    parameters(ODEPrecompileTest.f_noeval_good.sys) .=> collect(4:6))
+    [:σ, :ρ, :β] .=> collect(4:6))
 
 # These cases do not work, because they get defined in the ModelingToolkit's RGF cache.
 @test parentmodule(typeof(ODEPrecompileTest.f_bad.f.f_iip).parameters[2]) == ModelingToolkit

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -24,7 +24,6 @@ end
             @safetestset "Parsing Test" include("variable_parsing.jl")
             @safetestset "Simplify Test" include("simplify.jl")
             @safetestset "Direct Usage Test" include("direct.jl")
-            @safetestset "IndexCache Test" include("index_cache.jl")
             @safetestset "System Linearity Test" include("linearity.jl")
             @safetestset "Input Output Test" include("input_output_handling.jl")
             @safetestset "Clock Test" include("clock.jl")
@@ -65,6 +64,7 @@ end
 
     if GROUP == "All" || GROUP == "InterfaceII"
         @testset "InterfaceII" begin
+            @safetestset "IndexCache Test" include("index_cache.jl")
             @safetestset "Variable Utils Test" include("variable_utils.jl")
             @safetestset "Variable Metadata Test" include("test_variable_metadata.jl")
             @safetestset "OptimizationSystem Test" include("optimizationsystem.jl")


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
