### PR TITLE
fix: retain observed equations after `structural_simplify` of `SDESystem`

### DIFF
--- a/src/systems/systems.jl
+++ b/src/systems/systems.jl
@@ -156,6 +156,6 @@ function __structural_simplify(sys::AbstractSystem, io = nothing; simplify = fal
         noise_eqs = StructuralTransformations.tearing_substitute_expr(ode_sys, noise_eqs)
         return SDESystem(full_equations(ode_sys), noise_eqs,
             get_iv(ode_sys), unknowns(ode_sys), parameters(ode_sys);
-            name = nameof(ode_sys), is_scalar_noise)
+            name = nameof(ode_sys), is_scalar_noise, observed = observed(ode_sys))
     end
 end

--- a/test/sdesystem.jl
+++ b/test/sdesystem.jl
@@ -799,3 +799,13 @@ end
     prob = SDEProblem(sys, [], (0.0, 1.0), [])
     @test_nowarn solve(prob, RKMil())
 end
+
+@testset "Observed variables retained after `structural_simplify`" begin
+    @variables x(t) y(t) z(t)
+    @brownian a
+    @mtkbuild sys = System([D(x) ~ x + a, D(y) ~ y + a, z ~ x + y], t)
+    @test sys isa SDESystem
+    @test length(observed(sys)) == 1
+    prob = SDEProblem(sys, [x => 1.0, y => 1.0], (0.0, 1.0))
+    @test prob[z] ≈ 2.0
+end


### PR DESCRIPTION
Close #3175 

## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
