### PR TITLE
Updated tests for the new behaviour of SymbolicUtils simplify function

### DIFF
--- a/test/changeofvariables.jl
+++ b/test/changeofvariables.jl
@@ -135,7 +135,7 @@ new_sys = change_of_variables(sys, t, forward_subs, backward_subs)
 @test noise_eqs(new_sys)[1, 1] === value(σ)
 @test noise_eqs(new_sys)[1, 2] === value(0)
 @test noise_eqs(new_sys)[2, 1] === value(0)
-@test noise_eqs(new_sys)[2, 2] === value(substitute(2*α*y, backward_subs[2]))
+@test noise_eqs(new_sys)[2, 2] === value(simplify(substitute(2*α*y, backward_subs[2])))
 @test noise_eqs(new_sys)[3, 1] === value(σ)
 @test noise_eqs(new_sys)[3, 2] === value(α)
 


### PR DESCRIPTION
## Checklist

- [x ] Appropriate tests were added
- [x ] Any code changes were done in a way that does not break public API
- [ x] All documentation related to code changes were updated
- [ x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x ] Any new documentation only uses public API
  
## Additional context
`simplify` from SymbolicUtils is gonna improve. Previously
```
julia> simplify(x^0.5)
x^0.5
```
But now
```
julia> simplify(x^0.5)
sqrt(x)
```
This is going to break tests in ModelingToolkit/test/changeofvariables.jl because on line 138, `@test noise_eqs(new_sys)[2, 2] === value(substitute(2*α*y, backward_subs[2]))` is gonna be avaluated as `2sqrt(w(t))*α === 2(w(t)^0.5)*α` returning false, because `new_sys` comes from `change_of_variables` function that contains a `simplify` call.

I tought of several options to fix this test:
- changing line 138 to `@test noise_eqs(new_sys)[2, 2] === value(simplify(substitute(2*α*y, backward_subs[2])))
` (what i did in this pr)
- chagning line 138 to `simplify(noise_eqs(new_sys)[2, 2] - value(substitute(2*α*y, backward_subs[2])))===0`
- changing line 128 above to `backward_subs = [x => exp(z), y => sqrt(w), u => exp(v)]`

all of these work. I'd like some feedback :)