### PR TITLE
fix: retain system metadata when calling `flatten`

### DIFF
--- a/src/systems/diffeqs/odesystem.jl
+++ b/src/systems/diffeqs/odesystem.jl
@@ -409,6 +409,7 @@ function flatten(sys::ODESystem, noeqs = false)
             initialization_eqs = initialization_equations(sys),
             is_dde = is_dde(sys),
             tstops = symbolic_tstops(sys),
+            metadata = get_metadata(sys),
             checks = false)
     end
 end

--- a/src/systems/discrete_system/discrete_system.jl
+++ b/src/systems/discrete_system/discrete_system.jl
@@ -227,6 +227,7 @@ function flatten(sys::DiscreteSystem, noeqs = false)
             defaults = defaults(sys),
             name = nameof(sys),
             description = description(sys),
+            metadata = get_metadata(sys),
             checks = false)
     end
 end

--- a/src/systems/nonlinear/nonlinearsystem.jl
+++ b/src/systems/nonlinear/nonlinearsystem.jl
@@ -859,6 +859,7 @@ function flatten(sys::NonlinearSystem, noeqs = false)
             defaults = defaults(sys),
             name = nameof(sys),
             description = description(sys),
+            metadata = get_metadata(sys),
             checks = false)
     end
 end

--- a/src/systems/optimization/optimizationsystem.jl
+++ b/src/systems/optimization/optimizationsystem.jl
@@ -184,6 +184,7 @@ function flatten(sys::OptimizationSystem)
         constraints = constraints(sys),
         defaults = defaults(sys),
         name = nameof(sys),
+        metadata = get_metadata(sys),
         checks = false
     )
 end

--- a/test/components.jl
+++ b/test/components.jl
@@ -370,3 +370,39 @@ end
     ss = structural_simplify(cbar)
     @test isequal(cbar.foo.x, ss.foo.x)
 end
+
+@testset "Issue#3275: Metadata retained on `complete`" begin
+    @variables x(t) y(t)
+    @testset "ODESystem" begin
+        @named inner = ODESystem(D(x) ~ x, t)
+        @named outer = ODESystem(D(y) ~ y, t; systems = [inner], metadata = "test")
+        @test ModelingToolkit.get_metadata(outer) == "test"
+        sys = complete(outer)
+        @test ModelingToolkit.get_metadata(sys) == "test"
+    end
+    @testset "NonlinearSystem" begin
+        @named inner = NonlinearSystem([0 ~ x^2 + 4x + 4], [x], [])
+        @named outer = NonlinearSystem(
+            [0 ~ x^3 - y^3], [x, y], []; systems = [inner], metadata = "test")
+        @test ModelingToolkit.get_metadata(outer) == "test"
+        sys = complete(outer)
+        @test ModelingToolkit.get_metadata(sys) == "test"
+    end
+    k = ShiftIndex(t)
+    @testset "DiscreteSystem" begin
+        @named inner = DiscreteSystem([x(k) ~ x(k - 1) + x(k - 2)], t, [x], [])
+        @named outer = DiscreteSystem([y(k) ~ y(k - 1) + y(k - 2)], t, [x, y],
+            []; systems = [inner], metadata = "test")
+        @test ModelingToolkit.get_metadata(outer) == "test"
+        sys = complete(outer)
+        @test ModelingToolkit.get_metadata(sys) == "test"
+    end
+    @testset "OptimizationSystem" begin
+        @named inner = OptimizationSystem(x^2 + y^2 - 3, [x, y], [])
+        @named outer = OptimizationSystem(
+            x^3 - y, [x, y], []; systems = [inner], metadata = "test")
+        @test ModelingToolkit.get_metadata(outer) == "test"
+        sys = complete(outer)
+        @test ModelingToolkit.get_metadata(sys) == "test"
+    end
+end


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
