### PR TITLE
fix: add Julia 1.10 compatibility for Base.ispublic

### DIFF
--- a/src/ModelingToolkit.jl
+++ b/src/ModelingToolkit.jl
@@ -112,8 +112,11 @@ macro import_mtkbase()
         name in banned_names && continue
         startswith(string(name), '#') && continue
         push!(inner_using_expr.args, Expr(:., name))
-        if Base.ispublic(MTKBase, name) && !Base.isexported(MTKBase, name)
-            push!(inner_public_expr.args, name)
+        # Base.ispublic was added in Julia 1.11
+        @static if VERSION >= v"1.11"
+            if Base.ispublic(MTKBase, name) && !Base.isexported(MTKBase, name)
+                push!(inner_public_expr.args, name)
+            end
         end
     end
 


### PR DESCRIPTION
## Summary
- Fix `UndefVarError: ispublic not defined` error on Julia 1.10
- `Base.ispublic` was introduced in Julia 1.11, but the `@import_mtkbase` macro was calling it unconditionally
- Wrapped the call in `@static if VERSION >= v"1.11"` to maintain compatibility with Julia 1.9-1.10

## Test plan
- [x] Tested loading ModelingToolkit on Julia 1.10 - loads successfully
- [x] Tested loading ModelingToolkit on Julia 1.11 - loads successfully (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)