### PR TITLE
Fix deprecated ODEProblem API calls in documentation

### DIFF
--- a/docs/src/basics/Composition.md
+++ b/docs/src/basics/Composition.md
@@ -57,7 +57,7 @@ p = [decay1.a => 0.1
      decay2.a => 0.2]
 
 using OrdinaryDiffEq
-prob = ODEProblem(simplified_sys, x0, (0.0, 100.0), p)
+prob = ODEProblem(simplified_sys, [x0; p], (0.0, 100.0))
 sol = solve(prob, Tsit5())
 sol[decay2.f]
 ```

--- a/docs/src/basics/Events.md
+++ b/docs/src/basics/Events.md
@@ -418,7 +418,7 @@ ev = ModelingToolkit.SymbolicDiscreteCallback(
 @mtkcompile sys = System(
     D(x) ~ c * cos(x), t, [x], [c]; discrete_events = [ev])
 
-prob = ODEProblem(sys, [x => 0.0], (0.0, 2pi), [c => 1.0])
+prob = ODEProblem(sys, [x => 0.0, c => 1.0], (0.0, 2pi))
 sol = solve(prob, Tsit5())
 sol[c]
 ```
@@ -439,7 +439,7 @@ will be saved. If we repeat the above example with `c` not a `discrete_parameter
 @mtkcompile sys = System(
     D(x) ~ c * cos(x), t, [x], [c]; discrete_events = [1.0 => [c ~ Pre(c) + 1]])
 
-prob = ODEProblem(sys, [x => 0.0], (0.0, 2pi), [c => 1.0])
+prob = ODEProblem(sys, [x => 0.0, c => 1.0], (0.0, 2pi))
 sol = solve(prob, Tsit5())
 sol.ps[c] # sol[c] will error, since `c` is not a timeseries value
 ```

--- a/docs/src/tutorials/ode_modeling.md
+++ b/docs/src/tutorials/ode_modeling.md
@@ -36,7 +36,7 @@ end
 
 using OrdinaryDiffEq
 @mtkcompile fol = FOL()
-prob = ODEProblem(fol, [], (0.0, 10.0), [])
+prob = ODEProblem(fol, [], (0.0, 10.0))
 sol = solve(prob)
 
 using Plots

--- a/docs/src/tutorials/programmatically_generating.md
+++ b/docs/src/tutorials/programmatically_generating.md
@@ -49,7 +49,7 @@ eqs = [D(x) ~ (h - x) / τ] # create an array of equations
 # Perform the standard transformations and mark the model complete
 # Note: Complete models cannot be subsystems of other models!
 fol = mtkcompile(model)
-prob = ODEProblem(fol, [], (0.0, 10.0), [])
+prob = ODEProblem(fol, [], (0.0, 10.0))
 using OrdinaryDiffEq
 sol = solve(prob)
 


### PR DESCRIPTION
## Summary

This PR fixes the deprecated `ODEProblem` API calls in the documentation to use the new API that was introduced in recent versions of ModelingToolkit.jl.

## Changes

Updated the following documentation files to replace the deprecated 4-argument `ODEProblem(sys, u0, tspan, p)` signature with the new 3-argument signature where initial conditions and parameters are merged:

1. **docs/src/tutorials/ode_modeling.md** (Line 39)
   - Changed: `ODEProblem(fol, [], (0.0, 10.0), [])`
   - To: `ODEProblem(fol, [], (0.0, 10.0))`

2. **docs/src/tutorials/programmatically_generating.md** (Line 52)
   - Changed: `ODEProblem(fol, [], (0.0, 10.0), [])`
   - To: `ODEProblem(fol, [], (0.0, 10.0))`

3. **docs/src/basics/Events.md** (Lines 421, 442)
   - Changed: `ODEProblem(sys, [x => 0.0], (0.0, 2pi), [c => 1.0])`
   - To: `ODEProblem(sys, [x => 0.0, c => 1.0], (0.0, 2pi))`

4. **docs/src/basics/Composition.md** (Line 60)
   - Changed: `ODEProblem(simplified_sys, x0, (0.0, 100.0), p)`
   - To: `ODEProblem(simplified_sys, [x0; p], (0.0, 100.0))`

## Impact

These changes eliminate deprecation warnings that users encounter when running the "Copy-Pastable Simplified Example" and other tutorial code from the documentation. The updated examples now use the current recommended API.

## Test Plan

- [ ] Documentation builds successfully without errors
- [ ] Example code blocks run without deprecation warnings
- [ ] CI tests pass

Fixes #3996

🤖 Generated with [Claude Code](https://claude.com/claude-code)