### PR TITLE
feat: support multiple extend statements in MTKModel

### DIFF
--- a/docs/src/basics/MTKLanguage.md
+++ b/docs/src/basics/MTKLanguage.md
@@ -147,9 +147,9 @@ julia> ModelingToolkit.getdefault(model_c1.v)
 2.0
 ```
 
-#### `@extend` begin block
+#### `@extend` statement
 
-Partial systems can be extended in a higher system in two ways:
+One or more partial systems can be extended in a higher system with `@extend` statements. This can be done in two ways:
 
   - `@extend PartialSystem(var1 = value1)`
     
@@ -313,7 +313,8 @@ end
   - `:components`: The list of sub-components in the form of [[name, sub_component_name],...].
   - `:constants`: Dictionary of constants mapped to its metadata.
   - `:defaults`: Dictionary of variables and default values specified in the `@defaults`.
-  - `:extend`: The list of extended unknowns, name given to the base system, and name of the base system.
+  - `:extend`: The list of extended unknowns, parameters and components, name given to the base system, and name of the base system.
+    When multiple extend statements are present, latter two are returned as lists.
   - `:structural_parameters`: Dictionary of structural parameters mapped to their metadata.
   - `:parameters`: Dictionary of symbolic parameters mapped to their metadata. For
     parameter arrays, length is added to the metadata as `:size`.

--- a/src/systems/abstractsystem.jl
+++ b/src/systems/abstractsystem.jl
@@ -918,7 +918,7 @@ Mark a system as completed. A completed system is a system which is done being
 defined/modified and is ready for structural analysis or other transformations.
 This allows for analyses and optimizations to be performed which require knowing
 the global structure of the system.
-        
+
 One property to note is that if a system is complete, the system will no longer
 namespace its subsystems or variables, i.e. `isequal(complete(sys).v.i, v.i)`.
 """
@@ -1933,7 +1933,7 @@ function Base.show(
         end
     end
     limited = nrows < nsubs
-    limited && print(io, "\n  ⋮") # too many to print 
+    limited && print(io, "\n  ⋮") # too many to print
 
     # Print equations
     eqs = equations(sys)
@@ -3043,7 +3043,16 @@ function extend(sys::AbstractSystem, basesys::AbstractSystem;
     return T(args...; kwargs...)
 end
 
+function extend(sys, basesys::Vector{T}) where {T <: AbstractSystem}
+    foldl(extend, basesys, init = sys)
+end
+
 function Base.:(&)(sys::AbstractSystem, basesys::AbstractSystem; kwargs...)
+    extend(sys, basesys; kwargs...)
+end
+
+function Base.:(&)(
+        sys::AbstractSystem, basesys::Vector{T}; kwargs...) where {T <: AbstractSystem}
     extend(sys, basesys; kwargs...)
 end
 

--- a/test/model_parsing.jl
+++ b/test/model_parsing.jl
@@ -945,6 +945,15 @@ end
     end
 end
 
+@mtkmodel MidModelB begin
+    @parameters begin
+        b
+    end
+    @components begin
+        inmodel_b = InnerModel()
+    end
+end
+
 @mtkmodel OuterModel begin
     @extend MidModel()
     @equations begin
@@ -957,4 +966,16 @@ end
 @testset "Test unpacking of components in implicit extend" begin
     @named out = OuterModel()
     @test OuterModel.structure[:extend][1] == [:inmodel]
+end
+
+@mtkmodel MultipleExtend begin
+    @extend MidModel()
+    @extend MidModelB()
+end
+
+@testset "Multiple extend statements" begin
+    @named multiple_extend = MultipleExtend()
+    @test collect(nameof.(multiple_extend.systems)) == [:inmodel_b, :inmodel]
+    @test MultipleExtend.structure[:extend][1] == [:inmodel, :b, :inmodel_b]
+    @test tosymbol.(parameters(multiple_extend)) == [:b, :inmodel_b₊p, :inmodel₊p]
 end


### PR DESCRIPTION
One can add multiple extend statements in an MTKModel.

To support this, `extend` function now accepts more than two base systems.

Closes https://github.com/SciML/ModelingToolkit.jl/issues/2758

## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  

