### PR TITLE
fix first ODE perturbation example

### DIFF
--- a/docs/src/examples/perturbation.md
+++ b/docs/src/examples/perturbation.md
@@ -106,8 +106,7 @@ unknowns(sys)
 ```@example perturbation
 # the initial conditions
 # everything is zero except the initial velocity
-u0 = zeros(2order + 2)
-u0[2] = 1.0   # yˍt₁
+u0 = Dict([unknowns(sys) .=> 0; D(y[1]) => 1])
 
 prob = ODEProblem(sys, u0, (0, 3.0))
 sol = solve(prob; dtmax = 0.01);
@@ -169,8 +168,7 @@ We continue with converting 'eqs' to an `ODEProblem`, solving it, and finally pl
 
 ```@example perturbation
 # the initial conditions
-u0 = zeros(2order + 2)
-u0[1] = 1.0   # yˍt₁
+u0 = Dict([unknowns(sys) .=> 0; D(y[1]) => 1])
 
 prob = ODEProblem(sys, u0, (0, 50.0))
 sol = solve(prob; dtmax = 0.01)


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added (see very last bullet point below)
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context
This PR makes the first part from the Perturbation theory for ODEs example work. This fixes #1994.
The following things needed to be changed:
- `collect powers` included zero order terms in each order term,
- link to algebraic perturbation example from `Symbolics.jl` was wrong,
- indexing in definition and usage of `def_taylor` did not match,
- use `enumerate` instead of `eachindex` for symbolic arrays to get a linear index instead of a CartesianIndex (`eachindex(IndexLinear(), ...)` would also work).

The following things were not changed but would probably improve the example:
- Use `Symbolics.coeff` in `collect_powers`, but `coeff` currently can't be used to get the zeroth order term correctly (see second point in https://github.com/JuliaSymbolics/Symbolics.jl/issues/910).
- Start indexing of `y` and its derivative at zero, to match the order they represent, but non-one-based indexing isn't well supported yet (see #2670).
- It would probably be good to use the `@example ...` feature from `Documenter.jl` to add the output of commands to the documentation. This way it would be easier to detect when some change breaks the example.
