### PR TITLE
Copy parameter object before setting in `subset_tunables`

### DIFF
--- a/src/parameters.jl
+++ b/src/parameters.jl
@@ -172,7 +172,7 @@ function subset_tunables(sys, new_tunables)
         Note that array parameters can only be set as tunable or non-tunable, not partially tunable. They should be specified in the un-scalarized form.
         """))
     end
-    cur_ps = get_ps(sys)
+    cur_ps = copy(get_ps(sys))
     const_ps = toconstant.(diff_params)
 
     for (idx, p) in enumerate(cur_ps)

--- a/test/parameter_dependencies.jl
+++ b/test/parameter_dependencies.jl
@@ -198,6 +198,8 @@ end
     @test_throws ArgumentError ModelingToolkit.subset_tunables(sys_incomplete, new_tunables)
     sys_nonsplit = mtkcompile(pendulum_sys; split = false)
     @test_throws ArgumentError ModelingToolkit.subset_tunables(sys_nonsplit, new_tunables)
+
+    @test length(ModelingToolkit.tunable_parameters(sys)) == 3
 end
 
 struct CallableFoo

--- a/test/parameter_dependencies.jl
+++ b/test/parameter_dependencies.jl
@@ -200,7 +200,7 @@ end
     sys_nonsplit = mtkcompile(pendulum_sys; split = false)
     @test_throws ArgumentError ModelingToolkit.subset_tunables(sys_nonsplit, new_tunables)
 
-    @test length(ModelingToolkit.tunable_parameters(sys)) == length(old_tunables)
+    @test length(ModelingToolkit.tunable_parameters(sys, ModelingToolkit.parameters(sys))) == length(old_tunables)
 end
 
 struct CallableFoo

--- a/test/parameter_dependencies.jl
+++ b/test/parameter_dependencies.jl
@@ -184,6 +184,7 @@ end
     sys = mtkcompile(pendulum_sys)
 
     new_tunables = [L, b]
+    old_tunables = copy(ModelingToolkit.tunable_parameters(sys, ModelingToolkit.parameters(sys)))
     sys2 = ModelingToolkit.subset_tunables(sys, new_tunables)
     sys2_tunables = ModelingToolkit.tunable_parameters(sys2, ModelingToolkit.parameters(sys2))
     @test length(sys2_tunables) == 2
@@ -199,7 +200,7 @@ end
     sys_nonsplit = mtkcompile(pendulum_sys; split = false)
     @test_throws ArgumentError ModelingToolkit.subset_tunables(sys_nonsplit, new_tunables)
 
-    @test length(ModelingToolkit.tunable_parameters(sys)) == 3
+    @test length(ModelingToolkit.tunable_parameters(sys)) == length(old_tunables)
 end
 
 struct CallableFoo


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

closes https://github.com/SciML/ModelingToolkit.jl/issues/3921

cc @AayushSabharwal @SebastianM-C @ChrisRackauckas 

Add any other context about the problem here.
