### PR TITLE
Reduce TTF`@mtkmodel`

### DIFF
--- a/src/ModelingToolkit.jl
+++ b/src/ModelingToolkit.jl
@@ -233,17 +233,17 @@ PrecompileTools.@compile_workload begin
         end
         if structp
             @variables begin
-                x(t) = 0.0, [description="foo", guess=1.0]
+                x(t) = 0.0, [description = "foo", guess = 1.0]
             end
         else
             @variables begin
-                x(t) = 0.0, [description="foo w/o structp", guess=1.0]
+                x(t) = 0.0, [description = "foo w/o structp", guess = 1.0]
             end
         end
         @parameters begin
-            a = 1.0, [description="bar"]
+            a = 1.0, [description = "bar"]
             if structp
-                b=2*a, [description="if"]
+                b = 2 * a, [description = "if"]
             else
                 c
             end
@@ -251,7 +251,7 @@ PrecompileTools.@compile_workload begin
         @equations begin
             x ~ a + b
         end
-    end;
+    end
 end
 
 export AbstractTimeDependentSystem,

--- a/src/ModelingToolkit.jl
+++ b/src/ModelingToolkit.jl
@@ -225,11 +225,20 @@ PrecompileTools.@compile_workload begin
     @named sys = ODESystem([ModelingToolkit.D_nounits(x) ~ -x], ModelingToolkit.t_nounits)
     prob = ODEProblem(structural_simplify(sys), [x => 30.0], (0, 100), [], jac = true)
     @mtkmodel __testmod__ begin
+        @constants begin
+            c = 1.0
+        end
         @structural_parameters begin
             structp = false
         end
-        @variables begin
-            x(t) = 0.0, [description="foo", guess=1.0]
+        if structp
+            @variables begin
+                x(t) = 0.0, [description="foo", guess=1.0]
+            end
+        else
+            @variables begin
+                x(t) = 0.0, [description="foo w/o structp", guess=1.0]
+            end
         end
         @parameters begin
             a = 1.0, [description="bar"]

--- a/src/ModelingToolkit.jl
+++ b/src/ModelingToolkit.jl
@@ -224,6 +224,25 @@ PrecompileTools.@compile_workload begin
     @variables x(ModelingToolkit.t_nounits)
     @named sys = ODESystem([ModelingToolkit.D_nounits(x) ~ -x], ModelingToolkit.t_nounits)
     prob = ODEProblem(structural_simplify(sys), [x => 30.0], (0, 100), [], jac = true)
+    @mtkmodel __testmod__ begin
+        @structural_parameters begin
+            structp = false
+        end
+        @variables begin
+            x(t) = 0.0, [description="foo", guess=1.0]
+        end
+        @parameters begin
+            a = 1.0, [description="bar"]
+            if structp
+                b=2*a, [description="if"]
+            else
+                c
+            end
+        end
+        @equations begin
+            x ~ a + b
+        end
+    end;
 end
 
 export AbstractTimeDependentSystem,

