### PR TITLE
feat: implement `SciMLBase.detect_cycles`

### DIFF
--- a/src/systems/problem_utils.jl
+++ b/src/systems/problem_utils.jl
@@ -897,6 +897,13 @@ function Base.showerror(io::IO, e::InvalidKeyError)
     println(io, "pmap: $(join(e.params, ", "))")
 end
 
+function SciMLBase.detect_cycles(sys::AbstractSystem, varmap::Dict{Any, Any}, vars)
+    varmap = AnyDict(unwrap(k) => unwrap(v) for (k, v) in varmap)
+    vars = map(unwrap, vars)
+    cycles = check_substitution_cycles(varmap, vars)
+    return !isempty(cycles)
+end
+
 ##############
 # Legacy functions for backward compatibility
 ##############


### PR DESCRIPTION
This was added to SciMLBase a while ago, but not implemented here. It adds cyclic dependency detection to `remake`.

Waiting on https://github.com/SciML/SciMLBase.jl/pull/943 to be able to run tests properly.