### PR TITLE
Support Symbolic Arrays of arbitrary length

### DIFF
--- a/docs/src/basics/MTKLanguage.md
+++ b/docs/src/basics/MTKLanguage.md
@@ -63,13 +63,14 @@ end
     @structural_parameters begin
         f = sin
         N = 2
+        M = 3
     end
     begin
         v_var = 1.0
     end
     @variables begin
         v(t) = v_var
-        v_array(t)[1:2, 1:3]
+        v_array(t)[1:N, 1:M]
         v_for_defaults(t)
     end
     @extend ModelB(; p1)
@@ -324,10 +325,10 @@ For example, the structure of `ModelC` is:
 julia> ModelC.structure
 Dict{Symbol, Any} with 10 entries:
   :components            => Any[Union{Expr, Symbol}[:model_a, :ModelA], Union{Expr, Symbol}[:model_array_a, :ModelA, :(1:N)], Union{Expr, Symbol}[:model_array_b, :ModelA, :(1:N)]]
-  :variables             => Dict{Symbol, Dict{Symbol, Any}}(:v=>Dict(:default=>:v_var, :type=>Real), :v_array=>Dict(:type=>Real, :size=>(2, 3)), :v_for_defaults=>Dict(:type=>Real))
+  :variables             => Dict{Symbol, Dict{Symbol, Any}}(:v=>Dict(:default=>:v_var, :type=>Real), :v_for_defaults=>Dict(:type=>Real))
   :icon                  => URI("https://github.com/SciML/SciMLDocs/blob/main/docs/src/assets/logo.png")
-  :kwargs                => Dict{Symbol, Dict}(:f=>Dict(:value=>:sin), :N=>Dict(:value=>2), :v=>Dict{Symbol, Any}(:value=>:v_var, :type=>Real), :v_array=>Dict{Symbol, Union{Nothing, UnionAll}}(:value=>nothing, :type=>AbstractArray{Real}), :v_for_defaults=>Dict{Symbol, Union{Nothing, DataType}}(:value=>nothing, :type=>Real), :p1=>Dict(:value=>nothing))
-  :structural_parameters => Dict{Symbol, Dict}(:f=>Dict(:value=>:sin), :N=>Dict(:value=>2))
+  :kwargs                => Dict{Symbol, Dict}(:f => Dict(:value => :sin), :N => Dict(:value => 2), :M => Dict(:value => 3), :v => Dict{Symbol, Any}(:value => :v_var, :type => Real), :v_for_defaults => Dict{Symbol, Union{Nothing, DataType}}(:value => nothing, :type => Real), :p1 => Dict(:value => nothing)),
+  :structural_parameters => Dict{Symbol, Dict}(:f => Dict(:value => :sin), :N => Dict(:value => 2), :M => Dict(:value => 3))
   :independent_variable  => t
   :constants             => Dict{Symbol, Dict}(:c=>Dict{Symbol, Any}(:value=>1, :type=>Int64, :description=>"Example constant."))
   :extend                => Any[[:p2, :p1], Symbol("#mtkmodel__anonymous__ModelB"), :ModelB]

