### PR TITLE
Fix depwarn due to wrapping `Vararg` directly in `UnionAll`

### DIFF
--- a/src/systems/connectors.jl
+++ b/src/systems/connectors.jl
@@ -448,7 +448,7 @@ ignored. All analysis points in `ignored_system_aps` must contain systems (conne
 as their input/outputs.
 """
 function systems_to_ignore(ignored_system_aps::Vector{HierarchyAnalysisPointT},
-        systems::Union{Vector{<:AbstractSystem}, Tuple{Vararg{<:AbstractSystem}}})
+        systems::Union{Vector{S}, Tuple{Vararg{S}}}) where S <: AbstractSystem
     to_ignore = HierarchySystemT[]
     for ap in ignored_system_aps
         # if `systems` contains the input of the AP, ignore any outputs of the AP present in it.
@@ -476,7 +476,7 @@ points to be ignored. All analysis points in `ignored_system_aps` must contain v
 as their input/outputs.
 """
 function variables_to_ignore(ignored_variable_aps::Vector{HierarchyAnalysisPointT},
-        systems::Union{Vector{<:AbstractSystem}, Tuple{Vararg{<:AbstractSystem}}})
+        systems::Union{Vector{S}, Tuple{Vararg{S}}}) where S <: AbstractSystem
     to_ignore = HierarchyVariableT[]
     for ap in ignored_variable_aps
         ivar_hierarchy = HierarchyVariableT([ap[1].input; @view ap[2:end]])
@@ -503,7 +503,7 @@ be ignored. All analysis points in `ignored_system_aps` must contain variables a
 input/outputs.
 """
 function variables_to_ignore(ignored_variable_aps::Vector{HierarchyAnalysisPointT},
-        vars::Union{Vector{<:BasicSymbolic}, Tuple{Vararg{<:BasicSymbolic}}})
+        vars::Union{Vector{S}, Tuple{Vararg{S}}}) where S <: BasicSymbolic
     to_ignore = eltype(vars)[]
     for ap in ignored_variable_aps
         ivar_hierarchy = HierarchyVariableT([ap[1].input; @view ap[2:end]])

--- a/src/systems/connectors.jl
+++ b/src/systems/connectors.jl
@@ -448,7 +448,7 @@ ignored. All analysis points in `ignored_system_aps` must contain systems (conne
 as their input/outputs.
 """
 function systems_to_ignore(ignored_system_aps::Vector{HierarchyAnalysisPointT},
-        systems::Union{Vector{S}, Tuple{Vararg{S}}}) where S <: AbstractSystem
+        systems::Union{Vector{S}, Tuple{Vararg{S}}}) where {S <: AbstractSystem}
     to_ignore = HierarchySystemT[]
     for ap in ignored_system_aps
         # if `systems` contains the input of the AP, ignore any outputs of the AP present in it.
@@ -476,7 +476,7 @@ points to be ignored. All analysis points in `ignored_system_aps` must contain v
 as their input/outputs.
 """
 function variables_to_ignore(ignored_variable_aps::Vector{HierarchyAnalysisPointT},
-        systems::Union{Vector{S}, Tuple{Vararg{S}}}) where S <: AbstractSystem
+        systems::Union{Vector{S}, Tuple{Vararg{S}}}) where {S <: AbstractSystem}
     to_ignore = HierarchyVariableT[]
     for ap in ignored_variable_aps
         ivar_hierarchy = HierarchyVariableT([ap[1].input; @view ap[2:end]])
@@ -503,7 +503,7 @@ be ignored. All analysis points in `ignored_system_aps` must contain variables a
 input/outputs.
 """
 function variables_to_ignore(ignored_variable_aps::Vector{HierarchyAnalysisPointT},
-        vars::Union{Vector{S}, Tuple{Vararg{S}}}) where S <: BasicSymbolic
+        vars::Union{Vector{S}, Tuple{Vararg{S}}}) where {S <: BasicSymbolic}
     to_ignore = eltype(vars)[]
     for ap in ignored_variable_aps
         ivar_hierarchy = HierarchyVariableT([ap[1].input; @view ap[2:end]])


