### PR TITLE
fix: fix @mtkbuild not working when @mtkcompile is not imported

### DIFF
--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -5,7 +5,8 @@
 macro mtkbuild(exprs...)
     return quote
         Base.depwarn("`@mtkbuild` is deprecated. Use `@mtkcompile` instead.", :mtkbuild)
-        @mtkcompile $(exprs...)
+        $(Expr(:macrocall, var"@mtkcompile",
+            LineNumberNode(@__LINE__, @__FILE__), exprs...))
     end |> esc
 end
 

--- a/test/odesystem.jl
+++ b/test/odesystem.jl
@@ -1615,3 +1615,12 @@ end
     @test_nowarn push!(arr, sys)
     @test_nowarn TestWrapper(sys)
 end
+
+# ensure `@mtkbuild` works when `@mtkcompile` is not imported
+module MtkbuildTestModule
+import ModelingToolkit: @variables, System, t_nounits as t, D_nounits as D, @mtkbuild
+import Test: @test
+@variables x(t)
+@mtkbuild sys = System(D(x) ~ t, t)
+@test sys isa System
+end


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
