### PR TITLE
Fix UndefVarError for generate_ODENLStepData with nlstep=true

### DIFF
--- a/lib/ModelingToolkitBase/src/problems/odeproblem.jl
+++ b/lib/ModelingToolkitBase/src/problems/odeproblem.jl
@@ -1,3 +1,17 @@
+"""
+    generate_ODENLStepData(sys, u0, p, mm, nlstep_compile, nlstep_scc)
+
+Generate the NLStep data for implicit ODE solvers. This is a stub that throws an error
+if called without ModelingToolkit loaded. The actual implementation is provided by
+ModelingToolkit when it is loaded.
+"""
+function generate_ODENLStepData(sys, u0, p, mm, nlstep_compile, nlstep_scc)
+    error("""
+        `nlstep=true` requires ModelingToolkit.jl to be loaded.
+        Please add `using ModelingToolkit` to your code before creating an ODEProblem with `nlstep=true`.
+        """)
+end
+
 @fallback_iip_specialize function SciMLBase.ODEFunction{iip, spec}(
         sys::System; u0 = nothing, p = nothing, tgrad = false, jac = false,
         t = nothing, eval_expression = false, eval_module = @__MODULE__, sparse = false,

--- a/src/systems/solver_nlprob.jl
+++ b/src/systems/solver_nlprob.jl
@@ -1,4 +1,4 @@
-function generate_ODENLStepData(sys::System, u0, p, mm = calculate_massmatrix(sys),
+function MTKBase.generate_ODENLStepData(sys::System, u0, p, mm = calculate_massmatrix(sys),
         nlstep_compile::Bool = true, nlstep_scc::Bool = false)
     nlsys, outer_tmp, inner_tmp = inner_nlsystem(sys, mm, nlstep_compile)
     state = ProblemState(; u = u0, p)


### PR DESCRIPTION
## Summary

- Add a function stub in ModelingToolkitBase that throws a helpful error when `nlstep=true` is used without ModelingToolkit loaded
- ModelingToolkit overrides this stub with the actual implementation via `MTKBase.generate_ODENLStepData`

## Problem

When calling `ODEProblem(sys, u0, tspan, p; nlstep=true)`, the code fails with:
```
UndefVarError: `generate_ODENLStepData` not defined in `ModelingToolkitBase`
```

This happens because:
1. `generate_ODENLStepData` is defined in `ModelingToolkit/src/systems/solver_nlprob.jl`
2. But it's called from `ModelingToolkitBase/src/problems/odeproblem.jl:46`
3. The function isn't available in the `ModelingToolkitBase` module scope

## Solution

1. Add a stub function in `ModelingToolkitBase` that throws a helpful error message
2. Have `ModelingToolkit` override the stub by defining `MTKBase.generate_ODENLStepData`

## Test plan

- [x] Verified `nlstep=true` works when ModelingToolkit is loaded
- [x] Verified helpful error message appears when only ModelingToolkitBase is used

🤖 Generated with [Claude Code](https://claude.com/claude-code)