### PR TITLE
JumpSystem cleanup

### DIFF
--- a/src/systems/abstractsystem.jl
+++ b/src/systems/abstractsystem.jl
@@ -930,7 +930,7 @@ function complete(sys::AbstractSystem; split = true, flatten = true)
     # don't update unknowns to not disturb `structural_simplify` order
     # `GlobalScope`d unknowns will be picked up and added there
     @set! sys.ps = unique!(vcat(get_ps(sys), collect(newparams)))
-    
+
     if flatten
         eqs = equations(sys)
         if eqs isa AbstractArray && eltype(eqs) <: Equation

--- a/src/systems/abstractsystem.jl
+++ b/src/systems/abstractsystem.jl
@@ -923,15 +923,14 @@ One property to note is that if a system is complete, the system will no longer
 namespace its subsystems or variables, i.e. `isequal(complete(sys).v.i, v.i)`.
 """
 function complete(sys::AbstractSystem; split = true, flatten = true)
-    if !(sys isa JumpSystem)
-        newunknowns = OrderedSet()
-        newparams = OrderedSet()
-        iv = has_iv(sys) ? get_iv(sys) : nothing
-        collect_scoped_vars!(newunknowns, newparams, sys, iv; depth = -1)
-        # don't update unknowns to not disturb `structural_simplify` order
-        # `GlobalScope`d unknowns will be picked up and added there
-        @set! sys.ps = unique!(vcat(get_ps(sys), collect(newparams)))
-    end
+    newunknowns = OrderedSet()
+    newparams = OrderedSet()
+    iv = has_iv(sys) ? get_iv(sys) : nothing
+    collect_scoped_vars!(newunknowns, newparams, sys, iv; depth = -1)
+    # don't update unknowns to not disturb `structural_simplify` order
+    # `GlobalScope`d unknowns will be picked up and added there
+    @set! sys.ps = unique!(vcat(get_ps(sys), collect(newparams)))
+    
     if flatten
         eqs = equations(sys)
         if eqs isa AbstractArray && eltype(eqs) <: Equation

--- a/src/systems/jumps/jumpsystem.jl
+++ b/src/systems/jumps/jumpsystem.jl
@@ -219,7 +219,8 @@ end
 ##### MTK dispatches for JumpSystems #####
 function collect_vars!(unknowns, parameters, j::MassActionJump, iv; depth = 0, 
         op = Differential)    
-    for field in (j.scaled_rates, j.reactant_stoch, j.net_stoch)
+    collect_vars!(unknowns, parameters, j.scaled_rates, iv; depth, op)
+    for field in (j.reactant_stoch, j.net_stoch)
         for el in field
             collect_vars!(unknowns, parameters, el, iv; depth, op)
         end

--- a/src/systems/jumps/jumpsystem.jl
+++ b/src/systems/jumps/jumpsystem.jl
@@ -174,14 +174,15 @@ function JumpSystem(eqs, iv, unknowns, ps;
             "`default_u0` and `default_p` are deprecated. Use `defaults` instead.",
             :JumpSystem, force = true)
     end
-    defaults = Dict{Any,Any}(todict(defaults))
+    defaults = Dict{Any, Any}(todict(defaults))
     var_to_name = Dict()
     process_variables!(var_to_name, defaults, us′)
     process_variables!(var_to_name, defaults, ps′)
     process_variables!(var_to_name, defaults, [eq.lhs for eq in parameter_dependencies])
     process_variables!(var_to_name, defaults, [eq.rhs for eq in parameter_dependencies])
-    defaults = Dict{Any, Any}(value(k) => value(v) for (k, v) in pairs(defaults) 
-        if value(v) !== nothing)
+    #! format: off
+    defaults = Dict{Any, Any}(value(k) => value(v) for (k, v) in pairs(defaults) if value(v) !== nothing)
+    #! format: on
     isempty(observed) || collect_var_to_name!(var_to_name, (eq.lhs for eq in observed))
 
     sysnames = nameof.(systems)
@@ -218,8 +219,8 @@ end
 
 ##### MTK dispatches for JumpSystems #####
 eqtype_supports_collect_vars(j::MassActionJump) = true
-function collect_vars!(unknowns, parameters, j::MassActionJump, iv; depth = 0, 
-        op = Differential)    
+function collect_vars!(unknowns, parameters, j::MassActionJump, iv; depth = 0,
+        op = Differential)
     collect_vars!(unknowns, parameters, j.scaled_rates, iv; depth, op)
     for field in (j.reactant_stoch, j.net_stoch)
         for el in field
@@ -229,8 +230,8 @@ function collect_vars!(unknowns, parameters, j::MassActionJump, iv; depth = 0,
     return nothing
 end
 
-eqtype_supports_collect_vars(j::Union{ConstantRateJump,VariableRateJump}) = true
-function collect_vars!(unknowns, parameters, j::Union{ConstantRateJump,VariableRateJump}, 
+eqtype_supports_collect_vars(j::Union{ConstantRateJump, VariableRateJump}) = true
+function collect_vars!(unknowns, parameters, j::Union{ConstantRateJump, VariableRateJump},
         iv; depth = 0, op = Differential)
     collect_vars!(unknowns, parameters, j.rate, iv; depth, op)
     for eq in j.affect!
@@ -278,7 +279,7 @@ function assemble_vrj(
 
     outputvars = (value(affect.lhs) for affect in vrj.affect!)
     outputidxs = [unknowntoid[var] for var in outputvars]
-    affect = eval_or_rgf(generate_affect_function(js, vrj.affect!, outputidxs); 
+    affect = eval_or_rgf(generate_affect_function(js, vrj.affect!, outputidxs);
         eval_expression, eval_module)
     VariableRateJump(rate, affect)
 end
@@ -306,7 +307,7 @@ function assemble_crj(
 
     outputvars = (value(affect.lhs) for affect in crj.affect!)
     outputidxs = [unknowntoid[var] for var in outputvars]
-    affect = eval_or_rgf(generate_affect_function(js, crj.affect!, outputidxs); 
+    affect = eval_or_rgf(generate_affect_function(js, crj.affect!, outputidxs);
         eval_expression, eval_module)
     ConstantRateJump(rate, affect)
 end

--- a/src/systems/jumps/jumpsystem.jl
+++ b/src/systems/jumps/jumpsystem.jl
@@ -217,6 +217,7 @@ function JumpSystem(eqs, iv, unknowns, ps;
 end
 
 ##### MTK dispatches for JumpSystems #####
+eqtype_supports_collect_vars(j::MassActionJump) = true
 function collect_vars!(unknowns, parameters, j::MassActionJump, iv; depth = 0, 
         op = Differential)    
     collect_vars!(unknowns, parameters, j.scaled_rates, iv; depth, op)
@@ -228,6 +229,7 @@ function collect_vars!(unknowns, parameters, j::MassActionJump, iv; depth = 0,
     return nothing
 end
 
+eqtype_supports_collect_vars(j::Union{ConstantRateJump,VariableRateJump}) = true
 function collect_vars!(unknowns, parameters, j::Union{ConstantRateJump,VariableRateJump}, 
         iv; depth = 0, op = Differential)
     collect_vars!(unknowns, parameters, j.rate, iv; depth, op)

--- a/test/jumpsystem.jl
+++ b/test/jumpsystem.jl
@@ -341,15 +341,14 @@ let
     @test all(abs.(cmean .- cmean2) .<= 0.05 .* cmean)
 end
 
-
 # collect_vars! tests for jumps
-let 
+let
     @variables x1(t) x2(t) x3(t) x4(t) x5(t)
     @parameters p1 p2 p3 p4 p5
     j1 = ConstantRateJump(p1, [x1 ~ x1 + 1])
     j2 = MassActionJump(p2, [x2 => 1], [x3 => -1])
     j3 = VariableRateJump(p3, [x3 ~ x3 + 1, x4 ~ x4 + 1])
-    j4 = MassActionJump(p4*p5, [x1 => 1, x5 => 1], [x1 => -1, x5 => -1, x2 => 1])
+    j4 = MassActionJump(p4 * p5, [x1 => 1, x5 => 1], [x1 => -1, x5 => -1, x2 => 1])
     us = Set()
     ps = Set()
     iv = t
@@ -389,35 +388,36 @@ let
     p3 = ParentScope(ParentScope(p3))
     p4 = DelayParentScope(p4, 2)
     p5 = GlobalScope(p5)
-    
+
     j1 = ConstantRateJump(p1, [x1 ~ x1 + 1])
     j2 = MassActionJump(p2, [x2 => 1], [x3 => -1])
     j3 = VariableRateJump(p3, [x3 ~ x3 + 1, x4 ~ x4 + 1])
-    j4 = MassActionJump(p4*p5, [x1 => 1, x5 => 1], [x1 => -1, x5 => -1, x2 => 1])
+    j4 = MassActionJump(p4 * p5, [x1 => 1, x5 => 1], [x1 => -1, x5 => -1, x2 => 1])
     @named js = JumpSystem([j1, j2, j3, j4], t, [x1, x2, x3, x4, x5], [p1, p2, p3, p4, p5])
 
-    us = Set(); ps = Set()
+    us = Set()
+    ps = Set()
     iv = t
     MT.collect_scoped_vars!(us, ps, js, iv)
     @test issetequal(us, [x2])
     @test issetequal(ps, [p2])
 
-    empty!.((us,ps))
+    empty!.((us, ps))
     MT.collect_scoped_vars!(us, ps, js, iv; depth = 0)
     @test issetequal(us, [x1])
     @test issetequal(ps, [p1])
 
-    empty!.((us,ps))
+    empty!.((us, ps))
     MT.collect_scoped_vars!(us, ps, js, iv; depth = 1)
     @test issetequal(us, [x2])
     @test issetequal(ps, [p2])
 
-    empty!.((us,ps))
+    empty!.((us, ps))
     MT.collect_scoped_vars!(us, ps, js, iv; depth = 2)
     @test issetequal(us, [x3, x4])
     @test issetequal(ps, [p3, p4])
 
-    empty!.((us,ps))
+    empty!.((us, ps))
     MT.collect_scoped_vars!(us, ps, js, iv; depth = -1)
     @test issetequal(us, [x5])
     @test issetequal(ps, [p5])

--- a/test/jumpsystem.jl
+++ b/test/jumpsystem.jl
@@ -376,3 +376,49 @@ let
     @test issetequal(us, [x1, x5, x2])
     @test issetequal(ps, [p4, p5])
 end
+
+# scoping tests
+let
+    @variables x1(t) x2(t) x3(t) x4(t) x5(t)
+    x2 = ParentScope(x2)
+    x3 = ParentScope(ParentScope(x3))
+    x4 = DelayParentScope(x4, 2)
+    x5 = GlobalScope(x5)
+    @parameters p1 p2 p3 p4 p5
+    p2 = ParentScope(p2)
+    p3 = ParentScope(ParentScope(p3))
+    p4 = DelayParentScope(p4, 2)
+    p5 = GlobalScope(p5)
+    
+    j1 = ConstantRateJump(p1, [x1 ~ x1 + 1])
+    j2 = MassActionJump(p2, [x2 => 1], [x3 => -1])
+    j3 = VariableRateJump(p3, [x3 ~ x3 + 1, x4 ~ x4 + 1])
+    j4 = MassActionJump(p4*p5, [x1 => 1, x5 => 1], [x1 => -1, x5 => -1, x2 => 1])
+    @named js = JumpSystem([j1, j2, j3, j4], t, [x1, x2, x3, x4, x5], [p1, p2, p3, p4, p5])
+
+    us = Set(); ps = Set()
+    iv = t
+    MT.collect_scoped_vars!(us, ps, js, iv)
+    @test issetequal(us, [x2])
+    @test issetequal(ps, [p2])
+
+    empty!.((us,ps))
+    MT.collect_scoped_vars!(us, ps, js, iv; depth = 0)
+    @test issetequal(us, [x1])
+    @test issetequal(ps, [p1])
+
+    empty!.((us,ps))
+    MT.collect_scoped_vars!(us, ps, js, iv; depth = 1)
+    @test issetequal(us, [x2])
+    @test issetequal(ps, [p2])
+
+    empty!.((us,ps))
+    MT.collect_scoped_vars!(us, ps, js, iv; depth = 2)
+    @test issetequal(us, [x3, x4])
+    @test issetequal(ps, [p3, p4])
+
+    empty!.((us,ps))
+    MT.collect_scoped_vars!(us, ps, js, iv; depth = -1)
+    @test issetequal(us, [x5])
+    @test issetequal(ps, [p5])
+end

--- a/test/jumpsystem.jl
+++ b/test/jumpsystem.jl
@@ -340,3 +340,39 @@ let
 
     @test all(abs.(cmean .- cmean2) .<= 0.05 .* cmean)
 end
+
+
+# collect_vars! tests for jumps
+let 
+    @variables x1(t) x2(t) x3(t) x4(t) x5(t)
+    @parameters p1 p2 p3 p4 p5
+    j1 = ConstantRateJump(p1, [x1 ~ x1 + 1])
+    j2 = MassActionJump(p2, [x2 => 1], [x3 => -1])
+    j3 = VariableRateJump(p3, [x3 ~ x3 + 1, x4 ~ x4 + 1])
+    j4 = MassActionJump(p4*p5, [x1 => 1, x5 => 1], [x1 => -1, x5 => -1, x2 => 1])
+    us = Set()
+    ps = Set()
+    iv = t
+
+    MT.collect_vars!(us, ps, j1, iv)
+    @test issetequal(us, [x1])
+    @test issetequal(ps, [p1])
+
+    empty!(us)
+    empty!(ps)
+    MT.collect_vars!(us, ps, j2, iv)
+    @test issetequal(us, [x2, x3])
+    @test issetequal(ps, [p2])
+
+    empty!(us)
+    empty!(ps)
+    MT.collect_vars!(us, ps, j3, iv)
+    @test issetequal(us, [x3, x4])
+    @test issetequal(ps, [p3])
+
+    empty!(us)
+    empty!(ps)
+    MT.collect_vars!(us, ps, j4, iv)
+    @test issetequal(us, [x1, x5, x2])
+    @test issetequal(ps, [p4, p5])
+end


### PR DESCRIPTION
As a first step before working on making JumpSystems support coupled ODEs/SDEs, I wanted to clean up the code a bit. This 

1. Adds support for `collect_vars!` for `JumpSystems`.
2. Cleans up the constructor to be more in line with how the code works for other system types. If at some point refactoring of common code in constructors is done it should now be easier to see what is different in JumpSystems.

Note that JumpSystems would still need some more work to support hierarchical modeling (i.e. sub-systems and scoping).