### PR TITLE
fixing record from solution for observables in the BifurcationKit extension

### DIFF
--- a/ext/MTKBifurcationKitExt.jl
+++ b/ext/MTKBifurcationKitExt.jl
@@ -59,7 +59,7 @@ struct ObservableRecordFromSolution{S, T}
     end
 end
 # Functor function that computes the value.
-function (orfs::ObservableRecordFromSolution)(x, p)
+function (orfs::ObservableRecordFromSolution)(x, p; k...)
     # Updates the state values (in subs_vals).
     for state_idx in 1:(orfs.state_end_idxs)
         orfs.subs_vals[state_idx] = orfs.subs_vals[state_idx][1] => x[state_idx]

--- a/test/extensions/bifurcationkit.jl
+++ b/test/extensions/bifurcationkit.jl
@@ -162,4 +162,12 @@ let
     bf = bifurcationdiagram(bp, PALC(), 2, opts_br)
 
     @test bf.γ.specialpoint[1].param≈0.1 atol=1e-4 rtol=1e-4
+
+    # Test with plot variable as observable
+    pvar = ModelingToolkit.get_var_to_name(fol)[:RHS]
+    bp = BifurcationProblem(fol, u0, par, bif_par; plot_var = pvar)
+    opts_br = ContinuationPar(p_min = -1.0,
+        p_max = 1.0)
+    bf = bifurcationdiagram(bp, PALC(), 2, opts_br)
+    @test bf.γ.specialpoint[1].param≈0.1 atol=1e-4 rtol=1e-4
 end


### PR DESCRIPTION
## Additional context

Making the ObservedRecordFromSolution object work with the new definition of record_from_solution in BifurcationKit. 