### PR DESCRIPTION
This PR fixes depwarns introduced in https://github.com/SciML/ModelingToolkit.jl/pull/3469

cc @AayushSabharwal 

Starting julia with `--depwarn=error` results in

```julia
Precompiling ModelingToolkit...
Info Given ModelingToolkit was explicitly requested, output will be shown live 
ERROR: LoadError: Wrapping `Vararg` directly in UnionAll is deprecated (wrap the tuple instead).
You may need to write `f(x::Vararg{T})` rather than `f(x::Vararg{<:T})` or `f(x::Vararg{T}) where T` instead of `f(x::Vararg{T} where T)`.
Stacktrace:
 [1] UnionAll(v::Any, t::Any)
   @ Core ./boot.jl:299
 [2] top-level scope
   @ ~/.julia/packages/ModelingToolkit/r9J1w/src/systems/connectors.jl:442
 [3] include(mod::Module, _path::String)
   @ Base ./Base.jl:557
 [4] include(x::String)
   @ ModelingToolkit ~/.julia/packages/ModelingToolkit/r9J1w/src/ModelingToolkit.jl:4
 [5] top-level scope
   @ ~/.julia/packages/ModelingToolkit/r9J1w/src/ModelingToolkit.jl:157
 [6] include
   @ ./Base.jl:557 [inlined]
 [7] include_package_for_output(pkg::Base.PkgId, input::String, depot_path::Vector{String}, dl_load_path::Vector{String}, load_path::Vector{String}, concrete_deps::Vector{Pair{Base.PkgId, UInt128}}, source::Nothing)
   @ Base ./loading.jl:2881
 [8] top-level scope
   @ stdin:6
in expression starting at /home/sebastian/.julia/packages/ModelingToolkit/r9J1w/src/systems/connectors.jl:442
in expression starting at /home/sebastian/.julia/packages/ModelingToolkit/r9J1w/src/ModelingToolkit.jl:1
in expression starting at stdin:6
  ✗ ModelingToolkit
  ✗ ModelingToolkit → MTKChainRulesCoreExt
  1 dependency successfully precompiled in 14 seconds. 293 already precompiled.

ERROR: The following 2 direct dependencies failed to precompile:

ModelingToolkit 

Failed to precompile ModelingToolkit [961ee093-0014-501f-94e3-6117800e7a78] to "/home/sebastian/.julia/compiled/v1.11/ModelingToolkit/jl_rqOXzf".
ERROR: LoadError: Wrapping `Vararg` directly in UnionAll is deprecated (wrap the tuple instead).
You may need to write `f(x::Vararg{T})` rather than `f(x::Vararg{<:T})` or `f(x::Vararg{T}) where T` instead of `f(x::Vararg{T} where T)`.
Stacktrace:
 [1] UnionAll(v::Any, t::Any)
   @ Core ./boot.jl:299
 [2] top-level scope
   @ ~/.julia/packages/ModelingToolkit/r9J1w/src/systems/connectors.jl:442
 [3] include(mod::Module, _path::String)
   @ Base ./Base.jl:557
 [4] include(x::String)
   @ ModelingToolkit ~/.julia/packages/ModelingToolkit/r9J1w/src/ModelingToolkit.jl:4
 [5] top-level scope
   @ ~/.julia/packages/ModelingToolkit/r9J1w/src/ModelingToolkit.jl:157
 [6] include
   @ ./Base.jl:557 [inlined]
 [7] include_package_for_output(pkg::Base.PkgId, input::String, depot_path::Vector{String}, dl_load_path::Vector{String}, load_path::Vector{String}, concrete_deps::Vector{Pair{Base.PkgId, UInt128}}, source::Nothing)
   @ Base ./loading.jl:2881
 [8] top-level scope
   @ stdin:6
in expression starting at /home/sebastian/.julia/packages/ModelingToolkit/r9J1w/src/systems/connectors.jl:442
in expression starting at /home/sebastian/.julia/packages/ModelingToolkit/r9J1w/src/ModelingToolkit.jl:1
in expression starting at stdin:6
```