--- a/src/systems/model_parsing.jl
+++ b/src/systems/model_parsing.jl
@@ -640,7 +640,7 @@ function parse_constants!(exprs, dict, body, mod)
                 type = getfield(mod, type)
                 b = _type_check!(get_var(mod, b), a, type, :constants)
                 push!(exprs,
-                    :($(Symbolics_parse_vars(
+                    :($(Symbolics._parse_vars(
                         :constants, type, [:($a = $b), metadata], toconstant))))
                 dict[:constants][a] = Dict(:value => b, :type => type)
                 if @isdefined metadata
@@ -651,7 +651,7 @@ function parse_constants!(exprs, dict, body, mod)
             end
             Expr(:(=), a, Expr(:tuple, b, metadata)) => begin
                 push!(exprs,
-                    :($(Symbolics_parse_vars(
+                    :($(Symbolics._parse_vars(
                         :constants, Real, [:($a = $b), metadata], toconstant))))
                 dict[:constants][a] = Dict{Symbol, Any}(:value => get_var(mod, b))
                 for data in metadata.args
@@ -660,7 +660,7 @@ function parse_constants!(exprs, dict, body, mod)
             end
             Expr(:(=), a, b) => begin
                 push!(exprs,
-                    :($(Symbolics_parse_vars(
+                    :($(Symbolics._parse_vars(
                         :constants, Real, [:($a = $b)], toconstant))))
                 dict[:constants][a] = Dict(:value => get_var(mod, b))
             end
@@ -674,8 +674,6 @@ function parse_constants!(exprs, dict, body, mod)
         end
     end
 end
-# HACK: _parse_vars seems invalidated, so we use invokelatest
-Symbolics_parse_vars(x...) = invokelatest(Symbolics._parse_vars, x...)
 
 push_additional_defaults!(dict, a, b::Number) = dict[:defaults][a] = b
 push_additional_defaults!(dict, a, b::QuoteNode) = dict[:defaults][a] = b.value

--- a/src/systems/model_parsing.jl
+++ b/src/systems/model_parsing.jl
@@ -246,7 +246,8 @@ end
 # The comments indicate the syntax matched by a block; either when parsed directly
 # when it is called recursively for parsing a part of an expression.
 # These variable definitions are part of test suite in `test/model_parsing.jl`
-Base.@nospecializeinfer function parse_variable_def!(dict, mod, arg, varclass, kwargs, where_types;
+Base.@nospecializeinfer function parse_variable_def!(
+        dict, mod, arg, varclass, kwargs, where_types;
         def = nothing, type::Type = Real, meta = Dict{DataType, Expr}())
     @nospecialize
     arg isa LineNumberNode && return
@@ -1356,7 +1357,8 @@ push_something!(v, x...) = push_something!.(Ref(v), x)
 
 define_blocks(branch) = [Expr(branch), Expr(branch), Expr(branch), Expr(branch)]
 
-Base.@nospecializeinfer function parse_top_level_branch(condition, x, y = nothing, branch::Symbol = :if)
+Base.@nospecializeinfer function parse_top_level_branch(
+        condition, x, y = nothing, branch::Symbol = :if)
     @nospecialize
     blocks::Vector{Union{Expr, Nothing}} = component_blk, equations_blk, parameter_blk, variable_blk = define_blocks(branch)
 

--- a/src/systems/model_parsing.jl
+++ b/src/systems/model_parsing.jl
@@ -512,10 +512,9 @@ function generate_var!(dict, a, b, varclass, mod;
 end
 
 # Use the `t` defined in the `mod`. When it is unavailable, generate a new `t` with a warning.
-get_t(mod, t) = invokelatest(_get_t, mod, t)
-function _get_t(mod, t)
+function get_t(mod, t)
     try
-        _get_var(mod, t)
+        get_var(mod, t)
     catch e
         if e isa UndefVarError
             @warn("Could not find a predefined `t` in `$mod`; generating a new one within this model.\nConsider defining it or importing `t` (or `t_nounits`, `t_unitful` as `t`) from ModelingToolkit.")
@@ -590,8 +589,7 @@ function set_var_metadata(a, ms)
     a, metadata_with_exprs
 end
 
-get_var(mod, b) = invokelatest(_get_var, mod, b)
-function _get_var(mod::Module, b)
+function get_var(mod::Module, b)
     if b isa Symbol
         isdefined(mod, b) && return getproperty(mod, b)
         isdefined(@__MODULE__, b) && return getproperty(@__MODULE__, b)

--- a/src/systems/model_parsing.jl
+++ b/src/systems/model_parsing.jl
@@ -640,7 +640,7 @@ function parse_constants!(exprs, dict, body, mod)
                 type = getfield(mod, type)
                 b = _type_check!(get_var(mod, b), a, type, :constants)
                 push!(exprs,
-                    :($(Symbolics._parse_vars(
+                    :($(Symbolics_parse_vars(
                         :constants, type, [:($a = $b), metadata], toconstant))))
                 dict[:constants][a] = Dict(:value => b, :type => type)
                 if @isdefined metadata
@@ -651,7 +651,7 @@ function parse_constants!(exprs, dict, body, mod)
             end
             Expr(:(=), a, Expr(:tuple, b, metadata)) => begin
                 push!(exprs,
-                    :($(Symbolics._parse_vars(
+                    :($(Symbolics_parse_vars(
                         :constants, Real, [:($a = $b), metadata], toconstant))))
                 dict[:constants][a] = Dict{Symbol, Any}(:value => get_var(mod, b))
                 for data in metadata.args
@@ -660,7 +660,7 @@ function parse_constants!(exprs, dict, body, mod)
             end
             Expr(:(=), a, b) => begin
                 push!(exprs,
-                    :($(Symbolics._parse_vars(
+                    :($(Symbolics_parse_vars(
                         :constants, Real, [:($a = $b)], toconstant))))
                 dict[:constants][a] = Dict(:value => get_var(mod, b))
             end
@@ -674,6 +674,8 @@ function parse_constants!(exprs, dict, body, mod)
         end
     end
 end
+# HACK: _parse_vars seems invalidated, so we use invokelatest
+Symbolics_parse_vars(x...) = invokelatest(Symbolics._parse_vars, x...)
 
 push_additional_defaults!(dict, a, b::Number) = dict[:defaults][a] = b
 push_additional_defaults!(dict, a, b::QuoteNode) = dict[:defaults][a] = b.value

--- a/src/systems/model_parsing.jl
+++ b/src/systems/model_parsing.jl
@@ -246,8 +246,9 @@ end
 # The comments indicate the syntax matched by a block; either when parsed directly
 # when it is called recursively for parsing a part of an expression.
 # These variable definitions are part of test suite in `test/model_parsing.jl`
-function parse_variable_def!(dict, mod, arg, varclass, kwargs, where_types;
+Base.@nospecializeinfer function parse_variable_def!(dict, mod, arg, varclass, kwargs, where_types;
         def = nothing, type::Type = Real, meta = Dict{DataType, Expr}())
+    @nospecialize
     arg isa LineNumberNode && return
     MLStyle.@match arg begin
         # Parses: `a`

--- a/src/systems/model_parsing.jl
+++ b/src/systems/model_parsing.jl
@@ -1358,8 +1358,8 @@ push_something!(v, x...) = push_something!.(Ref(v), x)
 
 define_blocks(branch) = [Expr(branch), Expr(branch), Expr(branch), Expr(branch)]
 
-Base.@nospecializeinfer function parse_top_level_branch(condition, x::Expr, y::Union{Expr,Nothing} = nothing, branch::Symbol = :if)
-    @nospecialize condition x y
+Base.@nospecializeinfer function parse_top_level_branch(condition, x, y = nothing, branch::Symbol = :if)
+    @nospecialize
     blocks::Vector{Union{Expr, Nothing}} = component_blk, equations_blk, parameter_blk, variable_blk = define_blocks(branch)
 
     for arg in x


### PR DESCRIPTION
This PR attemts to reduce invaldiations of `@mtkmodel` code and thus enables precompilation of said macro. 

Still WIP, so far I've only removed invalidations on the toplevel `_model_macro` function, but this allready leads to a ~10s improvement in TTFX.

Below examples executed in new julia session
```julia
using ModelingToolkit
@time @eval @mtkmodel Mod begin
end;
# this PR
# 0.185190 seconds (735.61 k allocations: 37.985 MiB, 16.39% gc time, 97.47% compilation time: 91% of which was recompilation)
# master
# 16.592960 seconds (114.90 M allocations: 5.945 GiB, 9.04% gc time, 99.97% compilation time)
```
```julia
using ModelingToolkit
@time @eval @mtkmodel Mod begin
    @variables begin
        x(t)
        y(t)
    end
    @parameters begin
        p
    end
    @equations begin
        x ~ y + p
    end
end;
# this PR
# 12.499833 seconds (82.14 M allocations: 4.328 GiB, 9.96% gc time, 99.93% compilation time: 96% of which was recompilation)
# master
# 22.175370 seconds (121.23 M allocations: 6.330 GiB, 5.06% gc time, 99.96% compilation time: <1% of which was recompilation)
```

## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
