### PR TITLE
fix: fix callback with non-`Real` parameter and non-empty unknowns

### DIFF
--- a/src/systems/callbacks.jl
+++ b/src/systems/callbacks.jl
@@ -855,7 +855,7 @@ end
 function default_operating_point(affsys::AffectSystem)
     sys = system(affsys)
 
-    op = Dict(unknowns(sys) .=> 0.0)
+    op = AnyDict(unknowns(sys) .=> 0.0)
     for p in parameters(sys)
         T = symtype(p)
         if T <: Number

--- a/test/symbolic_events.jl
+++ b/test/symbolic_events.jl
@@ -1421,3 +1421,22 @@ end
     @named sys = System([D(y) ~ 2x + 1, x^2 ~ 2y^3], t; discrete_events = [dev])
     sys = @test_nowarn mtkcompile(sys)
 end
+
+@testset "Non-`Real` symtype parameters in callback with unknown" begin
+    @mtkmodel MWE begin
+        @variables begin
+            x(t) = 1.0
+        end
+        @parameters begin
+            p(t)::Int = 1
+        end
+        @equations begin
+            D(x) ~ p * x
+        end
+        @discrete_events begin
+            1.0 => [x ~ p * Pre(x) * sin(x)]
+        end
+    end
+    @mtkcompile sys = MWE()
+    @test_nowarn ODEProblem(sys, [], (0.0, 1.0))
+end


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
