### PR TITLE
Relax type constraints to allow callable parameters in pdeps

### DIFF
--- a/src/systems/abstractsystem.jl
+++ b/src/systems/abstractsystem.jl
@@ -3090,7 +3090,7 @@ function process_parameter_dependencies(pdeps, ps)
                  end
                  for p in pdeps]
     end
-    lhss = BasicSymbolic[]
+    lhss = []
     for p in pdeps
         if !isparameter(p.lhs)
             error("LHS of parameter dependency must be a single parameter. Found $(p.lhs).")
@@ -3101,6 +3101,7 @@ function process_parameter_dependencies(pdeps, ps)
         end
         push!(lhss, p.lhs)
     end
+    lhss = map(identity, lhss)
     pdeps = topsort_equations(pdeps, union(ps, lhss))
     ps = filter(ps) do p
         !any(isequal(p), lhss)

--- a/test/parameter_dependencies.jl
+++ b/test/parameter_dependencies.jl
@@ -177,6 +177,27 @@ end
     @test SciMLBase.successful_retcode(sol)
 end
 
+struct CallableFoo
+    p
+end
+
+(f::CallableFoo)(x) = f.p+x
+
+@testset "callable parameters" begin
+    @variables y(t) = 1
+    @parameters p = 2 (i::CallableFoo)(..)
+
+    eqs = [D(y) ~ i(t)+p]
+    @named model = ODESystem(eqs, t, [y], [p, i];
+        parameter_dependencies = [i ~ CallableFoo(p)])
+    sys = structural_simplify(model)
+
+    prob = ODEProblem(sys, [], (0.0, 1.0))
+    sol = solve(prob, Tsit5())
+
+    @test SciMLBase.successful_retcode(sol)
+end
+
 @testset "Clock system" begin
     dt = 0.1
     @variables x(t) y(t) u(t) yd(t) ud(t) r(t) z(t)

--- a/test/parameter_dependencies.jl
+++ b/test/parameter_dependencies.jl
@@ -178,16 +178,18 @@ end
 end
 
 struct CallableFoo
-    p
+    p::Any
 end
 
-(f::CallableFoo)(x) = f.p+x
+@register_symbolic CallableFoo(x)
+
+(f::CallableFoo)(x) = f.p + x
 
 @testset "callable parameters" begin
     @variables y(t) = 1
-    @parameters p = 2 (i::CallableFoo)(..)
+    @parameters p=2 (i::CallableFoo)(..)
 
-    eqs = [D(y) ~ i(t)+p]
+    eqs = [D(y) ~ i(t) + p]
     @named model = ODESystem(eqs, t, [y], [p, i];
         parameter_dependencies = [i ~ CallableFoo(p)])
     sys = structural_simplify(model)


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

Currently parameter dependencies assume that we only have `BasicSymbolic`. I tried to relax that constraint a bit to allow callable parameters to be stored too. If one has both callable parameters and normal ones in the parameter dependencies, I think that there might be a performance issue, but otherwise it should not affect nortmal usage.

@AayushSabharwal is this the right way of handling this issue? I think that for normal parametrs we store things in the non-numeric portion and that's splitted by types (?), so that might be better for the heterogenuous case.