--- a/docs/src/basics/MTKLanguage.md
+++ b/docs/src/basics/MTKLanguage.md
@@ -302,7 +302,7 @@ end
     
     For more examples of usage, checkout [ModelingToolkitStandardLibrary.jl](https://github.com/SciML/ModelingToolkitStandardLibrary.jl/)
 
-## More on `Model.structure`
+## [More on `Model.structure`](@id model_structure)
 
 `structure` stores metadata that describes composition of a model. It includes:
 
@@ -334,6 +334,46 @@ Dict{Symbol, Any} with 10 entries:
   :extend                => Any[[:p2, :p1], Symbol("#mtkmodel__anonymous__ModelB"), :ModelB]
   :defaults              => Dict{Symbol, Any}(:v_for_defaults=>2.0)
   :equations             => Any["model_a.k ~ f(v)"]
+```
+
+### Different ways to define symbolics arrays:
+
+`@mtkmodel` supports symbolics arrays in both `@parameters` and `@variables`.
+Using a structural parameters, symbolic arrays of arbitrary lengths can be defined.
+Refer the following example for different ways to define symbolic arrays.
+
+```@example mtkmodel-example
+@mtkmodel ModelWithArrays begin
+    @structural_parameters begin
+        N = 2
+        M = 3
+    end
+    @parameters begin
+        p1[1:4]
+        p2[1:N]
+        p3[1:N, 1:M] = 10,
+        [description = "A multi-dimensional array of arbitrary length with description"]
+        (p4[1:N, 1:M] = 10),
+        [description = "An alternate syntax for p3 to match the syntax of vanilla parameters macro"]
+    end
+    @variables begin
+        v1(t)[1:2] = 10, [description = "An array of variable `v1`"]
+        v2(t)[1:3] = [1, 2, 3]
+    end
+end
+```
+
+The size of symbolic array can be accessed via `:size` key, along with other metadata (refer [More on `Model.structure`](@ref model_structure))
+of the symbolic variable.
+
+```julia
+julia> ModelWithArrays.structure
+Dict{Symbol, Any} with 5 entries:
+    :variables => Dict{Symbol, Dict{Symbol, Any}}(:v2 => Dict(:value => :([1, 2, 3]), :type => Real, :size => (3,)), :v1 => Dict(:value => :v1, :type => Real, :description => "An array of variable `v1`", :size => (2,)))
+    :kwargs => Dict{Symbol, Dict}(:p2 => Dict{Symbol, Any}(:value => nothing, :type => Real, :size => (:N,)), :v1 => Dict{Symbol, Any}(:value => :v1, :type => Real, :description => "An array of variable `v1`", :size => (2,)), :N => Dict(:value => 2), :M => Dict(:value => 3), :p4 => Dict{Symbol, Any}(:value => 10, :type => Real, :description => "An alternate syntax for p3 to match the syntax of vanilla parameters macro", :size => (:N, :M)), :v2 => Dict{Symbol, Any}(:value => :([1, 2, 3]), :type => Real, :size => (3,)), :p1 => Dict{Symbol, Any}(:value => nothing, :type => Real, :size => (4,)), :p3 => Dict{Symbol, Any}(:value => :p3, :type => Real, :description => "A multi-dimensional array of arbitrary length with description", :size => (:N, :M)))
+    :structural_parameters => Dict{Symbol, Dict}(:N => Dict(:value => 2), :M => Dict(:value => 3))
+    :independent_variable => :t
+    :parameters => Dict{Symbol, Dict{Symbol, Any}}(:p2 => Dict(:value => nothing, :type => Real, :size => (:N,)), :p4 => Dict(:value => 10, :type => Real, :description => "An alternate syntax for p3 to match the syntax of vanilla parameters macro", :size => (:N, :M)), :p1 => Dict(:value => nothing, :type => Real, :size => (4,)), :p3 => Dict(:value => :p3, :type => Real, :description => "A multi-dimensional array of arbitrary length with description", :size => (:N, :M)))), false)
 ```
 
 ### Using conditional statements

--- a/src/systems/model_parsing.jl
+++ b/src/systems/model_parsing.jl
@@ -270,6 +270,8 @@ function parse_variable_def!(dict, mod, arg, varclass, kwargs, where_types;
                 varclass, where_types, meta)
             return var, def, Dict()
         end
+        Expr(:tuple, Expr(:(=), Expr(:ref, a, indices...), default_val), meta_val) ||
+        Expr(:tuple, Expr(:(=), Expr(:(::), Expr(:ref, a, indices...), type), default_val), meta_val) ||
         Expr(:tuple, Expr(:(::), Expr(:ref, a, indices...), type), meta_val) ||
         Expr(:tuple, Expr(:ref, a, indices...), meta_val) => begin
             (@isdefined type) || (type = Real)

--- a/src/systems/model_parsing.jl
+++ b/src/systems/model_parsing.jl
@@ -254,12 +254,6 @@ function parse_variable_def!(dict, mod, arg, varclass, kwargs, where_types;
             parse_variable_def!(
                 dict, mod, a, varclass, kwargs, where_types; def, type, meta)
         end
-        Expr(:(::), Expr(:call, a, b), type) => begin
-            type = getfield(mod, type)
-            def = _type_check!(def, a, type, varclass)
-            parse_variable_def!(
-                dict, mod, a, varclass, kwargs, where_types; def, type, meta)
-        end
         Expr(:call, a, b) => begin
             var = generate_var!(dict, a, b, varclass, mod; type)
             update_kwargs_and_metadata!(dict, kwargs, a, def, type,

--- a/test/model_parsing.jl
+++ b/test/model_parsing.jl
@@ -259,7 +259,8 @@ end
     @test all(collect(hasmetadata.(model.l, ModelingToolkit.VariableDescription)))
 
     @test all(lastindex.([model.a2, model.b2, model.d2, model.e2, model.h2]) .== 2)
-    @test size(model.l) == MockModel.structure[:parameters][:l][:size] == (2, 3)
+    @test size(model.l) == (2, 3)
+    @test MockModel.structure[:parameters][:l][:size] == (2, 3)
 
     model = complete(model)
     @test getdefault(model.cval) == 1
@@ -474,7 +475,8 @@ using ModelingToolkit: getdefault, scalarize
 
     @named model_with_component_array = ModelWithComponentArray()
 
-    @test eval(ModelWithComponentArray.structure[:parameters][:r][:unit]) == eval(u"Ω")
+    @test eval(ModelWithComponentArray.structure[:parameters][:r][:unit]) ==
+          eval(u"Ω")
     @test lastindex(parameters(model_with_component_array)) == 3
 
     # Test the constant `k`. Manually k's value should be kept in sync here

--- a/test/model_parsing.jl
+++ b/test/model_parsing.jl
@@ -281,17 +281,34 @@ end
 
 @testset "Arrays using vanilla-@variable syntax" begin
     @mtkmodel TupleInArrayDef begin
+        @structural_parameters begin
+            N
+            M
+        end
         @parameters begin
             (l(t)[1:2, 1:3] = 1), [description = "l is more than 1D"]
-            (l2(t)[1:3] = 2), [description = "l2 is 1D"]
-            (l3(t)[1:3]::Int = 3), [description = "l3 is 1D and has a type"]
+            (l2(t)[1:N, 1:M] = 2),
+            [description = "l is more than 1D, with arbitrary length"]
+            (l3(t)[1:3] = 3), [description = "l2 is 1D"]
+            (l4(t)[1:N] = 4), [description = "l2 is 1D, with arbitrary length"]
+            (l5(t)[1:3]::Int = 5), [description = "l3 is 1D and has a type"]
+            (l6(t)[1:N]::Int = 6),
+            [description = "l3 is 1D and has a type, with arbitrary length"]
         end
     end
 
-    @named arr = TupleInArrayDef()
+    N, M = 4, 5
+    @named arr = TupleInArrayDef(; N, M)
     @test getdefault(arr.l) == 1
     @test getdefault(arr.l2) == 2
     @test getdefault(arr.l3) == 3
+    @test getdefault(arr.l4) == 4
+    @test getdefault(arr.l5) == 5
+    @test getdefault(arr.l6) == 6
+
+    @test size(arr.l2) == (N, M)
+    @test size(arr.l4) == (N,)
+    @test size(arr.l6) == (N,)
 end
 
 @testset "Type annotation" begin

--- a/test/model_parsing.jl
+++ b/test/model_parsing.jl
@@ -279,6 +279,21 @@ end
     @test MockModel.structure[:defaults] == Dict(:n => 1.0, :n2 => "g()")
 end
 
+@testset "Arrays using vanilla-@variable syntax" begin
+    @mtkmodel TupleInArrayDef begin
+        @parameters begin
+            (l(t)[1:2, 1:3] = 1), [description = "l is more than 1D"]
+            (l2(t)[1:3] = 2), [description = "l2 is 1D"]
+            (l3(t)[1:3]::Int = 3), [description = "l3 is 1D and has a type"]
+        end
+    end
+
+    @named arr = TupleInArrayDef()
+    @test getdefault(arr.l) == 1
+    @test getdefault(arr.l2) == 2
+    @test getdefault(arr.l3) == 3
+end
+
 @testset "Type annotation" begin
     @mtkmodel TypeModel begin
         @structural_parameters begin


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

Following is now supported:
```julia
@mtkmodel ModelWithArrays begin
    @structural_parameters begin
        N = 2
        M = 3
    end
    @parameters begin
        p1[1:4]
        p2[1:N]
        p3[1:N, 1:M] = 10, [description = "A multi-dimensional array of arbitrary length with description"]
        (p4[1:N, 1:M] = 10), [description = "An alternate syntax for p3 to match the syntax of vanilla parameters macro"]
    end
    @variables begin
        v1(t)[1:2] = 10, [description = "An array of variable `v1`"]
        v2(t)[1:3] = [1, 2, 3]
    end
end
```
A dedicated section, in the docs, describes it.
