### PR TITLE
don't error on implicit parameter equation

### DIFF
--- a/src/systems/abstractsystem.jl
+++ b/src/systems/abstractsystem.jl
@@ -2808,18 +2808,16 @@ function process_parameter_equations(sys::AbstractSystem)
         vars!(varsbuf, eq; op = Union{Differential, Initial, Pre})
         # singular equations
         isempty(varsbuf) && continue
+
+        # only consider explicit parameter dependencies
+        isparameter(eq.lhs) || continue
+
         if all(varsbuf) do sym
             is_parameter(sys, sym) ||
                 symbolic_type(sym) == ArraySymbolic() &&
-                    is_sized_array_symbolic(sym) &&
-                    all(Base.Fix1(is_parameter, sys), collect(sym))
+                is_sized_array_symbolic(sym) &&
+                all(Base.Fix1(is_parameter, sys), collect(sym))
         end
-            if !isparameter(eq.lhs)
-                throw(ArgumentError("""
-                LHS of parameter dependency equation must be a single parameter. Found \
-                $(eq.lhs).
-                """))
-            end
             push!(pareq_idxs, i)
         end
     end

--- a/test/input_output_handling.jl
+++ b/test/input_output_handling.jl
@@ -465,3 +465,17 @@ end
     x = [1.0]
     @test_nowarn f[1](x, u, p, 0.0)
 end
+
+@testset "implicit focing of inputs" begin
+    @mtkmodel ImplicitForcing begin
+        @variables begin
+            u(t), [description = "Input Variable", input=true]
+            y(t), [description = "fully implicit output", output=true]
+        end
+        @equations begin
+            0 ~ sqrt(u) # implicitly forces output y because u=f(y) in  closed loop
+        end
+    end
+    @named implicit = ImplicitForcing()
+    mtkcompile(implicit; inputs = unbound_inputs(implicit)) # test for no error
+end


### PR DESCRIPTION
I use MTK to generate "open loop" models. In closed loop loop, it is possible that the input of a system directly depends on its output, i.e. $u_a = f(y_a)$.
```
 ┌────────┐y_a = u_b┌────────┐  
 │System A├──────→──┤System B│
 └────────┘         └────────┘
     └─────────←────────┘
     u_a       =      y_b
```
This means you may implicitly force $y_a$ by constraining $u_a$. Under those conditions, it makes sense to define implicit equations on inputs (which are handled as parameters internally). MTK@10 does not allow this anymore, because it sees an equation containing only parameters and requires it to be an explicit parameter equation.

Instead of throwing, I think it should just leave the equation as it is.
Alternatively, one could check if any of the parameters is an input and throws otherwise.

Example:
```julia
    @mtkmodel ImplicitForcing begin
        @variables begin
            u(t), [description = "Input Variable", input=true]
            y(t), [description = "fully implicit output", output=true]
        end
        @equations begin
            0 ~ sqrt(u) # implicitly forces output y because u=f(y) in  closed loop
        end
    end
    @named implicit = ImplicitForcing()
    mtkcompile(implicit; inputs = unbound_inputs(implicit)) # errors
```
```
ERROR: ArgumentError: LHS of parameter dependency equation must be a single parameter. Found 0.
```
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
