### PR TITLE
feat: add the unflattened system as a parent in `expand_connections`

### DIFF
--- a/lib/ModelingToolkitBase/src/systems/connectors.jl
+++ b/lib/ModelingToolkitBase/src/systems/connectors.jl
@@ -1042,9 +1042,11 @@ function expand_connections(sys::AbstractSystem, ::Val{with_source_info} = Val(f
     # set the bindingss for domain networks
     newbinds = get_domain_bindings(sys, domain_csets)
     # build the new system
+    _sys = sys
     sys = flatten(sys, true)
     @set! sys.eqs = eqs
     @set! sys.bindings = newbinds
+    @set! sys.parent = _sys
 
     if with_source_info
         return sys, source_info


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
