### PR TITLE
Add a mechanism to add additional passes to the end of structural simplification before completion.

### DIFF
--- a/src/systems/systems.jl
+++ b/src/systems/systems.jl
@@ -26,7 +26,7 @@ topological sort of the observed equations in `sys`.
 + `fully_determined=true` controls whether or not an error will be thrown if the number of equations don't match the number of inputs, outputs, and equations.
 """
 function structural_simplify(
-        sys::AbstractSystem, io = nothing; simplify = false, split = true,
+        sys::AbstractSystem, io = nothing; additional_passes = [], simplify = false, split = true,
         allow_symbolic = false, allow_parameter = true, conservative = false, fully_determined = true,
         kwargs...)
     isscheduled(sys) && throw(RepeatedStructuralSimplificationError())
@@ -48,6 +48,9 @@ function structural_simplify(
     end
     if newsys isa ODESystem || has_parent(newsys)
         @set! newsys.parent = complete(sys; split, flatten = false)
+    end
+    for pass in additional_passes 
+        newsys = pass(newsys)
     end
     newsys = complete(newsys; split)
     if has_defaults(newsys) && (defs = get_defaults(newsys)) !== nothing

--- a/src/systems/systems.jl
+++ b/src/systems/systems.jl
@@ -46,11 +46,11 @@ function structural_simplify(
             not yet supported.
         """)
     end
+    for pass in additional_passes
+        newsys = pass(newsys)
+    end
     if newsys isa ODESystem || has_parent(newsys)
         @set! newsys.parent = complete(sys; split, flatten = false)
-    end
-    for pass in additional_passes 
-        newsys = pass(newsys)
     end
     newsys = complete(newsys; split)
     if has_defaults(newsys) && (defs = get_defaults(newsys)) !== nothing

--- a/test/structural_transformation/utils.jl
+++ b/test/structural_transformation/utils.jl
@@ -152,3 +152,12 @@ end
         end
     end
 end
+
+@testset "additional passes" begin
+    @variables x(t) y(t)
+    @named sys = ODESystem([D(x) ~ x, y ~ x + t], t)
+    value = Ref(0)
+    pass(sys; kwargs...) = (value[] += 1; return sys)
+    structural_simplify(sys; additional_passes = [pass])
+    @test value[] == 1
+end


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

This is a preliminary idea for how to do it; we might want to have a trait-like system for this that's more powerful?
