### PR TITLE
fix: fix deprecated `@brownian` not working properly

### DIFF
--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -175,5 +175,5 @@ macro brownian(xs...)
     return quote
         Base.depwarn("`@brownian` is deprecated. Use `@brownians` instead", :brownian_macro)
         $(@__MODULE__).@brownians $(xs...)
-    end
+    end |> esc
 end

--- a/test/sdesystem.jl
+++ b/test/sdesystem.jl
@@ -948,4 +948,8 @@ end
 
 @testset "`@brownian` is deprecated" begin
     @test_deprecated @brownian a b c
+
+    @brownian p q
+    @test ModelingToolkit.isbrownian(p)
+    @test ModelingToolkit.isbrownian(q)
 end


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
