### PR TITLE
Specialize FMI extension to use FMIImport instead of FMI

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -45,7 +45,7 @@ Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
 UnPack = "3a884ed6-31ef-47d7-9d2a-63182c4928ed"
 
 [weakdeps]
-FMI = "14a09403-18e3-468f-ad8a-74f8dda2d9ac"
+FMIImport = "9fcbc62e-52a0-44e9-a616-1359a0008194"
 
 [sources.ModelingToolkitBase]
 subdir = "lib/ModelingToolkitBase"
@@ -53,7 +53,7 @@ subdir = "lib/ModelingToolkitBase"
 subdir = "lib/SciCompDSL"
 
 [extensions]
-MTKFMIExt = "FMI"
+MTKFMIExt = "FMIImport"
 
 [compat]
 ADTypes = "1.14.0"
@@ -69,7 +69,7 @@ DelayDiffEq = "5.61"
 DiffEqBase = "6.189.1"
 DifferentiationInterface = "0.6.47, 0.7"
 DocStringExtensions = "0.7, 0.8, 0.9"
-FMI = "0.14"
+FMIImport = "1"
 FillArrays = "1.13.0"
 FindFirstFunctions = "1"
 ForwardDiff = "0.10.3, 1"

--- a/ext/MTKFMIExt.jl
+++ b/ext/MTKFMIExt.jl
@@ -6,7 +6,7 @@ using ModelingToolkit: t_nounits as t, D_nounits as D
 using DocStringExtensions
 import ModelingToolkit as MTK
 import SciMLBase
-import FMI
+import FMIImport as FMI
 
 """
     $(TYPEDSIGNATURES)


### PR DESCRIPTION
## Summary

- Changes the MTKFMIExt extension to trigger on FMIImport instead of the full FMI.jl package
- This addresses issue #3905, which suggested specializing the FMI extension on the specific subpackage it needs

## Changes

1. Updated `[weakdeps]` to use FMIImport (UUID: 9fcbc62e-52a0-44e9-a616-1359a0008194)
2. Updated `[extensions]` to trigger on FMIImport  
3. Updated `[compat]` to require FMIImport version 1
4. Changed the extension import from `import FMI` to `import FMIImport as FMI`

## Why This Works

The previous investigation (mentioned in the issue comments) was incorrect. FMIImport.jl actually exports all the high-level functions the extension needs:
- `getStateValueReferencesAndNames`
- `getDerivateValueReferencesAndNames`
- `getInputValueReferencesAndNames`
- `getOutputValueReferencesAndNames`
- `getParameterValueReferencesAndNames`
- `dataTypeForValueReference`
- `getStartValue`
- And all the FMI2/FMI3 low-level functions

## Backward Compatibility

This is a non-breaking change because:
1. FMI.jl depends on FMIImport.jl, so loading FMI also loads FMIImport
2. The extension still works with both FMI and FMIImport
3. Users who only need FMU import functionality can now use the lighter FMIImport package

## Test Plan

- [x] Verified extension precompiles successfully with FMIImport
- [x] Verified extension loads when using FMIImport directly
- [x] Verified extension loads when using FMI (which depends on FMIImport)
- [x] Ran FMI tests (21/22 passed, 1 flaky test with numerical precision issue unrelated to this change)

Fixes #3905

🤖 Generated with [Claude Code](https://claude.com/claude-code)