### PR TITLE
Revert "feat: allow users to set array length via args in `@mtkmodel`"

### DIFF
--- a/docs/src/basics/MTKLanguage.md
+++ b/docs/src/basics/MTKLanguage.md
@@ -63,14 +63,13 @@ end
     @structural_parameters begin
         f = sin
         N = 2
-        M = 3
     end
     begin
         v_var = 1.0
     end
     @variables begin
         v(t) = v_var
-        v_array(t)[1:N, 1:M]
+        v_array(t)[1:2, 1:3]
         v_for_defaults(t)
     end
     @extend ModelB(; p1)
@@ -311,10 +310,10 @@ end
   - `:defaults`: Dictionary of variables and default values specified in the `@defaults`.
   - `:extend`: The list of extended unknowns, name given to the base system, and name of the base system.
   - `:structural_parameters`: Dictionary of structural parameters mapped to their metadata.
-  - `:parameters`: Dictionary of symbolic parameters mapped to their metadata. Metadata of
-    the parameter arrays is, for now, omitted.
-  - `:variables`: Dictionary of symbolic variables mapped to their metadata. Metadata of
-    the variable arrays is, for now, omitted.
+  - `:parameters`: Dictionary of symbolic parameters mapped to their metadata. For
+    parameter arrays, length is added to the metadata as `:size`.
+  - `:variables`: Dictionary of symbolic variables mapped to their metadata. For
+    variable arrays, length is added to the metadata as `:size`.
   - `:kwargs`: Dictionary of keyword arguments mapped to their metadata.
   - `:independent_variable`: Independent variable, which is added while generating the Model.
   - `:equations`: List of equations (represented as strings).
@@ -325,10 +324,10 @@ For example, the structure of `ModelC` is:
 julia> ModelC.structure
 Dict{Symbol, Any} with 10 entries:
   :components            => Any[Union{Expr, Symbol}[:model_a, :ModelA], Union{Expr, Symbol}[:model_array_a, :ModelA, :(1:N)], Union{Expr, Symbol}[:model_array_b, :ModelA, :(1:N)]]
-  :variables             => Dict{Symbol, Dict{Symbol, Any}}(:v=>Dict(:default=>:v_var, :type=>Real), :v_for_defaults=>Dict(:type=>Real))
+  :variables             => Dict{Symbol, Dict{Symbol, Any}}(:v=>Dict(:default=>:v_var, :type=>Real), :v_array=>Dict(:type=>Real, :size=>(2, 3)), :v_for_defaults=>Dict(:type=>Real))
   :icon                  => URI("https://github.com/SciML/SciMLDocs/blob/main/docs/src/assets/logo.png")
-  :kwargs                => Dict{Symbol, Dict}(:f => Dict(:value => :sin), :N => Dict(:value => 2), :M => Dict(:value => 3), :v => Dict{Symbol, Any}(:value => :v_var, :type => Real), :v_for_defaults => Dict{Symbol, Union{Nothing, DataType}}(:value => nothing, :type => Real), :p1 => Dict(:value => nothing)),
-  :structural_parameters => Dict{Symbol, Dict}(:f => Dict(:value => :sin), :N => Dict(:value => 2), :M => Dict(:value => 3))
+  :kwargs                => Dict{Symbol, Dict}(:f=>Dict(:value=>:sin), :N=>Dict(:value=>2), :v=>Dict{Symbol, Any}(:value=>:v_var, :type=>Real), :v_array=>Dict{Symbol, Union{Nothing, UnionAll}}(:value=>nothing, :type=>AbstractArray{Real}), :v_for_defaults=>Dict{Symbol, Union{Nothing, DataType}}(:value=>nothing, :type=>Real), :p1=>Dict(:value=>nothing))
+  :structural_parameters => Dict{Symbol, Dict}(:f=>Dict(:value=>:sin), :N=>Dict(:value=>2))
   :independent_variable  => t
   :constants             => Dict{Symbol, Dict}(:c=>Dict{Symbol, Any}(:value=>1, :type=>Int64, :description=>"Example constant."))
   :extend                => Any[[:p2, :p1], Symbol("#mtkmodel__anonymous__ModelB"), :ModelB]

--- a/test/model_parsing.jl
+++ b/test/model_parsing.jl
@@ -259,8 +259,7 @@ end
     @test all(collect(hasmetadata.(model.l, ModelingToolkit.VariableDescription)))
 
     @test all(lastindex.([model.a2, model.b2, model.d2, model.e2, model.h2]) .== 2)
-    @test size(model.l) == (2, 3)
-    @test_broken MockModel.structure[:parameters][:l][:size] == (2, 3)
+    @test size(model.l) == MockModel.structure[:parameters][:l][:size] == (2, 3)
 
     model = complete(model)
     @test getdefault(model.cval) == 1
@@ -314,6 +313,7 @@ end
     @test_throws TypeError TypeModel(; name = :throws, par3 = true)
     @test_throws TypeError TypeModel(; name = :throws, par4 = true)
     # par7 should be an AbstractArray of BigFloat.
+    @test_throws MethodError TypeModel(; name = :throws, par7 = rand(Int, 3, 3))
 
     # Test that array types are correctly added.
     @named type_model2 = TypeModel(; par5 = rand(BigFloat, 3))
