### PR TITLE
Fix type promotion in `InitializationProblem`s with vectors in the `u0map`

### DIFF
--- a/src/systems/diffeqs/abstractodesystem.jl
+++ b/src/systems/diffeqs/abstractodesystem.jl
@@ -1356,6 +1356,7 @@ function InitializationProblem{iip, specialize}(sys::AbstractODESystem,
         u0T = promote_type(u0T, typeof(fullmap[eq.lhs]))
     end
     if u0T != Union{}
+        u0T = eltype(u0T)
         u0map = Dict(k => if symbolic_type(v) == NotSymbolic() && !is_array_of_symbolics(v)
                          v isa AbstractArray ? u0T.(v) : u0T(v)
                      else


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

The current MTK breaks the docs example for MTKNN with

```julia
ERROR: MethodError: no method matching Vector{Float64}(::Float64)
The type `Vector{Float64}` exists, but no method is defined for this combination of argument types when trying to construct it.

Closest candidates are:
  Array{T, N}(::Missing, Any...) where {T, N}
   @ Base baseext.jl:43
  Array{T, N}(::Nothing, Any...) where {T, N}
   @ Base baseext.jl:42
  Vector{T}(::UndefInitializer, ::Tuple{Int64}) where T
   @ Core boot.jl:591
  ...

Stacktrace:
  [1] _broadcast_getindex_evalf
    @ ./broadcast.jl:673 [inlined]
  [2] _broadcast_getindex
    @ ./broadcast.jl:646 [inlined]
  [3] getindex
    @ ./broadcast.jl:605 [inlined]
  [4] copy
    @ ./broadcast.jl:906 [inlined]
  [5] materialize(bc::Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{…}, Nothing, Type{…}, Tuple{…}})
    @ Base.Broadcast ./broadcast.jl:867
  [6] #1558
    @ ~/.julia/dev/ModelingToolkit/src/systems/diffeqs/abstractodesystem.jl:1360 [inlined]
  [7] (::ModelingToolkit.var"#1558#1562")(::Pair{Any, Any})
    @ ModelingToolkit ./none:0
  [8] iterate
    @ ./generator.jl:48 [inlined]
  [9] grow_to!(dest::Dict{Any, Any}, itr::Base.Generator{Dict{Any, Any}, ModelingToolkit.var"#1558#1562"})
    @ Base ./abstractdict.jl:587
 [10] dict_with_eltype
    @ ./abstractdict.jl:641 [inlined]
 [11] Dict
    @ ./dict.jl:117 [inlined]
 [12] ModelingToolkit.InitializationProblem{…}(sys::ODESystem, t::Int64, u0map::Dict{…}, parammap::Dict{…}; guesses::Dict{…}, check_length::Bool, warn_initialize_determined::Bool, initialization_eqs::Vector{…}, fully_determined::Bool, check_units::Bool, kwargs::@Kwargs{…})
    @ ModelingToolkit ~/.julia/dev/ModelingToolkit/src/systems/diffeqs/abstractodesystem.jl:1359
 [13] (ModelingToolkit.InitializationProblem{…})(::ODESystem, ::Int64, ::Vararg{…}; kwargs::@Kwargs{…})
    @ ModelingToolkit ~/.julia/packages/ModelingToolkit/ompZE/src/systems/diffeqs/abstractodesystem.jl:1269
 [14] ModelingToolkit.InitializationProblem(::ODESystem, ::Int64, ::Vararg{…}; kwargs::@Kwargs{…})
    @ ModelingToolkit ~/.julia/packages/ModelingToolkit/ompZE/src/systems/diffeqs/abstractodesystem.jl:1257
 [15] process_SciMLProblem(constructor::Type, sys::ODESystem, u0map::Vector{…}, pmap::Vector{…}; build_initializeprob::Bool, implicit_dae::Bool, t::Int64, guesses::Dict{…}, warn_initialize_determined::Bool, initialization_eqs::Vector{…}, eval_expression::Bool, eval_module::Module, fully_determined::Bool, check_initialization_units::Bool, tofloat::Bool, use_union::Bool, u0_constructor::typeof(identity), du0map::Nothing, check_length::Bool, symbolic_u0::Bool, warn_cyclic_dependency::Bool, circular_dependency_max_cycle_length::Int64, circular_dependency_max_cycles::Int64, substitution_limit::Int64, kwargs::@Kwargs{})
    @ ModelingToolkit ~/.julia/packages/ModelingToolkit/ompZE/src/systems/problem_utils.jl:554
 [16] (ODEProblem{…})(sys::ODESystem, u0map::Vector{…}, tspan::Tuple{…}, parammap::Vector{…}; callback::Nothing, check_length::Bool, warn_initialize_determined::Bool, eval_expression::Bool, eval_module::Module, kwargs::@Kwargs{})
    @ ModelingToolkit ~/.julia/packages/ModelingToolkit/ompZE/src/systems/diffeqs/abstractodesystem.jl:836
 [17] (ODEProblem{…})(sys::ODESystem, u0map::Vector{…}, tspan::Tuple{…}, parammap::Vector{…})
    @ ModelingToolkit ~/.julia/packages/ModelingToolkit/ompZE/src/systems/diffeqs/abstractodesystem.jl:824
 [18] (ODEProblem{true})(::ODESystem, ::Vector{Any}, ::Vararg{Any}; kwargs::@Kwargs{})
    @ ModelingToolkit ~/.julia/packages/ModelingToolkit/ompZE/src/systems/diffeqs/abstractodesystem.jl:817
 [19] (ODEProblem{true})(::ODESystem, ::Vector{Any}, ::Vararg{Any})
    @ ModelingToolkit ~/.julia/packages/ModelingToolkit/ompZE/src/systems/diffeqs/abstractodesystem.jl:816
 [20] ODEProblem(::ODESystem, ::Vector{Any}, ::Vararg{Any}; kwargs::@Kwargs{})
    @ ModelingToolkit ~/.julia/packages/ModelingToolkit/ompZE/src/systems/diffeqs/abstractodesystem.jl:806
 [21] ODEProblem(::ODESystem, ::Vector{Any}, ::Vararg{Any})
    @ ModelingToolkit ~/.julia/packages/ModelingToolkit/ompZE/src/systems/diffeqs/abstractodesystem.jl:805
 [22] top-level scope
```

This is due to the type promotion for the `u0map`  in the initialization problem, which uses `uoT.(v)`, where `v isa AbstractArray`. Since the `u0T` type is computed via `typeof`, we should broadcast the `eltype`, not the full type.

I don't have a MWE for this, I tried adjusting the existing test for vector initial conditions, but I can't get this to reach that code path.