### PR TITLE
Trivial optimization in generate_initializesystem

### DIFF
--- a/src/systems/nonlinear/initializesystem.jl
+++ b/src/systems/nonlinear/initializesystem.jl
@@ -71,7 +71,6 @@ function generate_initializesystem_timevarying(sys::AbstractSystem;
     eqs_ics = Equation[]
     defs = copy(defaults(sys)) # copy so we don't modify sys.defaults
     additional_guesses = anydict(guesses)
-    additional_initialization_eqs = Vector{Equation}(initialization_eqs)
     guesses = merge(get_guesses(sys), additional_guesses)
     idxs_diff = isdiffeq.(eqs)
 
@@ -230,12 +229,10 @@ function generate_initializesystem_timeindependent(sys::AbstractSystem;
     eqs = equations(sys)
     trueobs, eqs = unhack_observed(observed(sys), eqs)
     vars = unique([unknowns(sys); getfield.(trueobs, :lhs)])
-    vars_set = Set(vars) # for efficient in-lookup
 
     eqs_ics = Equation[]
     defs = copy(defaults(sys)) # copy so we don't modify sys.defaults
     additional_guesses = anydict(guesses)
-    additional_initialization_eqs = Vector{Equation}(initialization_eqs)
     guesses = merge(get_guesses(sys), additional_guesses)
 
     # PREPROCESSING

--- a/src/systems/nonlinear/initializesystem.jl
+++ b/src/systems/nonlinear/initializesystem.jl
@@ -41,7 +41,7 @@ end
 """
 $(TYPEDSIGNATURES)
 
-Generate `System` of nonlinear equations which initializes a problem from specified initial conditions of an `AbstractTimeDependentSystem`.
+Generate `System` of nonlinear equations which initializes a problem from specified initial conditions of a time-dependent `AbstractSystem`.
 """
 function generate_initializesystem_timevarying(sys::AbstractSystem;
         op = Dict(),
@@ -218,7 +218,7 @@ end
 """
 $(TYPEDSIGNATURES)
 
-Generate `System` of nonlinear equations which initializes a problem from specified initial conditions of an `AbstractTimeDependentSystem`.
+Generate `System` of nonlinear equations which initializes a problem from specified initial conditions of a time-independent `AbstractSystem`.
 """
 function generate_initializesystem_timeindependent(sys::AbstractSystem;
         op = Dict(),

--- a/src/systems/nonlinear/initializesystem.jl
+++ b/src/systems/nonlinear/initializesystem.jl
@@ -190,11 +190,13 @@ function generate_initializesystem_timevarying(sys::AbstractSystem;
     push!(pars, get_iv(sys))
 
     # 8) use observed equations for guesses of observed variables if not provided
+    guessed = Set(keys(defs)) # x(t), D(x(t)), ...
+    guessed = union(guessed, Set(default_toterm.(guessed))) # x(t), D(x(t)), xˍt(t), ...
     for eq in trueobs
-        haskey(defs, eq.lhs) && continue
-        any(x -> isequal(default_toterm(x), eq.lhs), keys(defs)) && continue
-
-        defs[eq.lhs] = eq.rhs
+        if !(eq.lhs in guessed)
+            defs[eq.lhs] = eq.rhs
+            #push!(guessed, eq.lhs) # should not encounter eq.lhs twice, so don't need to track it
+        end
     end
     append!(eqs_ics, trueobs)
 

--- a/src/systems/systemstructure.jl
+++ b/src/systems/systemstructure.jl
@@ -431,7 +431,7 @@ function TearingState(sys; quick_cancel = false, check = true, sort_eqs = true)
     if sort_eqs
         # sort equations lexicographically to reduce simplification issues
         # depending on order due to NP-completeness of tearing.
-        sortidxs = Base.sortperm(eqs, by = string)
+        sortidxs = Base.sortperm(string.(eqs)) # "by = string" creates more strings
         eqs = eqs[sortidxs]
         original_eqs = original_eqs[sortidxs]
         symbolic_incidence = symbolic_incidence[sortidxs]


### PR DESCRIPTION
During profiling of `ODEProblem` in this example of my package, I found I saw being slowed down a lot by the line that calls `default_toterm` on every element in `keys(defs)` for every iteration in the loop, which I think could simply be precomputed before the loop.
```julia
using SymBoltz # https://github.com/hersle/SymBoltz.jl
using BenchmarkTools
M = ΛCDM() # a big System
Ms = mtkcompile(M)
pars = SymBoltz.parameters_Planck18(M) # some sym-to-num parameter dict
pars[M.k] = 1.0
@btime prob = ODEProblem(Ms, pars, (0.0, 10.0))
```
Before PR:
```
  2.607 s (27144415 allocations: 803.71 MiB)
```
After PR:
```
  995.616 ms (9386044 allocations: 317.20 MiB)
```
These changes give me a 3x speedup in construction of a big problem, and I think the logic should be equivalent before and after.