### PR TITLE
Allow subsetting `Initial`s in `subset_tunables`

### DIFF
--- a/src/parameters.jl
+++ b/src/parameters.jl
@@ -164,7 +164,7 @@ function subset_tunables(sys, new_tunables)
         throw(ArgumentError("Tunable parameters can only be changed for split systems."))
     end
 
-    cur_tunables = tunable_parameters(sys, parameters(sys))
+    cur_tunables = tunable_parameters(sys, tunable_parameters(sys))
     diff_params = setdiff(cur_tunables, new_tunables)
 
     if !isempty(setdiff(new_tunables, cur_tunables))


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

cc @SebastianM-C can you check if this is sufficient for your use cases, and we can add a test then

Add any other context about the problem here.
