### PR TITLE
fix: use `Diagonal` for diagonal mass matrices

### DIFF
--- a/src/systems/diffeqs/abstractodesystem.jl
+++ b/src/systems/diffeqs/abstractodesystem.jl
@@ -284,6 +284,9 @@ function calculate_massmatrix(sys::AbstractODESystem; simplify = false)
     end
     M = simplify ? ModelingToolkit.simplify.(M) : M
     # M should only contain concrete numbers
+    if isdiag(M)
+        M = Diagonal(M)
+    end
     M == I ? I : M
 end
 
@@ -410,6 +413,8 @@ function DiffEqBase.ODEFunction{iip, specialize}(sys::AbstractODESystem,
         SparseArrays.sparse(M)
     elseif u0 === nothing || M === I
         M
+    elseif M isa Diagonal
+        Diagonal(ArrayInterface.restructure(u0, diag(M)))
     else
         ArrayInterface.restructure(u0 .* u0', M)
     end

--- a/test/mass_matrix.jl
+++ b/test/mass_matrix.jl
@@ -1,4 +1,4 @@
-using OrdinaryDiffEq, ModelingToolkit, Test, LinearAlgebra
+using OrdinaryDiffEq, ModelingToolkit, Test, LinearAlgebra, StaticArrays
 using ModelingToolkit: t_nounits as t, D_nounits as D, MTKParameters
 
 @variables y(t)[1:3]
@@ -12,13 +12,18 @@ eqs = [D(y[1]) ~ -k[1] * y[1] + k[3] * y[2] * y[3],
 sys = complete(sys)
 @test_throws ArgumentError ODESystem(eqs, y[1])
 M = calculate_massmatrix(sys)
+@test M isa Diagonal
 @test M == [1 0 0
             0 1 0
             0 0 0]
 
 prob_mm = ODEProblem(sys, [y => [1.0, 0.0, 0.0]], (0.0, 1e5),
     [k => [0.04, 3e7, 1e4]])
+@test prob_mm.f.mass_matrix isa Diagonal{Float64, Vector{Float64}}
 sol = solve(prob_mm, Rodas5(), reltol = 1e-8, abstol = 1e-8)
+prob_mm = ODEProblem(sys, SA[y => [1.0, 0.0, 0.0]], (0.0, 1e5),
+    [k => [0.04, 3e7, 1e4]])
+@test prob_mm.f.mass_matrix isa Diagonal{Float64, SVector{3, Float64}}
 
 function rober(du, u, p, t)
     y₁, y₂, y₃ = u
@@ -43,3 +48,17 @@ eqs = [D(y[1]) ~ y[1], D(y[2]) ~ y[2], D(y[3]) ~ y[3]]
 @named sys = ODESystem(eqs, t, collect(y), [k])
 
 @test calculate_massmatrix(sys) === I
+
+@testset "Mass matrix `isa Diagonal` for `SDEProblem`" begin
+    eqs = [D(y[1]) ~ -k[1] * y[1] + k[3] * y[2] * y[3],
+        D(y[2]) ~ k[1] * y[1] - k[3] * y[2] * y[3] - k[2] * y[2]^2,
+        0 ~ y[1] + y[2] + y[3] - 1]
+
+    @named sys = ODESystem(eqs, t, collect(y), [k])
+    @named sys = SDESystem(sys, [1, 1, 0])
+    sys = complete(sys)
+    prob = SDEProblem(sys, [y => [1.0, 0.0, 0.0]], (0.0, 1e5), [k => [0.04, 3e7, 1e4]])
+    @test prob.f.mass_matrix isa Diagonal{Float64, Vector{Float64}}
+    prob = SDEProblem(sys, SA[y => [1.0, 0.0, 0.0]], (0.0, 1e5), [k => [0.04, 3e7, 1e4]])
+    @test prob.f.mass_matrix isa Diagonal{Float64, SVector{3, Float64}}
+end


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
