### PR TITLE
fix: `complete` with `split = false` removes the index cache

### DIFF
--- a/src/systems/abstractsystem.jl
+++ b/src/systems/abstractsystem.jl
@@ -985,6 +985,8 @@ function complete(sys::AbstractSystem; split = true, flatten = true)
             end
             @set! sys.ps = ordered_ps
         end
+    elseif has_index_cache(sys)
+        @set! sys.index_cache = nothing
     end
     if isdefined(sys, :initializesystem) && get_initializesystem(sys) !== nothing
         @set! sys.initializesystem = complete(get_initializesystem(sys); split)

--- a/src/systems/abstractsystem.jl
+++ b/src/systems/abstractsystem.jl
@@ -3003,8 +3003,8 @@ By default, the resulting system inherits `sys`'s name and description.
 See also [`compose`](@ref).
 """
 function extend(sys::AbstractSystem, basesys::AbstractSystem;
-    name::Symbol = nameof(sys), description = description(sys),
-    gui_metadata = get_gui_metadata(sys))
+        name::Symbol = nameof(sys), description = description(sys),
+        gui_metadata = get_gui_metadata(sys))
     T = SciMLBase.parameterless_type(basesys)
     ivs = independent_variables(basesys)
     if !(sys isa T)

--- a/test/odesystem.jl
+++ b/test/odesystem.jl
@@ -1495,3 +1495,12 @@ end
     sys2 = complete(sys)
     @test length(equations(sys2)) == total_eqs
 end
+
+@testset "`complete` with `split = false` removes the index cache" begin
+    @variables x(t)
+    @parameters p
+    @mtkbuild sys = ODESystem(D(x) ~ p * t, t)
+    @test ModelingToolkit.get_index_cache(sys) !== nothing
+    sys2 = complete(sys; split = false)
+    @test ModelingToolkit.get_index_cache(sys2) === nothing
+end


### PR DESCRIPTION
Close #3183 

## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
