### PR TITLE
fix: propagate `warn_initialize_determined` in `remake`

### DIFF
--- a/src/systems/nonlinear/initializesystem.jl
+++ b/src/systems/nonlinear/initializesystem.jl
@@ -575,7 +575,7 @@ function SciMLBase.remake_initialization_data(
                 resid_prototype = calculate_resid_prototype(
                     length(oldinitprob.f.resid_prototype), new_initu0, new_initp))
         end
-        initprob = remake(oldinitprob; f = newf, u0 = new_initu0, p = new_initp)
+        initprob = remake(oldinitprob; f = newf, u0 = new_initu0, p = new_initp, kwargs...)
         return SciMLBase.OverrideInitData(initprob, oldinitdata.update_initializeprob!,
             oldinitdata.initializeprobmap, oldinitdata.initializeprobpmap)
     end

--- a/src/systems/nonlinear/initializesystem.jl
+++ b/src/systems/nonlinear/initializesystem.jl
@@ -539,7 +539,7 @@ function is_parameter_solvable(p, pmap, defs, guesses)
 end
 
 function SciMLBase.remake_initialization_data(
-        sys::AbstractSystem, odefn, u0, t0, p, newu0, newp)
+        sys::AbstractSystem, odefn, u0, t0, p, newu0, newp, kwargs...)
     if u0 === missing && p === missing
         return odefn.initialization_data
     end
@@ -648,7 +648,7 @@ function SciMLBase.remake_initialization_data(
         u0map, pmap, defs, cmap, dvs, ps)
     kws = maybe_build_initialization_problem(
         sys, op, u0map, pmap, t0, defs, guesses, missing_unknowns;
-        use_scc, initialization_eqs, allow_incomplete = true)
+        use_scc, initialization_eqs, allow_incomplete = true, kwargs...)
     return get(kws, :initialization_data, nothing)
 end
 


### PR DESCRIPTION
Fix #3513, requires https://github.com/SciML/SciMLBase.jl/pull/978