### PR TITLE
Improve consistency and add parameter dependencies to system printing

### DIFF
--- a/src/systems/abstractsystem.jl
+++ b/src/systems/abstractsystem.jl
@@ -2045,6 +2045,11 @@ function Base.show(
         limited && printstyled(io, "\n  ⋮") # too many variables to print
     end
 
+    # Print parameter dependencies
+    npdeps = has_parameter_dependencies(sys) ? length(parameter_dependencies(sys)) : 0
+    npdeps > 0 && printstyled(io, "\nParameter dependencies ($npdeps):"; bold)
+    npdeps > 0 && hint && print(io, " see parameter_dependencies($name)")
+
     # Print observed
     nobs = has_observed(sys) ? length(observed(sys)) : 0
     nobs > 0 && printstyled(io, "\nObserved ($nobs):"; bold)

--- a/src/systems/diffeqs/odesystem.jl
+++ b/src/systems/diffeqs/odesystem.jl
@@ -717,10 +717,12 @@ function Base.show(io::IO, mime::MIME"text/plain", sys::ODESystem; hint = true, 
     invoke(Base.show, Tuple{typeof(io), typeof(mime), AbstractSystem},
         io, mime, sys; hint, bold)
 
+    name = nameof(sys)
+
     # Print initialization equations (unique to ODESystems)
     nini = length(initialization_equations(sys))
     nini > 0 && printstyled(io, "\nInitialization equations ($nini):"; bold)
-    nini > 0 && hint && print(io, " see initialization_equations(sys)")
+    nini > 0 && hint && print(io, " see initialization_equations($name)")
 
     return nothing
 end


### PR DESCRIPTION
Minor improvements. Now for example:

![image](https://github.com/user-attachments/assets/befa796a-d942-471f-936e-98924bef650c)
