### PR TITLE
Generic mechanism for debugging/logging functions

### DIFF
--- a/docs/pages.jl
+++ b/docs/pages.jl
@@ -31,6 +31,7 @@ pages = [
         "basics/InputOutput.md",
         "basics/MTKLanguage.md",
         "basics/Validation.md",
+        "basics/Debugging.md",
         "basics/DependencyGraphs.md",
         "basics/Precompilation.md",
         "basics/FAQ.md"],

--- a/docs/src/basics/Debugging.md
+++ b/docs/src/basics/Debugging.md
@@ -18,22 +18,18 @@ sys = structural_simplify(sys)
 
 This problem causes the ODE solver to crash:
 
-```@example debug
-prob = ODEProblem(sys, [], (0.0, 10.0), [])
-sol = solve(prob, Tsit5())
+```@repl debug
+prob = ODEProblem(sys, [], (0.0, 10.0), []);
+sol = solve(prob, Tsit5());
 ```
 
 This suggests *that* something went wrong, but not exactly *what* went wrong and *where* it did.
 In such situations, the `debug_system` function is helpful:
 
-```@example debug
-try # workaround to show Documenter.jl error (https://github.com/JuliaDocs/Documenter.jl/issues/1420#issuecomment-770539595) # hide
-dsys = debug_system(sys; functions = [sqrt])
-dprob = ODEProblem(dsys, [], (0.0, 10.0), [])
-dsol = solve(dprob, Tsit5())
-catch err # hide
-showerror(stderr, err) # hide
-end # hide
+```@repl debug
+dsys = debug_system(sys; functions = [sqrt]);
+dprob = ODEProblem(dsys, [], (0.0, 10.0), []);
+dsol = solve(dprob, Tsit5());
 ```
 
 Now we see that it crashed because `u1` decreased so much that it became negative and outside the domain of the `√` function.

--- a/docs/src/basics/Debugging.md
+++ b/docs/src/basics/Debugging.md
@@ -1,0 +1,44 @@
+# Debugging
+
+Every (mortal) modeler writes models that contain mistakes or are susceptible to numerical errors in their hunt for the perfect model.
+Debugging such errors is part of the modeling process, and ModelingToolkit includes some functionality that helps with this.
+
+For example, consider an ODE model with "dangerous" functions (here `√`):
+
+```@example debug
+using ModelingToolkit, OrdinaryDiffEq
+using ModelingToolkit: t_nounits as t, D_nounits as D
+
+@variables u1(t) u2(t) u3(t)
+eqs = [D(u1) ~ -√(u1), D(u2) ~ -√(u2), D(u3) ~ -√(u3)]
+defaults = [u1 => 1.0, u2 => 2.0, u3 => 3.0]
+@named sys = ODESystem(eqs, t; defaults)
+sys = structural_simplify(sys)
+```
+
+This problem causes the ODE solver to crash:
+
+```@example debug
+prob = ODEProblem(sys, [], (0.0, 10.0), [])
+sol = solve(prob, Tsit5())
+```
+
+This suggests *that* something went wrong, but not exactly *what* went wrong and *where* it did.
+In such situations, the `debug_system` function is helpful:
+
+```@example debug
+try # workaround to show Documenter.jl error (https://github.com/JuliaDocs/Documenter.jl/issues/1420#issuecomment-770539595) # hide
+dsys = debug_system(sys; functions = [sqrt])
+dprob = ODEProblem(dsys, [], (0.0, 10.0), [])
+dsol = solve(dprob, Tsit5())
+catch err # hide
+showerror(stderr, err) # hide
+end # hide
+```
+
+Now we see that it crashed because `u1` decreased so much that it became negative and outside the domain of the `√` function.
+We could have figured that out ourselves, but it is not always so obvious for more complex models.
+
+```@docs
+debug_system
+```

--- a/src/debugging.jl
+++ b/src/debugging.jl
@@ -6,10 +6,12 @@ struct LoggedFun{F}
     args::Any
     error_nonfinite::Bool
 end
