### PR TITLE
test: test `@named` always wrapping in `ParentScope`

### DIFF
--- a/test/odesystem.jl
+++ b/test/odesystem.jl
@@ -9,6 +9,7 @@ using SymbolicUtils: issym
 using ForwardDiff
 using ModelingToolkit: value
 using ModelingToolkit: t_nounits as t, D_nounits as D
+using Symbolics: unwrap
 
 # Define some variables
 @parameters σ ρ β
@@ -1731,4 +1732,27 @@ end
         sys, [x + 1, x + 2, x + t], return_inplace = true, expression = true)
     @test obsfn_expr_oop isa Expr
     @test obsfn_expr_iip isa Expr
+end
+
+@testset "`@named` always wraps in `ParentScope`" begin
+    function SysA(; name, var1)
+        @variables x(t)
+        scope = ModelingToolkit.getmetadata(unwrap(var1), ModelingToolkit.SymScope, nothing)
+        @test scope isa ParentScope
+        @test scope.parent isa ParentScope
+        @test scope.parent.parent isa LocalScope
+        return ODESystem(D(x) ~ var1, t; name)
+    end
+    function SysB(; name, var1)
+        @variables x(t)
+        @named subsys = SysA(; var1)
+        return ODESystem(D(x) ~ x, t; systems = [subsys], name)
+    end
+    function SysC(; name)
+        @variables x(t)
+        @named subsys = SysB(; var1 = x)
+        return ODESystem(D(x) ~ x, t; systems = [subsys], name)
+    end
+    @mtkbuild sys = SysC()
+    @test length(unknowns(sys)) == 3
 end


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
