### PR TITLE
Fix JET static analysis issues in linearization and solver_nlprob

### DIFF
--- a/src/systems/solver_nlprob.jl
+++ b/src/systems/solver_nlprob.jl
@@ -46,7 +46,7 @@ function inner_nlsystem(sys::System, mm, nlstep_compile::Bool)
     t = get_iv(sys)
     N = length(dvs)
     @assert length(eqs) == N
-    @assert mm == I || size(mm) == (N, N)
+    @assert mm isa UniformScaling || size(mm) == (N, N)
     rhss = [eq.rhs for eq in eqs]
     gamma1, gamma2, gamma3 = ODE_GAMMA
     c = ODE_C


### PR DESCRIPTION
## Summary

This PR addresses 4 JET.jl static analysis issues identified in ModelingToolkit:

### Changes

1. **Fix PreparedJacobian{false} constructor** (`linearization.jl:184`)
   - The constructor was incorrectly using `{true}` as the first type parameter instead of `{false}`
   - Missing `autodiff` argument in the constructor call

2. **Fix size(::UniformScaling) issue** (`solver_nlprob.jl:49`)
   - Changed `mm == I` check to `mm isa UniformScaling` since `size()` is not defined for `UniformScaling` types

3. **Fix length(::Nothing) issue** (`linearization.jl:314`)
   - Error message was calling `length(u)` when `u` is `nothing`
   - Changed to use `linfun.num_states` for the error message

4. **Fix generate_rhs getindex issue** (`linearization.jl:513`)
   - `generate_rhs` can return either `Expr` or `Tuple{Expr, Expr}` depending on the system
   - Added type check to handle both return types correctly

### JET Analysis Results

JET report improved from **21 to 17 issues** in ModelingToolkit-specific code. The remaining issues are:
- Legacy undefined references (`defaults`, `expected_scope_depth`) that would require larger refactoring
- Moshi `@match` pattern matching issues (upstream library)
- Union type dispatch in `SymbolicContinuousCallback`

### Test plan

- [x] Package precompiles successfully
- [x] Linearization tests pass (56 passed, 1 broken - pre-existing)
- [x] JET analysis confirms fixes

cc @ChrisRackauckas

🤖 Generated with [Claude Code](https://claude.com/claude-code)