### PR TITLE
test: make initializaton tests runnable from OrdinaryDiffEq

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -32,6 +32,7 @@ jobs:
         group:
           - InterfaceI
           - InterfaceII
+          - Initialization
           - SymbolicIndexingInterface
           - Extended
           - Extensions

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -61,10 +61,10 @@ end
     end
 
     if GROUP == "All" || GROUP == "Initialization"
-            @safetestset "Guess Propagation" include("guess_propagation.jl")
-            @safetestset "Hierarchical Initialization Equations" include("hierarchical_initialization_eqs.jl")
-            @safetestset "InitializationSystem Test" include("initializationsystem.jl")
-            @safetestset "Initial Values Test" include("initial_values.jl")
+        @safetestset "Guess Propagation" include("guess_propagation.jl")
+        @safetestset "Hierarchical Initialization Equations" include("hierarchical_initialization_eqs.jl")
+        @safetestset "InitializationSystem Test" include("initializationsystem.jl")
+        @safetestset "Initial Values Test" include("initial_values.jl")
     end
 
     if GROUP == "All" || GROUP == "InterfaceII"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -33,7 +33,6 @@ end
             @safetestset "Dynamic Quantities Test" include("dq_units.jl")
             @safetestset "Unitful Quantities Test" include("units.jl")
             @safetestset "Mass Matrix Test" include("mass_matrix.jl")
-            @safetestset "InitializationSystem Test" include("initializationsystem.jl")
             @safetestset "Guess Propagation" include("guess_propagation.jl")
             @safetestset "Hierarchical Initialization Equations" include("hierarchical_initialization_eqs.jl")
             @safetestset "Reduction Test" include("reduction.jl")
@@ -62,6 +61,10 @@ end
             @safetestset "Equation Type Accessors Test" include("equation_type_accessors.jl")
             @safetestset "Equations with complex values" include("complex.jl")
         end
+    end
+
+    if GROUP == "All" || GROUP == "InterfaceI" || GROUP == "Initialization"
+            @safetestset "InitializationSystem Test" include("initializationsystem.jl")
     end
 
     if GROUP == "All" || GROUP == "InterfaceII"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -33,8 +33,6 @@ end
             @safetestset "Dynamic Quantities Test" include("dq_units.jl")
             @safetestset "Unitful Quantities Test" include("units.jl")
             @safetestset "Mass Matrix Test" include("mass_matrix.jl")
-            @safetestset "Guess Propagation" include("guess_propagation.jl")
-            @safetestset "Hierarchical Initialization Equations" include("hierarchical_initialization_eqs.jl")
             @safetestset "Reduction Test" include("reduction.jl")
             @safetestset "Split Parameters Test" include("split_parameters.jl")
             @safetestset "StaticArrays Test" include("static_arrays.jl")
@@ -57,14 +55,16 @@ end
             @safetestset "Constants Test" include("constants.jl")
             @safetestset "Parameter Dependency Test" include("parameter_dependencies.jl")
             @safetestset "Generate Custom Function Test" include("generate_custom_function.jl")
-            @safetestset "Initial Values Test" include("initial_values.jl")
             @safetestset "Equation Type Accessors Test" include("equation_type_accessors.jl")
             @safetestset "Equations with complex values" include("complex.jl")
         end
     end
 
     if GROUP == "All" || GROUP == "InterfaceI" || GROUP == "Initialization"
+            @safetestset "Guess Propagation" include("guess_propagation.jl")
+            @safetestset "Hierarchical Initialization Equations" include("hierarchical_initialization_eqs.jl")
             @safetestset "InitializationSystem Test" include("initializationsystem.jl")
+            @safetestset "Initial Values Test" include("initial_values.jl")
     end
 
     if GROUP == "All" || GROUP == "InterfaceII"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -60,7 +60,7 @@ end
         end
     end
 
-    if GROUP == "All" || GROUP == "InterfaceI" || GROUP == "Initialization"
+    if GROUP == "All" || GROUP == "Initialization"
             @safetestset "Guess Propagation" include("guess_propagation.jl")
             @safetestset "Hierarchical Initialization Equations" include("hierarchical_initialization_eqs.jl")
             @safetestset "InitializationSystem Test" include("initializationsystem.jl")


### PR DESCRIPTION
OrdinaryDiffEq otherwise does not test `OverrideInit`

## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
