### PR TITLE
refactor: add error message for wrapped variable in `collect_var!`

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -606,6 +606,17 @@ end
 
 function collect_var!(unknowns, parameters, var, iv; depth = 0)
     isequal(var, iv) && return nothing
+    if Symbolics.iswrapped(var)
+        error("""
+        Internal Error. Please open an issue with an MWE.
+
+        Encountered a wrapped value in `collect_var!`. This function should only ever \
+        receive unwrapped symbolic variables. This is likely a bug in the code generating \
+        an expression passed to `collect_vars!` or `collect_scoped_vars!`. A common cause \
+        is using `substitute` or `fast_substitute` with rules where the values are \
+        wrapped symbolic variables.
+        """)
+    end
     check_scope_depth(getmetadata(var, SymScope, LocalScope()), depth) || return nothing
     var = setmetadata(var, SymScope, LocalScope())
     if iscalledparameter(var)


### PR DESCRIPTION
It is _very_ easy to end up with a wrapped variable (`Num`/`Arr`) in this function and think "this should just unwrap whatever it gets". That is not true, and this function should only ever receive unwrapped values. The error message makes this _very_ clear and helps avoid more insidious bugs involving `Num`s creeping inside symbolic expressions.