### PR TITLE
fix: fix `remake_buffer` adjoint when tangent is an array

### DIFF
--- a/ext/MTKChainRulesCoreExt.jl
+++ b/ext/MTKChainRulesCoreExt.jl
@@ -85,13 +85,19 @@ function ChainRulesCore.rrule(
             f′ = NoTangent()
             indp′ = NoTangent()
 
-            tunable = selected_tangents(buf′.tunable, tunable_idxs)
-            discrete = selected_tangents(buf′.discrete, disc_idxs)
-            constant = selected_tangents(buf′.constant, const_idxs)
-            nonnumeric = selected_tangents(buf′.nonnumeric, nn_idxs)
+            if buf′ isa AbstractArray
+                tunable = selected_tangents(buf′, tunable_idxs)
+                discrete = constant = nonnumeric = NoTangent()
+                vals′ = map(i -> buf′[i.idx], idxs)
+            else
+                tunable = selected_tangents(buf′.tunable, tunable_idxs)
+                discrete = selected_tangents(buf′.discrete, disc_idxs)
+                constant = selected_tangents(buf′.constant, const_idxs)
+                nonnumeric = selected_tangents(buf′.nonnumeric, nn_idxs)
+                vals′ = map(i -> MTK._ducktyped_parameter_values(buf′, i), idxs)
+            end
             oldbuf′ = Tangent{typeof(oldbuf)}(; tunable, discrete, constant, nonnumeric)
             idxs′ = NoTangent()
-            vals′ = map(i -> MTK._ducktyped_parameter_values(buf′, i), idxs)
             return f′, indp′, oldbuf′, idxs′, vals′
         end
     end


### PR DESCRIPTION
Draft because I'd like to add tests once https://github.com/SciML/SciMLSensitivity.jl/pull/1131 gets tagged.

## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
