### PR TITLE
Add backticks to close example code blocks

### DIFF
--- a/src/systems/abstractsystem.jl
+++ b/src/systems/abstractsystem.jl
@@ -3066,6 +3066,7 @@ eq2 = 0 ~ p - d*X
 @named osys = System([eq1, eq2], t)
 
 alg_equations(osys) # returns `[0 ~ p - d*X(t)]`.
+```
 """
 alg_equations(sys::AbstractSystem) = filter(is_alg_equation, equations(sys))
 
@@ -3085,6 +3086,7 @@ eq2 = 0 ~ p - d*X
 @named osys = System([eq1, eq2], t)
 
 diff_equations(osys) # returns `[Differential(t)(X(t)) ~ p - d*X(t)]`.
+```
 """
 diff_equations(sys::AbstractSystem) = filter(is_diff_equation, equations(sys))
 


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context
Adds triple backticks in docstrings for `alg_equations` and `diff_equations`