### PR TITLE
Update input_output_handling.jl to remove drop_expr

### DIFF
--- a/test/input_output_handling.jl
+++ b/test/input_output_handling.jl
@@ -140,8 +140,7 @@ if VERSION >= v"1.8" # :opaque_closure not supported before
         A, B, C, D = matrices
         obsf = ModelingToolkit.build_explicit_observed_function(ssys,
             [y],
-            inputs = [torque.tau.u],
-            drop_expr = identity)
+            inputs = [torque.tau.u])
         x = randn(size(A, 1))
         u = randn(size(B, 2))
         p = (getindex.(


### PR DESCRIPTION
`drop_expr` was disabled and left unused some time ago but it causes this test to break now

## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  