### PR TITLE
fix: unwrap substitution rules in `nlstep=true`

### DIFF
--- a/src/systems/solver_nlprob.jl
+++ b/src/systems/solver_nlprob.jl
@@ -48,8 +48,8 @@ function inner_nlsystem(sys::System, mm, nlstep_compile::Bool)
     outer_tmp = get_outer_tmp(N)
     inner_tmp = get_inner_tmp(N)
 
-    subrules = Dict([v => gamma2*v + inner_tmp[i] for (i, v) in enumerate(dvs)])
-    subrules[t] = c
+    subrules = Dict([v => unwrap(gamma2*v + inner_tmp[i]) for (i, v) in enumerate(dvs)])
+    subrules[t] = unwrap(c)
     new_rhss = map(Base.Fix2(fast_substitute, subrules), rhss)
     new_rhss = collect(outer_tmp) .+ gamma1 .* new_rhss .- gamma3 * mm * dvs
     new_eqs = [0 ~ rhs for rhs in new_rhss]


### PR DESCRIPTION
Close #3876 