### PR TITLE
Fix: Make `build explicit observed function` return Expr when `expression=true`

### DIFF
--- a/src/systems/diffeqs/odesystem.jl
+++ b/src/systems/diffeqs/odesystem.jl
@@ -567,12 +567,18 @@ function build_explicit_observed_function(sys, ts;
         sys, ts, args...; p_start, p_end, filter_observed = obsfilter,
         output_type, mkarray, try_namespaced = true, expression = Val{true})
     if fns isa Tuple
+        if expression
+            return return_inplace ? fns : fns[1]
+        end
         oop, iip = eval_or_rgf.(fns; eval_expression, eval_module)
         f = GeneratedFunctionWrapper{(
             p_start + is_dde(sys), length(args) - length(ps) + 1 + is_dde(sys), is_split(sys))}(
             oop, iip)
         return return_inplace ? (f, f) : f
     else
+        if expression 
+            return fns 
+        end
         f = eval_or_rgf(fns; eval_expression, eval_module)
         f = GeneratedFunctionWrapper{(
             p_start + is_dde(sys), length(args) - length(ps) + 1 + is_dde(sys), is_split(sys))}(

--- a/src/systems/diffeqs/odesystem.jl
+++ b/src/systems/diffeqs/odesystem.jl
@@ -576,8 +576,8 @@ function build_explicit_observed_function(sys, ts;
             oop, iip)
         return return_inplace ? (f, f) : f
     else
-        if expression 
-            return fns 
+        if expression
+            return fns
         end
         f = eval_or_rgf(fns; eval_expression, eval_module)
         f = GeneratedFunctionWrapper{(

--- a/test/odesystem.jl
+++ b/test/odesystem.jl
@@ -578,11 +578,6 @@ obsfn = ModelingToolkit.build_explicit_observed_function(
     outersys, bar(3outersys.sys.ms, 3outersys.sys.p))
 @test_nowarn obsfn(sol.u[1], prob.p, sol.t[1])
 
-@testset "Observed Function: Expression" begin
-    obsfn_expr = ModelingToolkit.build_explicit_observed_function(
-        outersys, bar(3outersys.sys.ms, 3outersys.sys.p), expression = true)
-    @test obsfn_expr isa Expr
-end
 # x/x
 @variables x(t)
 @named sys = ODESystem([D(x) ~ x / x], t)
@@ -1230,13 +1225,6 @@ end
     buffer = zeros(3)
     @test_nowarn obsfn(buffer, [1.0], ps, 3.0)
     @test buffer ≈ [2.0, 3.0, 4.0]
-
-    @testset "Observed Function: Expression" begin
-        obsfn_expr_oop, obsfn_expr_iip = ModelingToolkit.build_explicit_observed_function(
-            sys, [x + 1, x + P, x + t], return_inplace = true, expression = true)
-        @test obsfn_expr_oop isa Expr
-        @test obsfn_expr_iip isa Expr
-    end
 end
 
 # https://github.com/SciML/ModelingToolkit.jl/issues/2818
@@ -1735,4 +1723,16 @@ end
     cons = [x(3) ~ [2, 3, 3, 5, 4]]
     @mtkbuild ode = ODESystem(D(x(t)) ~ mat * x(t), t; constraints = cons)
     @test length(constraints(ModelingToolkit.get_constraintsystem(ode))) == 5
+end
+
+@testset "`build_explicit_observed_function` with `expression = true` returns `Expr`" begin
+    @variables x(t)
+    @mtkbuild sys = ODESystem(D(x) ~ 2x, t)
+    obsfn_expr = ModelingToolkit.build_explicit_observed_function(
+        sys, 2x + 1, expression = true)
+    @test obsfn_expr isa Expr
+    obsfn_expr_oop, obsfn_expr_iip = ModelingToolkit.build_explicit_observed_function(
+        sys, [x + 1, x + 2, x + t], return_inplace = true, expression = true)
+    @test obsfn_expr_oop isa Expr
+    @test obsfn_expr_iip isa Expr
 end

--- a/test/odesystem.jl
+++ b/test/odesystem.jl
@@ -578,10 +578,11 @@ obsfn = ModelingToolkit.build_explicit_observed_function(
     outersys, bar(3outersys.sys.ms, 3outersys.sys.p))
 @test_nowarn obsfn(sol.u[1], prob.p, sol.t[1])
 
-obsfn_expr = ModelingToolkit.build_explicit_observed_function(
-    outersys, bar(3outersys.sys.ms, 3outersys.sys.p), expression = true)
-@test obsfn_expr isa Expr
-
+@testset "Observed Function: Expression" begin
+    obsfn_expr = ModelingToolkit.build_explicit_observed_function(
+        outersys, bar(3outersys.sys.ms, 3outersys.sys.p), expression = true)
+    @test obsfn_expr isa Expr
+end
 # x/x
 @variables x(t)
 @named sys = ODESystem([D(x) ~ x / x], t)
@@ -1230,10 +1231,12 @@ end
     @test_nowarn obsfn(buffer, [1.0], ps, 3.0)
     @test buffer ≈ [2.0, 3.0, 4.0]
 
-    obsfn_expr_oop, obsfn_expr_iip = ModelingToolkit.build_explicit_observed_function(
-        sys, [x + 1, x + P, x + t], return_inplace = true, expression = true)
-    @test obsfn_expr_oop isa Expr
-    @test obsfn_expr_iip isa Expr
+    @testset "Observed Function: Expression" begin
+        obsfn_expr_oop, obsfn_expr_iip = ModelingToolkit.build_explicit_observed_function(
+            sys, [x + 1, x + P, x + t], return_inplace = true, expression = true)
+        @test obsfn_expr_oop isa Expr
+        @test obsfn_expr_iip isa Expr
+    end
 end
 
 # https://github.com/SciML/ModelingToolkit.jl/issues/2818

--- a/test/odesystem.jl
+++ b/test/odesystem.jl
@@ -578,6 +578,11 @@ obsfn = ModelingToolkit.build_explicit_observed_function(
     outersys, bar(3outersys.sys.ms, 3outersys.sys.p))
 @test_nowarn obsfn(sol.u[1], prob.p, sol.t[1])
 
+obsfn_expr = ModelingToolkit.build_explicit_observed_function(
+        outersys, bar(3outersys.sys.ms, 3outersys.sys.p), expression = true)
+@test obsfn_expr isa Expr
+
+
 # x/x
 @variables x(t)
 @named sys = ODESystem([D(x) ~ x / x], t)
@@ -1225,6 +1230,11 @@ end
     buffer = zeros(3)
     @test_nowarn obsfn(buffer, [1.0], ps, 3.0)
     @test buffer ≈ [2.0, 3.0, 4.0]
+
+    obsfn_expr_oop, obsfn_expr_iip = ModelingToolkit.build_explicit_observed_function(
+        sys, [x + 1, x + P, x + t], return_inplace = true, expression = true)
+    @test obsfn_expr_oop isa Expr 
+    @test obsfn_expr_iip isa Expr
 end
 
 # https://github.com/SciML/ModelingToolkit.jl/issues/2818

--- a/test/odesystem.jl
+++ b/test/odesystem.jl
@@ -579,9 +579,8 @@ obsfn = ModelingToolkit.build_explicit_observed_function(
 @test_nowarn obsfn(sol.u[1], prob.p, sol.t[1])
 
 obsfn_expr = ModelingToolkit.build_explicit_observed_function(
-        outersys, bar(3outersys.sys.ms, 3outersys.sys.p), expression = true)
+    outersys, bar(3outersys.sys.ms, 3outersys.sys.p), expression = true)
 @test obsfn_expr isa Expr
-
 
 # x/x
 @variables x(t)
@@ -1233,7 +1232,7 @@ end
 
     obsfn_expr_oop, obsfn_expr_iip = ModelingToolkit.build_explicit_observed_function(
         sys, [x + 1, x + P, x + t], return_inplace = true, expression = true)
-    @test obsfn_expr_oop isa Expr 
+    @test obsfn_expr_oop isa Expr
     @test obsfn_expr_iip isa Expr
 end
 


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
