### PR TITLE
Fix ODEProblem over JumpProblem

### DIFF
--- a/src/systems/jumps/jumpsystem.jl
+++ b/src/systems/jumps/jumpsystem.jl
@@ -502,7 +502,7 @@ function DiffEqBase.ODEProblem(sys::JumpSystem, u0map, tspan::Union{Tuple, Nothi
     else
         _, u0, p = process_SciMLProblem(EmptySciMLFunction, sys, u0map, parammap;
             t = tspan === nothing ? nothing : tspan[1], tofloat = false,
-            check_length = false)
+            check_length = false, build_initializeprob = false)
         f = (du, u, p, t) -> (du .= 0; nothing)
         observedfun = ObservedFunctionCache(sys; eval_expression, eval_module,
             checkbounds = get(kwargs, :checkbounds, false))


### PR DESCRIPTION
I don't understand why tests didn't catch this, but it is causing us issues in Catalyst with initialization-related errors for variable rate jump problems (that have no coupled ODEs). Given `build_initializeprob = false` is set to false in the coupled ODE-jump case, it seems like it was just an oversight to not include it here too.