### PR TITLE
fix: fix `linearization_function` not handling dependent parameter mapping

### DIFF
--- a/src/systems/abstractsystem.jl
+++ b/src/systems/abstractsystem.jl
@@ -2458,6 +2458,7 @@ function linearization_function(sys::AbstractSystem, inputs,
                 newps = deepcopy(sys_ps)
                 for (k, v) in p
                     if is_parameter(sys, k)
+                        v = fixpoint_sub(v, p)
                         setp(sys, k)(newps, v)
                     end
                 end

--- a/test/downstream/linearize.jl
+++ b/test/downstream/linearize.jl
@@ -307,6 +307,12 @@ matrices = linfun([1.0], Dict(p => 3.0), 1.0)
 # this would be 1 if the parameter value isn't respected
 @test matrices.f_u[] == 3.0
 
+@testset "linearization_function handles dependent values" begin
+    @parameters q
+    matrices = @test_nowarn linfun([1.0], Dict(p => 3q, q => 1.0), 1.0)
+    @test matrices.f_u[] == 3.0
+end
+
 @testset "Issue #2941" begin
     @variables x(t) y(t)
     @parameters p


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
