### PR TITLE
fix: fix unnecessary `oneunit` call in `get_unit`

### DIFF
--- a/src/systems/unit_check.jl
+++ b/src/systems/unit_check.jl
@@ -77,7 +77,7 @@ get_unit(x::SciMLBase.NullParameters) = unitless
 get_unit(op::typeof(instream), args) = get_unit(args[1])
 
 function get_unit(op, args) # Fallback
-    result = oneunit(op(get_unit.(args)...))
+    result = op(get_unit.(args)...)
     try
         get_unit(result)
     catch

--- a/test/units.jl
+++ b/test/units.jl
@@ -240,3 +240,10 @@ sys = complete(sys)
 @test isequal(ModelingToolkit.getdefault(sys.pt.a), sys.v * sys.τ)
 @test ModelingToolkit.getdefault(sys.v) ≈ 2.0
 @test ModelingToolkit.getdefault(sys.τ) ≈ 3.0
+
+@testset "Issue#3017" begin
+    @constants c = 1 [unit = us"mol/nmol"]
+    @variables k(t) [unit = us"mol/nmol"]
+    @test ModelingToolkit.get_unit(c) == ModelingToolkit.get_unit(-c)
+    @test_nowarn NonlinearSystem([k ~ c], [k], []; name=:example)
+end


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
