### PR TITLE
fix: allow accessing parameter dependencies via `Symbol` names

### DIFF
--- a/src/systems/index_cache.jl
+++ b/src/systems/index_cache.jl
@@ -277,7 +277,16 @@ function IndexCache(sys::AbstractSystem)
 
     dependent_pars = Set{BasicSymbolic}()
     for eq in parameter_dependencies(sys)
-        push!(dependent_pars, eq.lhs)
+        sym = eq.lhs
+        ttsym = default_toterm(sym)
+        rsym = renamespace(sys, sym)
+        rttsym = renamespace(sys, ttsym)
+        for s in [sym, ttsym, rsym, rttsym]
+            push!(dependent_pars, s)
+            if hasname(s) && (!iscall(s) || operation(s) != getindex)
+                symbol_to_variable[getname(s)] = sym
+            end
+        end
     end
 
     return IndexCache(

--- a/test/symbolic_indexing_interface.jl
+++ b/test/symbolic_indexing_interface.jl
@@ -185,3 +185,12 @@ get_dep = @test_nowarn getu(prob, 2p1)
     @test getu(prob, p1)(prob) == getu(prob, :p1)(prob)
     @test getu(prob, p2)(prob) == getu(prob, :p2)(prob)
 end
+
+@testset "Parameter dependencies as symbols" begin
+    @variables x(t) = 1.0
+    @parameters a=1 b
+    @named model = ODESystem(D(x) ~ x + a - b, t, parameter_dependencies = [b ~ a + 1])
+    sys = complete(model)
+    prob = ODEProblem(sys, [], (0.0, 1.0))
+    @test prob.ps[b] == prob.ps[:b]
+end


### PR DESCRIPTION
Close #3062

## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
