### PR TITLE
RFC: Expand derivatives in initialization equations before dummy derivative mapping

### DIFF
--- a/src/systems/nonlinear/initializesystem.jl
+++ b/src/systems/nonlinear/initializesystem.jl
@@ -77,7 +77,7 @@ function generate_initializesystem(sys::ODESystem;
     if !algebraic_only
         initialization_eqs = [get_initialization_eqs(sys); initialization_eqs]
         for eq in initialization_eqs
-            eq = fixpoint_sub(eq, diffmap) # expand dummy derivatives
+            eq = fixpoint_sub(expand_derivatives(eq), diffmap) # expand dummy derivatives
             push!(eqs_ics, eq)
         end
     end


### PR DESCRIPTION
This handles cases like `D(-x) ~ 0` which can happen during the fixed point substitution

The issue though is that if we have `D(y) ~ 0`, `y ~ -x`, then we need to substitute `D(-x) ~ 0` then change to `-D(x) ~ 0` and then substitute, so we need to somehow know to expand in the middle there.