### PR TITLE
ci: add benchmark CI

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,24 @@
+name: Benchmark this PR
+on:
+  pull_request:
+    branches:
+      - master
+    paths-ignore:
+      - 'docs/**'
+
+permissions:
+  pull-requests: write    # needed to post comments
+
+jobs:
+  bench:
+    name: "Benchmarks"
+    strategy:
+      matrix:
+        version:
+          - "1"
+          - "lts"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: MilesCranmer/AirspeedVelocity.jl@action-v1
+        with:
+          julia-version: "${{ matrix.version }}"

--- a/benchmark/Project.toml
+++ b/benchmark/Project.toml
@@ -1,0 +1,3 @@
+[deps]
+ModelingToolkitStandardLibrary = "16a59e39-deab-5bd0-87e4-056b12336739"
+OrdinaryDiffEqDefault = "50262376-6c5a-4cf5-baba-aaf4f84d72d7"

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -1,0 +1,54 @@
+using ModelingToolkit, BenchmarkTools
+using ModelingToolkitStandardLibrary
+using ModelingToolkitStandardLibrary.Thermal
+using OrdinaryDiffEqDefault
+
+const SUITE = BenchmarkGroup()
+
+@mtkmodel DCMotor begin
+    @structural_parameters begin
+        R = 0.5
+        L = 4.5e-3
+        k = 0.5
+        J = 0.02
+        f = 0.01
+        V_step = 10
+        tau_L_step = -3
+    end
+    @components begin
+        ground = Ground()
+        source = Voltage()
+        voltage_step = Blocks.Step(height = V_step, start_time = 0)
+        R1 = Resistor(R = R)
+        L1 = Inductor(L = L, i = 0.0)
+        emf = EMF(k = k)
+        fixed = Fixed()
+        load = Torque()
+        load_step = Blocks.Step(height = tau_L_step, start_time = 3)
+        inertia = Inertia(J = J)
+        friction = Damper(d = f)
+    end
+    @equations begin
+        connect(fixed.flange, emf.support, friction.flange_b)
+        connect(emf.flange, friction.flange_a, inertia.flange_a)
+        connect(inertia.flange_b, load.flange)
+        connect(load_step.output, load.tau)
+        connect(voltage_step.output, source.V)
+        connect(source.p, R1.p)
+        connect(R1.n, L1.p)
+        connect(L1.n, emf.p)
+        connect(emf.n, source.n, ground.g)
+    end
+end
+
+@named model = DCMotor()
+
+SUITE["mtkcompile"] = @benchmarkable mtkcompile($model)
+
+model = mtkcompile(model)
+u0 = unknowns(model) .=> 0.0
+tspan = (0.0, 6.0)
+SUITE["ODEProblem"] = @benchmarkable ODEProblem($model, $u0, $tspan)
+
+prob = ODEProblem(model, u0, tspan)
+SUITE["init"] = init($prob)


### PR DESCRIPTION
This adds a small benchmark workflow to run on PRs so we can be aware of any regressions such as the one fixed by #3693 