### PR TITLE
fix deprecated ODEProblem syntax in Debugging.md

### DIFF
--- a/docs/src/basics/Debugging.md
+++ b/docs/src/basics/Debugging.md
@@ -19,7 +19,7 @@ sys = mtkcompile(sys)
 This problem causes the ODE solver to crash:
 
 ```@repl debug
-prob = ODEProblem(sys, [], (0.0, 10.0), []);
+prob = ODEProblem(sys, [], (0.0, 10.0));
 sol = solve(prob, Tsit5());
 ```
 
@@ -28,7 +28,7 @@ In such situations, the `debug_system` function is helpful:
 
 ```@repl debug
 dsys = debug_system(sys; functions = [sqrt]);
-dprob = ODEProblem(dsys, [], (0.0, 10.0), []);
+dprob = ODEProblem(dsys, [], (0.0, 10.0));
 dsol = solve(dprob, Tsit5());
 ```
 


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
