### PR TITLE
Fix ImperativeAffect namespacing for arrays in non-root components

### DIFF
--- a/src/systems/imperative_affect.jl
+++ b/src/systems/imperative_affect.jl
@@ -101,10 +101,22 @@ end
 
 namespace_affects(af::ImperativeAffect, s) = namespace_affect(af, s)
 function namespace_affect(affect::ImperativeAffect, s)
+    rmn = []
+    for modded in modified(affect)
+        if modded isa AbstractArray
+            res = []
+            for m in modded
+                push!(res, renamespace(s, m))
+            end
+            push!(rmn, res)
+        else 
+            push!(rmn, renamespace(s, modded))
+        end
+    end
     ImperativeAffect(func(affect),
         namespace_expr.(observed(affect), (s,)),
         observed_syms(affect),
-        renamespace.((s,), modified(affect)),
+        rmn,
         modified_syms(affect),
         context(affect),
         affect.skip_checks)


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
