### PR TITLE
fix: check scope when discovering variables from equations

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -483,6 +483,7 @@ end
 
 function collect_var!(unknowns, parameters, var, iv)
     isequal(var, iv) && return nothing
+    getmetadata(var, SymScope, LocalScope()) == LocalScope() || return nothing
     if iscalledparameter(var)
         callable = getcalledparameter(var)
         push!(parameters, callable)

--- a/test/variable_scope.jl
+++ b/test/variable_scope.jl
@@ -1,9 +1,8 @@
 using ModelingToolkit
-using ModelingToolkit: SymScope
-using Symbolics: arguments, value
+using ModelingToolkit: SymScope, t_nounits as t, D_nounits as D
+using Symbolics: arguments, value, getname
 using Test
 
-@independent_variables t
 @variables a b(t) c d e(t)
 
 b = ParentScope(b)
@@ -52,7 +51,6 @@ end
 @test renamed([:foo :bar :baz], c) == Symbol("foo₊c")
 @test renamed([:foo :bar :baz], d) == :d
 
-@independent_variables t
 @parameters a b c d e f
 p = [a
      ParentScope(b)
@@ -84,3 +82,22 @@ arr1 = ODESystem(Equation[], t, [], []; name = :arr1) ∘ arr0
 arr_ps = ModelingToolkit.getname.(parameters(arr1))
 @test isequal(arr_ps[1], Symbol("xx"))
 @test isequal(arr_ps[2], Symbol("arr0₊xx"))
+
+function Foo(; name, p = 1)
+    @parameters p = p
+    @variables x(t)
+    return ODESystem(D(x) ~ p, t; name)
+end
+function Bar(; name, p = 2)
+    @parameters p = p
+    @variables x(t)
+    @named foo = Foo(; p)
+    return ODESystem(D(x) ~ p + t, t; systems = [foo], name)
+end
+@named bar = Bar()
+bar = complete(bar)
+@test length(parameters(bar)) == 2
+@test sort(getname.(parameters(bar))) == [:foo₊p, :p]
+defs = ModelingToolkit.defaults(bar)
+@test defs[bar.p] == 2
+@test isequal(defs[bar.foo.p], bar.p)


### PR DESCRIPTION
Before:
```julia
julia> function Foo(; name, p = 1)
           @parameters p = p
           @variables x(t)
           return ODESystem(D(x) ~ p, t; name)
       end
Foo (generic function with 1 method)

julia> function Bar(; name, p = 2)
           @parameters p = p
           @variables x(t)
           @named foo = Foo(; p)
           return ODESystem(D(x) ~ p + t, t; systems = [foo], name)
       end
Bar (generic function with 1 method)

julia> @named bar = Bar()
Model bar with 2 equations
Unknowns (2):
  x(t)
  foo₊x(t)
Parameters (1):
  p [defaults to 2]
```

After:
```julia
julia> @named bar = Bar()
Model bar with 2 equations
Unknowns (2):
  x(t)
  foo₊x(t)
Parameters (2):
  p [defaults to 2]
  foo₊p [defaults to p]
```

## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
