### PR TITLE
Disable unit checking of initialization problem during remake

### DIFF
--- a/src/systems/nonlinear/initializesystem.jl
+++ b/src/systems/nonlinear/initializesystem.jl
@@ -662,7 +662,7 @@ function SciMLBase.remake_initialization_data(
     kws = maybe_build_initialization_problem(
         sys, SciMLBase.isinplace(odefn), op, t0, defs, guesses,
         missing_unknowns; time_dependent_init, use_scc, initialization_eqs, floatT,
-        u0_constructor, p_constructor, allow_incomplete = true)
+        u0_constructor, p_constructor, allow_incomplete = true, check_units=false)
 
     odefn = remake(odefn; kws...)
     return SciMLBase.remake_initialization_data(sys, odefn, newu0, t0, newp, newu0, newp)

--- a/src/systems/nonlinear/initializesystem.jl
+++ b/src/systems/nonlinear/initializesystem.jl
@@ -662,7 +662,7 @@ function SciMLBase.remake_initialization_data(
     kws = maybe_build_initialization_problem(
         sys, SciMLBase.isinplace(odefn), op, t0, defs, guesses,
         missing_unknowns; time_dependent_init, use_scc, initialization_eqs, floatT,
-        u0_constructor, p_constructor, allow_incomplete = true, check_units=false)
+        u0_constructor, p_constructor, allow_incomplete = true, check_units = false)
 
     odefn = remake(odefn; kws...)
     return SciMLBase.remake_initialization_data(sys, odefn, newu0, t0, newp, newu0, newp)

--- a/test/initializationsystem.jl
+++ b/test/initializationsystem.jl
@@ -1112,6 +1112,10 @@ end
         guesses = ModelingToolkit.missing_variable_defaults(pend))
     sol = solve(prob, Rodas5P())
     @test SciMLBase.successful_retcode(sol)
+
+    prob2 = remake(prob, u0=[x => 0.5, y=>nothing])
+    sol2 = solve(prob2, Rodas5P())
+    @test SciMLBase.successful_retcode(sol2)
 end
 
 @testset "Issue#3205" begin

--- a/test/initializationsystem.jl
+++ b/test/initializationsystem.jl
@@ -1113,7 +1113,7 @@ end
     sol = solve(prob, Rodas5P())
     @test SciMLBase.successful_retcode(sol)
 
-    prob2 = remake(prob, u0=[x => 0.5, y=>nothing])
+    prob2 = remake(prob, u0 = [x => 0.5, y=>nothing])
     sol2 = solve(prob2, Rodas5P())
     @test SciMLBase.successful_retcode(sol2)
 end


### PR DESCRIPTION
This is the default during problem construction (problem_utils.jl:1305). Partial fix for #3283.

## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context
