### PR TITLE
fix: unwrap inputs/outputs in `System` constructor

### DIFF
--- a/src/systems/system.jl
+++ b/src/systems/system.jl
@@ -380,6 +380,9 @@ function System(eqs::Vector{Equation}, iv, dvs, ps, brownians = [];
 
     defaults = anydict(defaults)
     guesses = anydict(guesses)
+
+    inputs = unwrap.(inputs)
+    outputs = unwrap.(outputs)
     inputs = OrderedSet{BasicSymbolic}(inputs)
     outputs = OrderedSet{BasicSymbolic}(outputs)
     for subsys in systems


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Without unwrapping it will fail when trying to convert a `Num` into a `BasicSymbolic`