### PR TITLE
fix: fix `DEF` parameters for `split = true, flatten = false` systems

### DIFF
--- a/src/systems/abstractsystem.jl
+++ b/src/systems/abstractsystem.jl
@@ -769,7 +769,9 @@ function complete(sys::AbstractSystem; split = true, flatten = true)
     end
     if split && has_index_cache(sys)
         @set! sys.index_cache = IndexCache(sys)
-        all_ps = get_ps(sys)
+        # Ideally we'd do `get_ps` but if `flatten = false`
+        # we don't get all of them. So we call `parameters`.
+        all_ps = parameters(sys; initial_parameters = true)
         if !isempty(all_ps)
             # reorder parameters by portions
             ps_split = reorder_parameters(sys, all_ps)

--- a/src/systems/systems.jl
+++ b/src/systems/systems.jl
@@ -50,7 +50,7 @@ function structural_simplify(
         newsys = pass(newsys)
     end
     if newsys isa ODESystem || has_parent(newsys)
-        @set! newsys.parent = complete(sys; split, flatten = false)
+        @set! newsys.parent = complete(sys; split = false, flatten = false)
     end
     newsys = complete(newsys; split)
     if newsys′ isa Tuple

--- a/test/fmi/fmi.jl
+++ b/test/fmi/fmi.jl
@@ -32,7 +32,7 @@ const FMU_DIR = joinpath(@__DIR__, "fmus")
     @testset "v2, CS" begin
         fmu = loadFMU("SpringPendulum1D", "Dymola", "2022x"; type = :CS)
         @named inner = MTK.FMIComponent(
-            Val(2); fmu, communication_step_size = 0.001, type = :CS)
+            Val(2); fmu, communication_step_size = 1e-5, type = :CS)
         @variables x(t) = 1.0
         @mtkbuild sys = ODESystem([D(x) ~ x], t; systems = [inner])
         test_no_inputs_outputs(sys)
@@ -66,7 +66,7 @@ const FMU_DIR = joinpath(@__DIR__, "fmus")
     @testset "v3, CS" begin
         fmu = loadFMU("SpringPendulum1D", "Dymola", "2023x", "3.0"; type = :CS)
         @named inner = MTK.FMIComponent(
-            Val(3); fmu, communication_step_size = 0.001, type = :CS)
+            Val(3); fmu, communication_step_size = 1e-5, type = :CS)
         @variables x(t) = 1.0
         @mtkbuild sys = ODESystem([D(x) ~ x], t; systems = [inner])
         test_no_inputs_outputs(sys)
@@ -210,7 +210,7 @@ end
     @testset "v3, CS" begin
         fmu = loadFMU(joinpath(FMU_DIR, "StateSpace.fmu"); type = :CS)
         @named sspace = MTK.FMIComponent(
-            Val(3); fmu, communication_step_size = 1e-4, type = :CS,
+            Val(3); fmu, communication_step_size = 1e-6, type = :CS,
             reinitializealg = BrownFullBasicInit())
         @test MTK.isinput(sspace.u)
         @test MTK.isoutput(sspace.y)
@@ -259,9 +259,9 @@ end
     @testset "v2, CS" begin
         fmu = loadFMU(joinpath(FMU_DIR, "SimpleAdder.fmu"); type = :CS)
         @named adder1 = MTK.FMIComponent(
-            Val(2); fmu, type = :CS, communication_step_size = 1e-3)
+            Val(2); fmu, type = :CS, communication_step_size = 1e-5)
         @named adder2 = MTK.FMIComponent(
-            Val(2); fmu, type = :CS, communication_step_size = 1e-3)
+            Val(2); fmu, type = :CS, communication_step_size = 1e-5)
         sys, prob = build_looped_adders(adder1, adder2)
         sol = solve(prob,
             Tsit5();
@@ -300,9 +300,9 @@ end
     @testset "v3, CS" begin
         fmu = loadFMU(joinpath(FMU_DIR, "StateSpace.fmu"); type = :CS)
         @named sspace1 = MTK.FMIComponent(
-            Val(3); fmu, type = :CS, communication_step_size = 1e-4)
+            Val(3); fmu, type = :CS, communication_step_size = 1e-5)
         @named sspace2 = MTK.FMIComponent(
-            Val(3); fmu, type = :CS, communication_step_size = 1e-4)
+            Val(3); fmu, type = :CS, communication_step_size = 1e-5)
         sys, prob = build_looped_sspace(sspace1, sspace2)
         sol = solve(prob, Rodas5P(autodiff = false); reltol = 1e-8)
         @test SciMLBase.successful_retcode(sol)

--- a/test/split_parameters.jl
+++ b/test/split_parameters.jl
@@ -275,3 +275,40 @@ end
         @test_nowarn sol = solve(prob)
     end
 end
+
+@testset "" begin
+    @mtkmodel SubSystem begin
+        @parameters begin
+            c = 1
+        end
+        @variables begin
+            x(t)
+        end
+        @equations begin
+            D(x) ~ c * x
+        end
+    end
+
+    @mtkmodel System begin
+        @components begin
+            subsys = SubSystem()
+        end
+        @parameters begin
+            k = 1
+        end
+        @variables begin
+            y(t)
+        end
+        @equations begin
+            D(y) ~ k * y + subsys.x
+        end
+    end
+
+    @named sys = System()
+    sysref = complete(sys)
+    sys2 = complete(sys; split = true, flatten = false)
+    ps = Set(full_parameters(sys2))
+    @test sysref.k in ps
+    @test sysref.subsys.c in ps
+    @test length(ps) == 2
+end


### PR DESCRIPTION
Close #3401, #3322 