### PR TITLE
Make debugging page shorter

### DIFF
--- a/docs/src/basics/Debugging.md
+++ b/docs/src/basics/Debugging.md
@@ -57,7 +57,7 @@ We can use `debug_system` to log the failing assertions in each call to the RHS 
 ```@repl debug
 dsys = debug_system(sys; functions = []);
 dprob = ODEProblem(dsys, [], (0.0, 10.0));
-dsol = solve(dprob, Tsit5());
+dsol = solve(dprob, Tsit5(); dtmin = 0.1); # high dtmin only to show less clutter on this page
 ```
 
 Note the logs containing the failed assertion and corresponding message. To temporarily disable


### PR DESCRIPTION
Fix or mitigate https://github.com/SciML/ModelingToolkit.jl/issues/3882.
```julia-repl
julia> dsys = debug_system(sys; functions = []);
       dprob = ODEProblem(dsys, [], (0.0, 10.0));
       dsol = solve(dprob, Tsit5(); dtmin = 0.1); # high dtmin only to show less clutter on this page
┌ Error: Assertion (u1(t) + u2(t)) >= 2.0 failed:
│ Oh no!
└ @ ModelingToolkit ~/.julia/dev/ModelingToolkit.jl/src/debugging.jl:67
┌ Error: Assertion (u1(t) + u2(t)) >= 2.0 failed:
│ Oh no!
└ @ ModelingToolkit ~/.julia/dev/ModelingToolkit.jl/src/debugging.jl:67
┌ Error: Assertion (u1(t) + u2(t)) >= 2.0 failed:
│ Oh no!
└ @ ModelingToolkit ~/.julia/dev/ModelingToolkit.jl/src/debugging.jl:67
┌ Error: Assertion (u1(t) + u2(t)) >= 2.0 failed:
│ Oh no!
└ @ ModelingToolkit ~/.julia/dev/ModelingToolkit.jl/src/debugging.jl:67
┌ Error: Assertion (u1(t) + u2(t)) >= 2.0 failed:
│ Oh no!
└ @ ModelingToolkit ~/.julia/dev/ModelingToolkit.jl/src/debugging.jl:67
┌ Error: Assertion (u1(t) + u2(t)) >= 2.0 failed:
│ Oh no!
└ @ ModelingToolkit ~/.julia/dev/ModelingToolkit.jl/src/debugging.jl:67
┌ Warning: dt(0.1) <= dtmin(0.1) at t=0.4538820261379217, and step error estimate = NaN. Aborting. There is either an error in your model specification or the true solution is unstable.
└ @ SciMLBase ~/.julia/packages/SciMLBase/YE7xF/src/integrator_interface.jl:646
```