### PR TITLE
correct `sys.mass_a` to ``sys.mass_a`` in FMU example

### DIFF
--- a/docs/src/tutorials/fmi.md
+++ b/docs/src/tutorials/fmi.md
@@ -85,7 +85,7 @@ We can interpolate the solution object to obtain values at arbitrary time points
 just like a normal solution.
 
 ```@repl fmi
-sol(0.0:0.1:1.0; idxs = sys.mass_a)
+sol(0.0:0.1:1.0; idxs = sys.mass__a)
 ```
 
 FMUs following version 3 of the specification can be simulated with almost the same process. This time,


### PR DESCRIPTION
correct `sys.mass_a` to ``sys.mass_a`` in FMU example

## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

I only added `_` for acceleration parameter inside the FMU importing example 
