### PR TITLE
Add docstring references to solver documentation for problem constructors

### DIFF
--- a/docs/src/API/problems.md
+++ b/docs/src/API/problems.md
@@ -14,31 +14,31 @@ code for a variety of such numerical problems.
 
 ```@docs
 SciMLBase.ODEFunction
-SciMLBase.ODEProblem
+ODEProblem
 SciMLBase.DAEFunction
 SciMLBase.DAEProblem
 SciMLBase.SDEFunction
-SciMLBase.SDEProblem
+SDEProblem
 SciMLBase.DDEFunction
 SciMLBase.DDEProblem
 SciMLBase.SDDEFunction
 SciMLBase.SDDEProblem
-JumpProcesses.JumpProblem
+JumpProblem
 SciMLBase.BVProblem
-SciMLBase.DiscreteProblem
-SciMLBase.ImplicitDiscreteProblem
+DiscreteProblem
+ImplicitDiscreteProblem
 ```
 
 ## Linear and Nonlinear systems
 
 ```@docs
 SciMLBase.NonlinearFunction
-SciMLBase.NonlinearProblem
+NonlinearProblem
 SciMLBase.SCCNonlinearProblem
 SciMLBase.NonlinearLeastSquaresProblem
-SciMLBase.SteadyStateProblem
+SteadyStateProblem
 SciMLBase.IntervalNonlinearFunction
-SciMLBase.IntervalNonlinearProblem
+IntervalNonlinearProblem
 ModelingToolkit.HomotopyContinuationProblem
 SciMLBase.HomotopyNonlinearFunction
 SciMLBase.LinearProblem
@@ -48,7 +48,7 @@ SciMLBase.LinearProblem
 
 ```@docs
 SciMLBase.OptimizationFunction
-SciMLBase.OptimizationProblem
+OptimizationProblem
 SciMLBase.ODEInputFunction
 ModelingToolkit.JuMPDynamicOptProblem
 ModelingToolkit.InfiniteOptDynamicOptProblem

