### PR TITLE
Improve parameters and full_parameters

### DIFF
--- a/src/systems/abstractsystem.jl
+++ b/src/systems/abstractsystem.jl
@@ -1330,9 +1330,13 @@ end
 """
 $(TYPEDSIGNATURES)
 
-Get the parameters of the system `sys` and its subsystems.
+Get the standard parameters of the system `sys` and its subsystems.
 
-See also [`@parameters`](@ref) and [`ModelingToolkit.get_ps`](@ref).
+# Keyword arguments
+
+- `initial_parameters`: Whether to include parameters for initial values of variables in the initialization system.
+
+See also [`full_parameters`](@ref) and [`ModelingToolkit.get_ps`](@ref).
 """
 function parameters(sys::AbstractSystem; initial_parameters = false)
     ps = get_ps(sys)
@@ -1387,6 +1391,13 @@ function parameter_dependencies(sys::AbstractSystem)
     return vcat(namespaced_deps, pdeps)
 end
 
+"""
+$(TYPEDSIGNATURES)
+
+Get all parameters of the system `sys` and its subsystems, including initial values and dependent parameters.
+
+See also [`parameters`](@ref) and [`ModelingToolkit.get_ps`](@ref).
+"""
 function full_parameters(sys::AbstractSystem)
     vcat(parameters(sys; initial_parameters = true), dependent_parameters(sys))
 end

--- a/src/systems/abstractsystem.jl
+++ b/src/systems/abstractsystem.jl
@@ -1339,7 +1339,8 @@ Get the standard parameters of the system `sys` and its subsystems.
 
 See also [`full_parameters`](@ref) and [`ModelingToolkit.get_ps`](@ref).
 """
-function parameters(sys::AbstractSystem; initial_parameters = false, dependent_parameters = false)
+function parameters(
+        sys::AbstractSystem; initial_parameters = false, dependent_parameters = false)
     ps = get_ps(sys)
     if ps == SciMLBase.NullParameters()
         return []
@@ -1349,7 +1350,7 @@ function parameters(sys::AbstractSystem; initial_parameters = false, dependent_p
     end
     systems = get_systems(sys)
     ps = unique(isempty(systems) ? ps :
-                    [ps; reduce(vcat, namespace_parameters.(systems))])
+                [ps; reduce(vcat, namespace_parameters.(systems))])
     if !initial_parameters && !is_initializesystem(sys)
         filter!(x -> !iscall(x) || !isa(operation(x), Initial), ps)
     end


### PR DESCRIPTION
"Fix" https://github.com/SciML/ModelingToolkit.jl/issues/3507, or at least try to prevent others from running into the same.

Is it breaking to rename the keyword argument `initial_parameters` to `initial`? I would prefer `initial` and `dependent` over `initial_parameters` and `dependent_parameters`. I think the latter is too verbose and would grow out of hand if more flags are added in the future.