### PR TITLE
fix: generalize `SII.getname(::System)` to `::AbstractSystem`

### DIFF
--- a/lib/ModelingToolkitBase/src/systems/system.jl
+++ b/lib/ModelingToolkitBase/src/systems/system.jl
@@ -549,7 +549,7 @@ end
     throw(NonUniqueSubsystemsError(sysnames, unique_sysnames))
 end
 
-SymbolicIndexingInterface.getname(x::System) = nameof(x)
+SymbolicIndexingInterface.getname(x::AbstractSystem) = nameof(x)
 
 """
     $(TYPEDSIGNATURES)


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
