### PR TITLE
Fix cache issues with self-hosted runners

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -45,4 +45,8 @@ jobs:
     with:
       julia-version: "${{ matrix.version }}"
       group: "${{ matrix.group }}"
+      # Disable cache for self-hosted runners since they persist between runs
+      # Set USE_SELF_HOSTED repository variable to 'true' when using self-hosted runners
+      self-hosted: ${{ vars.USE_SELF_HOSTED == 'true' }}
+      cache: ${{ vars.USE_SELF_HOSTED != 'true' }}
     secrets: "inherit"


### PR DESCRIPTION
## Summary
- Adds conditional logic to disable julia-actions/cache for self-hosted runners
- Self-hosted runners persist between runs, causing cache action to fail when depot already exists  
- Uses `USE_SELF_HOSTED` repository variable to detect when using self-hosted runners

## Problem
As discussed in Slack, the caching fails on self-hosted runners because they don't clean slate between runs, so the depot already exists when the cache action tries to restore it.

Reference: https://github.com/SciML/ModelingToolkit.jl/actions/runs/16840335621/job/47712027510?pr=3869

## Solution
Following Ian Butterworth's suggestion, this PR:
1. Detects when using self-hosted runners via the `USE_SELF_HOSTED` repository variable
2. Passes `self-hosted: true` to the reusable workflow when the variable is set
3. Disables the cache action (`cache: false`) for self-hosted runners

## Usage
To use self-hosted runners, set the `USE_SELF_HOSTED` repository variable to `'true'` in the repository settings.

## Test Plan
- [ ] Verify CI passes with normal GitHub-hosted runners (cache enabled)
- [ ] Test with `USE_SELF_HOSTED='true'` to verify self-hosted runners work without cache errors

🤖 Generated with [Claude Code](https://claude.ai/code)