### PR TITLE
pass `ODESystem` kwargs via `@mtkmodel` constructor

### DIFF
--- a/src/systems/model_parsing.jl
+++ b/src/systems/model_parsing.jl
@@ -115,7 +115,8 @@ function _model_macro(mod, name, expr, isconnector)
         Ref(dict), [:constants, :defaults, :kwargs, :structural_parameters])
 
     sys = :($ODESystem($(flatten_equations)(equations), $iv, variables, parameters;
-        name, description = $description, systems, gui_metadata = $gui_metadata, defaults))
+        name, description = $description, systems,
+        gui_metadata = $gui_metadata, defaults, syskwargs...))
 
     if length(ext) == 0
         push!(exprs.args, :(var"#___sys___" = $sys))
@@ -137,11 +138,11 @@ function _model_macro(mod, name, expr, isconnector)
         ]))))
 
     f = if length(where_types) == 0
-        :($(Symbol(:__, name, :__))(; name, $(kwargs...)) = $exprs)
+        :($(Symbol(:__, name, :__))(; name, $(kwargs...), syskwargs...) = $exprs)
     else
         f_with_where = Expr(:where)
         push!(f_with_where.args,
-            :($(Symbol(:__, name, :__))(; name, $(kwargs...))), where_types...)
+            :($(Symbol(:__, name, :__))(; name, $(kwargs...), syskwargs...)), where_types...)
         :($f_with_where = $exprs)
     end
 

--- a/test/model_parsing.jl
+++ b/test/model_parsing.jl
@@ -1011,3 +1011,17 @@ end
         @test any(isequal(u), vars)
     end
 end
+
+@testset "Pass kwargs to ODESystem" begin
+    @mtkmodel UnitFailure begin
+        @variables begin
+            x(t), [unit = u"V"]
+            y(t), [unit = u"A"]
+        end
+        @equations begin
+            x ~ y
+        end
+    end
+    @test_throws ModelingToolkit.ValidationError UnitFailure(name = :uf)
+    UnitFailure(name = :uf, checks = false) # no error with passed kwarg
+end


### PR DESCRIPTION
I think it would be nice if you could pass kw args to the `ODESystem` constructor even if you system has been defined via `@mtkmodel`.
Motivating example:
```julia
    @mtkmodel UnitFailure begin
        @variables begin
            x(t), [unit = u"V"]
            y(t), [unit = u"A"]
        end
        @equations begin
            x ~ y
        end
    end
    UnitFailure(name = :uf, checks = false) # no error with passed kwarg
```

## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
 
