### PR TITLE
refactor: use `@deprecate_binding` to deprecate `ODESystem`

### DIFF
--- a/src/ModelingToolkit.jl
+++ b/src/ModelingToolkit.jl
@@ -138,9 +138,6 @@ $(TYPEDEF)
 TODO
 """
 abstract type AbstractSystem end
-# Solely so that `ODESystem` can be deprecated and still act as a valid type.
-# See `deprecations.jl`.
-abstract type IntermediateDeprecationSystem <: AbstractSystem end
 
 function independent_variable end
 

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -9,13 +9,7 @@ macro mtkbuild(exprs...)
     end |> esc
 end
 
-const ODESystem = IntermediateDeprecationSystem
-
-function IntermediateDeprecationSystem(args...; kwargs...)
-    Base.depwarn("`ODESystem(args...; kwargs...)` is deprecated. Use `System(args...; kwargs...) instead`.", :ODESystem)
-
-    return System(args...; kwargs...)
-end
+Base.@deprecate_binding ODESystem System
 
 for T in [:NonlinearSystem, :DiscreteSystem, :ImplicitDiscreteSystem]
     @eval @deprecate $T(args...; kwargs...) System(args...; kwargs...)

--- a/src/systems/system.jl
+++ b/src/systems/system.jl
@@ -24,7 +24,7 @@ structure.
 
 $(TYPEDFIELDS)
 """
-struct System <: IntermediateDeprecationSystem
+struct System <: AbstractSystem
     """
     $INTERNAL_FIELD_WARNING
     A unique integer tag for the system.


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