--- a/docs/src/API/problems.md
+++ b/docs/src/API/problems.md
@@ -14,41 +14,41 @@ code for a variety of such numerical problems.
 
 ```@docs
 SciMLBase.ODEFunction
-ODEProblem
+SciMLBase.ODEProblem(::System, ::Any, ::Any)
 SciMLBase.DAEFunction
-SciMLBase.DAEProblem
+SciMLBase.DAEProblem(::System, ::Any, ::Any)
 SciMLBase.SDEFunction
-SDEProblem
+SciMLBase.SDEProblem(::System, ::Any, ::Any)
 SciMLBase.DDEFunction
-SciMLBase.DDEProblem
+SciMLBase.DDEProblem(::System, ::Any, ::Any)
 SciMLBase.SDDEFunction
 SciMLBase.SDDEProblem
-JumpProblem
-SciMLBase.BVProblem
-DiscreteProblem
-ImplicitDiscreteProblem
+JumpProcesses.JumpProblem(::System, ::Any, ::Any)
+SciMLBase.BVProblem(::System, ::Any, ::Any)
+SciMLBase.DiscreteProblem
+SciMLBase.ImplicitDiscreteProblem
 ```
 
 ## Linear and Nonlinear systems
 
 ```@docs
 SciMLBase.NonlinearFunction
-NonlinearProblem
+SciMLBase.NonlinearProblem(::System, ::Any)
 SciMLBase.SCCNonlinearProblem
 SciMLBase.NonlinearLeastSquaresProblem
-SteadyStateProblem
+DiffEqBase.SteadyStateProblem(::System, ::Any)
 SciMLBase.IntervalNonlinearFunction
-IntervalNonlinearProblem
+SciMLBase.IntervalNonlinearProblem
 ModelingToolkit.HomotopyContinuationProblem
 SciMLBase.HomotopyNonlinearFunction
-SciMLBase.LinearProblem
+SciMLBase.LinearProblem(::System, ::Any)
 ```
 
 ## Optimization and optimal control
 
 ```@docs
 SciMLBase.OptimizationFunction
-OptimizationProblem
+SciMLBase.OptimizationProblem(::System, ::Any)
 SciMLBase.ODEInputFunction
 ModelingToolkit.JuMPDynamicOptProblem
 ModelingToolkit.InfiniteOptDynamicOptProblem

--- a/src/problems/bvproblem.jl
+++ b/src/problems/bvproblem.jl
@@ -7,7 +7,8 @@ Construct a `BVProblem` from a ModelingToolkit `System` for boundary value probl
 
 Beyond the arguments listed below, this constructor accepts all keyword arguments
 supported by the DifferentialEquations.jl `solve` function. For a complete list
-and detailed descriptions, see the [DifferentialEquations.jl solve documentation](https://docs.sciml.ai/DiffEqDocs/stable/basics/common_solver_opts/).
+and detailed descriptions, see the [ModelingToolkit.jl problem building documentation](https://docs.sciml.ai/ModelingToolkit/stable/API/problems/) 
+and the [DifferentialEquations.jl solve documentation](https://docs.sciml.ai/DiffEqDocs/stable/basics/common_solver_opts/).
 
 ## Arguments
 - `sys::System`: The ModelingToolkit system to convert (with boundary conditions)

--- a/src/problems/bvproblem.jl
+++ b/src/problems/bvproblem.jl
@@ -1,3 +1,30 @@
+"""
+    BVProblem(sys::System, op, tspan; kwargs...)
+
+Construct a `BVProblem` from a ModelingToolkit `System` for boundary value problems.
+
+## Additional Keyword Arguments
+
+Beyond the arguments listed below, this constructor accepts all keyword arguments
+supported by the DifferentialEquations.jl `solve` function. For a complete list
+and detailed descriptions, see the [DifferentialEquations.jl solve documentation](https://docs.sciml.ai/DiffEqDocs/stable/basics/common_solver_opts/).
+
+## Arguments
+- `sys::System`: The ModelingToolkit system to convert (with boundary conditions)
+- `op`: Operating point/initial conditions
+- `tspan`: Time span for the problem
+
+## Keywords
+- `check_compatibility=true`: Whether to check system compatibility
+- `cse=true`: Whether to perform common subexpression elimination
+- `checkbounds=false`: Whether to enable bounds checking
+- `eval_expression=false`: Whether to evaluate expressions
+- `eval_module=@__MODULE__`: Module for expression evaluation
+- `expression=Val{false}`: Expression evaluation mode
+- `guesses=Dict()`: Initial guesses for boundary value problem
+- `callback=nothing`: Callback functions (note: BVP solvers do not support callbacks)
+- `kwargs...`: Additional keyword arguments passed to the solver
+"""
 @fallback_iip_specialize function SciMLBase.BVProblem{iip, spec}(
         sys::System, op, tspan;
         check_compatibility = true, cse = true,

--- a/src/problems/daeproblem.jl
+++ b/src/problems/daeproblem.jl
@@ -68,7 +68,8 @@ Construct a `DAEProblem` from a ModelingToolkit `System` for differential-algebr
 
 Beyond the arguments listed below, this constructor accepts all keyword arguments
 supported by the DifferentialEquations.jl `solve` function. For a complete list
-and detailed descriptions, see the [DifferentialEquations.jl solve documentation](https://docs.sciml.ai/DiffEqDocs/stable/basics/common_solver_opts/).
+and detailed descriptions, see the [ModelingToolkit.jl problem building documentation](https://docs.sciml.ai/ModelingToolkit/stable/API/problems/) 
+and the [DifferentialEquations.jl solve documentation](https://docs.sciml.ai/DiffEqDocs/stable/basics/common_solver_opts/).
 
 ## Arguments
 - `sys::System`: The ModelingToolkit system to convert (differential-algebraic system)

--- a/src/problems/daeproblem.jl
+++ b/src/problems/daeproblem.jl
@@ -59,6 +59,31 @@
     return maybe_codegen_scimlfn(expression, DAEFunction{iip, spec}, args; kwargs...)
 end
 
+"""
+    DAEProblem(sys::System, op, tspan; kwargs...)
+
+Construct a `DAEProblem` from a ModelingToolkit `System` for differential-algebraic equations.
+
+## Additional Keyword Arguments
+
+Beyond the arguments listed below, this constructor accepts all keyword arguments
+supported by the DifferentialEquations.jl `solve` function. For a complete list
+and detailed descriptions, see the [DifferentialEquations.jl solve documentation](https://docs.sciml.ai/DiffEqDocs/stable/basics/common_solver_opts/).
+
+## Arguments
+- `sys::System`: The ModelingToolkit system to convert (differential-algebraic system)
+- `op`: Operating point/initial conditions
+- `tspan`: Time span for the problem
+
+## Keywords
+- `callback=nothing`: Callback functions for the solver
+- `check_length=true`: Whether to check length compatibility
+- `eval_expression=false`: Whether to evaluate expressions
+- `eval_module=@__MODULE__`: Module for expression evaluation
+- `check_compatibility=true`: Whether to check system compatibility
+- `expression=Val{false}`: Expression evaluation mode
+- `kwargs...`: Additional keyword arguments passed to the solver
+"""
 @fallback_iip_specialize function SciMLBase.DAEProblem{iip, spec}(
         sys::System, op, tspan;
         callback = nothing, check_length = true, eval_expression = false,

--- a/src/problems/ddeproblem.jl
+++ b/src/problems/ddeproblem.jl
@@ -38,6 +38,34 @@
     return maybe_codegen_scimlfn(expression, DDEFunction{iip, spec}, args; kwargs...)
 end
 
+"""
+    DDEProblem(sys::System, op, tspan; kwargs...)
+
+Construct a `DDEProblem` from a ModelingToolkit `System` for delay differential equations.
+
+## Additional Keyword Arguments
+
+Beyond the arguments listed below, this constructor accepts all keyword arguments
+supported by the DifferentialEquations.jl `solve` function. For a complete list
+and detailed descriptions, see the [DifferentialEquations.jl solve documentation](https://docs.sciml.ai/DiffEqDocs/stable/basics/common_solver_opts/).
+
+## Arguments
+- `sys::System`: The ModelingToolkit system to convert (must contain delay equations)
+- `op`: Operating point/initial conditions
+- `tspan`: Time span for the problem
+
+## Keywords
+- `callback=nothing`: Callback functions for the solver
+- `check_length=true`: Whether to check length compatibility
+- `cse=true`: Whether to perform common subexpression elimination
+- `checkbounds=false`: Whether to enable bounds checking
+- `eval_expression=false`: Whether to evaluate expressions
+- `eval_module=@__MODULE__`: Module for expression evaluation
+- `check_compatibility=true`: Whether to check system compatibility
+- `u0_constructor=identity`: Constructor for initial conditions
+- `expression=Val{false}`: Expression evaluation mode
+- `kwargs...`: Additional keyword arguments passed to the solver
+"""
 @fallback_iip_specialize function SciMLBase.DDEProblem{iip, spec}(
         sys::System, op, tspan;
         callback = nothing, check_length = true, cse = true, checkbounds = false,

--- a/src/problems/ddeproblem.jl
+++ b/src/problems/ddeproblem.jl
@@ -47,7 +47,8 @@ Construct a `DDEProblem` from a ModelingToolkit `System` for delay differential 
 
 Beyond the arguments listed below, this constructor accepts all keyword arguments
 supported by the DifferentialEquations.jl `solve` function. For a complete list
-and detailed descriptions, see the [DifferentialEquations.jl solve documentation](https://docs.sciml.ai/DiffEqDocs/stable/basics/common_solver_opts/).
+and detailed descriptions, see the [ModelingToolkit.jl problem building documentation](https://docs.sciml.ai/ModelingToolkit/stable/API/problems/) 
+and the [DifferentialEquations.jl solve documentation](https://docs.sciml.ai/DiffEqDocs/stable/basics/common_solver_opts/).
 
 ## Arguments
 - `sys::System`: The ModelingToolkit system to convert (must contain delay equations)

--- a/src/problems/jumpproblem.jl
+++ b/src/problems/jumpproblem.jl
@@ -1,3 +1,30 @@
+"""
+    JumpProblem(sys::System, op, tspan; kwargs...)
+
+Construct a `JumpProblem` from a ModelingToolkit `System` for jump processes.
+
+## Additional Keyword Arguments
+
+Beyond the arguments listed below, this constructor accepts all keyword arguments
+supported by the DifferentialEquations.jl `solve` function. For a complete list
+and detailed descriptions, see the [DifferentialEquations.jl solve documentation](https://docs.sciml.ai/DiffEqDocs/stable/basics/common_solver_opts/).
+
+## Arguments
+- `sys::System`: The ModelingToolkit system to convert (must contain jump processes)
+- `op`: Operating point/initial conditions
+- `tspan`: Time span for the problem (can be a tuple or nothing)
+
+## Keywords
+- `check_compatibility=true`: Whether to check system compatibility
+- `eval_expression=false`: Whether to evaluate expressions
+- `eval_module=@__MODULE__`: Module for expression evaluation
+- `checkbounds=false`: Whether to enable bounds checking
+- `cse=true`: Whether to perform common subexpression elimination
+- `aggregator=JumpProcesses.NullAggregator()`: Aggregator for jump processes
+- `callback=nothing`: Callback functions for the solver
+- `rng=nothing`: Random number generator
+- `kwargs...`: Additional keyword arguments passed to the solver
+"""
 @fallback_iip_specialize function JumpProcesses.JumpProblem{iip, spec}(
         sys::System, op, tspan::Union{Tuple, Nothing};
         check_compatibility = true, eval_expression = false, eval_module = @__MODULE__,

--- a/src/problems/jumpproblem.jl
+++ b/src/problems/jumpproblem.jl
@@ -7,7 +7,8 @@ Construct a `JumpProblem` from a ModelingToolkit `System` for jump processes.
 
 Beyond the arguments listed below, this constructor accepts all keyword arguments
 supported by the DifferentialEquations.jl `solve` function. For a complete list
-and detailed descriptions, see the [DifferentialEquations.jl solve documentation](https://docs.sciml.ai/DiffEqDocs/stable/basics/common_solver_opts/).
+and detailed descriptions, see the [ModelingToolkit.jl problem building documentation](https://docs.sciml.ai/ModelingToolkit/stable/API/problems/) 
+and the [DifferentialEquations.jl solve documentation](https://docs.sciml.ai/DiffEqDocs/stable/basics/common_solver_opts/).
 
 ## Arguments
 - `sys::System`: The ModelingToolkit system to convert (must contain jump processes)

--- a/src/problems/linearproblem.jl
+++ b/src/problems/linearproblem.jl
@@ -15,7 +15,8 @@ Construct a `LinearProblem` from a ModelingToolkit `System` for linear systems.
 
 Beyond the arguments listed below, this constructor accepts all keyword arguments
 supported by the LinearSolve.jl `solve` function. For a complete list
-and detailed descriptions, see the [LinearSolve.jl documentation](https://docs.sciml.ai/LinearSolve/stable/).
+and detailed descriptions, see the [ModelingToolkit.jl problem building documentation](https://docs.sciml.ai/ModelingToolkit/stable/API/problems/) 
+and the [LinearSolve.jl documentation](https://docs.sciml.ai/LinearSolve/stable/).
 
 ## Arguments
 - `sys::System`: The ModelingToolkit system to convert (linear system)

--- a/src/problems/linearproblem.jl
+++ b/src/problems/linearproblem.jl
@@ -6,6 +6,34 @@ function SciMLBase.LinearProblem(sys::System, op::StaticArray; kwargs...)
     SciMLBase.LinearProblem{false}(sys, op; kwargs...)
 end
 
+"""
+    LinearProblem(sys::System, op; kwargs...)
+
+Construct a `LinearProblem` from a ModelingToolkit `System` for linear systems.
+
+## Additional Keyword Arguments
+
+Beyond the arguments listed below, this constructor accepts all keyword arguments
+supported by the LinearSolve.jl `solve` function. For a complete list
+and detailed descriptions, see the [LinearSolve.jl documentation](https://docs.sciml.ai/LinearSolve/stable/).
+
+## Arguments
+- `sys::System`: The ModelingToolkit system to convert (linear system)
+- `op`: Operating point/initial conditions
+
+## Keywords
+- `check_length=true`: Whether to check length compatibility
+- `expression=Val{false}`: Expression evaluation mode
+- `check_compatibility=true`: Whether to check system compatibility
+- `sparse=false`: Whether to use sparse arrays
+- `eval_expression=false`: Whether to evaluate expressions
+- `eval_module=@__MODULE__`: Module for expression evaluation
+- `checkbounds=false`: Whether to enable bounds checking
+- `cse=true`: Whether to perform common subexpression elimination
+- `u0_constructor=identity`: Constructor for initial conditions
+- `u0_eltype=nothing`: Element type for initial conditions
+- `kwargs...`: Additional keyword arguments passed to the solver
+"""
 function SciMLBase.LinearProblem{iip}(
         sys::System, op; check_length = true, expression = Val{false},
         check_compatibility = true, sparse = false, eval_expression = false,

--- a/src/problems/nonlinearproblem.jl
+++ b/src/problems/nonlinearproblem.jl
@@ -54,6 +54,27 @@
     return maybe_codegen_scimlfn(expression, NonlinearFunction{iip, spec}, args; kwargs...)
 end
 
+"""
+    NonlinearProblem(sys::System, op; kwargs...)
+
+Construct a `NonlinearProblem` from a ModelingToolkit `System` for nonlinear equations.
+
+## Additional Keyword Arguments
+
+Beyond the arguments listed below, this constructor accepts all keyword arguments
+supported by the NonlinearSolve.jl `solve` function. For a complete list
+and detailed descriptions, see the [NonlinearSolve.jl documentation](https://docs.sciml.ai/NonlinearSolve/stable/).
+
+## Arguments
+- `sys::System`: The ModelingToolkit system to convert (nonlinear system)
+- `op`: Operating point/initial guess
+
+## Keywords
+- `expression=Val{false}`: Expression evaluation mode
+- `check_length=true`: Whether to check length compatibility
+- `check_compatibility=true`: Whether to check system compatibility
+- `kwargs...`: Additional keyword arguments passed to the solver
+"""
 @fallback_iip_specialize function SciMLBase.NonlinearProblem{iip, spec}(
         sys::System, op; expression = Val{false},
         check_length = true, check_compatibility = true, kwargs...) where {iip, spec}

--- a/src/problems/nonlinearproblem.jl
+++ b/src/problems/nonlinearproblem.jl
@@ -63,7 +63,8 @@ Construct a `NonlinearProblem` from a ModelingToolkit `System` for nonlinear equ
 
 Beyond the arguments listed below, this constructor accepts all keyword arguments
 supported by the NonlinearSolve.jl `solve` function. For a complete list
-and detailed descriptions, see the [NonlinearSolve.jl documentation](https://docs.sciml.ai/NonlinearSolve/stable/).
+and detailed descriptions, see the [ModelingToolkit.jl problem building documentation](https://docs.sciml.ai/ModelingToolkit/stable/API/problems/) 
+and the [NonlinearSolve.jl documentation](https://docs.sciml.ai/NonlinearSolve/stable/).
 
 ## Arguments
 - `sys::System`: The ModelingToolkit system to convert (nonlinear system)

--- a/src/problems/odeproblem.jl
+++ b/src/problems/odeproblem.jl
@@ -78,7 +78,8 @@ Construct an `ODEProblem` from a ModelingToolkit `System`.
 
 Beyond the arguments listed below, this constructor accepts all keyword arguments
 supported by the DifferentialEquations.jl `solve` function. For a complete list
-and detailed descriptions, see the [DifferentialEquations.jl solve documentation](https://docs.sciml.ai/DiffEqDocs/stable/basics/common_solver_opts/).
+and detailed descriptions, see the [ModelingToolkit.jl problem building documentation](https://docs.sciml.ai/ModelingToolkit/stable/API/problems/) 
+and the [DifferentialEquations.jl solve documentation](https://docs.sciml.ai/DiffEqDocs/stable/basics/common_solver_opts/).
 
 ## Arguments
 - `sys::System`: The ModelingToolkit system to convert

--- a/src/problems/odeproblem.jl
+++ b/src/problems/odeproblem.jl
@@ -69,6 +69,31 @@
     maybe_codegen_scimlfn(expression, ODEFunction{iip, spec}, args; kwargs...)
 end
 
+"""
+    ODEProblem(sys::System, op, tspan; kwargs...)
+
+Construct an `ODEProblem` from a ModelingToolkit `System`.
+
+## Additional Keyword Arguments
+
+Beyond the arguments listed below, this constructor accepts all keyword arguments
+supported by the DifferentialEquations.jl `solve` function. For a complete list
+and detailed descriptions, see the [DifferentialEquations.jl solve documentation](https://docs.sciml.ai/DiffEqDocs/stable/basics/common_solver_opts/).
+
+## Arguments
+- `sys::System`: The ModelingToolkit system to convert
+- `op`: Operating point/initial conditions
+- `tspan`: Time span for the problem
+
+## Keywords
+- `callback=nothing`: Callback functions for the solver
+- `check_length=true`: Whether to check length compatibility
+- `eval_expression=false`: Whether to evaluate expressions
+- `expression=Val{false}`: Expression evaluation mode
+- `eval_module=@__MODULE__`: Module for expression evaluation
+- `check_compatibility=true`: Whether to check system compatibility
+- `kwargs...`: Additional keyword arguments passed to the solver
+"""
 @fallback_iip_specialize function SciMLBase.ODEProblem{iip, spec}(
         sys::System, op, tspan;
         callback = nothing, check_length = true, eval_expression = false,

--- a/src/problems/optimizationproblem.jl
+++ b/src/problems/optimizationproblem.jl
@@ -88,6 +88,28 @@ function SciMLBase.OptimizationProblem(sys::System, args...; kwargs...)
     return OptimizationProblem{true}(sys, args...; kwargs...)
 end
 
+"""
+    OptimizationProblem(sys::System, op; kwargs...)
+
+Construct an `OptimizationProblem` from a ModelingToolkit `System` for optimization.
+
+## Additional Keyword Arguments
+
+Beyond the arguments listed below, this constructor accepts all keyword arguments
+supported by the Optimization.jl `solve` function. For a complete list
+and detailed descriptions, see the [Optimization.jl documentation](https://docs.sciml.ai/Optimization/stable/).
+
+## Arguments
+- `sys::System`: The ModelingToolkit system to convert (optimization system with cost and constraints)
+- `op`: Operating point/initial guess
+
+## Keywords
+- `lb=nothing`: Lower bounds for optimization variables
+- `ub=nothing`: Upper bounds for optimization variables
+- `check_compatibility=true`: Whether to check system compatibility
+- `expression=Val{false}`: Expression evaluation mode
+- `kwargs...`: Additional keyword arguments passed to the solver
+"""
 function SciMLBase.OptimizationProblem{iip}(
         sys::System, op; lb = nothing,
         ub = nothing, check_compatibility = true, expression = Val{false},

--- a/src/problems/optimizationproblem.jl
+++ b/src/problems/optimizationproblem.jl
@@ -97,7 +97,8 @@ Construct an `OptimizationProblem` from a ModelingToolkit `System` for optimizat
 
 Beyond the arguments listed below, this constructor accepts all keyword arguments
 supported by the Optimization.jl `solve` function. For a complete list
-and detailed descriptions, see the [Optimization.jl documentation](https://docs.sciml.ai/Optimization/stable/).
+and detailed descriptions, see the [ModelingToolkit.jl problem building documentation](https://docs.sciml.ai/ModelingToolkit/stable/API/problems/) 
+and the [Optimization.jl documentation](https://docs.sciml.ai/Optimization/stable/).
 
 ## Arguments
 - `sys::System`: The ModelingToolkit system to convert (optimization system with cost and constraints)

--- a/src/problems/sdeproblem.jl
+++ b/src/problems/sdeproblem.jl
@@ -64,6 +64,33 @@
     return maybe_codegen_scimlfn(expression, SDEFunction{iip, spec}, args; kwargs...)
 end
 
+"""
+    SDEProblem(sys::System, op, tspan; kwargs...)
+
+Construct an `SDEProblem` from a ModelingToolkit `System` with noise.
+
+## Additional Keyword Arguments
+
+Beyond the arguments listed below, this constructor accepts all keyword arguments
+supported by the DifferentialEquations.jl `solve` function. For a complete list
+and detailed descriptions, see the [DifferentialEquations.jl solve documentation](https://docs.sciml.ai/DiffEqDocs/stable/basics/common_solver_opts/).
+
+## Arguments
+- `sys::System`: The ModelingToolkit system to convert (must contain noise equations)
+- `op`: Operating point/initial conditions
+- `tspan`: Time span for the problem
+
+## Keywords
+- `callback=nothing`: Callback functions for the solver
+- `check_length=true`: Whether to check length compatibility
+- `eval_expression=false`: Whether to evaluate expressions
+- `eval_module=@__MODULE__`: Module for expression evaluation
+- `check_compatibility=true`: Whether to check system compatibility
+- `sparse=false`: Whether to use sparse arrays
+- `sparsenoise=sparse`: Whether to use sparse noise representation
+- `expression=Val{false}`: Expression evaluation mode
+- `kwargs...`: Additional keyword arguments passed to the solver
+"""
 @fallback_iip_specialize function SciMLBase.SDEProblem{iip, spec}(
         sys::System, op, tspan;
         callback = nothing, check_length = true, eval_expression = false,

--- a/src/problems/sdeproblem.jl
+++ b/src/problems/sdeproblem.jl
@@ -73,7 +73,8 @@ Construct an `SDEProblem` from a ModelingToolkit `System` with noise.
 
 Beyond the arguments listed below, this constructor accepts all keyword arguments
 supported by the DifferentialEquations.jl `solve` function. For a complete list
-and detailed descriptions, see the [DifferentialEquations.jl solve documentation](https://docs.sciml.ai/DiffEqDocs/stable/basics/common_solver_opts/).
+and detailed descriptions, see the [ModelingToolkit.jl problem building documentation](https://docs.sciml.ai/ModelingToolkit/stable/API/problems/) 
+and the [DifferentialEquations.jl solve documentation](https://docs.sciml.ai/DiffEqDocs/stable/basics/common_solver_opts/).
 
 ## Arguments
 - `sys::System`: The ModelingToolkit system to convert (must contain noise equations)


### PR DESCRIPTION
## Summary

This PR adds comprehensive docstrings to all major problem constructors in ModelingToolkit.jl that reference the appropriate solver documentation for extended keyword arguments.

## Changes Made

### DifferentialEquations.jl References
- **ODEProblem**: Added docstring with reference to [DifferentialEquations.jl solve documentation](https://docs.sciml.ai/DiffEqDocs/stable/basics/common_solver_opts/)
- **SDEProblem**: Added docstring with reference to DifferentialEquations.jl solve documentation
- **DAEProblem**: Added docstring with reference to DifferentialEquations.jl solve documentation  
- **BVProblem**: Added docstring with reference to DifferentialEquations.jl solve documentation
- **DDEProblem**: Added docstring with reference to DifferentialEquations.jl solve documentation
- **JumpProblem**: Added docstring with reference to DifferentialEquations.jl solve documentation

### NonlinearSolve.jl References
- **NonlinearProblem**: Added docstring with reference to [NonlinearSolve.jl documentation](https://docs.sciml.ai/NonlinearSolve/stable/)

### Other Solver References
- **OptimizationProblem**: Added docstring with reference to [Optimization.jl documentation](https://docs.sciml.ai/Optimization/stable/)
- **LinearProblem**: Added docstring with reference to [LinearSolve.jl documentation](https://docs.sciml.ai/LinearSolve/stable/)

## Motivation

Previously, users had no clear indication that ModelingToolkit problem constructors accept additional keyword arguments beyond those explicitly listed. This led to confusion about available solver options.

Each docstring now includes:
1. Clear documentation of the explicit parameters
2. A prominent "Additional Keyword Arguments" section
3. Direct links to the relevant solver documentation
4. Explanation that `kwargs...` are passed through to the solver

## Test Plan

- [x] Formatted code with JuliaFormatter
- [x] All changes are documentation-only (no functional changes)
- [x] Verified docstrings render correctly in Julia help system

🤖 Generated with [Claude Code](https://claude.ai/code)