### PR TITLE
Fix initialization with non-1-indexed array variables

### DIFF
--- a/src/systems/problem_utils.jl
+++ b/src/systems/problem_utils.jl
@@ -161,7 +161,11 @@ function add_fallbacks!(
                 val = @something get(varmap, arrvar, nothing) get(varmap, ttarrvar, nothing) get(
                     fallbacks, arrvar, nothing) get(fallbacks, ttarrvar, nothing) Some(nothing)
                 if val !== nothing
-                    val = val[idxs...]
+                    idxs = CartesianIndex(idxs...)
+                    if iscall(val) && operation(val) == StructuralTransformations.change_origin # TODO: remove hack
+                        idxs -= arguments(val)[1] - eachindex(val)[1] # subtract non-1-based offset
+                    end
+                    val = val[idxs]
                     is_sized_array_symbolic(arrvar) && push!(arrvars, arrvar)
                 end
             else


### PR DESCRIPTION
An attempt at fixing https://github.com/SciML/ModelingToolkit.jl/issues/3659.

Is there a cleaner way to do it, without the `if change_origin` "hack"?