### PR TITLE
Don't check units during initialization

### DIFF
--- a/src/systems/problem_utils.jl
+++ b/src/systems/problem_utils.jl
@@ -396,7 +396,7 @@ Keyword arguments:
 - `eval_module`: If `eval_expression == true`, the module to `eval` into. Otherwise, the module
   in which to generate the `RuntimeGeneratedFunction`.
 - `fully_determined`: Override whether the initialization system is fully determined.
-- `check_units`: Enable or disable unit checks.
+- `check_units`: Enable or disable unit checks when constructing the initialization problem.
 - `tofloat`, `use_union`: Passed to [`better_varmap_to_vars`](@ref) for building `u0` (and
   possibly `p`).
 - `u0_constructor`: A function to apply to the `u0` value returned from `better_varmap_to_vars`
@@ -414,7 +414,7 @@ function process_SciMLProblem(
         implicit_dae = false, t = nothing, guesses = AnyDict(),
         warn_initialize_determined = true, initialization_eqs = [],
         eval_expression = false, eval_module = @__MODULE__, fully_determined = false,
-        check_units = true, tofloat = true, use_union = false,
+        check_units = false, tofloat = true, use_union = false,
         u0_constructor = identity, du0map = nothing, check_length = true, symbolic_u0 = false, kwargs...)
     dvs = unknowns(sys)
     ps = parameters(sys)

--- a/src/systems/problem_utils.jl
+++ b/src/systems/problem_utils.jl
@@ -396,7 +396,8 @@ Keyword arguments:
 - `eval_module`: If `eval_expression == true`, the module to `eval` into. Otherwise, the module
   in which to generate the `RuntimeGeneratedFunction`.
 - `fully_determined`: Override whether the initialization system is fully determined.
-- `check_units`: Enable or disable unit checks when constructing the initialization problem.
+- `check_initialization_units`: Enable or disable unit checks when constructing the
+  initialization problem.
 - `tofloat`, `use_union`: Passed to [`better_varmap_to_vars`](@ref) for building `u0` (and
   possibly `p`).
 - `u0_constructor`: A function to apply to the `u0` value returned from `better_varmap_to_vars`
@@ -414,7 +415,7 @@ function process_SciMLProblem(
         implicit_dae = false, t = nothing, guesses = AnyDict(),
         warn_initialize_determined = true, initialization_eqs = [],
         eval_expression = false, eval_module = @__MODULE__, fully_determined = false,
-        check_units = false, tofloat = true, use_union = false,
+        check_initialization_units = false, tofloat = true, use_union = false,
         u0_constructor = identity, du0map = nothing, check_length = true, symbolic_u0 = false, kwargs...)
     dvs = unknowns(sys)
     ps = parameters(sys)
@@ -464,7 +465,7 @@ function process_SciMLProblem(
             !isempty(initialization_equations(sys))) && t !== nothing
             initializeprob = ModelingToolkit.InitializationProblem(
                 sys, t, u0map, pmap; guesses, warn_initialize_determined,
-                initialization_eqs, eval_expression, eval_module, fully_determined, check_units)
+                initialization_eqs, eval_expression, eval_module, fully_determined, check_units = check_initialization_units)
             initializeprobmap = getu(initializeprob, unknowns(sys))
 
             punknowns = [p

--- a/src/systems/problem_utils.jl
+++ b/src/systems/problem_utils.jl
@@ -465,7 +465,8 @@ function process_SciMLProblem(
             !isempty(initialization_equations(sys))) && t !== nothing
             initializeprob = ModelingToolkit.InitializationProblem(
                 sys, t, u0map, pmap; guesses, warn_initialize_determined,
-                initialization_eqs, eval_expression, eval_module, fully_determined, check_units = check_initialization_units)
+                initialization_eqs, eval_expression, eval_module, fully_determined,
+                check_units = check_initialization_units)
             initializeprobmap = getu(initializeprob, unknowns(sys))
 
             punknowns = [p


### PR DESCRIPTION
...because initialization problems don't correctly handle units and units have already been checked during system initialization.

## Checklist

- [X] Appropriate tests were added
- [X] Any code changes were done in a way that does not break public API
- [X] All documentation related to code changes were updated
- [X] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [X] Any new documentation only uses public API
  
## Additional context

Fixes #3086
