### PR TITLE
Do not attempt to promote to Union

### DIFF
--- a/src/systems/nonlinear/nonlinearsystem.jl
+++ b/src/systems/nonlinear/nonlinearsystem.jl
@@ -712,6 +712,9 @@ function SciMLBase.SCCNonlinearProblem{iip}(sys::NonlinearSystem, u0map,
             k = unwrap(k)
             v = unwrap(v)
             T = symtype(k)
+            while T isa Union
+                T = promote_type(T.a, T.b)
+            end
             buf = get!(() -> Any[], cachevars, T)
             push!(buf, v)
             buf = get!(() -> Any[], cacheexprs, T)


### PR DESCRIPTION
Sometimes `symtype` returns a union like `Union{Float64, Int64}`
```julia
julia> @variables x::Float64
1-element Vector{Num}:
 x

julia> ModelingToolkit.symtype(ifelse(x > 0, x, 0))
Union{Float64, Int64}
```


and then 
```julia
buf = get!(() -> Any[], cachevars, T)
```
fails.

This is (very) likely to occur with JSML, which appears to type things with `Float64`

## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