-LoggedFunctionException(lf::LoggedFun, args, msg) = LoggedFunctionException(
-    "Function $(lf.f)($(join(lf.args, ", "))) " * msg * " with input" *
-    join("\n  " .* string.(lf.args .=> args)) # one line for each "var => val" for readability
-)
+function LoggedFunctionException(lf::LoggedFun, args, msg)
+    LoggedFunctionException(
+        "Function $(lf.f)($(join(lf.args, ", "))) " * msg * " with input" *
+        join("\n  " .* string.(lf.args .=> args)) # one line for each "var => val" for readability
+    )
+end
 Base.showerror(io::IO, err::LoggedFunctionException) = print(io, err.msg)
 Base.nameof(lf::LoggedFun) = nameof(lf.f)
 SymbolicUtils.promote_symtype(::LoggedFun, Ts...) = Real
@@ -30,7 +32,9 @@ function logged_fun(f, args...; error_nonfinite = true) # remember to update err
     term(LoggedFun(f, args, error_nonfinite), args..., type = Real)
 end
 
-debug_sub(eq::Equation, funcs; kw...) = debug_sub(eq.lhs, funcs; kw...) ~ debug_sub(eq.rhs, funcs; kw...)
+function debug_sub(eq::Equation, funcs; kw...)
+    debug_sub(eq.lhs, funcs; kw...) ~ debug_sub(eq.rhs, funcs; kw...)
+end
 function debug_sub(ex, funcs; kw...)
     iscall(ex) || return ex
     f = operation(ex)

--- a/src/debugging.jl
+++ b/src/debugging.jl
@@ -1,5 +1,3 @@
-const LOGGED_FUN = Set([log, sqrt, (^), /, inv])
-
 struct LoggedFunctionException <: Exception
     msg::String
 end
@@ -32,11 +30,11 @@ function logged_fun(f, args...; error_nonfinite = true) # remember to update err
     term(LoggedFun(f, args, error_nonfinite), args..., type = Real)
 end
 
-debug_sub(eq::Equation; kw...) = debug_sub(eq.lhs; kw...) ~ debug_sub(eq.rhs; kw...)
-function debug_sub(ex; kw...)
+debug_sub(eq::Equation, funcs; kw...) = debug_sub(eq.lhs, funcs; kw...) ~ debug_sub(eq.rhs, funcs; kw...)
+function debug_sub(ex, funcs; kw...)
     iscall(ex) || return ex
     f = operation(ex)
-    args = map(debug_sub, arguments(ex))
-    f in LOGGED_FUN ? logged_fun(f, args...; kw...) :
+    args = map(ex -> debug_sub(ex, funcs; kw...), arguments(ex))
+    f in funcs ? logged_fun(f, args...; kw...) :
     maketerm(typeof(ex), f, args, metadata(ex))
 end

--- a/src/systems/abstractsystem.jl
+++ b/src/systems/abstractsystem.jl
@@ -2266,18 +2266,14 @@ Replace functions with singularities with a function that errors with symbolic
 information. E.g.
 
 ```julia-repl
-julia> sys = debug_system(sys)
+julia> sys = debug_system(complete(sys))
 
-julia> sys = complete(sys)
-
-julia> prob = ODEProblem(sys, [1.0, 0.0], (0.0, 1.0))
+julia> prob = ODEProblem(sys, [0.0, 2.0], (0.0, 1.0))
 
 julia> prob.f(prob.u0, prob.p, 0.0)
-ERROR: Function log(-cos(Q(t))) errors with input
-  -cos(Q(t)) => -1.0
-Stacktrace:
-  [1] (::ModelingToolkit.LoggedFun{typeof(log)})(num_args::Float64)
-  ...
+ERROR: Function /(1, sin(P(t))) output non-finite value Inf with input
+  1 => 1
+  sin(P(t)) => 0.0
 ```
 """
 function debug_system(sys::AbstractSystem)

--- a/src/systems/abstractsystem.jl
+++ b/src/systems/abstractsystem.jl
@@ -2266,19 +2266,17 @@ Replace functions with singularities with a function that errors with symbolic
 information. E.g.
 
 ```julia-repl
-julia> sys = debug_system(sys);
+julia> sys = debug_system(sys)
 
-julia> sys = complete(sys);
+julia> sys = complete(sys)
 
-julia> prob = ODEProblem(sys, [], (0, 1.0));
+julia> prob = ODEProblem(sys, [1.0, 0.0], (0.0, 1.0))
 
-julia> du = zero(prob.u0);
-
-julia> prob.f(du, prob.u0, prob.p, 0.0)
-ERROR: DomainError with (-1.0,):
-log errors with input(s): -cos(Q(t)) => -1.0
+julia> prob.f(prob.u0, prob.p, 0.0)
+ERROR: Function log(-cos(Q(t))) errors with input
+  -cos(Q(t)) => -1.0
 Stacktrace:
-  [1] (::ModelingToolkit.LoggedFun{typeof(log)})(args::Float64)
+  [1] (::ModelingToolkit.LoggedFun{typeof(log)})(num_args::Float64)
   ...
 ```
 """

