### PR TITLE
fix: only use `OffsetArray` if starting index is not 1

### DIFF
--- a/src/structural_transformation/symbolics_tearing.jl
+++ b/src/structural_transformation/symbolics_tearing.jl
@@ -592,7 +592,9 @@ function tearing_reassemble(state::TearingState, var_eq_matching,
 
         # respect non-1-indexed arrays
         # TODO: get rid of this hack together with the above hack, then remove OffsetArrays dependency
-        obs_arr_subs[arg1] = Origin(index_first)(obs_arr_subs[arg1])
+        if !isone(index_first)
+            obs_arr_subs[arg1] = Origin(index_first)(obs_arr_subs[arg1])
+        end
     end
     for i in eachindex(neweqs)
         neweqs[i] = fast_substitute(neweqs[i], obs_arr_subs; operator = Symbolics.Operator)


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
