### PR TITLE
Fix @mtkmodel to work without using ModelingToolkit

### DIFF
--- a/src/systems/model_parsing.jl
+++ b/src/systems/model_parsing.jl
@@ -42,8 +42,9 @@ function flatten_equations(eqs::Vector{Union{Equation, Vector{Equation}}})
 end
 
 function _model_macro(mod, fullname::Union{Expr, Symbol}, expr, isconnector)
+    MTK = ModelingToolkit
     if fullname isa Symbol
-        name, type = fullname, :System
+        name, type = fullname, :($MTK.System)
     else
         if fullname.head == :(::)
             name, type = fullname.args
@@ -74,9 +75,9 @@ function _model_macro(mod, fullname::Union{Expr, Symbol}, expr, isconnector)
     push!(exprs.args, :(parameters = []))
     # We build `System` by default; vectors can't be created for `System` as it is
     # a function.
-    push!(exprs.args, :(systems = ModelingToolkit.AbstractSystem[]))
-    push!(exprs.args, :(equations = Union{Equation, Vector{Equation}}[]))
-    push!(exprs.args, :(defaults = Dict{Num, Union{Number, Symbol, Function}}()))
+    push!(exprs.args, :(systems = $MTK.AbstractSystem[]))
+    push!(exprs.args, :(equations = Union{$MTK.Equation, Vector{$MTK.Equation}}[]))
+    push!(exprs.args, :(defaults = Dict{$MTK.Num, Union{Number, Symbol, Function}}()))
 
     Base.remove_linenums!(expr)
     for arg in expr.args

--- a/test/model_parsing.jl
+++ b/test/model_parsing.jl
@@ -1058,3 +1058,24 @@ end
     @test isequal(constrs[2], -4 + ex.y ≲ 0)
     @test ModelingToolkit.get_consolidate(ex)([1, 2]) ≈ 1 + log(2)
 end
+
+module NoUsingMTK  # From #3640
+using ModelingToolkit: @mtkmodel, @variables, @parameters, t_nounits as t
+
+@mtkmodel MyModel begin
+    @variables begin
+        x(t)
+        y(t)
+    end
+    @parameters begin
+        a
+    end
+    @equations begin
+        y ~ a * x
+    end
+end
+end
+
+@testset "Model can be defined even without `using MTK` (#3640)" begin
+    @test NoUsingMTK.MyModel(; name=:foo) isa ModelingToolkit.AbstractSystem  # just test that it ran fine
+end


### PR DESCRIPTION
Fix #3640 

Incidentally,  `include("test/model_parsing.jl")` at the REPL fails with 

```julia
ERROR: LoadError: IOError: stat("//www.w3.org/2000\\svg\" width=\"80\" height=\"30\">\n<path d=\"M10 15\nl15 0\nl2.5 -5\nl5 10\nl5 -10\nl5 10\nl5 -10\nl5 10\nl2.5 -5\nl15 0\" stroke=\"black\" stroke-width=\"1\" stroke-linejoin=\"bevel\" fill=\"none\"><\\path>\n<\\svg>\n"): unknown error (UNKNOWN)
```
on Windows. Is there any easy fix for that?