### PR TITLE
Fix trivial typo in documentation

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -152,7 +152,7 @@ Below is an incomplete list of extension libraries one may want to be aware of:
 
 All of the symbolic systems have a direct conversion to a numerical system, which
 can then be handled through the SciML interfaces. For example, after building a
-model and performing symbolic manipulations, an `System` can be converted into
+model and performing symbolic manipulations, a `System` can be converted into
 an `ODEProblem` to then be solved by a numerical ODE solver. Below is a list of
 the solver libraries which are the numerical targets of the ModelingToolkit
 system:


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
