### PR TITLE
Fix CI deprecation warnings

### DIFF
--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -28,8 +28,8 @@ jobs:
       - uses: julia-actions/julia-downgrade-compat@v2
         with:
           skip: Pkg,TOML
-      - uses: julia-actions/julia-buildpkg@latest
-      - uses: julia-actions/julia-runtest@latest
+      - uses: julia-actions/julia-buildpkg@1
+      - uses: julia-actions/julia-runtest@1
         with:
           ALLOW_RERESOLVE: false
         env:

--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -28,8 +28,8 @@ jobs:
       - uses: julia-actions/julia-downgrade-compat@v2
         with:
           skip: Pkg,TOML
-      - uses: julia-actions/julia-buildpkg@v1
-      - uses: julia-actions/julia-runtest@v1
+      - uses: julia-actions/julia-buildpkg@latest
+      - uses: julia-actions/julia-runtest@latest
         with:
           ALLOW_RERESOLVE: false
         env:

--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -45,7 +45,7 @@ jobs:
           - {user: Neuroblox, repo: Neuroblox.jl, group: All}
     steps:
       - uses: actions/checkout@v4
-      - uses: julia-actions/setup-julia@v1
+      - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.julia-version }}
           arch: x64

--- a/.github/workflows/ReleaseTest.yml
+++ b/.github/workflows/ReleaseTest.yml
@@ -29,7 +29,7 @@ jobs:
           - {package: Catalyst, group: All}
     steps:
       - uses: actions/checkout@v4
-      - uses: julia-actions/setup-julia@v1
+      - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.julia-version }}
           arch: x64


### PR DESCRIPTION
## Summary
- Updated julia-actions/setup-julia from v1 to v2 in Downstream.yml and ReleaseTest.yml
- Updated julia-actions/julia-buildpkg and julia-actions/julia-runtest from v1 to @latest in Downgrade.yml
- Resolves Node.js 16 deprecation warnings by migrating to actions that support Node.js 20

## Test plan
- [x] Validated YAML syntax is correct
- [ ] CI workflows should run without deprecation warnings
- [ ] All existing functionality should continue to work as expected

🤖 Generated with [Claude Code](https://claude.ai/code)