### PR TITLE
fix: fix `getproperty` syntax on `structural_simplify(complete(sys))`

### DIFF
--- a/src/systems/abstractsystem.jl
+++ b/src/systems/abstractsystem.jl
@@ -1122,7 +1122,7 @@ function Base.propertynames(sys::AbstractSystem; private = false)
         return fieldnames(typeof(sys))
     else
         if has_parent(sys) && (parent = get_parent(sys); parent !== nothing)
-            sys = parent
+            return propertynames(parent; private)
         end
         names = Symbol[]
         for s in get_systems(sys)
@@ -1144,7 +1144,7 @@ end
 
 function Base.getproperty(sys::AbstractSystem, name::Symbol; namespace = !iscomplete(sys))
     if has_parent(sys) && (parent = get_parent(sys); parent !== nothing)
-        sys = parent
+        return getproperty(parent, name; namespace)
     end
     wrap(getvar(sys, name; namespace = namespace))
 end

--- a/test/components.jl
+++ b/test/components.jl
@@ -350,3 +350,23 @@ end
     @test_throws ArgumentError simp.inner₊p
     @test_throws ArgumentError outer.inner₊p
 end
+
+@testset "`getproperty` on `structural_simplify(complete(sys))`" begin
+    @mtkmodel Foo begin
+        @variables begin
+            x(t)
+        end
+    end
+    @mtkmodel Bar begin
+        @components begin
+            foo = Foo()
+        end
+        @equations begin
+            D(foo.x) ~ foo.x
+        end
+    end
+    @named bar = Bar()
+    cbar = complete(bar)
+    ss = structural_simplify(cbar)
+    @test isequal(cbar.foo.x, ss.foo.x)
+end


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
