### PR TITLE
Fix interpretation of nonlinear system overdetermined defaults

### DIFF
--- a/src/systems/nonlinear/nonlinearsystem.jl
+++ b/src/systems/nonlinear/nonlinearsystem.jl
@@ -539,7 +539,7 @@ function DiffEqBase.NonlinearProblem{iip}(sys::NonlinearSystem, u0map,
         end
     end
     f, u0, p = process_SciMLProblem(NonlinearFunction{iip}, sys, u0map, parammap;
-        check_length, kwargs...)
+        check_length, build_initializeprob = false, kwargs...)
     pt = something(get_metadata(sys), StandardNonlinearProblem())
     NonlinearProblem{iip}(f, u0, p, pt; filter_kwargs(kwargs)...)
 end
@@ -568,7 +568,7 @@ function DiffEqBase.NonlinearLeastSquaresProblem{iip}(sys::NonlinearSystem, u0ma
         error("A completed `NonlinearSystem` is required. Call `complete` or `structural_simplify` on the system before creating a `NonlinearLeastSquaresProblem`")
     end
     f, u0, p = process_SciMLProblem(NonlinearFunction{iip}, sys, u0map, parammap;
-        check_length, kwargs...)
+        check_length, build_initializeprob = false, kwargs...)
     pt = something(get_metadata(sys), StandardNonlinearProblem())
     NonlinearLeastSquaresProblem{iip}(f, u0, p; filter_kwargs(kwargs)...)
 end
@@ -681,7 +681,8 @@ function SciMLBase.SCCNonlinearProblem{iip}(sys::NonlinearSystem, u0map,
     obs = observed(sys)
 
     _, u0, p = process_SciMLProblem(
-        EmptySciMLFunction, sys, u0map, parammap; eval_expression, eval_module, kwargs...)
+        EmptySciMLFunction, sys, u0map, parammap; eval_expression, eval_module, 
+        build_initializeprob = false, kwargs...)
 
     explicitfuns = []
     nlfuns = []
@@ -832,7 +833,8 @@ function DiffEqBase.IntervalNonlinearProblem(sys::NonlinearSystem, uspan::NTuple
         error("`IntervalNonlinearProblem` only supports with a single equation and a single unknown.")
     end
     f, u0, p = process_SciMLProblem(
-        IntervalNonlinearFunction, sys, unknowns(sys) .=> uspan[1], parammap; kwargs...)
+        IntervalNonlinearFunction, sys, unknowns(sys) .=> uspan[1], parammap; 
+        build_initializeprob = false, kwargs...)
 
     return IntervalNonlinearProblem(f, uspan, p; filter_kwargs(kwargs)...)
 end
@@ -865,7 +867,7 @@ function NonlinearProblemExpr{iip}(sys::NonlinearSystem, u0map,
         error("A completed `NonlinearSystem` is required. Call `complete` or `structural_simplify` on the system before creating a `NonlinearProblemExpr`")
     end
     f, u0, p = process_SciMLProblem(NonlinearFunctionExpr{iip}, sys, u0map, parammap;
-        check_length, kwargs...)
+        check_length, build_initializeprob = false, kwargs...)
     linenumbers = get(kwargs, :linenumbers, true)
 
     ex = quote
@@ -905,7 +907,7 @@ function NonlinearLeastSquaresProblemExpr{iip}(sys::NonlinearSystem, u0map,
         error("A completed `NonlinearSystem` is required. Call `complete` or `structural_simplify` on the system before creating a `NonlinearProblemExpr`")
     end
     f, u0, p = process_SciMLProblem(NonlinearFunctionExpr{iip}, sys, u0map, parammap;
-        check_length, kwargs...)
+        check_length, build_initializeprob = false, kwargs...)
     linenumbers = get(kwargs, :linenumbers, true)
 
     ex = quote
@@ -933,7 +935,8 @@ function IntervalNonlinearProblemExpr(sys::NonlinearSystem, uspan::NTuple{2},
         error("`IntervalNonlinearProblemExpr` only supports with a single equation and a single unknown.")
     end
     f, u0, p = process_SciMLProblem(
-        IntervalNonlinearFunctionExpr, sys, unknowns(sys) .=> uspan[1], parammap; kwargs...)
+        IntervalNonlinearFunctionExpr, sys, unknowns(sys) .=> uspan[1], parammap; 
+        build_initializeprob = false, kwargs...)
     linenumbers = get(kwargs, :linenumbers, true)
 
     ex = quote

--- a/test/nonlinearsystem.jl
+++ b/test/nonlinearsystem.jl
@@ -380,3 +380,22 @@ end
     @test_throws ["single equation", "unknown"] IntervalNonlinearFunctionExpr(
         sys, (0.0, 1.0))
 end
+
+@testset "Overconditioned Initial Conditions" begin
+    # Define the nonlinear system
+    @variables x=1.0 y=0.0 z=0.0
+    @parameters σ=10.0 ρ=26.0 β=8 / 3
+
+    eqs = [0 ~ σ * (y - x),
+        0 ~ x * (ρ - z) - y,
+        0 ~ x * y - β * z]
+    @mtkbuild ns = NonlinearSystem(eqs, [x, y, z], [σ, ρ, β])
+
+    # Convert the symbolic system into a numerical system
+    prob = NonlinearProblem(ns, [])
+
+    # Solve the numerical problem
+    sol = solve(prob, NewtonRaphson())
+    @test SciMLBase.successful_retcode(sol)
+    @test norm(sol.resid) < 1e-12 
+end


### PR DESCRIPTION
```julia
using ModelingToolkit, NonlinearSolve

# Define the nonlinear system
@variables x=1.0 y z=0.0
@parameters σ=10.0 ρ=26.0 β=8 / 3

eqs = [0 ~ σ * (y - x),
    0 ~ x * (ρ - z) - y,
    0 ~ x * y - β * z]
@mtkbuild ns = NonlinearSystem(eqs, [x, y, z], [σ, ρ, β])

# Convert the symbolic system into a numerical system
prob = NonlinearProblem(ns, [])

# Solve the numerical problem
sol = solve(prob, NewtonRaphson())
```

This failed because of an initialization failure. This is because those conditions cannot be satisfied with the nonlinear system. But that doesn't make sense: the purpose of a nonlinear system is to find the set of values that satisfies the system. So this case should not be building initialization problems, there is no reason to assume that the user's initial guess satisfies the system, and in fact, you should assume if basically never does as the point is to solve the system.

There can be an argument to have the initialization specifically for the parameters, but that can be added in the future. For now, this is fixing a major regression and adding a test to make sure this doesn't regress again.

OptimizationSystem should be similarly checked as its initial conditions should be handled similarly.
