### PR TITLE
Less restrictive `promote_u0_p`

### DIFF
--- a/src/systems/nonlinear/initializesystem.jl
+++ b/src/systems/nonlinear/initializesystem.jl
@@ -601,7 +601,7 @@ function promote_u0_p(u0, p::MTKParameters, t0)
     return u0, p
 end
 
-function promote_u0_p(u0, p::AbstractArray, t0)
+function promote_u0_p(u0, p, t0)
     return DiffEqBase.promote_u0(u0, p, t0), DiffEqBase.promote_u0(p, u0, t0)
 end
 


### PR DESCRIPTION
https://github.com/SciML/ModelingToolkit.jl/pull/3572 broke our downstream code that uses `p::Function`s (to be evaluated at integration time `t`) as parameters.

Given that none of the other involved functions restricts `p` explicitly to a `Union{AbstractArray,MTKParameters}`, IMO it seems natural to use `DiffEqBase.promote_u0` as a generic fallback and not only in the case `p::AbstractArray`.
