### PR TITLE
fix: some fixes related to usage of array symbolics

### DIFF
--- a/src/systems/nonlinear/initializesystem.jl
+++ b/src/systems/nonlinear/initializesystem.jl
@@ -12,7 +12,9 @@ function generate_initializesystem(sys::ODESystem;
         algebraic_only = false,
         check_units = true, check_defguess = false,
         name = nameof(sys), kwargs...)
-    vars = unique([unknowns(sys); getfield.((observed(sys)), :lhs)])
+    trueobs = unhack_observed(observed(sys))
+    @show trueobs
+    vars = unique([unknowns(sys); getfield.(trueobs, :lhs)])
     vars_set = Set(vars) # for efficient in-lookup
 
     eqs = equations(sys)
@@ -24,7 +26,7 @@ function generate_initializesystem(sys::ODESystem;
     D = Differential(get_iv(sys))
     diffmap = merge(
         Dict(eq.lhs => eq.rhs for eq in eqs_diff),
-        Dict(D(eq.lhs) => D(eq.rhs) for eq in observed(sys))
+        Dict(D(eq.lhs) => D(eq.rhs) for eq in trueobs)
     )
 
     # 1) process dummy derivatives and u0map into initialization system
@@ -166,15 +168,14 @@ function generate_initializesystem(sys::ODESystem;
     )
 
     # 7) use observed equations for guesses of observed variables if not provided
-    obseqs = observed(sys)
-    for eq in obseqs
+    for eq in trueobs
         haskey(defs, eq.lhs) && continue
         any(x -> isequal(default_toterm(x), eq.lhs), keys(defs)) && continue
 
         defs[eq.lhs] = eq.rhs
     end
 
-    eqs_ics = Symbolics.substitute.([eqs_ics; obseqs], (paramsubs,))
+    eqs_ics = Symbolics.substitute.([eqs_ics; trueobs], (paramsubs,))
     vars = [vars; collect(values(paramsubs))]
     for k in keys(defs)
         defs[k] = substitute(defs[k], paramsubs)
@@ -322,5 +323,39 @@ function SciMLBase.remake_initializeprob(sys::ODESystem, odefn, u0, t0, p)
         return initprob, update_initializeprob!, initprobmap, initprobpmap
     else
         return nothing, nothing, nothing, nothing
+    end
+end
+
+"""
+Counteracts the CSE/array variable hacks in `symbolics_tearing.jl` so it works with
+initialization.
+"""
+function unhack_observed(eqs::Vector{Equation})
+    subs = Dict()
+    tempvars = Set()
+    rm_idxs = Int[]
+    for (i, eq) in enumerate(eqs)
+        iscall(eq.rhs) || continue
+        if operation(eq.rhs) == StructuralTransformations.change_origin
+            push!(rm_idxs, i)
+            continue
+        end
+        if operation(eq.rhs) == StructuralTransformations.getindex_wrapper
+            var, idxs = arguments(eq.rhs)
+            subs[eq.rhs] = var[idxs...]
+            push!(tempvars, var)
+        end
+    end
+
+    for (i, eq) in enumerate(eqs)
+        if eq.lhs in tempvars
+            subs[eq.lhs] = eq.rhs
+            push!(rm_idxs, i)
+        end
+    end
+
+    eqs = eqs[setdiff(eachindex(eqs), rm_idxs)]
+    return map(eqs) do eq
+        fixpoint_sub(eq.lhs, subs) ~ fixpoint_sub(eq.rhs, subs)
     end
 end

--- a/src/systems/nonlinear/initializesystem.jl
+++ b/src/systems/nonlinear/initializesystem.jl
@@ -13,7 +13,6 @@ function generate_initializesystem(sys::ODESystem;
         check_units = true, check_defguess = false,
         name = nameof(sys), kwargs...)
     trueobs = unhack_observed(observed(sys))
-    @show trueobs
     vars = unique([unknowns(sys); getfield.(trueobs, :lhs)])
     vars_set = Set(vars) # for efficient in-lookup
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -389,7 +389,13 @@ function vars!(vars, O; op = Differential)
             f = getcalledparameter(O)
             push!(vars, f)
             for arg in arguments(O)
-                vars!(vars, arg; op)
+                if symbolic_type(arg) == NotSymbolic() && arg isa AbstractArray
+                    for el in arg
+                        vars!(vars, unwrap(el); op)
+                    end
+                else
+                    vars!(vars, arg; op)
+                end
             end
             return vars
         end
@@ -397,7 +403,7 @@ function vars!(vars, O; op = Differential)
     end
     if symbolic_type(O) == NotSymbolic() && O isa AbstractArray
         for arg in O
-            vars!(vars, arg; op)
+            vars!(vars, unwrap(arg); op)
         end
         return vars
     end

--- a/test/odesystem.jl
+++ b/test/odesystem.jl
@@ -1447,3 +1447,11 @@ end
     @parameters p
     @test_nowarn ODESystem(Equation[], t; parameter_dependencies = [p ~ 1.0], name = :a)
 end
+
+@testset "Variable discovery in arrays of `Num` inside callable symbolic" begin
+    @variables x(t) y(t)
+    @parameters foo(::AbstractVector)
+    sys = @test_nowarn ODESystem(D(x) ~ foo([x, 2y]), t; name = :sys)
+    @test length(unknowns(sys)) == 2
+    @test any(isequal(y), unknowns(sys))
+end

--- a/test/structural_transformation/utils.jl
+++ b/test/structural_transformation/utils.jl
@@ -53,6 +53,14 @@ end
     @test any(eq -> isequal(eq.lhs, z), observed(sys))
     prob = ODEProblem(sys, [x => 1.0], (0.0, 1.0), [foo => _tmp_fn])
     @test_nowarn prob.f(prob.u0, prob.p, 0.0)
+
+    isys = ModelingToolkit.generate_initializesystem(sys)
+    @test length(unknowns(isys)) == 5
+    @test length(equations(isys)) == 4
+    @test !any(equations(isys)) do eq
+        iscall(eq.rhs) && operation(eq.rhs) in [StructuralTransformations.getindex_wrapper,
+            StructuralTransformations.change_origin]
+    end
 end
 
 @testset "scalarized array observed calling same function multiple times" begin
@@ -69,4 +77,12 @@ end
     prob = ODEProblem(sys, [x => 1.0], (0.0, 1.0), [foo => _tmp_fn2])
     @test_nowarn prob.f(prob.u0, prob.p, 0.0)
     @test val[] == 1
+
+    isys = ModelingToolkit.generate_initializesystem(sys)
+    @test length(unknowns(isys)) == 3
+    @test length(equations(isys)) == 2
+    @test !any(equations(isys)) do eq
+        iscall(eq.rhs) && operation(eq.rhs) in [StructuralTransformations.getindex_wrapper,
+            StructuralTransformations.change_origin]
+    end
 end

--- a/test/structural_transformation/utils.jl
+++ b/test/structural_transformation/utils.jl
@@ -48,9 +48,25 @@ end
     @mtkbuild sys = ODESystem(
         [D(x) ~ z[1] + z[2] + foo(z)[1], y[1] ~ 2t, y[2] ~ 3t, z ~ foo(y)], t)
     @test length(equations(sys)) == 1
-    @test length(observed(sys)) == 6
+    @test length(observed(sys)) == 7
     @test any(eq -> isequal(eq.lhs, y), observed(sys))
     @test any(eq -> isequal(eq.lhs, z), observed(sys))
     prob = ODEProblem(sys, [x => 1.0], (0.0, 1.0), [foo => _tmp_fn])
     @test_nowarn prob.f(prob.u0, prob.p, 0.0)
+end
+
+@testset "scalarized array observed calling same function multiple times" begin
+    @variables x(t) y(t)[1:2]
+    @parameters foo(::Real)[1:2]
+    val = Ref(0)
+    function _tmp_fn2(x)
+        val[] += 1
+        return [x, 2x]
+    end
+    @mtkbuild sys = ODESystem([D(x) ~ y[1] + y[2], y ~ foo(x)], t)
+    @test length(equations(sys)) == 1
+    @test length(observed(sys)) == 3
+    prob = ODEProblem(sys, [x => 1.0], (0.0, 1.0), [foo => _tmp_fn2])
+    @test_nowarn prob.f(prob.u0, prob.p, 0.0)
+    @test val[] == 1
 end


### PR DESCRIPTION
Requires https://github.com/JuliaSymbolics/Symbolics.jl/pull/1307

Regarding the improvement of the "hack", the issue with the old implementation was that it put `OffsetArray`s inside equations, which we can't codegen (`SymbolicUtils.Code.create_array(::Type{<:OffsetArray}, ...)` doesn't exist). This fixes that so we generate code equivalent to `y = OffsetArrays.Origin(0)([1, 2, 3])`.

## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