--- a/src/systems/abstractsystem.jl
+++ b/src/systems/abstractsystem.jl
@@ -2282,7 +2282,7 @@ Stacktrace:
 """
 function debug_system(sys::AbstractSystem)
     if has_systems(sys) && !isempty(get_systems(sys))
-        error("debug_system only works on systems with no sub-systems!")
+        error("debug_system(sys) only works on systems with no sub-systems! Consider flattening it with flatten(sys) or structural_simplify(sys) first.")
     end
     if has_eqs(sys)
         @set! sys.eqs = debug_sub.(equations(sys))

--- a/src/systems/abstractsystem.jl
+++ b/src/systems/abstractsystem.jl
@@ -2278,7 +2278,8 @@ ERROR: Function /(1, sin(P(t))) output non-finite value Inf with input
   sin(P(t)) => 0.0
 ```
 """
-function debug_system(sys::AbstractSystem; functions = [log, sqrt, (^), /, inv, asin, acos], kw...)
+function debug_system(
+        sys::AbstractSystem; functions = [log, sqrt, (^), /, inv, asin, acos], kw...)
     if !(functions isa Set)
         functions = Set(functions) # more efficient "in" lookup
     end

--- a/src/systems/abstractsystem.jl
+++ b/src/systems/abstractsystem.jl
@@ -2260,11 +2260,11 @@ macro mtkbuild(exprs...)
 end
 
 """
-    debug_system(sys::AbstractSystem; error_nonfinite = true)
+    debug_system(sys::AbstractSystem; functions = [log, sqrt, (^), /, inv, asin, acos], error_nonfinite = true)
 
-Replace functions with singularities with a function that errors with symbolic
-information. If `error_nonfinite`, debugged functions that output nonfinite values
-(like `Inf` or `NaN`) also display errors, even though the raw function itself
+Wrap `functions` in `sys` so any error thrown in them shows helpful symbolic-numeric
+information about its input. If `error_nonfinite`, functions that output nonfinite
+values (like `Inf` or `NaN`) also display errors, even though the raw function itself
 does not throw an exception (like `1/0`). For example:
 
 ```julia-repl
@@ -2278,15 +2278,18 @@ ERROR: Function /(1, sin(P(t))) output non-finite value Inf with input
   sin(P(t)) => 0.0
 ```
 """
-function debug_system(sys::AbstractSystem; kw...)
+function debug_system(sys::AbstractSystem; functions = [log, sqrt, (^), /, inv, asin, acos], kw...)
+    if !(functions isa Set)
+        functions = Set(functions) # more efficient "in" lookup
+    end
     if has_systems(sys) && !isempty(get_systems(sys))
         error("debug_system(sys) only works on systems with no sub-systems! Consider flattening it with flatten(sys) or structural_simplify(sys) first.")
     end
     if has_eqs(sys)
-        @set! sys.eqs = debug_sub.(equations(sys); kw...)
+        @set! sys.eqs = debug_sub.(equations(sys), Ref(functions); kw...)
     end
     if has_observed(sys)
-        @set! sys.observed = debug_sub.(observed(sys); kw...)
+        @set! sys.observed = debug_sub.(observed(sys), Ref(functions); kw...)
     end
     return sys
 end

--- a/src/systems/abstractsystem.jl
+++ b/src/systems/abstractsystem.jl
@@ -2260,10 +2260,12 @@ macro mtkbuild(exprs...)
 end
 
 """
-$(SIGNATURES)
+    debug_system(sys::AbstractSystem; error_nonfinite = true)
 
 Replace functions with singularities with a function that errors with symbolic
-information. E.g.
+information. If `error_nonfinite`, debugged functions that output nonfinite values
+(like `Inf` or `NaN`) also display errors, even though the raw function itself
+does not throw an exception (like `1/0`). For example:
 
 ```julia-repl
 julia> sys = debug_system(complete(sys))
@@ -2276,15 +2278,15 @@ ERROR: Function /(1, sin(P(t))) output non-finite value Inf with input
   sin(P(t)) => 0.0
 ```
 """
