### PR TITLE
[ci-skip] Revert JuliaFormatter PR #3846

### DIFF
--- a/docs/src/API/variables.md
+++ b/docs/src/API/variables.md
@@ -293,7 +293,7 @@ For systems that contain parameters with metadata like described above, have som
 In the example below, we define a system with tunable parameters and extract bounds vectors
 
 ```@example metadata
-@variables x(t)=0 u(t)=0 [input = true] y(t)=0 [output = true]
+@variables x(t)=0 u(t)=0 [input=true] y(t)=0 [output=true]
 @parameters T [tunable = true, bounds = (0, Inf)]
 @parameters k [tunable = true, bounds = (0, Inf)]
 eqs = [D(x) ~ (-x + k * u) / T # A first-order system with time constant T and gain k

--- a/docs/src/basics/Events.md
+++ b/docs/src/basics/Events.md
@@ -497,7 +497,8 @@ so far we aren't using anything that's not possible with the implicit interface.
 You can also write
 
 ```julia
-[temp ~ furnace_off_threshold] => ModelingToolkit.ImperativeAffect(modified = (;
+[temp ~
+ furnace_off_threshold] => ModelingToolkit.ImperativeAffect(modified = (;
     furnace_on)) do x, o, i, c
     @set! x.furnace_on = false
 end

--- a/docs/src/basics/MTKLanguage.md
+++ b/docs/src/basics/MTKLanguage.md
@@ -382,7 +382,7 @@ Refer the following example for different ways to define symbolic arrays.
         p1[1:4]
         p2[1:N]
         p3[1:N,
-        1:M] = 10,
+            1:M] = 10,
         [description = "A multi-dimensional array of arbitrary length with description"]
         (p4[1:N, 1:M] = 10),
         [description = "An alternate syntax for p3 to match the syntax of vanilla parameters macro"]

--- a/docs/src/basics/Validation.md
+++ b/docs/src/basics/Validation.md
@@ -108,7 +108,7 @@ function ModelingToolkit.get_unit(op::typeof(dummycomplex), args)
 end
 
 sts = @variables a(t)=0 [unit = u"cm"]
-ps = @parameters s=-1 [unit = u"cm"] c=c [unit = u"cm"]
+ps = @parameters s=-1 [unit=u"cm"] c=c [unit=u"cm"]
 eqs = [D(a) ~ dummycomplex(c, s);]
 sys = System(
     eqs, t, [sts...;], [ps...;], name = :sys, checks = ~ModelingToolkit.CheckUnits)

--- a/docs/src/examples/perturbation.md
+++ b/docs/src/examples/perturbation.md
@@ -100,7 +100,7 @@ plot(sol, idxs = substitute(x_series, ϵ => 0.1); label = "Perturbative (ϵ=0.1)
 
 x_exact(t, ϵ) = exp(-ϵ * t) * sin(√(1 - ϵ^2) * t) / √(1 - ϵ^2)
 @assert isapprox(
-    sol(π / 2; idxs = substitute(x_series, ϵ => 0.1)), x_exact(π / 2, 0.1); atol = 1e-2) # compare around 1st peak # hide
+    sol(π/2; idxs = substitute(x_series, ϵ => 0.1)), x_exact(π/2, 0.1); atol = 1e-2) # compare around 1st peak # hide
 plot!(sol.t, x_exact.(sol.t, 0.1); label = "Exact (ϵ=0.1)")
 ```
 

--- a/docs/src/examples/sparse_jacobians.md
+++ b/docs/src/examples/sparse_jacobians.md
@@ -27,16 +27,16 @@ function brusselator_2d_loop(du, u, p, t)
         jm1 = limit(i + 1, N), limit(i - 1, N), limit(j + 1, N),
         limit(j - 1, N)
         du[i,
-        j,
-        1] = alpha * (u[im1, j, 1] + u[ip1, j, 1] + u[i, jp1, 1] + u[i, jm1, 1] -
-              4u[i, j, 1]) +
-             B + u[i, j, 1]^2 * u[i, j, 2] - (A + 1) * u[i, j, 1] +
-             brusselator_f(x, y, t)
+            j,
+            1] = alpha * (u[im1, j, 1] + u[ip1, j, 1] + u[i, jp1, 1] + u[i, jm1, 1] -
+                  4u[i, j, 1]) +
+                 B + u[i, j, 1]^2 * u[i, j, 2] - (A + 1) * u[i, j, 1] +
+                 brusselator_f(x, y, t)
         du[i,
-        j,
-        2] = alpha * (u[im1, j, 2] + u[ip1, j, 2] + u[i, jp1, 2] + u[i, jm1, 2] -
-              4u[i, j, 2]) +
-             A * u[i, j, 1] - u[i, j, 1]^2 * u[i, j, 2]
+            j,
+            2] = alpha * (u[im1, j, 2] + u[ip1, j, 2] + u[i, jp1, 2] + u[i, jm1, 2] -
+                  4u[i, j, 2]) +
+                 A * u[i, j, 1] - u[i, j, 1]^2 * u[i, j, 2]
     end
 end
 p = (3.4, 1.0, 10.0, step(xyd_brusselator))

--- a/docs/src/examples/tearing_parallelism.md
+++ b/docs/src/examples/tearing_parallelism.md
@@ -15,7 +15,7 @@ using ModelingToolkit: t_nounits as t, D_nounits as D
 
 # Basic electric components
 @connector function Pin(; name)
-    @variables v(t)=1.0 i(t)=1.0 [connect = Flow]
+    @variables v(t)=1.0 i(t)=1.0 [connect=Flow]
     System(Equation[], t, [v, i], [], name = name)
 end
 
@@ -36,7 +36,7 @@ function ConstantVoltage(; name, V = 1.0)
 end
 
 @connector function HeatPort(; name)
-    @variables T(t)=293.15 Q_flow(t)=0.0 [connect = Flow]
+    @variables T(t)=293.15 Q_flow(t)=0.0 [connect=Flow]
     System(Equation[], t, [T, Q_flow], [], name = name)
 end
 

--- a/ext/MTKCasADiDynamicOptExt.jl
+++ b/ext/MTKCasADiDynamicOptExt.jl
@@ -57,7 +57,7 @@ function (M::MXLinearInterpolation)(τ)
     (i > length(M.t) || i < 1) && error("Cannot extrapolate past the tspan.")
     colons = ntuple(_ -> (:), length(size(M.u)) - 1)
     if i < length(M.t)
-        M.u[colons..., i] + Δ * (M.u[colons..., i + 1] - M.u[colons..., i])
+        M.u[colons..., i] + Δ*(M.u[colons..., i + 1] - M.u[colons..., i])
     else
         M.u[colons..., i]
     end
@@ -131,10 +131,10 @@ function MTK.lowered_integral(model::CasADiModel, expr, lo, hi)
     for (i, t) in enumerate(model.U.t)
         if lo < t < hi
             Δt = min(dt, t - lo)
-            total += (0.5 * Δt * (expr[i] + expr[i - 1]))
+            total += (0.5*Δt*(expr[i] + expr[i - 1]))
         elseif t >= hi && (t - dt < hi)
             Δt = hi - t + dt
-            total += (0.5 * Δt * (expr[i] + expr[i - 1]))
+            total += (0.5*Δt*(expr[i] + expr[i - 1]))
         end
     end
     model.tₛ * total
@@ -219,7 +219,7 @@ end
 function MTK.get_V_values(model::CasADiModel)
     value_getter = MTK.successful_solve(model) ? CasADi.debug_value : CasADi.value
     (nu, nt) = size(model.V.u)
-    if nu * nt != 0
+    if nu*nt != 0
         V_vals = value_getter(model.solver_opti, model.V.u)
         size(V_vals, 2) == 1 && (V_vals = V_vals')
         V_vals = [[V_vals[i, j] for i in 1:nu] for j in 1:nt]

--- a/ext/MTKInfiniteOptExt.jl
+++ b/ext/MTKInfiniteOptExt.jl
@@ -49,7 +49,7 @@ end
 
 MTK.generate_internal_model(m::Type{InfiniteOptModel}) = InfiniteModel()
 function MTK.generate_time_variable!(m::InfiniteModel, tspan, tsteps)
-    @infinite_parameter(m, t in [tspan[1], tspan[2]], num_supports=length(tsteps))
+    @infinite_parameter(m, t in [tspan[1], tspan[2]], num_supports = length(tsteps))
 end
 function MTK.generate_state_variable!(m::InfiniteModel, u0::Vector, ns, ts)
     @variable(m, U[i = 1:ns], Infinite(m[:t]), start=u0[i])
@@ -59,7 +59,7 @@ function MTK.generate_input_variable!(m::InfiniteModel, c0, nc, ts)
 end
 
 function MTK.generate_timescale!(m::InfiniteModel, guess, is_free_t)
-    @variable(m, tₛ≥0, start=guess)
+    @variable(m, tₛ ≥ 0, start = guess)
     if !is_free_t
         fix(tₛ, 1, force = true)
         set_start_value(tₛ, 1)
@@ -69,11 +69,11 @@ end
 
 function MTK.add_constraint!(m::InfiniteOptModel, expr::Union{Equation, Inequality})
     if expr isa Equation
-        @constraint(m.model, expr.lhs - expr.rhs==0)
+        @constraint(m.model, expr.lhs - expr.rhs == 0)
     elseif expr.relational_op === Symbolics.geq
-        @constraint(m.model, expr.lhs - expr.rhs≥0)
+        @constraint(m.model, expr.lhs - expr.rhs ≥ 0)
     else
-        @constraint(m.model, expr.lhs - expr.rhs≤0)
+        @constraint(m.model, expr.lhs - expr.rhs ≤ 0)
     end
 end
 MTK.set_objective!(m::InfiniteOptModel, expr) = @objective(m.model, Min, expr)

--- a/ext/MTKPyomoDynamicOptExt.jl
+++ b/ext/MTKPyomoDynamicOptExt.jl
@@ -142,17 +142,17 @@ end
 function MTK.lowered_integral(m::PyomoDynamicOptModel, arg, lo, hi)
     @unpack model, model_sym, t_sym, dummy_sym = m
     total = 0
-    dt = Pyomo.pyconvert(Float64, (model.t.at(-1) - model.t.at(1)) / (model.steps - 1))
+    dt = Pyomo.pyconvert(Float64, (model.t.at(-1) - model.t.at(1))/(model.steps - 1))
     f = Symbolics.build_function(arg, model_sym, t_sym, expression = false)
     for (i, t) in enumerate(model.t)
         if Bool(lo < t) && Bool(t < hi)
-            t_p = model.t.at(i - 1)
+            t_p = model.t.at(i-1)
             Δt = min(t - lo, t - t_p)
-            total += 0.5 * Δt * (f(model, t) + f(model, t_p))
+            total += 0.5*Δt*(f(model, t) + f(model, t_p))
         elseif Bool(t >= hi) && Bool(t - dt < hi)
-            t_p = model.t.at(i - 1)
+            t_p = model.t.at(i-1)
             Δt = hi - t + dt
-            total += 0.5 * Δt * (f(model, t) + f(model, t_p))
+            total += 0.5*Δt*(f(model, t) + f(model, t_p))
         end
     end
     PyomoVar(model.tₛ * total)

--- a/src/bipartite_graph.jl
+++ b/src/bipartite_graph.jl
@@ -635,6 +635,7 @@ function Graphs.incidence_matrix(g::BipartiteGraph, val = true)
     I = Int[]
     J = Int[]
     for i in 𝑠vertices(g), n in 𝑠neighbors(g, i)
+
         push!(I, i)
         push!(J, n)
     end

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -72,6 +72,7 @@ for T in [:ODEProblem, :DDEProblem, :SDEProblem, :SDDEProblem, :DAEProblem,
     end
 
     for pType in [SciMLBase.NullParameters, Nothing], uType in [Any, Nothing]
+
         @eval function SciMLBase.$T(sys::System, u0::$uType, tspan, p::$pType; kw...)
             ctor = string($T)
             pT = string($(QuoteNode(pType)))
@@ -152,6 +153,7 @@ for T in [:NonlinearProblem, :NonlinearLeastSquaresProblem,
         end
     end
     for pType in [SciMLBase.NullParameters, Nothing], uType in [Any, Nothing]
+
         @eval function SciMLBase.$T(sys::System, u0::$uType, p::$pType; kw...)
             ctor = string($T)
             pT = string($(QuoteNode(pType)))

--- a/src/inputoutput.jl
+++ b/src/inputoutput.jl
@@ -120,7 +120,7 @@ function same_or_inner_namespace(u, var)
     nu == nv ||           # namespaces are the same
         startswith(nv, nu) || # or nv starts with nu, i.e., nv is an inner namespace to nu
         occursin(NAMESPACE_SEPARATOR, string(getname(var))) &&
-            !occursin(NAMESPACE_SEPARATOR, string(getname(u))) # or u is top level but var is internal
+        !occursin(NAMESPACE_SEPARATOR, string(getname(u))) # or u is top level but var is internal
 end
 
 function inner_namespace(u, var)
@@ -129,7 +129,7 @@ function inner_namespace(u, var)
     nu == nv && return false
     startswith(nv, nu) || # or nv starts with nu, i.e., nv is an inner namespace to nu
         occursin(NAMESPACE_SEPARATOR, string(getname(var))) &&
-            !occursin(NAMESPACE_SEPARATOR, string(getname(u))) # or u is top level but var is internal
+        !occursin(NAMESPACE_SEPARATOR, string(getname(u))) # or u is top level but var is internal
 end
 
 """

--- a/src/structural_transformation/bareiss.jl
+++ b/src/structural_transformation/bareiss.jl
@@ -131,6 +131,7 @@ end
 
 function bareiss_update!(zero!, M::StridedMatrix, k, swapto, pivot, prev_pivot)
     @inbounds for i in (k + 1):size(M, 2), j in (k + 1):size(M, 1)
+
         M[j, i] = exactdiv(M[j, i] * pivot - M[j, k] * M[k, i], prev_pivot)
     end
     zero!(M, (k + 1):size(M, 1), k)
@@ -269,6 +270,7 @@ function reduce_echelon!(A::AbstractMatrix{T}, rank, d,
     end
     @label out
     @inbounds for i in (rank + 1):m, j in 1:n
+
         A[i, j] = zero(T)
     end
     isreduced && return A

--- a/src/structural_transformation/codegen.jl
+++ b/src/structural_transformation/codegen.jl
@@ -45,6 +45,7 @@ function torn_system_with_nlsolve_jacobian_sparsity(state, var_eq_matching, var_
     var_rename = ones(Int64, ndsts(graph))
     nlsolve_vars = Int[]
     for i in nlsolve_scc_idxs, c in var_sccs[i]
+
         append!(nlsolve_vars, c)
         for v in c
             var_rename[v] = 0

--- a/src/structural_transformation/symbolics_tearing.jl
+++ b/src/structural_transformation/symbolics_tearing.jl
@@ -338,6 +338,7 @@ function generate_derivative_variables!(
     # We need the inverse mapping of `var_sccs` to update it efficiently later.
     v_to_scc = Vector{NTuple{2, Int}}(undef, ndsts(graph))
     for (i, scc) in enumerate(var_sccs), (j, v) in enumerate(scc)
+
         v_to_scc[v] = (i, j)
     end
     # Pairs of `(x_t, dx)` added below
@@ -475,7 +476,7 @@ function find_duplicate_dd(dv, solvable_graph, diff_to_var, linear_eqs, mm)
         if length(nzs) == 2 &&
            (abs(nzs[1]) == 1 && nzs[1] == -nzs[2]) &&
            (v_t = rvs[1] == dv ? rvs[2] : rvs[1];
-           diff_to_var[v_t] === nothing)
+               diff_to_var[v_t] === nothing)
             @assert dv in rvs
             return eq, v_t
         end
@@ -1128,6 +1129,7 @@ function add_additional_history!(
     # We need the inverse mapping of `var_sccs` to update it efficiently later.
     v_to_scc = Vector{NTuple{2, Int}}(undef, ndsts(graph))
     for (i, scc) in enumerate(var_sccs), (j, v) in enumerate(scc)
+
         v_to_scc[v] = (i, j)
     end
 

--- a/src/structural_transformation/tearing.jl
+++ b/src/structural_transformation/tearing.jl
@@ -74,6 +74,7 @@ function free_equations(graph, vars_scc, var_eq_matching, varfilter::F) where {F
     ne = nsrcs(graph)
     seen_eqs = falses(ne)
     for vars in vars_scc, var in vars
+
         varfilter(var) || continue
         ieq = var_eq_matching[var]
         if ieq isa Int

--- a/src/structural_transformation/utils.jl
+++ b/src/structural_transformation/utils.jl
@@ -170,6 +170,7 @@ function sorted_incidence_matrix(ts::TransformationState, val = true; only_algeq
     varidx = 0
     eqidx = 0
     for vs in var_scc, v in vs
+
         eq = var_eq_matching[v]
         if eq !== unassigned
             eqsmap[eq] = (eqidx += 1)
@@ -255,9 +256,9 @@ function find_eq_solvables!(state::TearingState, ieq, to_rm = Int[], coeffs = no
                     # if any of the variables in `a` are present in fullvars (taking into account arrays)
                     if any(
                         v -> any(isequal(v), fullvars) ||
-                            symbolic_type(v) == ArraySymbolic() &&
-                                Symbolics.shape(v) != Symbolics.Unknown() &&
-                                any(x -> any(isequal(x), fullvars), collect(v)),
+                             symbolic_type(v) == ArraySymbolic() &&
+                             Symbolics.shape(v) != Symbolics.Unknown() &&
+                             any(x -> any(isequal(x), fullvars), collect(v)),
                         vars(
                             a; op = Union{Differential, Shift, Pre, Sample, Hold, Initial}))
                         continue

--- a/src/systems/abstractsystem.jl
+++ b/src/systems/abstractsystem.jl
@@ -1570,7 +1570,8 @@ function full_equations(sys::AbstractSystem; simplify = false)
     subs = get_substitutions(sys)
     neweqs = map(equations(sys)) do eq
         if iscall(eq.lhs) && operation(eq.lhs) isa Union{Shift, Differential}
-            return substitute_and_simplify(eq.lhs, subs, simplify) ~ substitute_and_simplify(
+            return substitute_and_simplify(eq.lhs, subs, simplify) ~
+                   substitute_and_simplify(
                 eq.rhs, subs,
                 simplify)
         else
@@ -2755,10 +2756,10 @@ function process_parameter_equations(sys::AbstractSystem)
         if all(varsbuf) do sym
             is_parameter(sys, sym) ||
                 symbolic_type(sym) == ArraySymbolic() &&
-                    is_sized_array_symbolic(sym) &&
-                        all(Base.Fix1(is_parameter, sys), collect(sym)) ||
+                is_sized_array_symbolic(sym) &&
+                all(Base.Fix1(is_parameter, sys), collect(sym)) ||
                 iscall(sym) &&
-                    operation(sym) === getindex && is_parameter(sys, arguments(sym)[1])
+                operation(sym) === getindex && is_parameter(sys, arguments(sym)[1])
         end
             # Everything in `varsbuf` is a parameter, so this is a cheap `is_parameter`
             # check.

--- a/src/systems/alias_elimination.jl
+++ b/src/systems/alias_elimination.jl
@@ -215,6 +215,7 @@ function find_linear_variables(graph, linear_equations, var_to_diff, irreducible
                 eqs = get(var_to_lineq, v, nothing)
                 eqs === nothing && continue
                 for eq in eqs, v′ in 𝑠neighbors(graph, eq)
+
                     if linear_variables[v′]
                         linear_variables[v′] = false
                         push!(stack, v′)
@@ -224,6 +225,7 @@ function find_linear_variables(graph, linear_equations, var_to_diff, irreducible
         end
     end
     for eq in linear_equations, v in 𝑠neighbors(graph, eq)
+
         linear_variables[v] = true
         vlineqs = get!(() -> BitSet(), var_to_lineq, v)
         push!(vlineqs, eq)

--- a/src/systems/callbacks.jl
+++ b/src/systems/callbacks.jl
@@ -573,7 +573,7 @@ function Base.:(==)(e1::AbstractCallback, e2::AbstractCallback)
     (is_discrete(e1) === is_discrete(e2)) || return false
     (isequal(e1.conditions, e2.conditions) && isequal(e1.affect, e2.affect) &&
      isequal(e1.initialize, e2.initialize) && isequal(e1.finalize, e2.finalize)) &&
-        isequal(e1.reinitializealg, e2.reinitializealg) ||
+    isequal(e1.reinitializealg, e2.reinitializealg) ||
         return false
     is_discrete(e1) ||
         (isequal(e1.affect_neg, e2.affect_neg) && isequal(e1.rootfind, e2.rootfind))

--- a/src/systems/diffeqs/basic_transformations.jl
+++ b/src/systems/diffeqs/basic_transformations.jl
@@ -146,7 +146,7 @@ function change_of_variables(
                 ex = substitute(ex, eqs.lhs => eqs.rhs)
                 if isSDE
                     for (noise, B) in zip(neq, brownvars)
-                        ex = ex + 1 / 2 * noise^2 * second + noise * first * B
+                        ex = ex + 1/2 * noise^2 * second + noise*first*B
                     end
                 end
             end

--- a/src/systems/if_lifting.jl
+++ b/src/systems/if_lifting.jl
@@ -376,68 +376,68 @@ const CONDITION_SIMPLIFIER = Rewriters.Fixpoint(Rewriters.Postwalk(Rewriters.Cha
                                                                                     # simple boolean laws
                                                                                     (@rule (!!(~x)) => (~x))
                                                                                     (@rule ((~x) &
-                                                                                    true) => (~x))
+                                                                                            true) => (~x))
                                                                                     (@rule ((~x) &
-                                                                                    false) => false)
+                                                                                            false) => false)
                                                                                     (@rule ((~x) |
-                                                                                    true) => true)
+                                                                                            true) => true)
                                                                                     (@rule ((~x) |
-                                                                                    false) => (~x))
+                                                                                            false) => (~x))
                                                                                     (@rule ((~x) &
-                                                                                    !(~x)) => false)
+                                                                                            !(~x)) => false)
                                                                                     (@rule ((~x) |
-                                                                                    !(~x)) => true)
+                                                                                            !(~x)) => true)
                                                                                     # reversed order of the above, because it matters and `@acrule` refuses to do its job
                                                                                     (@rule (true &
-                                                                                    (~x)) => (~x))
+                                                                                            (~x)) => (~x))
                                                                                     (@rule (false &
-                                                                                    (~x)) => false)
+                                                                                            (~x)) => false)
                                                                                     (@rule (true |
-                                                                                    (~x)) => true)
+                                                                                            (~x)) => true)
                                                                                     (@rule (false |
-                                                                                    (~x)) => (~x))
+                                                                                            (~x)) => (~x))
                                                                                     (@rule (!(~x) &
-                                                                                    (~x)) => false)
+                                                                                            (~x)) => false)
                                                                                     (@rule (!(~x) |
-                                                                                    (~x)) => true)
+                                                                                            (~x)) => true)
                                                                                     # idempotent
                                                                                     (@rule ((~x) &
-                                                                                    (~x)) => (~x))
+                                                                                            (~x)) => (~x))
                                                                                     (@rule ((~x) |
-                                                                                    (~x)) => (~x))
+                                                                                            (~x)) => (~x))
                                                                                     # ifelse with determined branches
                                                                                     (@rule ifelse(
-                                                                                    (~x),
-                                                                                    true,
-                                                                                    false) => (~x))
+                                                                                        (~x),
+                                                                                        true,
+                                                                                        false) => (~x))
                                                                                     (@rule ifelse(
-                                                                                    (~x),
-                                                                                    false,
-                                                                                    true) => !(~x))
+                                                                                        (~x),
+                                                                                        false,
+                                                                                        true) => !(~x))
                                                                                     # ifelse with identical branches
                                                                                     (@rule ifelse(
-                                                                                    (~x),
-                                                                                    (~y),
-                                                                                    (~y)) => (~y))
+                                                                                        (~x),
+                                                                                        (~y),
+                                                                                        (~y)) => (~y))
                                                                                     (@rule ifelse(
-                                                                                    (~x),
-                                                                                    (~y),
-                                                                                    !(~y)) => ((~x) &
-                                                                                               (~y)))
+                                                                                        (~x),
+                                                                                        (~y),
+                                                                                        !(~y)) => ((~x) &
+                                                                                                   (~y)))
                                                                                     (@rule ifelse(
-                                                                                    (~x),
-                                                                                    !(~y),
-                                                                                    (~y)) => ((~x) &
-                                                                                              !(~y)))
+                                                                                        (~x),
+                                                                                        !(~y),
+                                                                                        (~y)) => ((~x) &
+                                                                                                  !(~y)))
                                                                                     # ifelse with determined condition
                                                                                     (@rule ifelse(
-                                                                                    true,
-                                                                                    (~x),
-                                                                                    (~y)) => (~x))
+                                                                                        true,
+                                                                                        (~x),
+                                                                                        (~y)) => (~x))
                                                                                     (@rule ifelse(
-                                                                                    false,
-                                                                                    (~x),
-                                                                                    (~y)) => (~y))])))
+                                                                                        false,
+                                                                                        (~x),
+                                                                                        (~y)) => (~y))])))
 
 """
 If lifting converts (nested) if statements into a series of continuous events + a logically equivalent if statement + parameters.

--- a/src/systems/model_parsing.jl
+++ b/src/systems/model_parsing.jl
@@ -86,16 +86,16 @@ function _model_macro(mod, fullname::Union{Expr, Symbol}, expr, isconnector)
         elseif arg.head == :if
             MLStyle.@match arg begin
                 Expr(:if,
-                condition,
-                x) => begin
+                    condition,
+                    x) => begin
                     parse_conditional_model_statements(comps, dict, eqs, exprs, kwargs,
                         mod, ps, vs, where_types,
                         parse_top_level_branch(condition, x.args)...)
                 end
                 Expr(:if,
-                condition,
-                x,
-                y) => begin
+                    condition,
+                    x,
+                    y) => begin
                     parse_conditional_model_statements(comps, dict, eqs, exprs, kwargs,
                         mod, ps, vs, where_types,
                         parse_top_level_branch(condition, x.args, y)...)
@@ -279,8 +279,8 @@ Base.@nospecializeinfer function parse_variable_def!(
         # Recursively called by: `par2(t)::Int`
         # Recursively called by: `par3(t)::BigFloat = 1.0`
         Expr(:(::),
-        a,
-        type) => begin
+            a,
+            type) => begin
             type = getfield(mod, type)
             parse_variable_def!(
                 dict, mod, a, varclass, kwargs, where_types; def, type, meta)
@@ -291,8 +291,8 @@ Base.@nospecializeinfer function parse_variable_def!(
         # Recursively called by: `par2(t)::Int`
         # Recursively called by: `par3(t)::BigFloat = 1.0`
         Expr(:call,
-        a,
-        b) => begin
+            a,
+            b) => begin
             var = generate_var!(dict, a, b, varclass, mod; type)
             update_kwargs_and_metadata!(dict, kwargs, a, def, type,
                 varclass, where_types, meta)
@@ -317,7 +317,7 @@ Base.@nospecializeinfer function parse_variable_def!(
         # `h2(t)[1:2], [description = "h2(t)"]`
         Expr(:tuple, Expr(:(=), Expr(:ref, a, indices...), default_val), meta_val) ||
         Expr(:tuple, Expr(:(=), Expr(:(::), Expr(:ref, a, indices...), type), default_val),
-        meta_val) ||
+            meta_val) ||
         Expr(:tuple, Expr(:(::), Expr(:ref, a, indices...), type), meta_val) ||
         Expr(:tuple, Expr(:ref, a, indices...), meta_val) => begin
             (@isdefined type) || (type = Real)
@@ -352,8 +352,8 @@ Base.@nospecializeinfer function parse_variable_def!(
         # `l(t)[1:2, 1:3] = 2, [description = "l is more than 1D"]`
         Expr(:(=), Expr(:(::), Expr(:ref, a, indices...), type), def_n_meta) ||
         Expr(:(=),
-        Expr(:ref, a, indices...),
-        def_n_meta) => begin
+            Expr(:ref, a, indices...),
+            def_n_meta) => begin
             (@isdefined type) || (type = Real)
             varname = Meta.isexpr(a, :call) ? a.args[1] : a
             if Meta.isexpr(def_n_meta, :tuple)
@@ -414,8 +414,8 @@ Base.@nospecializeinfer function parse_variable_def!(
         # `a2[1:2]`
         Expr(:(::), Expr(:ref, a, indices...), type) ||
         Expr(:ref,
-        a,
-        indices...) => begin
+            a,
+            indices...) => begin
             (@isdefined type) || (type = Real)
             varname = a isa Expr && a.head == :call ? a.args[1] : a
             if varclass == :parameters
@@ -446,8 +446,8 @@ Base.@nospecializeinfer function parse_variable_def!(
         # Parses: `par0::Bool = true`
         # Parses: `par3(t)::BigFloat = 1.0`
         Expr(:(=),
-        a,
-        b) => begin
+            a,
+            b) => begin
             Base.remove_linenums!(b)
             def, meta = parse_default(mod, b)
             var, def,
@@ -467,8 +467,8 @@ Base.@nospecializeinfer function parse_variable_def!(
         # Parses: `h(t), [description = "h(t)"]`
         # Parses: `par2(t)::Int`
         Expr(:tuple,
-        a,
-        b) => begin
+            a,
+            b) => begin
             meta = parse_metadata(mod, b)
             var, def,
             _ = parse_variable_def!(
@@ -711,8 +711,8 @@ function parse_structural_parameters!(exprs, sps, dict, mod, body, kwargs)
     for arg in body.args
         MLStyle.@match arg begin
             Expr(:(=),
-            Expr(:(::), a, type),
-            b) => begin
+                Expr(:(::), a, type),
+                b) => begin
                 type = getfield(mod, type)
                 b = _type_check!(get_var(mod, b), a, type, :structural_parameters)
                 push!(sps, a)
@@ -721,8 +721,8 @@ function parse_structural_parameters!(exprs, sps, dict, mod, body, kwargs)
                     :value => b, :type => type)
             end
             Expr(:(=),
-            a,
-            b) => begin
+                a,
+                b) => begin
                 push!(sps, a)
                 push!(kwargs, Expr(:kw, a, b))
                 dict[:structural_parameters][a] = dict[:kwargs][a] = Dict(:value => b)
@@ -767,7 +767,7 @@ function extend_args!(a, b, dict, expr, kwargs, has_param = false)
                 dict[:kwargs][x] = Dict(:value => y)
             end
             Expr(:parameters,
-            x...) => begin
+                x...) => begin
                 has_param = true
                 extend_args!(a, arg, dict, expr, kwargs, has_param)
             end
@@ -832,8 +832,8 @@ function parse_extend!(exprs, ext, dict, mod, body, kwargs)
     body = deepcopy(body)
     MLStyle.@match body begin
         Expr(:(=),
-        a,
-        b) => begin
+            a,
+            b) => begin
             if Meta.isexpr(b, :(=))
                 vars = a
                 if !Meta.isexpr(vars, :tuple)
@@ -848,8 +848,8 @@ function parse_extend!(exprs, ext, dict, mod, body, kwargs)
             end
         end
         Expr(:call,
-        a′,
-        _...) => begin
+            a′,
+            _...) => begin
             a = Symbol(Symbol("#mtkmodel"), :__anonymous__, a′)
             b = body
             if (model = getproperty(mod, b.args[1])) isa Model
@@ -1029,8 +1029,8 @@ function parse_variables!(exprs, vs, dict, mod, body, varclass, kwargs, where_ty
         arg isa LineNumberNode && continue
         MLStyle.@match arg begin
             Expr(:if,
-            condition,
-            x) => begin
+                condition,
+                x) => begin
                 conditional_expr = Expr(:if, condition, Expr(:block))
                 conditional_dict = handle_conditional_vars!(x,
                     conditional_expr.args[2],
@@ -1042,9 +1042,9 @@ function parse_variables!(exprs, vs, dict, mod, body, varclass, kwargs, where_ty
                 push_conditional_dict!(dict, condition, conditional_dict, nothing, varclass)
             end
             Expr(:if,
-            condition,
-            x,
-            y) => begin
+                condition,
+                x,
+                y) => begin
                 conditional_expr = Expr(:if, condition, Expr(:block))
                 conditional_dict = handle_conditional_vars!(x,
                     conditional_expr.args[2],
@@ -1129,14 +1129,14 @@ function parse_equations!(exprs, eqs, dict, body)
     for arg in body.args
         MLStyle.@match arg begin
             Expr(:if, condition,
-            x) => begin
+                x) => begin
                 ifexpr = Expr(:if)
                 eq_entry = handle_if_x_equations!(condition, dict, ifexpr, x)
                 push!(exprs, ifexpr)
                 push!(dict[:equations], (:if, condition, eq_entry))
             end
             Expr(:if, condition, x,
-            y) => begin
+                y) => begin
                 ifexpr = Expr(:if)
                 xeq_entry = handle_if_x_equations!(condition, dict, ifexpr, x)
                 yeq_entry = handle_if_y_equations!(ifexpr, y, dict)
@@ -1284,8 +1284,8 @@ function component_args!(a, b, varexpr, kwargs; index_name = nothing)
                 component_args!(a, arg, varexpr, kwargs)
             end
             Expr(:kw,
-            x,
-            y) => begin
+                x,
+                y) => begin
                 varname, _varname = _rename(a, x)
                 b.args[i] = Expr(:kw, x, _varname)
                 if isnothing(index_name)
@@ -1315,8 +1315,8 @@ function _parse_components!(body, kwargs)
 
     MLStyle.@match arg begin
         Expr(:(=),
-        a,
-        Expr(:comprehension, Expr(:generator, b, Expr(:(=), c, d)))) => begin
+            a,
+            Expr(:comprehension, Expr(:generator, b, Expr(:(=), c, d)))) => begin
             array_varexpr = Expr(:block)
 
             push!(comp_names, :($a...))
@@ -1328,13 +1328,13 @@ function _parse_components!(body, kwargs)
             expr = _named_idxs(a, d, :($c -> $b); extra_args = array_varexpr)
         end
         Expr(:(=),
-        a,
-        Expr(:comprehension, Expr(:generator, b, Expr(:filter, e, Expr(:(=), c, d))))) => begin
+            a,
+            Expr(:comprehension, Expr(:generator, b, Expr(:filter, e, Expr(:(=), c, d))))) => begin
             error("List comprehensions with conditional statements aren't supported.")
         end
         Expr(:(=),
-        a,
-        Expr(:comprehension, Expr(:generator, b, Expr(:(=), c, d), e...))) => begin
+            a,
+            Expr(:comprehension, Expr(:generator, b, Expr(:(=), c, d), e...))) => begin
             # Note that `e` is of the form `Tuple{Expr(:(=), c, d)}`
             error("More than one index isn't supported while building component array")
         end
@@ -1343,8 +1343,8 @@ function _parse_components!(body, kwargs)
             error("Multiple `@components` block detected within a single block")
         end
         Expr(:(=),
-        a,
-        Expr(:for, Expr(:(=), c, d), b)) => begin
+            a,
+            Expr(:for, Expr(:(=), c, d), b)) => begin
             Base.remove_linenums!(b)
             array_varexpr = Expr(:block)
             push!(array_varexpr.args, b.args[1:(end - 1)]...)
@@ -1421,13 +1421,13 @@ function parse_components!(exprs, cs, dict, compbody, kwargs)
     for arg in compbody.args
         MLStyle.@match arg begin
             Expr(:if, condition,
-            x) => begin
+                x) => begin
                 handle_conditional_components(condition, dict, exprs, kwargs, x)
             end
             Expr(:if,
-            condition,
-            x,
-            y) => begin
+                condition,
+                x,
+                y) => begin
                 handle_conditional_components(condition, dict, exprs, kwargs, x, y)
             end
             # Either the arg is top level component declaration or an invalid cause - both are handled by `_parse_components`
@@ -1462,7 +1462,7 @@ Base.@nospecializeinfer function parse_top_level_branch(
         condition, x, y = nothing, branch::Symbol = :if)
     @nospecialize
     blocks::Vector{Union{Expr,
-    Nothing}} = component_blk, equations_blk, parameter_blk,
+        Nothing}} = component_blk, equations_blk, parameter_blk,
     variable_blk = define_blocks(branch)
 
     for arg in x

--- a/src/systems/parameter_buffer.jl
+++ b/src/systems/parameter_buffer.jl
@@ -316,9 +316,9 @@ function SciMLStructures.replace!(::SciMLStructures.Initials, p::MTKParameters, 
 end
 
 for (Portion, field, recurse) in [(SciMLStructures.Discrete, :discrete, 1)
-                                  (SciMLStructures.Constants, :constant, 1)
-                                  (Nonnumeric, :nonnumeric, 1)
-                                  (SciMLStructures.Caches, :caches, 1)]
+     (SciMLStructures.Constants, :constant, 1)
+     (Nonnumeric, :nonnumeric, 1)
+     (SciMLStructures.Caches, :caches, 1)]
     @eval function SciMLStructures.canonicalize(::$Portion, p::MTKParameters)
         as_vector = buffer_to_arraypartition(p.$field)
         repack = let p = p

--- a/src/systems/problem_utils.jl
+++ b/src/systems/problem_utils.jl
@@ -1207,8 +1207,8 @@ function maybe_build_initialization_problem(
 
     return (;
         initialization_data = SciMLBase.OverrideInitData(
-            initializeprob, update_initializeprob!, initializeprobmap,
-            initializeprobpmap; metadata = meta, is_update_oop = Val(true)))
+        initializeprob, update_initializeprob!, initializeprobmap,
+        initializeprobpmap; metadata = meta, is_update_oop = Val(true)))
 end
 
 """
@@ -1465,7 +1465,7 @@ function process_SciMLProblem(
         kwargs = merge(kwargs,
             (;
                 resid_prototype = u0_constructor(calculate_resid_prototype(
-                    length(eqs), u0, p))))
+                length(eqs), u0, p))))
     end
 
     f = constructor(sys; u0 = u0, p = p,

--- a/src/systems/solver_nlprob.jl
+++ b/src/systems/solver_nlprob.jl
@@ -48,7 +48,7 @@ function inner_nlsystem(sys::System, mm)
     outer_tmp = get_outer_tmp(N)
     inner_tmp = get_inner_tmp(N)
 
-    subrules = Dict([v => gamma2 * v + inner_tmp[i] for (i, v) in enumerate(dvs)])
+    subrules = Dict([v => gamma2*v + inner_tmp[i] for (i, v) in enumerate(dvs)])
     subrules[t] = c
     new_rhss = map(Base.Fix2(fast_substitute, subrules), rhss)
     new_rhss = collect(outer_tmp) .+ gamma1 .* new_rhss .- gamma3 * mm * dvs

--- a/src/systems/systems.jl
+++ b/src/systems/systems.jl
@@ -109,6 +109,7 @@ function __mtkcompile(sys::AbstractSystem; simplify = false,
             dvar2eq[fullvars[dv]] = only(deqs)
         end
         for (j, bj) in enumerate(brown_vars), i in 𝑑neighbors(graph, bj)
+
             push!(Is, i)
             push!(Js, j)
             eq = new_eqs[i]

--- a/src/systems/systemstructure.jl
+++ b/src/systems/systemstructure.jl
@@ -20,7 +20,7 @@ using SparseArrays
 function quick_cancel_expr(expr)
     Rewriters.Postwalk(quick_cancel,
         similarterm = (x, f, args;
-        kws...) -> maketerm(typeof(x), f, args,
+            kws...) -> maketerm(typeof(x), f, args,
             SymbolicUtils.metadata(x),
             kws...))(expr)
 end
@@ -272,8 +272,8 @@ end
 function symbolic_contains(var, set)
     var in set ||
         symbolic_type(var) == ArraySymbolic() &&
-            Symbolics.shape(var) != Symbolics.Unknown() &&
-            all(x -> x in set, Symbolics.scalarize(var))
+        Symbolics.shape(var) != Symbolics.Unknown() &&
+        all(x -> x in set, Symbolics.scalarize(var))
 end
 
 function TearingState(sys; quick_cancel = false, check = true, sort_eqs = true)
@@ -518,6 +518,7 @@ function TearingState(sys; quick_cancel = false, check = true, sort_eqs = true)
     # build incidence graph
     graph = BipartiteGraph(neqs, nvars, Val(false))
     for (ie, vars) in enumerate(symbolic_incidence), v in vars
+
         jv = var2idx[v]
         add_edge!(graph, ie, jv)
     end

--- a/test/basic_transformations.jl
+++ b/test/basic_transformations.jl
@@ -127,7 +127,7 @@ end
     p = [v => 10.0]
     prob = ODEProblem(Mx, [u0; p], (0.0, 20.0)) # 1 = dy/dx = (dy/dt)/(dx/dt) means equal initial horizontal and vertical velocities
     sol = solve(prob, Tsit5(); reltol = 1e-5)
-    @test all(isapprox.(sol[Mx.y], sol[Mx.x - g * (Mx.t)^2 / 2]; atol = 1e-10)) # compare to analytical solution (x(t) = v*t, y(t) = v*t - g*t^2/2)
+    @test all(isapprox.(sol[Mx.y], sol[Mx.x - g * (Mx.t) ^ 2 / 2]; atol = 1e-10)) # compare to analytical solution (x(t) = v*t, y(t) = v*t - g*t^2/2)
 end
 
 @testset "Change independent variable (free fall with 2nd order horizontal equation)" begin
@@ -140,7 +140,7 @@ end
     u0 = [Mx.y => 0.0, Dx(Mx.y) => 1.0, Mx.t => 0.0, Mx.xˍt => 10.0]
     prob = ODEProblem(Mx, u0, (0.0, 20.0)) # 1 = dy/dx = (dy/dt)/(dx/dt) means equal initial horizontal and vertical velocities
     sol = solve(prob, Tsit5(); reltol = 1e-5)
-    @test all(isapprox.(sol[Mx.y], sol[Mx.x - g * (Mx.t)^2 / 2]; atol = 1e-10)) # compare to analytical solution (x(t) = v*t, y(t) = v*t - g*t^2/2)
+    @test all(isapprox.(sol[Mx.y], sol[Mx.x - g * (Mx.t) ^ 2 / 2]; atol = 1e-10)) # compare to analytical solution (x(t) = v*t, y(t) = v*t - g*t^2/2)
 end
 
 @testset "Change independent variable (crazy 3rd order nonlinear system)" begin
@@ -159,8 +159,8 @@ end
     @variables x xˍt(x) xˍt(x) y(x) t(x)
     Dx = Differential(x)
     areequivalent(eq1,
-    eq2) = isequal(expand(eq1.lhs - eq2.lhs), 0) &&
-           isequal(expand(eq1.rhs - eq2.rhs), 0)
+        eq2) = isequal(expand(eq1.lhs - eq2.lhs), 0) &&
+               isequal(expand(eq1.rhs - eq2.rhs), 0)
     eq1lhs = xˍt^3 * (Dx^3)(y) + xˍt^2 * Dx(y) * (Dx^2)(xˍt) +
              xˍt * Dx(y) * (Dx(xˍt))^2 +
              3 * xˍt^2 * (Dx^2)(y) * Dx(xˍt)
@@ -195,8 +195,9 @@ end
     @test Set(equations(M2)) == Set([
         t ~ √(x),
         xˍt ~ 2t,
-        xˍt * Dx(y) ~ 1fc(t) + 2fc(x) + 3fc(y) +
-                      1callme(f, t) + 2callme(f, x) + 3callme(f, y)
+        xˍt * Dx(y) ~
+        1fc(t) + 2fc(x) + 3fc(y) +
+        1callme(f, t) + 2callme(f, x) + 3callme(f, y)
     ])
 
     _f = LinearInterpolation([1.0, 1.0], [-100.0, +100.0]) # constant value 1
@@ -231,7 +232,7 @@ end
     prob = ODEProblem(Mx, u0, (0.0, 20.0)) # 1 = dy/dx = (dy/dt)/(dx/dt) means equal initial horizontal and vertical velocities
     sol = solve(prob, Tsit5(); reltol = 1e-5)
     # compare to analytical solution (x(t) = v*t, y(t) = v*t - g*t^2/2)
-    @test all(isapprox.(sol[Mx.y], sol[Mx.x - g * (Mx.t_units)^2 / 2]; atol = 1e-10))
+    @test all(isapprox.(sol[Mx.y], sol[Mx.x - g * (Mx.t_units) ^ 2 / 2]; atol = 1e-10))
 end
 
 @testset "Change independent variable, no equations" begin

--- a/test/changeofvariables.jl
+++ b/test/changeofvariables.jl
@@ -13,7 +13,7 @@ eqs = [D(D(z)) ~ ones(2, 2)]
 @parameters α
 @variables x(t)
 D = Differential(t)
-eqs = [D(x) ~ α * x]
+eqs = [D(x) ~ α*x]
 
 tspan = (0.0, 1.0)
 def = [x => 1.0, α => -0.5]
@@ -38,12 +38,12 @@ new_sol = solve(new_prob, Tsit5())
 @variables x(t)
 D = Differential(t)
 eqs = [D(x) ~ t^2 + α - x^2]
-def = [x => 1.0, α => 1.0]
+def = [x=>1.0, α => 1.0]
 @mtkcompile sys = System(eqs, t; defaults = def)
 
 @variables z(t)
-forward_subs = [t + α / (x + t) => z]
-backward_subs = [x => α / (z - t) - t]
+forward_subs = [t + α/(x+t) => z]
+backward_subs = [x => α/(z-t) - t]
 
 new_sys = change_of_variables(
     sys, t, forward_subs, backward_subs; simplify = true, t0 = 0.0)
@@ -65,7 +65,7 @@ new_sol = solve(new_prob, Tsit5())
 x = reshape(x, 3, 1)
 D = Differential(t)
 A = [0.0 -1.0 0.0; -0.5 0.5 0.0; 0.0 0.0 -1.0]
-right = A * x
+right = A*x
 eqs = vec(D.(x) .~ right)
 
 tspan = (0.0, 10.0)
@@ -80,8 +80,8 @@ T_inv = inv(T)
 
 @variables z(t)[1:3]
 z = reshape(z, 3, 1)
-forward_subs = vec(T_inv * x .=> z)
-backward_subs = vec(x .=> T * z)
+forward_subs = vec(T_inv*x .=> z)
+backward_subs = vec(x .=> T*z)
 
 new_sys = change_of_variables(sys, t, forward_subs, backward_subs; simplify = true)
 
@@ -106,14 +106,14 @@ value = ModelingToolkit.value
 @parameters μ σ
 @variables x(t) y(t)
 D = Differential(t)
-eqs = [D(x) ~ μ * x + σ * x * B]
+eqs = [D(x) ~ μ*x + σ*x*B]
 
-def = [x => 0.0, μ => 2.0, σ => 1.0]
+def = [x=>0.0, μ => 2.0, σ=>1.0]
 @mtkcompile sys = System(eqs, t; defaults = def)
 forward_subs = [log(x) => y]
 backward_subs = [x => exp(y)]
 new_sys = change_of_variables(sys, t, forward_subs, backward_subs)
-@test equations(new_sys)[1] == (D(y) ~ μ - 1 / 2 * σ^2)
+@test equations(new_sys)[1] == (D(y) ~ μ - 1/2*σ^2)
 @test noise_eqs(new_sys)[1] === value(σ)
 
 #Multiple Brownian and equations
@@ -122,27 +122,27 @@ new_sys = change_of_variables(sys, t, forward_subs, backward_subs)
 @parameters μ σ α
 @variables x(t) y(t) z(t) w(t) u(t) v(t)
 D = Differential(t)
-eqs = [D(x) ~ μ * x + σ * x * Bx, D(y) ~ α * By, D(u) ~ μ * u + σ * u * Bx + α * u * By]
-def = [x => 0.0, y => 0.0, u => 0.0, μ => 2.0, σ => 1.0, α => 3.0]
+eqs = [D(x) ~ μ*x + σ*x*Bx, D(y) ~ α*By, D(u) ~ μ*u + σ*u*Bx + α*u*By]
+def = [x=>0.0, y => 0.0, u=>0.0, μ => 2.0, σ=>1.0, α=>3.0]
 forward_subs = [log(x) => z, y^2 => w, log(u) => v]
 backward_subs = [x => exp(z), y => w^0.5, u => exp(v)]
 
 @mtkcompile sys = System(eqs, t; defaults = def)
 new_sys = change_of_variables(sys, t, forward_subs, backward_subs)
-@test equations(new_sys)[1] == (D(z) ~ μ - 1 / 2 * σ^2)
+@test equations(new_sys)[1] == (D(z) ~ μ - 1/2*σ^2)
 @test equations(new_sys)[2] == (D(w) ~ α^2)
-@test equations(new_sys)[3] == (D(v) ~ μ - 1 / 2 * (α^2 + σ^2))
+@test equations(new_sys)[3] == (D(v) ~ μ - 1/2*(α^2 + σ^2))
 @test noise_eqs(new_sys)[1, 1] === value(σ)
 @test noise_eqs(new_sys)[1, 2] === value(0)
 @test noise_eqs(new_sys)[2, 1] === value(0)
-@test noise_eqs(new_sys)[2, 2] === value(substitute(2 * α * y, backward_subs[2]))
+@test noise_eqs(new_sys)[2, 2] === value(substitute(2*α*y, backward_subs[2]))
 @test noise_eqs(new_sys)[3, 1] === value(σ)
 @test noise_eqs(new_sys)[3, 2] === value(α)
 
 # Test for  Brownian instead of noise
 @named sys = System(eqs, t; defaults = def)
 new_sys = change_of_variables(sys, t, forward_subs, backward_subs; simplify = false)
-@test simplify(equations(new_sys)[1]) == simplify((D(z) ~ μ - 1 / 2 * σ^2 + σ * Bx))
-@test simplify(equations(new_sys)[2]) == simplify((D(w) ~ α^2 + 2 * α * w^0.5 * By))
+@test simplify(equations(new_sys)[1]) == simplify((D(z) ~ μ - 1/2*σ^2 + σ*Bx))
+@test simplify(equations(new_sys)[2]) == simplify((D(w) ~ α^2 + 2*α*w^0.5*By))
 @test simplify(equations(new_sys)[3]) ==
-      simplify((D(v) ~ μ - 1 / 2 * (α^2 + σ^2) + σ * Bx + α * By))
+      simplify((D(v) ~ μ - 1/2*(α^2 + σ^2) + σ*Bx + α*By))

--- a/test/dde.jl
+++ b/test/dde.jl
@@ -35,8 +35,9 @@ sol2 = solve(prob2, alg, reltol = 1e-7, abstol = 1e-10)
 @variables x₀(t) x₁(t) x₂(..)
 tau = 1
 eqs = [D(x₀) ~ (v0 / (1 + beta0 * (x₂(t - tau)^2))) * (p0 - q0) * x₀ - d0 * x₀
-       D(x₁) ~ (v0 / (1 + beta0 * (x₂(t - tau)^2))) * (1 - p0 + q0) * x₀ +
-               (v1 / (1 + beta1 * (x₂(t - tau)^2))) * (p1 - q1) * x₁ - d1 * x₁
+       D(x₁) ~
+       (v0 / (1 + beta0 * (x₂(t - tau)^2))) * (1 - p0 + q0) * x₀ +
+       (v1 / (1 + beta1 * (x₂(t - tau)^2))) * (p1 - q1) * x₁ - d1 * x₁
        D(x₂(t)) ~ (v1 / (1 + beta1 * (x₂(t - tau)^2))) * (1 - p1 + q1) * x₁ - d2 * x₂(t)]
 @mtkcompile sys = System(eqs, t)
 @test ModelingToolkit.is_dde(sys)
@@ -174,7 +175,7 @@ end
 
 @testset "Issue#3165 DDEs with non-tunables" begin
     @variables x(..) = 1.0
-    @parameters w=1.0 [tunable = false] τ=0.5
+    @parameters w=1.0 [tunable=false] τ=0.5
     eqs = [D(x(t)) ~ -w * x(t - τ)]
 
     @named sys = System(eqs, t)

--- a/test/dep_graphs.jl
+++ b/test/dep_graphs.jl
@@ -70,21 +70,21 @@ import ModelingToolkit: value
 
     @testset "Case $i" for (i, test_case) in enumerate([test_case_1, test_case_2])
         (;         # filter out vrjs in making graphs
-        eqs,         # eq to vars they depend on
-        eq_sdeps,
-        eq_sidepsf,
-        eq_sidepsb,         # eq to params they depend on
-        eq_pdeps,
-        eq_pidepsf,
-        eq_pidepsb,         # var to eqs that modify them
-        s_eqdepsf,
-        s_eqdepsb,
-        var_eq_ne,         # eq to eqs that depend on them
-        eq_eqdeps,
-        eq_eq_ne,         # var to vars that depend on them
-        var_vardeps,
-        var_var_ne
-) = test_case
+            eqs,         # eq to vars they depend on
+            eq_sdeps,
+            eq_sidepsf,
+            eq_sidepsb,         # eq to params they depend on
+            eq_pdeps,
+            eq_pidepsf,
+            eq_pidepsb,         # var to eqs that modify them
+            s_eqdepsf,
+            s_eqdepsb,
+            var_eq_ne,         # eq to eqs that depend on them
+            eq_eqdeps,
+            eq_eq_ne,         # var to vars that depend on them
+            var_vardeps,
+            var_var_ne
+        ) = test_case
         deps = equation_dependencies(js; eqs)
         @test length(deps) == length(eq_sdeps)
         @test all([issetequal(a, b) for (a, b) in zip(eq_sdeps, deps)])

--- a/test/dq_units.jl
+++ b/test/dq_units.jl
@@ -39,18 +39,18 @@ System(eqs, t, name = :sys, checks = false)
 
 # connection validation
 @connector function Pin(; name)
-    sts = @variables(v(t)=1.0, [unit = u"V"],
-        i(t)=1.0, [unit = u"A", connect = Flow])
+    sts = @variables(v(t)=1.0, [unit=u"V"],
+        i(t)=1.0, [unit=u"A", connect=Flow])
     System(Equation[], t, sts, []; name = name)
 end
 @connector function OtherPin(; name)
-    sts = @variables(v(t)=1.0, [unit = u"mV"],
-        i(t)=1.0, [unit = u"mA", connect = Flow])
+    sts = @variables(v(t)=1.0, [unit=u"mV"],
+        i(t)=1.0, [unit=u"mA", connect=Flow])
     System(Equation[], t, sts, []; name = name)
 end
 @connector function LongPin(; name)
-    sts = @variables(v(t)=1.0, [unit = u"V"],
-        i(t)=1.0, [unit = u"A", connect = Flow],
+    sts = @variables(v(t)=1.0, [unit=u"V"],
+        i(t)=1.0, [unit=u"A", connect=Flow],
         x(t)=1.0)
     System(Equation[], t, sts, []; name = name)
 end

--- a/test/extensions/homotopy_continuation.jl
+++ b/test/extensions/homotopy_continuation.jl
@@ -192,7 +192,7 @@ end
     disallowed_y = [7, 5, 4]
     @test all(!isapprox(sol[x]; atol = 1e-8), disallowed_x)
     @test all(!isapprox(sol[y]; atol = 1e-8), disallowed_y)
-    @test abs(sol[x^2 - 4x + y]) >= 1e-8
+    @test abs(sol[x ^ 2 - 4x + y]) >= 1e-8
 
     p = parameter_values(prob)
     for val in disallowed_x

--- a/test/extensions/test_infiniteopt.jl
+++ b/test/extensions/test_infiniteopt.jl
@@ -53,13 +53,13 @@ m = InfiniteModel(optimizer_with_attributes(Ipopt.Optimizer,
 guess_xs = [t -> pi, t -> 0.1][permutation]
 guess_us = [t -> 0.1]
 InfiniteOpt.@variables(m,
-    begin
-        # state variables
-        (lb[i] <= x[i = 1:nx] <= ub[i], Infinite(τ), start = guess_xs[i]) # state variables
-        -10 <= u[i = 1:nu] <= 10, Infinite(τ), (start = guess_us[i]) # control variables
-        0 <= tf <= 10, (start = 5) # Final time
-        0.2 <= L <= 0.6, (start = 0.4) # Length parameter
-    end)
+begin
+    # state variables
+    (lb[i] <= x[i = 1:nx] <= ub[i], Infinite(τ), start = guess_xs[i]) # state variables
+    -10 <= u[i = 1:nu] <= 10, Infinite(τ), (start = guess_us[i]) # control variables
+    0 <= tf <= 10, (start = 5) # Final time
+    0.2 <= L <= 0.6, (start = 0.4) # Length parameter
+end)
 
 # Trace the dynamics
 x0 = ModelingToolkit.get_u0(io_sys, [model.θ => 0, model.ω => 0])

--- a/test/fmi/fmi.jl
+++ b/test/fmi/fmi.jl
@@ -177,7 +177,7 @@ end
     end
 
     function build_sspace_model(sspace)
-        @variables u(t)=1.0 x(t)=1.0 y(t) [guess = 1.0]
+        @variables u(t)=1.0 x(t)=1.0 y(t) [guess=1.0]
         @mtkcompile sys = System(
             [sspace.u ~ u, D(u) ~ t, D(x) ~ sspace.x + sspace.y, y^2 ~ sspace.y + sspace.x], t;
             systems = [sspace]

--- a/test/initial_values.jl
+++ b/test/initial_values.jl
@@ -7,7 +7,7 @@ using SymbolicIndexingInterface
 
 @variables x(t)[1:3]=[1.0, 2.0, 3.0] y(t) z(t)[1:2]
 
-@mtkcompile sys=System([D(x) ~ t * x], t) simplify=false
+@mtkcompile sys=System([D(x)~t*x], t) simplify=false
 reorderer = getsym(sys, x)
 @test reorderer(get_u0(sys, [])) == [1.0, 2.0, 3.0]
 @test reorderer(get_u0(sys, [x => [2.0, 3.0, 4.0]])) == [2.0, 3.0, 4.0]
@@ -15,10 +15,10 @@ reorderer = getsym(sys, x)
 @test get_u0(sys, [2.0, 3.0, 4.0]) == [2.0, 3.0, 4.0]
 
 @mtkcompile sys=System([
-        D(x) ~ 3x,
-        D(y) ~ t,
-        D(z[1]) ~ z[2] + t,
-        D(z[2]) ~ y + z[1]
+        D(x)~3x,
+        D(y)~t,
+        D(z[1])~z[2]+t,
+        D(z[2])~y+z[1]
     ], t) simplify=false
 
 @test_throws ModelingToolkit.MissingVariablesError get_u0(sys, [])
@@ -119,7 +119,7 @@ end
 @testset "split=false systems with all parameter defaults" begin
     @variables x(t) = 1.0
     @parameters p=1.0 q=2.0 r=3.0
-    @mtkcompile sys=System(D(x) ~ p * x + q * t + r, t) split=false
+    @mtkcompile sys=System(D(x)~p*x+q*t+r, t) split=false
     prob = @test_nowarn ODEProblem(sys, [], (0.0, 1.0))
     @test prob.p isa Vector{Float64}
 end
@@ -254,7 +254,7 @@ end
 @testset "Array initials and scalar parameters with `split = false`" begin
     @variables x(t)[1:2]
     @parameters p
-    @mtkcompile sys=System([D(x[1]) ~ x[1], D(x[2]) ~ x[2] + p], t) split=false
+    @mtkcompile sys=System([D(x[1])~x[1], D(x[2])~x[2]+p], t) split=false
     ps = Set(parameters(sys; initial_parameters = true))
     @test length(ps) == 5
     for i in 1:2

--- a/test/initializationsystem.jl
+++ b/test/initializationsystem.jl
@@ -461,7 +461,7 @@ prob = ODEProblem(simpsys, [z => 1.0, y => 1.0], tspan, guesses = [x => 2.0])
 sol = solve(prob, Tsit5())
 @test sol[[x, y], 1] == [0.0, 1.0]
 
-@test_warn "underdetermined" prob=ODEProblem(
+@test_warn "underdetermined" prob = ODEProblem(
     simpsys, [], tspan, guesses = [x => 2.0, y => 1.0])
 
 # Late Binding initialization_eqs
@@ -601,7 +601,7 @@ end
     # `rhss` allows adding terms to the end of equations (only 2 equations allowed) to influence
     # the system type (brownian vars to turn it into an SDE).
     @testset "$Problem with $(SciMLBase.parameterless_type(alg)) and $ctor ctor" for (
-    (Problem, alg, rhss), (ctor, expectedT)) in Iterators.product(
+        (Problem, alg, rhss), (ctor, expectedT)) in Iterators.product(
         [
             (ODEProblem, Tsit5(), zeros(2)),
             (SDEProblem, ImplicitEM(), [a, b]),
@@ -779,7 +779,7 @@ end
 
     @testset "No initialization for variables" begin
         @variables x=1.0 y=0.0 z=0.0
-        @parameters σ=10.0 ρ=26.0 β=8 / 3
+        @parameters σ=10.0 ρ=26.0 β=8/3
 
         eqs = [0 ~ σ * (y - x),
             0 ~ x * (ρ - z) - y,
@@ -824,7 +824,7 @@ end
             @test SciMLBase.successful_retcode(sol)
         end
 
-        @parameters p=2.0 q=missing [guess = 1.0] c=1.0
+        @parameters p=2.0 q=missing [guess=1.0] c=1.0
         @variables x=1.0 z=3.0
 
         # eqs = [0 ~ p * (y - x),
@@ -886,7 +886,7 @@ end
     x = _x(t)
 
     @testset "$Problem with $(SciMLBase.parameterless_type(typeof(alg)))" for (
-    System, Problem, alg, rhss) in [
+        System, Problem, alg, rhss) in [
         (ModelingToolkit.System, ODEProblem, Tsit5(), zeros(2)),
         (ModelingToolkit.System, SDEProblem, ImplicitEM(), [a, b]),
         (ModelingToolkit.System, DDEProblem, MethodOfSteps(Tsit5()), [_x(t - 0.1), 0.0]),
@@ -916,7 +916,7 @@ end
     x = _x(t)
 
     @testset "$Problem with $(SciMLBase.parameterless_type(typeof(alg)))" for (
-    System, Problem, alg, rhss) in [
+        System, Problem, alg, rhss) in [
         (ModelingToolkit.System, ODEProblem, Tsit5(), 0),
         (ModelingToolkit.System, SDEProblem, ImplicitEM(), a),
         (ModelingToolkit.System, DDEProblem, MethodOfSteps(Tsit5()), _x(t - 0.1)),
@@ -940,7 +940,7 @@ end
     x = _x(t)
 
     @testset "$Problem with $(SciMLBase.parameterless_type(typeof(alg)))" for (
-    Problem, alg, rhss) in [
+        Problem, alg, rhss) in [
         (ODEProblem, Tsit5(), zeros(2)),
         (SDEProblem, ImplicitEM(), [a, b]),
         (DDEProblem, MethodOfSteps(Tsit5()), [_x(t - 0.1), 0.0]),
@@ -973,7 +973,7 @@ end
     x = _x(t)
 
     @testset "$Problem with $(SciMLBase.parameterless_type(typeof(alg)))" for (
-    System, Problem, alg, rhss) in [
+        System, Problem, alg, rhss) in [
         (ModelingToolkit.System, ODEProblem, Tsit5(), 0),
         (ModelingToolkit.System, SDEProblem, ImplicitEM(), a),
         (ModelingToolkit.System, DDEProblem, MethodOfSteps(Tsit5()), _x(t - 0.1)),
@@ -1031,7 +1031,7 @@ end
     x = _x(t)
 
     @testset "$Problem with $(SciMLBase.parameterless_type(typeof(alg)))" for (
-    System, Problem, alg, rhss) in [
+        System, Problem, alg, rhss) in [
         (ModelingToolkit.System, ODEProblem, Tsit5(), 0),
         (ModelingToolkit.System, SDEProblem, ImplicitEM(), a),
         (ModelingToolkit.System, DDEProblem, MethodOfSteps(Tsit5()), _x(t - 0.1)),
@@ -1113,7 +1113,7 @@ end
     sol = solve(prob, Rodas5P())
     @test SciMLBase.successful_retcode(sol)
 
-    prob2 = remake(prob, u0 = [x => 0.5, y => nothing])
+    prob2 = remake(prob, u0 = [x => 0.5, y=>nothing])
     sol2 = solve(prob2, Rodas5P())
     @test SciMLBase.successful_retcode(sol2)
 end
@@ -1201,7 +1201,7 @@ end
 
 @testset "DAEProblem initialization" begin
     @variables x(t) [guess = 1.0] y(t) [guess = 1.0]
-    @parameters p=missing [guess = 1.0] q=missing [guess = 1.0]
+    @parameters p=missing [guess=1.0] q=missing [guess=1.0]
     @mtkcompile sys = System(
         [D(x) ~ p * y + q, x^3 + y^3 ~ 5], t; initialization_eqs = [p^2 + q^3 ~ 3])
 

--- a/test/input_output_handling.jl
+++ b/test/input_output_handling.jl
@@ -157,7 +157,7 @@ end
     for split in [true, false]
         simplify = true
 
-        @variables x(t)=0 u(t)=0 [input = true]
+        @variables x(t)=0 u(t)=0 [input=true]
         eqs = [
             D(x) ~ -x + u
         ]
@@ -176,7 +176,7 @@ end
         @test f[1](x, u, p, 1) ≈ -x + u
 
         # With disturbance inputs
-        @variables x(t)=0 u(t)=0 [input = true] d(t)=0
+        @variables x(t)=0 u(t)=0 [input=true] d(t)=0
         eqs = [
             D(x) ~ -x + u + d^2
         ]
@@ -196,7 +196,7 @@ end
         @test f[1](x, u, p, 1) ≈ -x + u
 
         ## With added d argument
-        @variables x(t)=0 u(t)=0 [input = true] d(t)=0
+        @variables x(t)=0 u(t)=0 [input=true] d(t)=0
         eqs = [
             D(x) ~ -x + u + d^2
         ]
@@ -433,7 +433,7 @@ matrices = ModelingToolkit.reorder_unknowns(
 # @test sminreal(G[1, 3]) ≈ sminreal(P[1,1])*dist
 
 @testset "Observed functions with inputs" begin
-    @variables x(t)=0 u(t)=0 [input = true]
+    @variables x(t)=0 u(t)=0 [input=true]
     eqs = [
         D(x) ~ -x + u
     ]
@@ -458,7 +458,7 @@ end
 end
 
 @testset "With callable symbolic" begin
-    @variables x(t)=0 u(t)=0 [input = true]
+    @variables x(t)=0 u(t)=0 [input=true]
     @parameters p(::Real) = (x -> 2x)
     eqs = [D(x) ~ -x + p(u)]
     @named sys = System(eqs, t)

--- a/test/inputoutput.jl
+++ b/test/inputoutput.jl
@@ -29,11 +29,11 @@ sys = connected
 
 collapsed_eqs = [
     D(lorenz1.x) ~ (lorenz1.σ * (lorenz1.y - lorenz1.x) +
-                    (lorenz2.x + lorenz2.y - lorenz2.z)),
+     (lorenz2.x + lorenz2.y - lorenz2.z)),
     D(lorenz1.y) ~ lorenz1.x * (lorenz1.ρ - lorenz1.z) - lorenz1.y,
     D(lorenz1.z) ~ lorenz1.x * lorenz1.y - (lorenz1.β * lorenz1.z),
     D(lorenz2.x) ~ (lorenz2.σ * (lorenz2.y - lorenz2.x) +
-                    (lorenz1.x + lorenz1.y - lorenz1.z)),
+     (lorenz1.x + lorenz1.y - lorenz1.z)),
     D(lorenz2.y) ~ lorenz2.x * (lorenz2.ρ - lorenz2.z) - lorenz2.y,
     D(lorenz2.z) ~ lorenz2.x * lorenz2.y - (lorenz2.β * lorenz2.z)]
 

--- a/test/jacobiansparsity.jl
+++ b/test/jacobiansparsity.jl
@@ -13,16 +13,16 @@ function brusselator_2d_loop(du, u, p, t)
         ip1, im1, jp1, jm1 = lim(i + 1, N), lim(i - 1, N), lim(j + 1, N),
         lim(j - 1, N)
         du[i,
-        j,
-        1] = alpha * (u[im1, j, 1] + u[ip1, j, 1] + u[i, jp1, 1] + u[i, jm1, 1] -
-              4u[i, j, 1]) +
-             B + u[i, j, 1]^2 * u[i, j, 2] - (A + 1) * u[i, j, 1] +
-             brusselator_f(x, y, t)
+            j,
+            1] = alpha * (u[im1, j, 1] + u[ip1, j, 1] + u[i, jp1, 1] + u[i, jm1, 1] -
+                  4u[i, j, 1]) +
+                 B + u[i, j, 1]^2 * u[i, j, 2] - (A + 1) * u[i, j, 1] +
+                 brusselator_f(x, y, t)
         du[i,
-        j,
-        2] = alpha * (u[im1, j, 2] + u[ip1, j, 2] + u[i, jp1, 2] + u[i, jm1, 2] -
-              4u[i, j, 2]) +
-             A * u[i, j, 1] - u[i, j, 1]^2 * u[i, j, 2]
+            j,
+            2] = alpha * (u[im1, j, 2] + u[ip1, j, 2] + u[i, jp1, 2] + u[i, jm1, 2] -
+                  4u[i, j, 2]) +
+                 A * u[i, j, 1] - u[i, j, 1]^2 * u[i, j, 2]
     end
 end
 

--- a/test/linearize.jl
+++ b/test/linearize.jl
@@ -18,13 +18,13 @@ new = [x4, x1, x3, x2]
 old = [x1, x2, x3, x4]
 lsys = ModelingToolkit.reorder_unknowns(mats, old, new)
 P = [0 1 0 0; 0 0 0 1; 0 0 1 0; 1 0 0 0]
-@test isequal(P * new, old)
+@test isequal(P*new, old)
 @test lsys.A == ModelingToolkit.similarity_transform(mats, P).A
 
 # r is an input, and y is an output.
 @independent_variables t
 @variables x(t)=0 y(t)=0 u(t)=0 r(t)=0
-@variables x(t)=0 y(t)=0 u(t)=0 r(t)=0 [input = true]
+@variables x(t)=0 y(t)=0 u(t)=0 r(t)=0 [input=true]
 @parameters kp = 1
 D = Differential(t)
 

--- a/test/modelingtoolkitize.jl
+++ b/test/modelingtoolkitize.jl
@@ -18,16 +18,16 @@ function brusselator_2d_loop(du, u, p, t)
         jm1 = limit(i + 1, N), limit(i - 1, N), limit(j + 1, N),
         limit(j - 1, N)
         du[i,
-        j,
-        1] = alpha * (u[im1, j, 1] + u[ip1, j, 1] + u[i, jp1, 1] + u[i, jm1, 1] -
-              4u[i, j, 1]) +
-             B + u[i, j, 1]^2 * u[i, j, 2] - (A + 1) * u[i, j, 1] +
-             brusselator_f(x, y, t)
+            j,
+            1] = alpha * (u[im1, j, 1] + u[ip1, j, 1] + u[i, jp1, 1] + u[i, jm1, 1] -
+                  4u[i, j, 1]) +
+                 B + u[i, j, 1]^2 * u[i, j, 2] - (A + 1) * u[i, j, 1] +
+                 brusselator_f(x, y, t)
         du[i,
-        j,
-        2] = alpha * (u[im1, j, 2] + u[ip1, j, 2] + u[i, jp1, 2] + u[i, jm1, 2] -
-              4u[i, j, 2]) +
-             A * u[i, j, 1] - u[i, j, 1]^2 * u[i, j, 2]
+            j,
+            2] = alpha * (u[im1, j, 2] + u[ip1, j, 2] + u[i, jp1, 2] + u[i, jm1, 2] -
+                  4u[i, j, 2]) +
+                 A * u[i, j, 1] - u[i, j, 1]^2 * u[i, j, 2]
     end
 end
 
@@ -262,7 +262,7 @@ sys = modelingtoolkitize(prob)
 @test [ModelingToolkit.defaults(sys)[s] for s in unknowns(sys)] == u0
 @test [ModelingToolkit.defaults(sys)[s] for s in parameters(sys)] == [10, 20]
 
-@parameters sig=10 rho=28.0 beta=8 / 3
+@parameters sig=10 rho=28.0 beta=8/3
 @variables x(t)=100 y(t)=1.0 z(t)=1
 
 eqs = [D(x) ~ sig * (y - x),

--- a/test/mtkparameters.jl
+++ b/test/mtkparameters.jl
@@ -56,8 +56,8 @@ setp(sys, a)(ps, 1.0)
 @test getp(sys, a)(ps) == getp(sys, b)(ps) / 2 == getp(sys, c)(ps) / 3 == 1.0
 
 for (portion, values) in [(Tunable(), [1.0, 5.0, 6.0, 7.0])
-                          (Discrete(), [3.0])
-                          (Constants(), vcat([0.1, 0.2, 0.3], ones(9), [4.0]))]
+     (Discrete(), [3.0])
+     (Constants(), vcat([0.1, 0.2, 0.3], ones(9), [4.0]))]
     buffer, repack, alias = canonicalize(portion, ps)
     @test alias
     @test sort(collect(buffer)) == values
@@ -173,7 +173,7 @@ ps = [p => 1.0] # Value for `d` is missing
 
 # scalar parameters only
 function level1()
-    @parameters p1=0.5 [tunable = true] p2=1 [tunable = true] p3=3 [tunable = false] p4=3 [tunable = true] y0=1
+    @parameters p1=0.5 [tunable=true] p2=1 [tunable=true] p3=3 [tunable=false] p4=3 [tunable=true] y0=1
     @variables x(t)=2 y(t)=y0
     D = Differential(t)
 
@@ -188,7 +188,7 @@ end
 
 # scalar and vector parameters
 function level2()
-    @parameters p1=0.5 [tunable = true] (p23[1:2]=[1, 3.0]) [tunable = true] p4=3 [tunable = false] y0=1
+    @parameters p1=0.5 [tunable=true] (p23[1:2]=[1, 3.0]) [tunable=true] p4=3 [tunable=false] y0=1
     @variables x(t)=2 y(t)=y0
     D = Differential(t)
 
@@ -203,7 +203,7 @@ end
 
 # scalar and vector parameters with different scalar types
 function level3()
-    @parameters p1=0.5 [tunable = true] (p23[1:2]=[1, 3.0]) [tunable = true] p4::Int=3 [tunable = true] y0::Int=1
+    @parameters p1=0.5 [tunable=true] (p23[1:2]=[1, 3.0]) [tunable=true] p4::Int=3 [tunable=true] y0::Int=1
     @variables x(t)=2 y(t)=y0
     D = Differential(t)
 

--- a/test/nonlinearsystem.jl
+++ b/test/nonlinearsystem.jl
@@ -408,7 +408,7 @@ end
     @test prob.f.initialization_data.initializeprobmap === nothing
     sol = solve(prob)
     @test SciMLBase.successful_retcode(sol)
-    @test sol.ps[p^3 + q^3]≈sol.ps[4r] atol=1e-10
+    @test sol.ps[p ^ 3 + q ^ 3]≈sol.ps[4r] atol=1e-10
 
     @testset "Differential inside expression also substituted" begin
         @named sys = System([0 ~ y * D(x) + x^2 - p, 0 ~ x * D(y) + y * p], t)

--- a/test/odesystem.jl
+++ b/test/odesystem.jl
@@ -816,7 +816,7 @@ Set(unknowns(new_sys2)) == Set([new_sys2.x1, new_sys2.sys1.x1,
     new_sys2.sub.s1, new_sys2.sub.s2])
 
 let # Issue https://github.com/SciML/ModelingToolkit.jl/issues/2322
-    @parameters a=10 b=a / 10 c=a / 20
+    @parameters a=10 b=a/10 c=a/20
 
     Dt = D
 
@@ -1384,7 +1384,7 @@ end
     @mtkcompile sys = System([D(x) ~ x, y^2 ~ x + sum(p)], t)
     prob = DAEProblem(sys, [D(x) => x, D(y) => D(x) / 2y], (0.0, 1.0))
     sol = solve(prob, DFBDF(), abstol = 1e-8, reltol = 1e-8)
-    @test sol[x]≈sol[y^2 - sum(p)] atol=1e-5
+    @test sol[x]≈sol[y ^ 2 - sum(p)] atol=1e-5
 end
 
 @testset "Symbolic tstops" begin

--- a/test/reduction.jl
+++ b/test/reduction.jl
@@ -172,7 +172,7 @@ nlprob.f(residual, reducedsol.u, pp)
 
 N = 5
 @variables xs[1:N]
-A = reshape(1:(N^2), N, N)
+A = reshape(1:(N ^ 2), N, N)
 eqs = xs ~ A * xs
 @named sys′ = System(eqs, [xs], [])
 sys = mtkcompile(sys′)

--- a/test/scc_nonlinear_problem.jl
+++ b/test/scc_nonlinear_problem.jl
@@ -186,10 +186,10 @@ import ModelingToolkitStandardLibrary.Hydraulic.IsothermalCompressible as IC
     liquid_pressure(rho, rho_0, bulk) = (rho / rho_0 - 1) * bulk
     gas_pressure(rho, rho_0, p_gas, rho_gas) = rho * ((0 - p_gas) / (rho_0 - rho_gas))
     full_pressure(rho,
-    rho_0,
-    bulk,
-    p_gas,
-    rho_gas) = ifelse(
+        rho_0,
+        bulk,
+        p_gas,
+        rho_gas) = ifelse(
         rho >= rho_0, liquid_pressure(rho, rho_0, bulk),
         gas_pressure(rho, rho_0, p_gas, rho_gas))
 

--- a/test/sciml_problem_inputs.jl
+++ b/test/sciml_problem_inputs.jl
@@ -111,6 +111,7 @@ end
     # Simulates problems for all input types, checking that identical solutions are found.
     # test failure.
     for u0 in u0_alts, p in p_alts
+
         oprob = remake(base_oprob; u0, p)
         @test base_sol == solve(oprob, Tsit5(); saveat = 1.0)
         eprob = remake(base_eprob; u0, p)
@@ -124,6 +125,7 @@ end
     base_sol = solve(base_nlprob, NewtonRaphson())
     # Solves problems for all input types, checking that identical solutions are found.
     for u0 in u0_alts, p in p_alts
+
         nlprob = remake(base_nlprob; u0, p)
         @test base_sol == solve(nlprob, NewtonRaphson())
     end
@@ -140,6 +142,7 @@ end
     # Simulates problems for all input types, checking that identical solutions are found.
     # test failure.
     for u0 in u0_alts, p in p_alts
+
         ssprob = remake(base_ssprob; u0, p)
         @test base_sol == solve(ssprob, DynamicSS(Tsit5()))
         eprob = remake(base_eprob; u0, p)
@@ -206,6 +209,7 @@ end
         (idiscsys, ImplicitDiscreteProblem{true, SciMLBase.FullSpecialize})
     ]
         @testset "$(typeof(u0)) - $(typeof(p))" for u0 in u0s, p in ps
+
             if u0 isa Vector{Float64} && ctor <: ImplicitDiscreteProblem
                 u0 = ones(2)
             end
@@ -224,6 +228,7 @@ end
         (optsys, OptimizationProblem{true})
     ]
         @testset "$(typeof(u0)) - $(typeof(p))" for u0 in u0s, p in ps
+
             @test_warn ["deprecated"] ctor(sys, u0, p)
         end
     end

--- a/test/stream_connectors.jl
+++ b/test/stream_connectors.jl
@@ -265,7 +265,7 @@ sys_exp = expand_connections(compose(sys, [sp1, sp2]))
 
 # array var
 @connector function VecPin(; name)
-    sts = @variables v(t)[1:2]=[1.0, 0.0] i(t)[1:2]=1.0 [connect = Flow]
+    sts = @variables v(t)[1:2]=[1.0, 0.0] i(t)[1:2]=1.0 [connect=Flow]
     System(Equation[], t, [sts...;], []; name = name)
 end
 
@@ -284,7 +284,7 @@ sys = expand_connections(compose(simple, [vp1, vp2, vp3]))
              0 ~ -vp1.i[2] - vp2.i[2] - vp3.i[2]])
 
 @connector function VectorHeatPort(; name, N = 100, T0 = 0.0, Q0 = 0.0)
-    @variables (T(t))[1:N]=T0 (Q(t))[1:N]=Q0 [connect = Flow]
+    @variables (T(t))[1:N]=T0 (Q(t))[1:N]=Q0 [connect=Flow]
     System(Equation[], t, [T; Q], []; name = name)
 end
 

--- a/test/structural_transformation/index_reduction.jl
+++ b/test/structural_transformation/index_reduction.jl
@@ -68,5 +68,5 @@ let
         sys, [x => 1, y => 0, D(x) => 0.0, g => 1], (0.0, 10.0), guesses = [λ => 0.0])
     sol = solve(prob, Rodas5P())
     @test SciMLBase.successful_retcode(sol)
-    @test sol[x^2 + y^2][end] < 1.1
+    @test sol[x ^ 2 + y ^ 2][end] < 1.1
 end

--- a/test/symbolic_events.jl
+++ b/test/symbolic_events.jl
@@ -437,7 +437,7 @@ end
             spring, damper)
     end
     connect_sd(
-    sd, m1, m2) = [
+        sd, m1, m2) = [
         sd.spring.x ~ m1.pos - m2.pos, sd.damper.vel ~ m1.vel - m2.vel]
     sd_force(sd) = -sd.spring.k * sd.spring.x - sd.damper.c * sd.damper.vel
     @named mass1 = Mass(; m = 1)
@@ -1094,9 +1094,9 @@ end
     inited = false
     finaled = false
     a = ModelingToolkit.ImperativeAffect(f = (
-    m, o, ctx, int) -> (inited = true; return (;)))
+        m, o, ctx, int) -> (inited = true; return (;)))
     b = ModelingToolkit.ImperativeAffect(f = (
-    m, o, ctx, int) -> (finaled = true; return (;)))
+        m, o, ctx, int) -> (finaled = true; return (;)))
     cb2 = ModelingToolkit.SymbolicContinuousCallback(
         [x ~ 0.1], nothing, initialize = a, finalize = b)
     @mtkcompile sys = System(D(x) ~ -1, t, [x], []; continuous_events = [cb1, cb2])
@@ -1405,7 +1405,7 @@ end
     @test scc.affect isa ModelingToolkit.AffectSystem
     @test length(ModelingToolkit.all_equations(scc.affect)) == 5 # 1 affect, 3 algebraic, 1 observed
 
-    u0 = [x => -1 / 2, D(x) => 1 / 2, g => 1]
+    u0 = [x => -1/2, D(x) => 1/2, g => 1]
     prob = ODEProblem(pend, u0, (0.0, 5.0))
     sol = solve(prob, FBDF())
     @test SciMLBase.successful_retcode(sol)

--- a/test/test_variable_metadata.jl
+++ b/test/test_variable_metadata.jl
@@ -117,7 +117,7 @@ d = FakeNormal()
 ## System interface
 @independent_variables t
 Dₜ = Differential(t)
-@variables x(t)=0 [bounds = (-10, 10)] u(t)=0 [input = true] y(t)=0 [output = true]
+@variables x(t)=0 [bounds=(-10, 10)] u(t)=0 [input=true] y(t)=0 [output=true]
 @parameters T [bounds = (0, Inf)]
 @parameters k [tunable = true, bounds = (0, Inf)]
 @parameters k2 [tunable = false]

--- a/test/units.jl
+++ b/test/units.jl
@@ -66,19 +66,19 @@ System(eqs, t, name = :sys, checks = false)
 
 # connection validation
 @connector function Pin(; name)
-    sts = @variables(v(t)=1.0, [unit = u"V"],
-        i(t)=1.0, [unit = u"A", connect = Flow])
+    sts = @variables(v(t)=1.0, [unit=u"V"],
+        i(t)=1.0, [unit=u"A", connect=Flow])
     System(Equation[], t, sts, []; name = name)
 end
 @connector function OtherPin(; name)
-    sts = @variables(v(t)=1.0, [unit = u"mV"],
-        i(t)=1.0, [unit = u"mA", connect = Flow])
+    sts = @variables(v(t)=1.0, [unit=u"mV"],
+        i(t)=1.0, [unit=u"mA", connect=Flow])
     System(Equation[], t, sts, []; name = name)
 end
 @connector function LongPin(; name)
-    sts = @variables(v(t)=1.0, [unit = u"V"],
-        i(t)=1.0, [unit = u"A", connect = Flow],
-        x(t)=1.0, [unit = NoUnits])
+    sts = @variables(v(t)=1.0, [unit=u"V"],
+        i(t)=1.0, [unit=u"A", connect=Flow],
+        x(t)=1.0, [unit=NoUnits])
     System(Equation[], t, sts, []; name = name)
 end
 @named p1 = Pin()

--- a/test/variable_parsing.jl
+++ b/test/variable_parsing.jl
@@ -88,7 +88,7 @@ end
 @test getmetadata(x, VariableUnit) == u
 @test getmetadata(y, VariableDefaultValue) === 2
 
-@variables x=[1, 2] [connect = Flow, unit = u] y=2
+@variables x=[1, 2] [connect=Flow, unit=u] y=2
 
 @test getmetadata(x, VariableDefaultValue) == [1, 2]
 @test getmetadata(x, VariableConnectType) == Flow


### PR DESCRIPTION
This reverts the JuliaFormatter changes from PR #3846 (commit 891793ea).

The formatting is being reverted because JuliaFormatter had issues with line breaking that have now been addressed in JuliaFormatter.jl PR#933. Once that PR is merged and a new version is released, formatting can be reapplied with better results.

**Note:** This PR has [ci-skip] to avoid running tests since this is just reverting formatting changes.