### PR TITLE
[v10] feat: make `@named` always wrap arguments in `ParentScope`

### DIFF
--- a/src/systems/abstractsystem.jl
+++ b/src/systems/abstractsystem.jl
@@ -2371,11 +2371,7 @@ function default_to_parentscope(v)
     uv = unwrap(v)
     uv isa Symbolic || return v
     apply_to_variables(v) do sym
-        if !hasmetadata(uv, SymScope)
-            ParentScope(sym)
-        else
-            sym
-        end
+        ParentScope(sym)
     end
 end
 

--- a/test/components.jl
+++ b/test/components.jl
@@ -109,7 +109,7 @@ function rc_component(; name, R = 1, C = 1)
     @named p = Pin()
     @named n = Pin()
     @named resistor = Resistor(R = R) # test parent scope default of @named
-    @named capacitor = Capacitor(C = ParentScope(C))
+    @named capacitor = Capacitor(C = C)
     eqs = [connect(p, resistor.p);
            connect(resistor.n, capacitor.p);
            connect(capacitor.n, n)]


### PR DESCRIPTION
Let's see what this breaks.