### PR TITLE
Replace `vcat(eqs...)` with `reduce(vcat, eqs)`

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1217,7 +1217,9 @@ end
 Find all the unknowns and parameters from the equations of a SDESystem or ODESystem. Return re-ordered equations, differential variables, all variables, and parameters.
 """
 function process_equations(eqs, iv)
-    eltype(eqs) <: Vector && (eqs = vcat(eqs...))
+    if eltype(eqs) <: AbstractVector
+        eqs = reduce(vcat, eqs)
+    end
     eqs = collect(eqs)
 
     diffvars = OrderedSet()


### PR DESCRIPTION
A recent PR introduced this line. The splatting seems unnecessary.