### PR TITLE
Remove outdated Julia version checks from tests

### DIFF
--- a/test/clock.jl
+++ b/test/clock.jl
@@ -298,42 +298,6 @@ eqs = [yd ~ Sample(dt)(y)
     ss = mtkcompile(cl)
     ss_nosplit = mtkcompile(cl; split = false)
 
-    prob = ODEProblem(ss, [x => 0.0, kp => 1.0], (0.0, 1.0))
-    prob_nosplit = ODEProblem(ss_nosplit, [x => 0.0, kp => 1.0], (0.0, 1.0))
-    sol = solve(prob, Tsit5(), kwargshandle = KeywordArgSilent)
-    sol_nosplit = solve(prob_nosplit, Tsit5(), kwargshandle = KeywordArgSilent)
-
-    function foo!(dx, x, p, t)
-        kp, ud1, ud2 = p
-        dx[1] = -x[1] + ud1 + ud2
-    end
-
-    function affect1!(integrator)
-        kp = integrator.p[1]
-        y = integrator.u[1]
-        r = 1.0
-        ud1 = kp * (r - y)
-        integrator.p[2] = ud1
-        nothing
-    end
-    function affect2!(integrator)
-        kp = integrator.p[1]
-        y = integrator.u[1]
-        r = 1.0
-        ud2 = kp * (r - y)
-        integrator.p[3] = ud2
-        nothing
-    end
-    cb1 = PeriodicCallback(affect1!, dt; final_affect = true, initial_affect = true)
-    cb2 = PeriodicCallback(affect2!, dt2; final_affect = true, initial_affect = true)
-    cb = CallbackSet(cb1, cb2)
-    #                                           kp   ud1  ud2
-    prob = ODEProblem(foo!, [0.0], (0.0, 1.0), [1.0, 1.0, 1.0], callback = cb)
-    sol2 = solve(prob, Tsit5())
-
-    @test sol.u≈sol2.u atol=1e-6
-    @test sol_nosplit.u≈sol2.u atol=1e-6
-
     ##
     @info "Testing hybrid system with components"
     using ModelingToolkitStandardLibrary.Blocks

--- a/test/clock.jl
+++ b/test/clock.jl
@@ -298,43 +298,41 @@ eqs = [yd ~ Sample(dt)(y)
     ss = mtkcompile(cl)
     ss_nosplit = mtkcompile(cl; split = false)
 
-    if VERSION >= v"1.7"
-        prob = ODEProblem(ss, [x => 0.0, kp => 1.0], (0.0, 1.0))
-        prob_nosplit = ODEProblem(ss_nosplit, [x => 0.0, kp => 1.0], (0.0, 1.0))
-        sol = solve(prob, Tsit5(), kwargshandle = KeywordArgSilent)
-        sol_nosplit = solve(prob_nosplit, Tsit5(), kwargshandle = KeywordArgSilent)
+    prob = ODEProblem(ss, [x => 0.0, kp => 1.0], (0.0, 1.0))
+    prob_nosplit = ODEProblem(ss_nosplit, [x => 0.0, kp => 1.0], (0.0, 1.0))
+    sol = solve(prob, Tsit5(), kwargshandle = KeywordArgSilent)
+    sol_nosplit = solve(prob_nosplit, Tsit5(), kwargshandle = KeywordArgSilent)
 
-        function foo!(dx, x, p, t)
-            kp, ud1, ud2 = p
-            dx[1] = -x[1] + ud1 + ud2
-        end
-
-        function affect1!(integrator)
-            kp = integrator.p[1]
-            y = integrator.u[1]
-            r = 1.0
-            ud1 = kp * (r - y)
-            integrator.p[2] = ud1
-            nothing
-        end
-        function affect2!(integrator)
-            kp = integrator.p[1]
-            y = integrator.u[1]
-            r = 1.0
-            ud2 = kp * (r - y)
-            integrator.p[3] = ud2
-            nothing
-        end
-        cb1 = PeriodicCallback(affect1!, dt; final_affect = true, initial_affect = true)
-        cb2 = PeriodicCallback(affect2!, dt2; final_affect = true, initial_affect = true)
-        cb = CallbackSet(cb1, cb2)
-        #                                           kp   ud1  ud2
-        prob = ODEProblem(foo!, [0.0], (0.0, 1.0), [1.0, 1.0, 1.0], callback = cb)
-        sol2 = solve(prob, Tsit5())
-
-        @test sol.u≈sol2.u atol=1e-6
-        @test sol_nosplit.u≈sol2.u atol=1e-6
+    function foo!(dx, x, p, t)
+        kp, ud1, ud2 = p
+        dx[1] = -x[1] + ud1 + ud2
     end
+
+    function affect1!(integrator)
+        kp = integrator.p[1]
+        y = integrator.u[1]
+        r = 1.0
+        ud1 = kp * (r - y)
+        integrator.p[2] = ud1
+        nothing
+    end
+    function affect2!(integrator)
+        kp = integrator.p[1]
+        y = integrator.u[1]
+        r = 1.0
+        ud2 = kp * (r - y)
+        integrator.p[3] = ud2
+        nothing
+    end
+    cb1 = PeriodicCallback(affect1!, dt; final_affect = true, initial_affect = true)
+    cb2 = PeriodicCallback(affect2!, dt2; final_affect = true, initial_affect = true)
+    cb = CallbackSet(cb1, cb2)
+    #                                           kp   ud1  ud2
+    prob = ODEProblem(foo!, [0.0], (0.0, 1.0), [1.0, 1.0, 1.0], callback = cb)
+    sol2 = solve(prob, Tsit5())
+
+    @test sol.u≈sol2.u atol=1e-6
+    @test sol_nosplit.u≈sol2.u atol=1e-6
 
     ##
     @info "Testing hybrid system with components"

--- a/test/clock.jl
+++ b/test/clock.jl
@@ -298,6 +298,42 @@ eqs = [yd ~ Sample(dt)(y)
     ss = mtkcompile(cl)
     ss_nosplit = mtkcompile(cl; split = false)
 
+    prob = ODEProblem(ss, [x => 0.0, kp => 1.0], (0.0, 1.0))
+    prob_nosplit = ODEProblem(ss_nosplit, [x => 0.0, kp => 1.0], (0.0, 1.0))
+    sol = solve(prob, Tsit5(), kwargshandle = KeywordArgSilent)
+    sol_nosplit = solve(prob_nosplit, Tsit5(), kwargshandle = KeywordArgSilent)
+
+    function foo!(dx, x, p, t)
+        kp, ud1, ud2 = p
+        dx[1] = -x[1] + ud1 + ud2
+    end
+
+    function affect1!(integrator)
+        kp = integrator.p[1]
+        y = integrator.u[1]
+        r = 1.0
+        ud1 = kp * (r - y)
+        integrator.p[2] = ud1
+        nothing
+    end
+    function affect2!(integrator)
+        kp = integrator.p[1]
+        y = integrator.u[1]
+        r = 1.0
+        ud2 = kp * (r - y)
+        integrator.p[3] = ud2
+        nothing
+    end
+    cb1 = PeriodicCallback(affect1!, dt; final_affect = true, initial_affect = true)
+    cb2 = PeriodicCallback(affect2!, dt2; final_affect = true, initial_affect = true)
+    cb = CallbackSet(cb1, cb2)
+    #                                           kp   ud1  ud2
+    prob = ODEProblem(foo!, [0.0], (0.0, 1.0), [1.0, 1.0, 1.0], callback = cb)
+    sol2 = solve(prob, Tsit5())
+
+    @test sol.u≈sol2.u atol=1e-6
+    @test sol_nosplit.u≈sol2.u atol=1e-6
+    
     ##
     @info "Testing hybrid system with components"
     using ModelingToolkitStandardLibrary.Blocks

--- a/test/direct.jl
+++ b/test/direct.jl
@@ -240,6 +240,21 @@ kwargs = (; name = 3)
 @test cool_name[1] == (42,)
 @test collect(cool_name[2]) == [:name => 3]
 
+name = 3
+@named cool_name = foo(42; name)
+@test cool_name[1] == (42,)
+@test collect(cool_name[2]) == [:name => name]
+@named cool_name = foo(; name)
+@test collect(cool_name) == [:name => name]
+
+ff = 3
+@named cool_name = foo(42; ff)
+@test cool_name[1] == (42,)
+@test collect(cool_name[2]) == [pp; :ff => ff]
+
+@named cool_name = foo(; ff)
+@test collect(cool_name) == [pp; :ff => ff]
+
 foo(i; name) = (; i, name)
 @named goo[1:3] = foo(10)
 @test isequal(goo, [(i = 10, name = Symbol(:goo_, i)) for i in 1:3])

--- a/test/direct.jl
+++ b/test/direct.jl
@@ -240,22 +240,20 @@ kwargs = (; name = 3)
 @test cool_name[1] == (42,)
 @test collect(cool_name[2]) == [:name => 3]
 
-if VERSION >= v"1.5"
-    name = 3
-    @named cool_name = foo(42; name)
-    @test cool_name[1] == (42,)
-    @test collect(cool_name[2]) == [:name => name]
-    @named cool_name = foo(; name)
-    @test collect(cool_name) == [:name => name]
+name = 3
+@named cool_name = foo(42; name)
+@test cool_name[1] == (42,)
+@test collect(cool_name[2]) == [:name => name]
+@named cool_name = foo(; name)
+@test collect(cool_name) == [:name => name]
 
-    ff = 3
-    @named cool_name = foo(42; ff)
-    @test cool_name[1] == (42,)
-    @test collect(cool_name[2]) == [pp; :ff => ff]
+ff = 3
+@named cool_name = foo(42; ff)
+@test cool_name[1] == (42,)
+@test collect(cool_name[2]) == [pp; :ff => ff]
 
-    @named cool_name = foo(; ff)
-    @test collect(cool_name) == [pp; :ff => ff]
-end
+@named cool_name = foo(; ff)
+@test collect(cool_name) == [pp; :ff => ff]
 
 foo(i; name) = (; i, name)
 @named goo[1:3] = foo(10)

--- a/test/direct.jl
+++ b/test/direct.jl
@@ -240,21 +240,6 @@ kwargs = (; name = 3)
 @test cool_name[1] == (42,)
 @test collect(cool_name[2]) == [:name => 3]
 
-name = 3
-@named cool_name = foo(42; name)
-@test cool_name[1] == (42,)
-@test collect(cool_name[2]) == [:name => name]
-@named cool_name = foo(; name)
-@test collect(cool_name) == [:name => name]
-
-ff = 3
-@named cool_name = foo(42; ff)
-@test cool_name[1] == (42,)
-@test collect(cool_name[2]) == [pp; :ff => ff]
-
-@named cool_name = foo(; ff)
-@test collect(cool_name) == [pp; :ff => ff]
-
 foo(i; name) = (; i, name)
 @named goo[1:3] = foo(10)
 @test isequal(goo, [(i = 10, name = Symbol(:goo_, i)) for i in 1:3])

--- a/test/input_output_handling.jl
+++ b/test/input_output_handling.jl
@@ -8,10 +8,8 @@ using ModelingToolkit: t_nounits as t, D_nounits as D
 eqs = [D(xx) ~ some_input]
 @named model = System(eqs, t)
 @test_throws ExtraVariablesSystemException mtkcompile(model)
-if VERSION >= v"1.8"
-    err = "In particular, the unset input(s) are:\n some_input(t)"
-    @test_throws err mtkcompile(model)
-end
+err = "In particular, the unset input(s) are:\n some_input(t)"
+@test_throws err mtkcompile(model)
 
 # Test input handling
 @variables x(t) u(t) [input = true] v(t)[1:2] [input = true]

--- a/test/input_output_handling.jl
+++ b/test/input_output_handling.jl
@@ -8,6 +8,8 @@ using ModelingToolkit: t_nounits as t, D_nounits as D
 eqs = [D(xx) ~ some_input]
 @named model = System(eqs, t)
 @test_throws ExtraVariablesSystemException mtkcompile(model)
+err = "In particular, the unset input(s) are:\n some_input(t)"
+@test_throws err mtkcompile(model)
 
 # Test input handling
 @variables x(t) u(t) [input = true] v(t)[1:2] [input = true]

--- a/test/input_output_handling.jl
+++ b/test/input_output_handling.jl
@@ -8,8 +8,6 @@ using ModelingToolkit: t_nounits as t, D_nounits as D
 eqs = [D(xx) ~ some_input]
 @named model = System(eqs, t)
 @test_throws ExtraVariablesSystemException mtkcompile(model)
-err = "In particular, the unset input(s) are:\n some_input(t)"
-@test_throws err mtkcompile(model)
 
 # Test input handling
 @variables x(t) u(t) [input = true] v(t)[1:2] [input = true]


### PR DESCRIPTION
## Summary
- Removed conditional code for Julia v1.7, v1.5, and v1.8 from test files
- These version checks are no longer necessary since Julia v1.10 is now the LTS version
- Affected files: `test/clock.jl`, `test/direct.jl`, `test/input_output_handling.jl`

## Details
Since the current LTS is Julia v1.10, version checks for older Julia versions (v1.5, v1.7, v1.8) are no longer needed. This PR removes these conditional branches to simplify the test code.

## Test plan
- [ ] CI tests pass
- [ ] No functional changes, only removed version conditionals

🤖 Generated with [Claude Code](https://claude.ai/code)