@@ -474,8 +474,7 @@ using ModelingToolkit: getdefault, scalarize
 
     @named model_with_component_array = ModelWithComponentArray()
 
-    @test_broken eval(ModelWithComponentArray.structure[:parameters][:r][:unit]) ==
-                 eval(u"Ω")
+    @test eval(ModelWithComponentArray.structure[:parameters][:r][:unit]) == eval(u"Ω")
     @test lastindex(parameters(model_with_component_array)) == 3
 
     # Test the constant `k`. Manually k's value should be kept in sync here
@@ -876,46 +875,4 @@ end
             end
         end),
         false)
-end
-
-@testset "Array Length as an Input" begin
-    @mtkmodel VaryingLengthArray begin
-        @structural_parameters begin
-            N
-            M
-        end
-        @parameters begin
-            p1[1:N]
-            p2[1:N, 1:M]
-        end
-        @variables begin
-            v1(t)[1:N]
-            v2(t)[1:N, 1:M]
-        end
-    end
-
-    @named model = VaryingLengthArray(N = 2, M = 3)
-    @test length(model.p1) == 2
-    @test size(model.p2) == (2, 3)
-    @test length(model.v1) == 2
-    @test size(model.v2) == (2, 3)
-
-    @mtkmodel WithMetadata begin
-        @structural_parameters begin
-            N
-        end
-        @parameters begin
-            p_only_default[1:N] = 101
-            p_only_metadata[1:N], [description = "this only has metadata"]
-            p_both_default_and_metadata[1:N] = 102,
-            [description = "this has both default value and metadata"]
-        end
-    end
-
-    @named with_metadata = WithMetadata(N = 10)
-    @test getdefault(with_metadata.p_only_default) == 101
-    @test getdescription(with_metadata.p_only_metadata) == "this only has metadata"
-    @test getdefault(with_metadata.p_both_default_and_metadata) == 102
-    @test getdescription(with_metadata.p_both_default_and_metadata) ==
-          "this has both default value and metadata"
 end


### PR DESCRIPTION
Reverts SciML/ModelingToolkit.jl#3055

The above PR broke the following example.

```julia
julia> using ModelingToolkit

julia> @mtkmodel Fixed begin
           @parameters begin
               (r[1:2] = [0, 0]), [description = "Fixed absolute xy-position, resolved in planarWorld frame"]
               phi = 0, [description = "Fixed angle"]
           end

           @components begin
               frame_b = Frame()
           end

           @equations begin
               frame_b.x ~ r[1]
               frame_b.y ~ r[2]
               frame_b.phi ~ phi
           end
       end
ERROR: LoadError: KeyError: key :parameters not found
Stacktrace:
 [1] getindex
   @ ./dict.jl:498 [inlined]
 [2] parse_variable_def!(dict::Dict{…}, mod::Module, arg::Expr, varclass::Symbol, kwargs::OrderedCollections.OrderedSet{…}, where_types::Vector{…}; def::Nothing, indices::Nothing, type::Type, meta::Dict{…})
   @ ModelingToolkit ~/src/julia/ModelingToolkit/src/systems/model_parsing.jl:329
 [3] parse_variable_def!
   @ ~/src/julia/ModelingToolkit/src/systems/model_parsing.jl:193 [inlined]
 [4] parse_variable_arg(dict::Dict{…}, mod::Module, arg::Expr, varclass::Symbol, kwargs::OrderedCollections.OrderedSet{…}, where_types::Vector{…})
   @ ModelingToolkit ~/src/julia/ModelingToolkit/src/systems/model_parsing.jl:751
 [5] parse_variable_arg!(exprs::Vector{…}, vs::Vector{…}, dict::Dict{…}, mod::Module, arg::Expr, varclass::Symbol, kwargs::OrderedCollections.OrderedSet{…}, where_types::Vector{…})
   @ ModelingToolkit ~/src/julia/ModelingToolkit/src/systems/model_parsing.jl:716
 [6] parse_variables!(exprs::Vector{…}, vs::Vector{…}, dict::Dict{…}, mod::Module, body::Expr, varclass::Symbol, kwargs::OrderedCollections.OrderedSet{…}, where_types::Vector{…})
   @ ModelingToolkit ~/src/julia/ModelingToolkit/src/systems/model_parsing.jl:902
 [7] parse_model!(exprs::Vector{…}, comps::Vector{…}, ext::Base.RefValue{…}, eqs::Vector{…}, icon::Base.RefValue{…}, vs::Vector{…}, ps::Vector{…}, sps::Vector{…}, c_evts::Vector{…}, d_evts::Vector{…}, dict::Dict{…}, mod::Module, arg::Expr, kwargs::OrderedCollections.OrderedSet{…}, where_types::Vector{…})
   @ ModelingToolkit ~/src/julia/ModelingToolkit/src/systems/model_parsing.jl:505
 [8] _model_macro(mod::Module, name::Symbol, expr::Expr, isconnector::Bool)
   @ ModelingToolkit ~/src/julia/ModelingToolkit/src/systems/model_parsing.jl:71
 [9] var"@mtkmodel"(__source__::LineNumberNode, __module__::Module, name::Symbol, body::Any)
   @ ModelingToolkit ~/src/julia/ModelingToolkit/src/systems/model_parsing.jl:33
in expression starting at REPL[2]:1
Some type information was truncated. Use `show(err)` to see complete types.
```