-function debug_system(sys::AbstractSystem)
+function debug_system(sys::AbstractSystem; kw...)
     if has_systems(sys) && !isempty(get_systems(sys))
         error("debug_system(sys) only works on systems with no sub-systems! Consider flattening it with flatten(sys) or structural_simplify(sys) first.")
     end
     if has_eqs(sys)
-        @set! sys.eqs = debug_sub.(equations(sys))
+        @set! sys.eqs = debug_sub.(equations(sys); kw...)
     end
     if has_observed(sys)
-        @set! sys.observed = debug_sub.(observed(sys))
+        @set! sys.observed = debug_sub.(observed(sys); kw...)
     end
     return sys
 end

--- a/test/odesystem.jl
+++ b/test/odesystem.jl
@@ -939,7 +939,7 @@ testdict = Dict([:name => "test"])
 sys = complete(debug_system(sys))
 prob = ODEProblem(sys, [], (0.0, 1.0))
 @test_throws "log(-cos(Q(t))) errors" prob.f([1, 0], prob.p, 0.0)
-@test prob.f([0, 2], prob.p, 0.0)[1] == 1 / 0
+@test_throws "/(1, sin(P(t))) output non-finite value" prob.f([0, 2], prob.p, 0.0)
 
 let
     @variables x(t) = 1

--- a/test/odesystem.jl
+++ b/test/odesystem.jl
@@ -931,22 +931,15 @@ testdict = Dict([:name => "test"])
 @named sys = ODESystem(eqs, t, metadata = testdict)
 @test get_metadata(sys) == testdict
 
-@variables P(t)=0 Q(t)=2
-∂t = D
-
-eqs = [∂t(Q) ~ 1 / sin(P)
-       ∂t(P) ~ log(-cos(Q))]
-@named sys = ODESystem(eqs, t, [P, Q], [])
-sys = complete(debug_system(sys));
-prob = ODEProblem(sys, [], (0, 1.0));
-du = zero(prob.u0);
-if VERSION < v"1.8"
-    @test_throws DomainError prob.f(du, [1, 0], prob.p, 0.0)
-    @test_throws DomainError prob.f(du, [0, 2], prob.p, 0.0)
-else
-    @test_throws "-cos(Q(t))" prob.f(du, [1, 0], prob.p, 0.0)
-    @test_throws "sin(P(t))" prob.f(du, [0, 2], prob.p, 0.0)
-end
+@variables P(t) = NaN Q(t) = NaN
+@named sys = ODESystem([
+    D(Q) ~ 1 / sin(P)
+    D(P) ~ log(-cos(Q))
+], t, [P, Q], [])
+sys = complete(debug_system(sys))
+prob = ODEProblem(sys, [], (0.0, 1.0))
+@test_throws "log(-cos(Q(t))) errors" prob.f([1, 0], prob.p, 0.0)
+@test prob.f([0, 2], prob.p, 0.0)[1] == 1 / 0
 
 let
     @variables x(t) = 1

--- a/test/odesystem.jl
+++ b/test/odesystem.jl
@@ -931,11 +931,9 @@ testdict = Dict([:name => "test"])
 @named sys = ODESystem(eqs, t, metadata = testdict)
 @test get_metadata(sys) == testdict
 
-@variables P(t) = NaN Q(t) = NaN
-@named sys = ODESystem([
-    D(Q) ~ 1 / sin(P)
-    D(P) ~ log(-cos(Q))
-], t, [P, Q], [])
+@variables P(t)=NaN Q(t)=NaN
+eqs = [D(Q) ~ 1 / sin(P), D(P) ~ log(-cos(Q))]
+@named sys = ODESystem(eqs, t, [P, Q], [])
 sys = complete(debug_system(sys))
 prob = ODEProblem(sys, [], (0.0, 1.0))
 @test_throws "log(-cos(Q(t))) errors" prob.f([1, 0], prob.p, 0.0)


### PR DESCRIPTION
I find `debug_system()` very helpful for seeing where code generated by symbolics crashes. But it currently only handles a limited set of error types. It also duplicates domain-checking logic that must be added for every function that is to be debugged, so I think it scales poorly.

I propose this generic mechanism instead, which handles any error type, relies on the original functions' error/domain handling, and lets the user pass which functions they want debugged.

## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API