### PR TITLE
Switch from JuliaFormatter to Runic.jl for code formatting

### DIFF
--- a/.JuliaFormatter.toml
+++ b/.JuliaFormatter.toml
@@ -1,2 +1,0 @@
-style = "sciml"
-format_markdown = true

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -1,14 +1,19 @@
-name: "Format Check"
+name: format-check
 
 on:
   push:
     branches:
       - 'master'
-      - v10
+      - 'main'
+      - 'release-'
     tags: '*'
   pull_request:
 
 jobs:
-  format-check:
-    name: "Format Check"
-    uses: "SciML/.github/.github/workflows/format-check.yml@v1"
+  runic:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: fredrikekre/runic-action@v1
+        with:
+          version: '1'

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -69,7 +69,8 @@ N = 25
 
 defval = collect(x) * collect(x)'
 @mtkcompile model = System(
-    [D(x) ~ x], t, [x], [A]; defaults = [A => defval], guesses = [A => fill(NaN, N, N)])
+    [D(x) ~ x], t, [x], [A]; defaults = [A => defval], guesses = [A => fill(NaN, N, N)]
+)
 
 u0 = [x => rand(N)]
 prob = ODEProblem(model, u0, tspan)
@@ -79,7 +80,7 @@ large_param_init["init"] = @benchmarkable init($prob)
 
 sparse_analytical_jacobian = SUITE["sparse_analytical_jacobian"]
 
-eqs = [D(x[i]) ~ prod(x[j] for j in 1:N if (i+j) % 3 == 0) for i in 1:N]
+eqs = [D(x[i]) ~ prod(x[j] for j in 1:N if (i + j) % 3 == 0) for i in 1:N]
 @mtkcompile model = System(eqs, t)
 u0 = collect(x .=> 1.0)
 tspan = (0.0, 1.0)

--- a/demo.jl
+++ b/demo.jl
@@ -1,11 +1,11 @@
 macro mtkcompile(ex...)
-    quote
+    return quote
         @mtkbuild $(ex...)
     end
 end
 
 function mtkcompile(args...; kwargs...)
-    structural_simplify(args...; kwargs...)
+    return structural_simplify(args...; kwargs...)
 end
 
 #################################
@@ -17,9 +17,11 @@ using ModelingToolkit: t_nounits as t, D_nounits as D
 
 @parameters g
 @variables x(t) y(t) λ(t)
-eqs = [D(D(x)) ~ λ * x
-       D(D(y)) ~ λ * y - g
-       x^2 + y^2 ~ 1]
+eqs = [
+    D(D(x)) ~ λ * x
+    D(D(y)) ~ λ * y - g
+    x^2 + y^2 ~ 1
+]
 @mtkcompile pend = System(eqs, t)
 prob = ODEProblem(pend, [x => -1, y => 0], (0.0, 10.0), [g => 1], guesses = [λ => 1])
 
@@ -34,7 +36,7 @@ sol = solve(prob, FBDF())
 eqs = [
     D(x) ~ σ * (y - x) + 0.1x * a,
     D(y) ~ x * (ρ - z) - y + 0.1y * a,
-    D(z) ~ x * y - β * z + 0.1z * a
+    D(z) ~ x * y - β * z + 0.1z * a,
 ]
 
 @mtkcompile sys1 = System(eqs, t)
@@ -42,23 +44,28 @@ eqs = [
 eqs = [
     D(x) ~ σ * (y - x),
     D(y) ~ x * (ρ - z) - y,
-    D(z) ~ x * y - β * z
+    D(z) ~ x * y - β * z,
 ]
 
-noiseeqs = [0.1*x;
-            0.1*y;
-            0.1*z;;]
+noiseeqs = [
+    0.1 * x;
+    0.1 * y;
+    0.1 * z;;
+]
 
 @mtkcompile sys2 = SDESystem(eqs, noiseeqs, t)
 
 u0 = [
     x => 1.0,
     y => 0.0,
-    z => 0.0]
+    z => 0.0,
+]
 
-p = [σ => 28.0,
+p = [
+    σ => 28.0,
     ρ => 10.0,
-    β => 8 / 3]
+    β => 8 / 3,
+]
 
 sdeprob = SDEProblem(sys1, u0, (0.0, 10.0), p)
 sdesol = solve(sdeprob, ImplicitEM())
@@ -70,18 +77,22 @@ odeprob = ODEProblem(sys1, u0, (0.0, 10.0), p; check_compatibility = false)
 @parameters σ ρ β
 
 # Define a nonlinear system
-eqs = [0 ~ σ * (y - x),
+eqs = [
+    0 ~ σ * (y - x),
     y ~ x * (ρ - z),
-    β * z ~ x * y]
+    β * z ~ x * y,
+]
 @mtkcompile sys = System(eqs)
 
 ## ImplicitDiscrete Affects
 
 @parameters g
 @variables x(t) y(t) λ(t)
-eqs = [D(D(x)) ~ λ * x
-       D(D(y)) ~ λ * y - g
-       x^2 + y^2 ~ 1]
+eqs = [
+    D(D(x)) ~ λ * x
+    D(D(y)) ~ λ * y - g
+    x^2 + y^2 ~ 1
+]
 c_evt = [t ~ 5.0] => [x ~ Pre(x) + 0.1]
 @mtkcompile pend = System(eqs, t, continuous_events = c_evt)
 prob = ODEProblem(pend, [x => -1, y => 0], (0.0, 10.0), [g => 1], guesses = [λ => 1])

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -14,17 +14,24 @@ cp("./docs/Project.toml", "./docs/src/assets/Project.toml", force = true)
 
 include("pages.jl")
 
-mathengine = MathJax3(Dict(:loader => Dict("load" => ["[tex]/require", "[tex]/mathtools"]),
-    :tex => Dict("inlineMath" => [["\$", "\$"], ["\\(", "\\)"]],
-        "packages" => [
-            "base",
-            "ams",
-            "autoload",
-            "mathtools",
-            "require"
-        ])))
+mathengine = MathJax3(
+    Dict(
+        :loader => Dict("load" => ["[tex]/require", "[tex]/mathtools"]),
+        :tex => Dict(
+            "inlineMath" => [["\$", "\$"], ["\\(", "\\)"]],
+            "packages" => [
+                "base",
+                "ams",
+                "autoload",
+                "mathtools",
+                "require",
+            ]
+        )
+    )
+)
 
-makedocs(sitename = "ModelingToolkit.jl",
+makedocs(
+    sitename = "ModelingToolkit.jl",
     authors = "Chris Rackauckas",
     modules = [ModelingToolkit, MTKFMIExt],
     clean = true, doctest = false, linkcheck = true,
@@ -33,7 +40,7 @@ makedocs(sitename = "ModelingToolkit.jl",
         "https://epubs.siam.org/doi/10.1137/0903023",
         # this link tends to fail linkcheck stochastically and often takes much longer to succeed
         # even in the browser it takes ages
-        "http://www.scholarpedia.org/article/Differential-algebraic_equations"
+        "http://www.scholarpedia.org/article/Differential-algebraic_equations",
     ],
     format = Documenter.HTML(;
         assets = ["assets/favicon.ico"],
@@ -41,8 +48,12 @@ makedocs(sitename = "ModelingToolkit.jl",
         canonical = "https://docs.sciml.ai/ModelingToolkit/stable/",
         prettyurls = (get(ENV, "CI", nothing) == "true"),
         # This page gets especially big with all the problem docstrings
-        size_threshold_ignore = ["API/problems.md"]),
-    pages = pages)
+        size_threshold_ignore = ["API/problems.md"]
+    ),
+    pages = pages
+)
 
-deploydocs(repo = "github.com/SciML/ModelingToolkit.jl.git";
-    push_preview = true)
+deploydocs(
+    repo = "github.com/SciML/ModelingToolkit.jl.git";
+    push_preview = true
+)

--- a/docs/pages.jl
+++ b/docs/pages.jl
@@ -1,7 +1,8 @@
 pages = [
     "Home" => "index.md",
     "tutorials/ode_modeling.md",
-    "Tutorials" => Any["tutorials/acausal_components.md",
+    "Tutorials" => Any[
+        "tutorials/acausal_components.md",
         "tutorials/nonlinear.md",
         "tutorials/initialization.md",
         "tutorials/optimization.md",
@@ -19,22 +20,30 @@ pages = [
         "tutorials/callable_params.md",
         "tutorials/linear_analysis.md",
         "tutorials/disturbance_modeling.md",
-        "tutorials/fmi.md"],
+        "tutorials/fmi.md",
+    ],
     "Examples" => Any[
-        "Basic Examples" => Any["examples/higher_order.md",
+        "Basic Examples" => Any[
+            "examples/higher_order.md",
             "examples/spring_mass.md",
             "examples/modelingtoolkitize_index_reduction.md",
-            "examples/remake.md"],
-        "Advanced Examples" => Any["examples/tearing_parallelism.md",
+            "examples/remake.md",
+        ],
+        "Advanced Examples" => Any[
+            "examples/tearing_parallelism.md",
             "examples/sparse_jacobians.md",
-            "examples/perturbation.md"]],
-    "API" => Any["API/System.md",
+            "examples/perturbation.md",
+        ],
+    ],
+    "API" => Any[
+        "API/System.md",
         "API/variables.md",
         "API/model_building.md",
         "API/problems.md",
         "API/dynamic_opt.md",
         "API/codegen.md",
-        "API/PDESystem.md"],
+        "API/PDESystem.md",
+    ],
     "Basics" => Any[
         "basics/Composition.md",
         "basics/Events.md",
@@ -45,10 +54,12 @@ pages = [
         "basics/Debugging.md",
         "basics/DependencyGraphs.md",
         "basics/Precompilation.md",
-        "basics/FAQ.md"],
+        "basics/FAQ.md",
+    ],
     "comparison.md",
     "Internal Details" => Any[
         "internals.md",
         "internals/structural_transformation.md",
-        "internals/bipartite_graph.md"]
+        "internals/bipartite_graph.md",
+    ],
 ]

--- a/ext/MTKFMIExt.jl
+++ b/ext/MTKFMIExt.jl
@@ -35,9 +35,13 @@ macro statuscheck(expr)
     return quote
         status = $expr
         fnname = $fnname
-        if status !== nothing && ((status isa Tuple && status[1] == $fmiTrue) ||
-            (!(status isa Tuple) && status != $fmiStatusOK &&
-             status != $fmiStatusWarning))
+        if status !== nothing && (
+                (status isa Tuple && status[1] == $fmiTrue) ||
+                    (
+                    !(status isa Tuple) && status != $fmiStatusOK &&
+                        status != $fmiStatusWarning
+                )
+            )
             if status != $fmiStatusFatal
                 $fmiTerminate(wrapper.instance)
             end
@@ -56,7 +60,8 @@ end
         `FMI.getStateValueReferencesAndNames` to work.
     """
     function FMI.getValueReferencesAndNames(
-            md::FMI.fmi3ModelDescription; vrs = md.valueReferences)
+            md::FMI.fmi3ModelDescription; vrs = md.valueReferences
+        )
         dict = Dict{FMI.fmi3ValueReference, Array{String}}()
         for vr in vrs
             dict[vr] = FMI.valueReferenceToString(md, vr)
@@ -92,8 +97,10 @@ with the name `namespace__variable`.
   CoSimulation FMU respectively.
 - `name`: The name of the system.
 """
-function MTK.FMIComponent(::Val{Ver}; fmu = nothing, tolerance = 1e-6,
-        communication_step_size = nothing, reinitializealg = nothing, type, name) where {Ver}
+function MTK.FMIComponent(
+        ::Val{Ver}; fmu = nothing, tolerance = 1.0e-6,
+        communication_step_size = nothing, reinitializealg = nothing, type, name
+    ) where {Ver}
     if Ver != 2 && Ver != 3
         throw(ArgumentError("FMI Version must be `2` or `3`"))
     end
@@ -119,8 +126,10 @@ function MTK.FMIComponent(::Val{Ver}; fmu = nothing, tolerance = 1e-6,
     der_observed = Equation[]
 
     # parse states
-    fmi_variables_to_mtk_variables!(fmu, FMI.getStateValueReferencesAndNames(fmu),
-        value_references, diffvars, states, observed)
+    fmi_variables_to_mtk_variables!(
+        fmu, FMI.getStateValueReferencesAndNames(fmu),
+        value_references, diffvars, states, observed
+    )
     # create a symbolic variable __mtk_internal_u to pass to the relevant registered
     # functions as the state vector
     if isempty(diffvars)
@@ -137,7 +146,7 @@ function MTK.FMIComponent(::Val{Ver}; fmu = nothing, tolerance = 1e-6,
         # CS FMUs do their own independent integration in a periodic callback, so their
         # unknowns are discrete variables in the `ODESystem`. A default of `missing` allows
         # them to be solved for during initialization.
-        @discretes __mtk_internal_u(t)[1:length(diffvars)]=missing [guess = diffvars]
+        @discretes __mtk_internal_u(t)[1:length(diffvars)] = missing [guess = diffvars]
         push!(observed, __mtk_internal_u ~ copy(diffvars))
     end
 
@@ -153,14 +162,18 @@ function MTK.FMIComponent(::Val{Ver}; fmu = nothing, tolerance = 1e-6,
     end
     fmi_variables_to_mtk_variables!(
         fmu, FMI.getDerivateValueReferencesAndNames(fmu), value_references, dervars,
-        states, der_observed; postprocess_variable = derivative_order_postprocess)
+        states, der_observed; postprocess_variable = derivative_order_postprocess
+    )
     @assert length(derivative_order) == length(dervars)
 
     # parse the inputs to the FMU
     inputs = []
-    fmi_variables_to_mtk_variables!(fmu, FMI.getInputValueReferencesAndNames(fmu),
+    fmi_variables_to_mtk_variables!(
+        fmu, FMI.getInputValueReferencesAndNames(fmu),
         value_references, inputs, states, observed; postprocess_variable = v -> MTK.setinput(
-            v, true))
+            v, true
+        )
+    )
     # create a symbolic variable for the input buffer
     __mtk_internal_x = copy(inputs)
     if isempty(__mtk_internal_x)
@@ -169,16 +182,19 @@ function MTK.FMIComponent(::Val{Ver}; fmu = nothing, tolerance = 1e-6,
 
     # parse the outputs of the FMU
     outputs = []
-    fmi_variables_to_mtk_variables!(fmu, FMI.getOutputValueReferencesAndNames(fmu),
+    fmi_variables_to_mtk_variables!(
+        fmu, FMI.getOutputValueReferencesAndNames(fmu),
         value_references, outputs, states, observed; postprocess_variable = v -> MTK.setoutput(
-            v, true))
+            v, true
+        )
+    )
     # create the output buffer. This is only required for CoSimulation to pass it to
     # the callback affect
     if type == :CS
         if isempty(outputs)
             __mtk_internal_o = Float64[]
         else
-            @discretes __mtk_internal_o(t)[1:length(outputs)]=missing [guess = zeros(length(outputs))]
+            @discretes __mtk_internal_o(t)[1:length(outputs)] = missing [guess = zeros(length(outputs))]
             push!(observed, __mtk_internal_o ~ outputs)
         end
     end
@@ -189,7 +205,8 @@ function MTK.FMIComponent(::Val{Ver}; fmu = nothing, tolerance = 1e-6,
     parameter_dependencies = Equation[]
     fmi_variables_to_mtk_variables!(
         fmu, FMI.getParameterValueReferencesAndNames(fmu), value_references,
-        params, [], parameter_dependencies, defs; parameters = true)
+        params, [], parameter_dependencies, defs; parameters = true
+    )
     # create a symbolic variable for the parameter buffer
     __mtk_internal_p = copy(params)
     if isempty(__mtk_internal_p)
@@ -208,11 +225,13 @@ function MTK.FMIComponent(::Val{Ver}; fmu = nothing, tolerance = 1e-6,
     if Ver == 2
         @parameters (wrapper::FMI2InstanceWrapper)(..)[1:buffer_length] = FMI2InstanceWrapper(
             fmu, derivative_value_references, state_value_references, output_value_references,
-            param_value_references, input_value_references, tolerance)
+            param_value_references, input_value_references, tolerance
+        )
     else
         @parameters (wrapper::FMI3InstanceWrapper)(..)[1:buffer_length] = FMI3InstanceWrapper(
             fmu, derivative_value_references, state_value_references,
-            output_value_references, param_value_references, input_value_references)
+            output_value_references, param_value_references, input_value_references
+        )
     end
 
     # any additional initialization equations for the system
@@ -238,7 +257,8 @@ function MTK.FMIComponent(::Val{Ver}; fmu = nothing, tolerance = 1e-6,
         finalize_affect = MTK.ImperativeAffect(fmiFinalize!; observed = (; wrapper))
         step_affect = MTK.ImperativeAffect(Returns((;)))
         instance_management_callback = MTK.SymbolicDiscreteCallback(
-            (t == t - 1), step_affect; finalize = finalize_affect, reinitializealg = SciMLBase.NoInit())
+            (t == t - 1), step_affect; finalize = finalize_affect, reinitializealg = SciMLBase.NoInit()
+        )
 
         push!(params, wrapper)
         append!(observed, der_observed)
@@ -252,16 +272,21 @@ function MTK.FMIComponent(::Val{Ver}; fmu = nothing, tolerance = 1e-6,
         # for co-simulation, we need to ensure the output buffer is solved for
         # during initialization
         for (i, x) in enumerate(collect(__mtk_internal_o))
-            push!(initialization_eqs,
+            push!(
+                initialization_eqs,
                 x ~ functor(
-                    wrapper, __mtk_internal_u, __mtk_internal_x, __mtk_internal_p, t)[i])
+                    wrapper, __mtk_internal_u, __mtk_internal_x, __mtk_internal_p, t
+                )[i]
+            )
         end
 
         diffeqs = Equation[]
 
         # use `ImperativeAffect` for instance management here
-        cb_observed = (; inputs = __mtk_internal_x, params = copy(params),
-            t, wrapper, dt = communication_step_size)
+        cb_observed = (;
+            inputs = __mtk_internal_x, params = copy(params),
+            t, wrapper, dt = communication_step_size,
+        )
         cb_modified = (;)
         # modify the outputs if present
         if symbolic_type(__mtk_internal_o) != NotSymbolic()
@@ -271,15 +296,19 @@ function MTK.FMIComponent(::Val{Ver}; fmu = nothing, tolerance = 1e-6,
         if symbolic_type(__mtk_internal_u) != NotSymbolic()
             cb_modified = (cb_modified..., states = __mtk_internal_u)
         end
-        initialize_affect = MTK.ImperativeAffect(fmiCSInitialize!; observed = cb_observed,
-            modified = cb_modified, ctx = _functor)
+        initialize_affect = MTK.ImperativeAffect(
+            fmiCSInitialize!; observed = cb_observed,
+            modified = cb_modified, ctx = _functor
+        )
         finalize_affect = MTK.ImperativeAffect(fmiFinalize!; observed = (; wrapper))
         # the callback affect performs the stepping
         step_affect = MTK.ImperativeAffect(
-            fmiCSStep!; observed = cb_observed, modified = cb_modified, ctx = _functor)
+            fmiCSStep!; observed = cb_observed, modified = cb_modified, ctx = _functor
+        )
         instance_management_callback = MTK.SymbolicDiscreteCallback(
             communication_step_size, step_affect; initialize = initialize_affect,
-            finalize = finalize_affect, reinitializealg)
+            finalize = finalize_affect, reinitializealg
+        )
 
         # guarded in case there are no outputs/states and the variable is `[]`.
         symbolic_type(__mtk_internal_o) == NotSymbolic() || push!(params, __mtk_internal_o)
@@ -290,8 +319,10 @@ function MTK.FMIComponent(::Val{Ver}; fmu = nothing, tolerance = 1e-6,
 
     eqs = [observed; diffeqs]
     bindings = [eq.lhs => eq.rhs for eq in parameter_dependencies]
-    return System(eqs, t, states, params; bindings, initial_conditions = defs,
-        discrete_events = [instance_management_callback], name, initialization_eqs)
+    return System(
+        eqs, t, states, params; bindings, initial_conditions = defs,
+        discrete_events = [instance_management_callback], name, initialization_eqs
+    )
 end
 
 """
@@ -314,7 +345,8 @@ defaults.
 function fmi_variables_to_mtk_variables!(
         fmu::Union{FMI.FMU2, FMI.FMU3}, varmap::AbstractDict,
         value_references::AbstractDict, truevars, allvars,
-        obseqs, defs = Dict(); parameters = false, postprocess_variable = identity)
+        obseqs, defs = Dict(); parameters = false, postprocess_variable = identity
+    )
     for (valRef, varnames) in varmap
         stateT = FMI.dataTypeForValueReference(fmu, valRef)
         snames = Symbol[]
@@ -325,11 +357,15 @@ function fmi_variables_to_mtk_variables!(
             push!(ders, der)
         end
         if parameters
-            vars = [postprocess_variable(MTK.unwrap(only(@parameters $sname::stateT)))
-                    for sname in snames]
+            vars = [
+                postprocess_variable(MTK.unwrap(only(@parameters $sname::stateT)))
+                    for sname in snames
+            ]
         else
-            vars = [postprocess_variable(MTK.unwrap(only(@variables $sname(t)::stateT)))
-                    for sname in snames]
+            vars = [
+                postprocess_variable(MTK.unwrap(only(@variables $sname(t)::stateT)))
+                    for sname in snames
+            ]
         end
         for i in eachindex(vars)
             der = ders[i]
@@ -351,6 +387,7 @@ function fmi_variables_to_mtk_variables!(
         defval = FMI.getStartValue(fmu, valRef)
         defs[vars[1]] = defval
     end
+    return
 end
 
 """
@@ -429,7 +466,7 @@ end
 Create an `FMI2InstanceWrapper` with no instance.
 """
 function FMI2InstanceWrapper(fmu, ders, states, outputs, params, inputs, tolerance)
-    FMI2InstanceWrapper(fmu, ders, states, outputs, params, inputs, tolerance, nothing)
+    return FMI2InstanceWrapper(fmu, ders, states, outputs, params, inputs, tolerance, nothing)
 end
 
 Base.nameof(::FMI2InstanceWrapper) = :FMI2InstanceWrapper
@@ -446,15 +483,20 @@ time. Returns the created instance, which is also stored in `wrapper.instance`.
 function get_instance_common!(wrapper::FMI2InstanceWrapper, inputs, params, t)
     wrapper.instance = FMI.fmi2Instantiate!(wrapper.fmu)::FMI.FMU2Component
     if !isempty(inputs)
-        @statuscheck FMI.fmi2SetReal(wrapper.instance, wrapper.input_value_references,
-            Csize_t(length(wrapper.param_value_references)), inputs)
+        @statuscheck FMI.fmi2SetReal(
+            wrapper.instance, wrapper.input_value_references,
+            Csize_t(length(wrapper.param_value_references)), inputs
+        )
     end
     if !isempty(params)
-        @statuscheck FMI.fmi2SetReal(wrapper.instance, wrapper.param_value_references,
-            Csize_t(length(wrapper.param_value_references)), params)
+        @statuscheck FMI.fmi2SetReal(
+            wrapper.instance, wrapper.param_value_references,
+            Csize_t(length(wrapper.param_value_references)), params
+        )
     end
     @statuscheck FMI.fmi2SetupExperiment(
-        wrapper.instance, FMI.fmi2True, wrapper.tolerance, t, FMI.fmi2False, t)
+        wrapper.instance, FMI.fmi2True, wrapper.tolerance, t, FMI.fmi2False, t
+    )
     @statuscheck FMI.fmi2EnterInitializationMode(wrapper.instance)
     return wrapper.instance
 end
@@ -492,8 +534,10 @@ function get_instance_CS!(wrapper::FMI2InstanceWrapper, states, inputs, params, 
     if wrapper.instance === nothing
         get_instance_common!(wrapper, inputs, params, t)
         if !isempty(states)
-            @statuscheck FMI.fmi2SetReal(wrapper.instance, wrapper.state_value_references,
-                Csize_t(length(wrapper.state_value_references)), states)
+            @statuscheck FMI.fmi2SetReal(
+                wrapper.instance, wrapper.state_value_references,
+                Csize_t(length(wrapper.state_value_references)), states
+            )
         end
         @statuscheck FMI.fmi2ExitInitializationMode(wrapper.instance)
     end
@@ -506,7 +550,7 @@ end
 Call `fmiXCompletedIntegratorStep` with `noSetFMUStatePriorToCurrentPoint` as false.
 """
 function partiallyCompleteIntegratorStep(wrapper::FMI2InstanceWrapper)
-    @statuscheck FMI.fmi2CompletedIntegratorStep(wrapper.instance, FMI.fmi2False)
+    return @statuscheck FMI.fmi2CompletedIntegratorStep(wrapper.instance, FMI.fmi2False)
 end
 
 """
@@ -519,7 +563,7 @@ function reset_instance!(wrapper::FMI2InstanceWrapper)
     wrapper.instance === nothing && return
     FMI.fmi2Terminate(wrapper.instance)
     FMI.fmi2FreeInstance!(wrapper.instance)
-    wrapper.instance = nothing
+    return wrapper.instance = nothing
 end
 
 """
@@ -569,7 +613,7 @@ end
 Create an `FMI3InstanceWrapper` with no instance.
 """
 function FMI3InstanceWrapper(fmu, ders, states, outputs, params, inputs)
-    FMI3InstanceWrapper(fmu, ders, states, outputs, params, inputs, nothing)
+    return FMI3InstanceWrapper(fmu, ders, states, outputs, params, inputs, nothing)
 end
 
 Base.nameof(::FMI3InstanceWrapper) = :FMI3InstanceWrapper
@@ -585,14 +629,18 @@ of `wrapper.input_value_references`. `params` should be in the order of
 """
 function get_instance_common!(wrapper::FMI3InstanceWrapper, inputs, params, t)
     if !isempty(params)
-        @statuscheck FMI.fmi3SetFloat64(wrapper.instance, wrapper.param_value_references,
-            params)
+        @statuscheck FMI.fmi3SetFloat64(
+            wrapper.instance, wrapper.param_value_references,
+            params
+        )
     end
     @statuscheck FMI.fmi3EnterInitializationMode(
-        wrapper.instance, FMI.fmi3False, zero(FMI.fmi3Float64), t, FMI.fmi3False, t)
+        wrapper.instance, FMI.fmi3False, zero(FMI.fmi3Float64), t, FMI.fmi3False, t
+    )
     if !isempty(inputs)
         @statuscheck FMI.fmi3SetFloat64(
-            wrapper.instance, wrapper.input_value_references, inputs)
+            wrapper.instance, wrapper.input_value_references, inputs
+        )
     end
 
     return wrapper.instance
@@ -631,11 +679,13 @@ See `get_instance_common!` for a description of the arguments.
 function get_instance_CS!(wrapper::FMI3InstanceWrapper, states, inputs, params, t)
     if wrapper.instance === nothing
         wrapper.instance = FMI.fmi3InstantiateCoSimulation!(
-            wrapper.fmu; eventModeUsed = false)::FMI.FMU3Instance
+            wrapper.fmu; eventModeUsed = false
+        )::FMI.FMU3Instance
         get_instance_common!(wrapper, inputs, params, t)
         if !isempty(states)
             @statuscheck FMI.fmi3SetFloat64(
-                wrapper.instance, wrapper.state_value_references, states)
+                wrapper.instance, wrapper.state_value_references, states
+            )
         end
         @statuscheck FMI.fmi3ExitInitializationMode(wrapper.instance)
     end
@@ -649,9 +699,10 @@ function partiallyCompleteIntegratorStep(wrapper::FMI3InstanceWrapper)
     enterEventMode = Ref(FMI.fmi3False)
     terminateSimulation = Ref(FMI.fmi3False)
     @statuscheck FMI.fmi3CompletedIntegratorStep!(
-        wrapper.instance, FMI.fmi3False, enterEventMode, terminateSimulation)
+        wrapper.instance, FMI.fmi3False, enterEventMode, terminateSimulation
+    )
     @assert enterEventMode[] == FMI.fmi3False
-    @assert terminateSimulation[] == FMI.fmi3False
+    return @assert terminateSimulation[] == FMI.fmi3False
 end
 
 """
@@ -661,11 +712,12 @@ function reset_instance!(wrapper::FMI3InstanceWrapper)
     wrapper.instance === nothing && return
     FMI.fmi3Terminate(wrapper.instance)
     FMI.fmi3FreeInstance!(wrapper.instance)
-    wrapper.instance = nothing
+    return wrapper.instance = nothing
 end
 
 @register_array_symbolic (fn::FMI2InstanceWrapper)(
-    states::Vector{<:Real}, inputs::Vector{<:Real}, params::Vector{<:Real}, t::Real) begin
+    states::Vector{<:Real}, inputs::Vector{<:Real}, params::Vector{<:Real}, t::Real
+) begin
     size = (length(states) + length(fn.output_value_references),)
     eltype = eltype(states)
     ndims = 1
@@ -673,7 +725,8 @@ end
 
 @register_array_symbolic (fn::FMI3InstanceWrapper)(
     wrapper::FMI3InstanceWrapper, states::Vector{<:Real},
-    inputs::Vector{<:Real}, params::Vector{<:Real}, t::Real) begin
+    inputs::Vector{<:Real}, params::Vector{<:Real}, t::Real
+) begin
     size = (length(states) + length(fn.output_value_references),)
     eltype = eltype(states)
     ndims = 1
@@ -687,7 +740,8 @@ for continuous state derivatives and output variables respectively. Needs to be 
 callable struct to enable symbolic registration with an inferred return size.
 """
 function (wrapper::Union{FMI2InstanceWrapper, FMI3InstanceWrapper})(
-        states, inputs, params, t)
+        states, inputs, params, t
+    )
     instance = get_instance_ME!(wrapper, inputs, params, t)
 
     # TODO: Find a way to do this without allocating. We can't pass a view to these
@@ -697,12 +751,16 @@ function (wrapper::Union{FMI2InstanceWrapper, FMI3InstanceWrapper})(
     # Defined in FMIBase.jl/src/eval.jl
     # Doesn't seem to be documented, but somehow this is the only way to
     # propagate inputs to the FMU consistently. I have no idea why.
-    instance(; x = states, u = inputs, u_refs = wrapper.input_value_references,
-        p = params, p_refs = wrapper.param_value_references, t = t)
+    instance(;
+        x = states, u = inputs, u_refs = wrapper.input_value_references,
+        p = params, p_refs = wrapper.param_value_references, t = t
+    )
     # the spec requires completing the step before getting updated derivative/output values
     partiallyCompleteIntegratorStep(wrapper)
-    instance(; dx = states_buffer, dx_refs = wrapper.derivative_value_references,
-        y = outputs_buffer, y_refs = wrapper.output_value_references)
+    instance(;
+        dx = states_buffer, dx_refs = wrapper.derivative_value_references,
+        y = outputs_buffer, y_refs = wrapper.output_value_references
+    )
     return [states_buffer; outputs_buffer]
 end
 
@@ -758,7 +816,8 @@ end
 
 @register_array_symbolic (fn::FMI2CSFunctor)(
     wrapper::FMI2InstanceWrapper, states::Vector{<:Real},
-    inputs::Vector{<:Real}, params::Vector{<:Real}, t::Real) begin
+    inputs::Vector{<:Real}, params::Vector{<:Real}, t::Real
+) begin
     size = (length(states) + length(fn.output_value_references),)
     eltype = eltype(states)
     ndims = 1
@@ -815,7 +874,8 @@ function fmiCSStep!(m, o, ctx::FMI2CSFunctor, integrator)
     instance = get_instance_CS!(wrapper, states, inputs, params, integrator.t)
     if !isempty(inputs)
         FMI.fmi2SetReal(
-            instance, wrapper.input_value_references, Csize_t(length(inputs)), inputs)
+            instance, wrapper.input_value_references, Csize_t(length(inputs)), inputs
+        )
     end
     @statuscheck FMI.fmi2DoStep(instance, integrator.t - dt, dt, FMI.fmi2True)
 
@@ -865,7 +925,8 @@ end
 
 @register_array_symbolic (fn::FMI3CSFunctor)(
     wrapper::FMI3InstanceWrapper, states::Vector{<:Real},
-    inputs::Vector{<:Real}, params::Vector{<:Real}, t::Real) begin
+    inputs::Vector{<:Real}, params::Vector{<:Real}, t::Real
+) begin
     size = (length(states) + length(fn.output_value_references),)
     eltype = eltype(states)
     ndims = 1
@@ -915,7 +976,8 @@ function fmiCSStep!(m, o, ctx::FMI3CSFunctor, integrator)
     lastSuccessfulTime = Ref(zero(FMI.fmi3Float64))
     @statuscheck FMI.fmi3DoStep!(
         instance, integrator.t - dt, dt, FMI.fmi3True, eventEncountered,
-        terminateSimulation, earlyReturn, lastSuccessfulTime)
+        terminateSimulation, earlyReturn, lastSuccessfulTime
+    )
     @assert eventEncountered[] == FMI.fmi3False
     @assert terminateSimulation[] == FMI.fmi3False
     @assert earlyReturn[] == FMI.fmi3False

--- a/lib/ModelingToolkitBase/ext/MTKChainRulesCoreExt.jl
+++ b/lib/ModelingToolkitBase/ext/MTKChainRulesCoreExt.jl
@@ -13,16 +13,20 @@ function ChainRulesCore.rrule(::Type{MTKParameters}, tunables, args...)
     function mtp_pullback(dt)
         dt = unthunk(dt)
         dtunables = dt isa AbstractArray ? dt : dt.tunable
-        (NoTangent(), dtunables[1:length(tunables)],
-            ntuple(_ -> NoTangent(), length(args))...)
+        return (
+            NoTangent(), dtunables[1:length(tunables)],
+            ntuple(_ -> NoTangent(), length(args))...,
+        )
     end
-    MTKParameters(tunables, args...), mtp_pullback
+    return MTKParameters(tunables, args...), mtp_pullback
 end
 
 function subset_idxs(idxs, portion, template)
-    ntuple(Val(length(template))) do subi
-        result = [Base.tail(idx.idx)
-                  for idx in idxs if idx.portion == portion && idx.idx[1] == subi]
+    return ntuple(Val(length(template))) do subi
+        result = [
+            Base.tail(idx.idx)
+                for idx in idxs if idx.portion == portion && idx.idx[1] == subi
+        ]
         if isempty(result)
             result = []
         end
@@ -33,16 +37,18 @@ end
 selected_tangents(::NoTangent, _) = ()
 selected_tangents(::ZeroTangent, _) = ZeroTangent()
 function selected_tangents(
-        tangents::AbstractArray{T}, idxs::Vector{Tuple{Int}}) where {T <: Number}
-    selected_tangents(tangents, map(only, idxs))
+        tangents::AbstractArray{T}, idxs::Vector{Tuple{Int}}
+    ) where {T <: Number}
+    return selected_tangents(tangents, map(only, idxs))
 end
 function selected_tangents(tangents::AbstractArray{T}, idxs...) where {T <: Number}
     newtangents = copy(tangents)
     view(newtangents, idxs...) .= zero(T)
-    newtangents
+    return newtangents
 end
 function selected_tangents(
-        tangents::AbstractVector{T}, idxs) where {S <: Number, T <: AbstractArray{S}}
+        tangents::AbstractVector{T}, idxs
+    ) where {S <: Number, T <: AbstractArray{S}}
     newtangents = copy(tangents)
     for i in idxs
         j, k... = i
@@ -52,7 +58,7 @@ function selected_tangents(
             newtangents[j] = selected_tangents(newtangents[j], k...)
         end
     end
-    newtangents
+    return newtangents
 end
 function selected_tangents(tangents::AbstractVector{T}, idxs) where {T <: AbstractArray}
     newtangents = similar(tangents, Union{T, NoTangent})
@@ -65,17 +71,19 @@ function selected_tangents(tangents::AbstractVector{T}, idxs) where {T <: Abstra
             newtangents[j] = selected_tangents(newtangents[j], k...)
         end
     end
-    newtangents
+    return newtangents
 end
 function selected_tangents(
-        tangents::Union{Tangent{<:Tuple}, Tangent{T, <:Tuple}}, idxs) where {T}
-    ntuple(Val(length(tangents))) do i
+        tangents::Union{Tangent{<:Tuple}, Tangent{T, <:Tuple}}, idxs
+    ) where {T}
+    return ntuple(Val(length(tangents))) do i
         selected_tangents(tangents[i], idxs[i])
     end
 end
 
 function ChainRulesCore.rrule(
-        ::typeof(remake_buffer), indp, oldbuf::MTKParameters, idxs, vals)
+        ::typeof(remake_buffer), indp, oldbuf::MTKParameters, idxs, vals
+    )
     if idxs isa AbstractSet
         idxs = collect(idxs)
     end
@@ -85,10 +93,12 @@ function ChainRulesCore.rrule(
     newbuf = remake_buffer(indp, oldbuf, idxs, vals)
     tunable_idxs = reduce(
         vcat, (idx.idx for idx in idxs if idx.portion isa SciMLStructures.Tunable);
-        init = Union{Int, AbstractVector{Int}}[])
+        init = Union{Int, AbstractVector{Int}}[]
+    )
     initials_idxs = reduce(
         vcat, (idx.idx for idx in idxs if idx.portion isa SciMLStructures.Initials);
-        init = Union{Int, AbstractVector{Int}}[])
+        init = Union{Int, AbstractVector{Int}}[]
+    )
     disc_idxs = subset_idxs(idxs, SciMLStructures.Discrete(), oldbuf.discrete)
     const_idxs = subset_idxs(idxs, SciMLStructures.Constants(), oldbuf.constant)
     nn_idxs = subset_idxs(idxs, NONNUMERIC_PORTION, oldbuf.nonnumeric)
@@ -105,13 +115,14 @@ function ChainRulesCore.rrule(
             constant = selected_tangents(buf′.constant, const_idxs)
             nonnumeric = selected_tangents(buf′.nonnumeric, nn_idxs)
             oldbuf′ = Tangent{typeof(oldbuf)}(;
-                tunable, initials, discrete, constant, nonnumeric)
+                tunable, initials, discrete, constant, nonnumeric
+            )
             idxs′ = NoTangent()
             vals′ = map(i -> _ducktyped_parameter_values(buf′, i), idxs)
             return f′, indp′, oldbuf′, idxs′, vals′
         end
     end
-    newbuf, pullback
+    return newbuf, pullback
 end
 
 ChainRulesCore.@non_differentiable Base.getproperty(sys::AbstractSystem, x::Symbol)

--- a/lib/ModelingToolkitBase/ext/MTKJuliaFormatterExt.jl
+++ b/lib/ModelingToolkitBase/ext/MTKJuliaFormatterExt.jl
@@ -6,7 +6,7 @@ import JuliaFormatter
 function readable_code(expr::Expr)
     expr = Base.remove_linenums!(_readable_code(expr))
     rec_remove_macro_linenums!(expr)
-    JuliaFormatter.format_text(string(expr), JuliaFormatter.SciMLStyle())
+    return JuliaFormatter.format_text(string(expr), JuliaFormatter.SciMLStyle())
 end
 
 end

--- a/lib/ModelingToolkitBase/ext/MTKLabelledArraysExt.jl
+++ b/lib/ModelingToolkitBase/ext/MTKLabelledArraysExt.jl
@@ -3,11 +3,11 @@ module MTKLabelledArraysExt
 using ModelingToolkitBase, LabelledArrays
 using ModelingToolkitBase: _defvar, toparam, variable, varnames_length_check
 function ModelingToolkitBase.define_vars(u::Union{SLArray, LArray}, t)
-    [ModelingToolkitBase._defvar(x)(t) for x in LabelledArrays.symnames(typeof(u))]
+    return [ModelingToolkitBase._defvar(x)(t) for x in LabelledArrays.symnames(typeof(u))]
 end
 
 function ModelingToolkitBase.define_params(p::Union{SLArray, LArray}, t, names = nothing)
-    if names === nothing
+    return if names === nothing
         [toparam(variable(x)) for x in LabelledArrays.symnames(typeof(p))]
     else
         varnames_length_check(p, names)

--- a/lib/ModelingToolkitBase/ext/MTKLatexifyExt.jl
+++ b/lib/ModelingToolkitBase/ext/MTKLatexifyExt.jl
@@ -11,7 +11,7 @@ using Latexify
 end
 
 function Base.show(io::IO, ::MIME"text/latex", ap::ModelingToolkitBase.Connection)
-    print(io, latexify(ap))
+    return print(io, latexify(ap))
 end
 
 @latexrecipe function f(sys::ModelingToolkitBase.AbstractSystem)
@@ -19,7 +19,7 @@ end
 end
 
 function Base.show(io::IO, ::MIME"text/latex", x::ModelingToolkitBase.AbstractSystem)
-    print(io, "\$\$ " * latexify(x) * " \$\$")
+    return print(io, "\$\$ " * latexify(x) * " \$\$")
 end
 
 @latexrecipe function f(ap::ModelingToolkitBase.AnalysisPoint)
@@ -32,7 +32,7 @@ end
 end
 
 function Base.show(io::IO, ::MIME"text/latex", ap::ModelingToolkitBase.AnalysisPoint)
-    print(io, latexify(ap))
+    return print(io, latexify(ap))
 end
 
 end

--- a/lib/ModelingToolkitBase/ext/MTKPyomoDynamicOptExt.jl
+++ b/lib/ModelingToolkitBase/ext/MTKPyomoDynamicOptExt.jl
@@ -8,17 +8,21 @@ using Setfield
 import SymbolicUtils as SU
 const MTK = ModelingToolkitBase
 
-const SPECIAL_FUNCTIONS_DICT = Dict([acos => Pyomo.py_acos,
-    acosh => Pyomo.py_acosh,
-    asin => Pyomo.py_asin,
-    tan => Pyomo.py_tan,
-    atanh => Pyomo.py_atanh,
-    cos => Pyomo.py_cos,
-    log => Pyomo.py_log,
-    sin => Pyomo.py_sin,
-    sqrt => Pyomo.py_sqrt,
-    exp => Pyomo.py_exp,
-    abs2 => (x -> x^2)])
+const SPECIAL_FUNCTIONS_DICT = Dict(
+    [
+        acos => Pyomo.py_acos,
+        acosh => Pyomo.py_acosh,
+        asin => Pyomo.py_asin,
+        tan => Pyomo.py_tan,
+        atanh => Pyomo.py_atanh,
+        cos => Pyomo.py_cos,
+        log => Pyomo.py_log,
+        sin => Pyomo.py_sin,
+        sqrt => Pyomo.py_sqrt,
+        exp => Pyomo.py_exp,
+        abs2 => (x -> x^2),
+    ]
+)
 
 struct PyomoDynamicOptModel{T}
     model::ConcreteModel
@@ -37,13 +41,15 @@ struct PyomoDynamicOptModel{T}
     function PyomoDynamicOptModel(model, U, V, P, tₛ, is_free_final, tsteps)
         @variables MODEL_SYM::Symbolics.symstruct(ConcreteModel) T_SYM DUMMY_SYM
         model.dU = dae.DerivativeVar(U, wrt = model.t, initialize = 0)
-        new{typeof(P)}(model, U, V, P, tₛ, is_free_final, tsteps, nothing,
-            PyomoVar(model.dU), MODEL_SYM, T_SYM, DUMMY_SYM)
+        return new{typeof(P)}(
+            model, U, V, P, tₛ, is_free_final, tsteps, nothing,
+            PyomoVar(model.dU), MODEL_SYM, T_SYM, DUMMY_SYM
+        )
     end
 end
 
 struct PyomoDynamicOptProblem{uType, tType, isinplace, P, F, K} <:
-       SciMLBase.AbstractDynamicOptProblem{uType, tType, isinplace}
+    SciMLBase.AbstractDynamicOptProblem{uType, tType, isinplace}
     f::F
     u0::uType
     tspan::tType
@@ -52,62 +58,71 @@ struct PyomoDynamicOptProblem{uType, tType, isinplace, P, F, K} <:
     kwargs::K
 
     function PyomoDynamicOptProblem(f, u0, tspan, p, model, kwargs...)
-        new{typeof(u0), typeof(tspan), SciMLBase.isinplace(f, 5),
-            typeof(p), typeof(f), typeof(kwargs)}(f, u0, tspan, p, model, kwargs)
+        return new{
+            typeof(u0), typeof(tspan), SciMLBase.isinplace(f, 5),
+            typeof(p), typeof(f), typeof(kwargs),
+        }(f, u0, tspan, p, model, kwargs)
     end
 end
 
 function pysym_getproperty(s::Union{Num, SymbolicT}, name::Symbol)
-    Symbolics.wrap(SymbolicUtils.term(
-        _getproperty, Symbolics.unwrap(s), Val{name}(), type = Symbolics.Struct{PyomoVar}))
+    return Symbolics.wrap(
+        SymbolicUtils.term(
+            _getproperty, Symbolics.unwrap(s), Val{name}(), type = Symbolics.Struct{PyomoVar}
+        )
+    )
 end
 _getproperty(s, name::Val{fieldname}) where {fieldname} = getproperty(s, fieldname)
 
-function MTK.PyomoDynamicOptProblem(sys::System, op, tspan;
+function MTK.PyomoDynamicOptProblem(
+        sys::System, op, tspan;
         dt = nothing, steps = nothing, tune_parameters = false,
-        guesses = Dict(), kwargs...)
+        guesses = Dict(), kwargs...
+    )
     prob,
-    pmap = MTK.process_DynamicOptProblem(PyomoDynamicOptProblem, PyomoDynamicOptModel,
-        sys, op, tspan; dt, steps, tune_parameters, guesses, kwargs...)
+        pmap = MTK.process_DynamicOptProblem(
+        PyomoDynamicOptProblem, PyomoDynamicOptModel,
+        sys, op, tspan; dt, steps, tune_parameters, guesses, kwargs...
+    )
     conc_model = prob.wrapped_model.model
     MTK.add_equational_constraints!(prob.wrapped_model, sys, pmap, tspan)
-    prob
+    return prob
 end
 
 function MTK.generate_internal_model(m::Type{PyomoDynamicOptModel})
-    ConcreteModel(pyomo.ConcreteModel())
+    return ConcreteModel(pyomo.ConcreteModel())
 end
 
 function MTK.generate_time_variable!(m::ConcreteModel, tspan, tsteps)
     m.steps = length(tsteps)
     m.t = dae.ContinuousSet(initialize = tsteps, bounds = tspan)
-    m.time = pyomo.Var(m.t)
+    return m.time = pyomo.Var(m.t)
 end
 
 function MTK.generate_state_variable!(m::ConcreteModel, u0, ns, ts)
     m.u_idxs = pyomo.RangeSet(1, ns)
     init_f = Pyomo.pyfunc((m, i, t) -> (u0[Pyomo.pyconvert(Int, i)]))
     m.U = pyomo.Var(m.u_idxs, m.t, initialize = init_f)
-    PyomoVar(m.U)
+    return PyomoVar(m.U)
 end
 
 function MTK.generate_input_variable!(m::ConcreteModel, c0, nc, ts)
     m.v_idxs = pyomo.RangeSet(1, nc)
     init_f = Pyomo.pyfunc((m, i, t) -> (c0[Pyomo.pyconvert(Int, i)]))
     m.V = pyomo.Var(m.v_idxs, m.t, initialize = init_f)
-    PyomoVar(m.V)
+    return PyomoVar(m.V)
 end
 
 function MTK.generate_tunable_params!(m::ConcreteModel, p0, np)
     m.p_idxs = pyomo.RangeSet(1, np)
     init_f = Pyomo.pyfunc((m, i) -> (p0[Pyomo.pyconvert(Int, i)]))
     m.P = pyomo.Var(m.p_idxs, initialize = init_f)
-    PyomoVar(m.P)
+    return PyomoVar(m.P)
 end
 
 function MTK.generate_timescale!(m::ConcreteModel, guess, is_free_t)
     m.tₛ = is_free_t ? pyomo.Var(initialize = guess, bounds = (0, Inf)) : Pyomo.Py(1)
-    PyomoVar(m.tₛ)
+    return PyomoVar(m.tₛ)
 end
 
 function MTK.add_constraint!(pmodel::PyomoDynamicOptModel, cons; n_idxs = 1)
@@ -120,10 +135,11 @@ function MTK.add_constraint!(pmodel::PyomoDynamicOptModel, cons; n_idxs = 1)
         cons.lhs - cons.rhs ≤ 0
     end
     expr = Symbolics.substitute(
-        Symbolics.unwrap(expr), SPECIAL_FUNCTIONS_DICT, fold = false)
+        Symbolics.unwrap(expr), SPECIAL_FUNCTIONS_DICT, fold = false
+    )
 
     cons_sym = Symbol("cons", hash(cons))
-    if SU.query(isequal(Symbolics.unwrap(t_sym)), expr)
+    return if SU.query(isequal(Symbolics.unwrap(t_sym)), expr)
         f = eval(Symbolics.build_function(expr, model_sym, t_sym))
         setproperty!(model, cons_sym, pyomo.Constraint(model.t, rule = Pyomo.pyfunc(f)))
     else
@@ -135,7 +151,7 @@ end
 function MTK.set_objective!(pmodel::PyomoDynamicOptModel, expr)
     @unpack model, model_sym, t_sym, dummy_sym = pmodel
     expr = Symbolics.substitute(expr, SPECIAL_FUNCTIONS_DICT, fold = false)
-    if SU.query(isequal(Symbolics.unwrap(t_sym)), expr)
+    return if SU.query(isequal(Symbolics.unwrap(t_sym)), expr)
         f = eval(Symbolics.build_function(expr, model_sym, t_sym))
         model.obj = pyomo.Objective(model.t, rule = Pyomo.pyfunc(f))
     else
@@ -148,36 +164,37 @@ function MTK.add_initial_constraints!(model::PyomoDynamicOptModel, u0, u0_idxs, 
     for i in u0_idxs
         model.U[i, 0].fix(u0[i])
     end
+    return
 end
 
 function MTK.lowered_integral(m::PyomoDynamicOptModel, arg, lo, hi)
     @unpack model, model_sym, t_sym, dummy_sym = m
     total = 0
-    dt = Pyomo.pyconvert(Float64, (model.t.at(-1) - model.t.at(1))/(model.steps - 1))
+    dt = Pyomo.pyconvert(Float64, (model.t.at(-1) - model.t.at(1)) / (model.steps - 1))
     f = Symbolics.build_function(arg, model_sym, t_sym, expression = false)
     for (i, t) in enumerate(model.t)
         if Bool(lo < t) && Bool(t < hi)
-            t_p = model.t.at(i-1)
+            t_p = model.t.at(i - 1)
             Δt = min(t - lo, t - t_p)
-            total += 0.5*Δt*(f(model, t) + f(model, t_p))
+            total += 0.5 * Δt * (f(model, t) + f(model, t_p))
         elseif Bool(t >= hi) && Bool(t - dt < hi)
-            t_p = model.t.at(i-1)
+            t_p = model.t.at(i - 1)
             Δt = hi - t + dt
-            total += 0.5*Δt*(f(model, t) + f(model, t_p))
+            total += 0.5 * Δt * (f(model, t) + f(model, t_p))
         end
     end
-    PyomoVar(model.tₛ * total)
+    return PyomoVar(model.tₛ * total)
 end
 
 function MTK.lowered_derivative(m::PyomoDynamicOptModel, i)
     mdU = Symbolics.value(pysym_getproperty(m.model_sym, :dU))
-    Symbolics.unwrap(mdU[i, m.t_sym])
+    return Symbolics.unwrap(mdU[i, m.t_sym])
 end
 
 function MTK.lowered_var(m::PyomoDynamicOptModel, uv, i, t)
     X = Symbolics.value(pysym_getproperty(m.model_sym, uv))
     var = t isa Union{Num, SymbolicT} ? X[i, m.t_sym] : X[i, t]
-    Symbolics.unwrap(var)
+    return Symbolics.unwrap(var)
 end
 
 # For Pyomo, we need to create symbolic representations for pmap
@@ -187,7 +204,7 @@ function MTK.get_param_for_pmap(m::ConcreteModel, P::PyomoVar, i)
     # The actual PyomoVar will be accessed via the symbolic representation
     @variables MODEL_SYM::Symbolics.symstruct(ConcreteModel)
     P_sym = Symbolics.value(pysym_getproperty(MODEL_SYM, :P))
-    Symbolics.unwrap(P_sym[i])
+    return Symbolics.unwrap(P_sym[i])
 end
 
 MTK.needs_individual_tunables(m::ConcreteModel) = true
@@ -198,11 +215,12 @@ struct PyomoCollocation <: AbstractCollocation
 end
 
 function MTK.PyomoCollocation(solver, derivative_method = LagrangeRadau(5))
-    PyomoCollocation(solver, derivative_method)
+    return PyomoCollocation(solver, derivative_method)
 end
 
 function MTK.prepare_and_optimize!(
-        prob::PyomoDynamicOptProblem, collocation; verbose, kwargs...)
+        prob::PyomoDynamicOptProblem, collocation; verbose, kwargs...
+    )
     solver_m = prob.wrapped_model.model.clone()
     dm = collocation.derivative_method
     discretizer = TransformationFactory(dm)
@@ -210,12 +228,14 @@ function MTK.prepare_and_optimize!(
         error("The Lagrange-Radau and Lagrange-Legendre collocations currently cannot be used for free final problems.")
     end
     ncp = Pyomo.is_finite_difference(dm) ? 1 : dm.np
-    discretizer.apply_to(solver_m, wrt = solver_m.t, nfe = solver_m.steps - 1,
-        scheme = Pyomo.scheme_string(dm))
+    discretizer.apply_to(
+        solver_m, wrt = solver_m.t, nfe = solver_m.steps - 1,
+        scheme = Pyomo.scheme_string(dm)
+    )
 
     solver = SolverFactory(string(collocation.solver))
     results = solver.solve(solver_m, tee = true)
-    PyomoOutput(results, solver_m)
+    return PyomoOutput(results, solver_m)
 end
 
 struct PyomoOutput
@@ -225,31 +245,33 @@ end
 
 function MTK.get_U_values(output::PyomoOutput)
     m = output.model
-    [[Pyomo.pyconvert(Float64, pyomo.value(m.U[i, t])) for i in m.u_idxs] for t in m.t]
+    return [[Pyomo.pyconvert(Float64, pyomo.value(m.U[i, t])) for i in m.u_idxs] for t in m.t]
 end
 function MTK.get_V_values(output::PyomoOutput)
     m = output.model
-    [[Pyomo.pyconvert(Float64, pyomo.value(m.V[i, t])) for i in m.v_idxs] for t in m.t]
+    return [[Pyomo.pyconvert(Float64, pyomo.value(m.V[i, t])) for i in m.v_idxs] for t in m.t]
 end
 function MTK.get_P_values(output::PyomoOutput)
     m = output.model
-    [Pyomo.pyconvert(Float64, pyomo.value(m.P[i])) for i in m.p_idxs]
+    return [Pyomo.pyconvert(Float64, pyomo.value(m.P[i])) for i in m.p_idxs]
 end
 function MTK.get_t_values(output::PyomoOutput)
     m = output.model
-    Pyomo.pyconvert(Float64, pyomo.value(m.tₛ)) * [Pyomo.pyconvert(Float64, t) for t in m.t]
+    return Pyomo.pyconvert(Float64, pyomo.value(m.tₛ)) * [Pyomo.pyconvert(Float64, t) for t in m.t]
 end
 
 function MTK.objective_value(output::PyomoOutput)
-    Pyomo.pyconvert(Float64, pyomo.value(output.model.obj))
+    return Pyomo.pyconvert(Float64, pyomo.value(output.model.obj))
 end
 
 function MTK.successful_solve(output::PyomoOutput)
     r = output.result
     ss = r.solver.status
     tc = r.solver.termination_condition
-    if Bool(ss == opt.SolverStatus.ok) && (Bool(tc == opt.TerminationCondition.optimal) ||
-        Bool(tc == opt.TerminationCondition.locallyOptimal))
+    if Bool(ss == opt.SolverStatus.ok) && (
+            Bool(tc == opt.TerminationCondition.optimal) ||
+                Bool(tc == opt.TerminationCondition.locallyOptimal)
+        )
         return true
     else
         return false

--- a/lib/ModelingToolkitBase/src/ModelingToolkitBase.jl
+++ b/lib/ModelingToolkitBase/src/ModelingToolkitBase.jl
@@ -12,14 +12,14 @@ using PrecompileTools, Reexport
     import REPL
     using OffsetArrays: Origin
     import BlockArrays: BlockArray, BlockedArray, Block, blocksize, blocksizes, blockpush!,
-                        undef_blocks, blocks
+        undef_blocks, blocks
 end
 
 import SymbolicUtils
 import SymbolicUtils as SU
 import SymbolicUtils: iscall, arguments, operation, maketerm, promote_symtype,
-                      isadd, ismul, ispow, issym, FnType, isconst, BSImpl,
-                      @rule, Rewriters, substitute, metadata, BasicSymbolic
+    isadd, ismul, ispow, issym, FnType, isconst, BSImpl,
+    @rule, Rewriters, substitute, metadata, BasicSymbolic
 using SymbolicUtils.Code
 import SymbolicUtils.Code: toexpr
 import SymbolicUtils.Rewriters: Chain, Postwalk, Prewalk, Fixpoint
@@ -56,8 +56,8 @@ using SciMLStructures
 using Compat
 using AbstractTrees
 using SciMLBase: StandardODEProblem, StandardNonlinearProblem, handle_varmap, TimeDomain,
-                 PeriodicClock, Clock, SolverStepClock, ContinuousClock, OverrideInit,
-                 NoInit
+    PeriodicClock, Clock, SolverStepClock, ContinuousClock, OverrideInit,
+    NoInit
 import Moshi
 using Moshi.Data: @data
 using Reexport
@@ -72,23 +72,23 @@ using RuntimeGeneratedFunctions: drop_expr
 
 using Symbolics: degree, VartypeT, SymbolicT
 using Symbolics: parse_vars, value, @derivatives, get_variables,
-                 exprs_occur_in, symbolic_linear_solve, unwrap, wrap,
-                 VariableSource, getname, variable,
-                 NAMESPACE_SEPARATOR, setdefaultval, Arr,
-                 hasnode, fixpoint_sub, CallAndWrap, SArgsT, SSym, STerm
+    exprs_occur_in, symbolic_linear_solve, unwrap, wrap,
+    VariableSource, getname, variable,
+    NAMESPACE_SEPARATOR, setdefaultval, Arr,
+    hasnode, fixpoint_sub, CallAndWrap, SArgsT, SSym, STerm
 const NAMESPACE_SEPARATOR_SYMBOL = Symbol(NAMESPACE_SEPARATOR)
 import Symbolics: rename, get_variables!, _solve, hessian_sparsity,
-                  jacobian_sparsity, isaffine, islinear, _iszero, _isone,
-                  tosymbol, lower_varname, diff2term, var_from_nested_derivative,
-                  BuildTargets, JuliaTarget, StanTarget, CTarget, MATLABTarget,
-                  ParallelForm, SerialForm, MultithreadedForm, build_function,
-                  rhss, lhss, gradient, linear_expansion,
-                  jacobian, hessian, derivative, sparsejacobian, sparsehessian,
-                  scalarize, hasderiv
+    jacobian_sparsity, isaffine, islinear, _iszero, _isone,
+    tosymbol, lower_varname, diff2term, var_from_nested_derivative,
+    BuildTargets, JuliaTarget, StanTarget, CTarget, MATLABTarget,
+    ParallelForm, SerialForm, MultithreadedForm, build_function,
+    rhss, lhss, gradient, linear_expansion,
+    jacobian, hessian, derivative, sparsejacobian, sparsehessian,
+    scalarize, hasderiv
 
 import DiffEqBase: @add_kwonly
 export independent_variables, unknowns, observables, parameters, bound_parameters,
-       continuous_events, discrete_events
+    continuous_events, discrete_events
 @reexport using Symbolics
 @reexport using UnPack
 RuntimeGeneratedFunctions.init(@__MODULE__)
@@ -107,11 +107,11 @@ export @derivatives
 for fun in [:toexpr]
     @eval begin
         function $fun(eq::Equation; kw...)
-            Expr(:call, :(==), $fun(eq.lhs; kw...), $fun(eq.rhs; kw...))
+            return Expr(:call, :(==), $fun(eq.lhs; kw...), $fun(eq.rhs; kw...))
         end
 
         function $fun(ineq::Inequality; kw...)
-            if ineq.relational_op == Symbolics.leq
+            return if ineq.relational_op == Symbolics.leq
                 Expr(:call, :(<=), $fun(ineq.lhs; kw...), $fun(ineq.rhs; kw...))
             else
                 Expr(:call, :(>=), $fun(ineq.lhs; kw...), $fun(ineq.rhs; kw...))
@@ -234,7 +234,7 @@ end
 const D_nounits = Differential(t_nounits)
 
 export ODEFunction, convert_system_indepvar,
-       System, OptimizationSystem, JumpSystem, SDESystem, NonlinearSystem, ODESystem
+    System, OptimizationSystem, JumpSystem, SDESystem, NonlinearSystem, ODESystem
 export SDEFunction
 export DiscreteProblem, DiscreteFunction
 export ImplicitDiscreteProblem, ImplicitDiscreteFunction
@@ -248,17 +248,17 @@ export SteadyStateProblem
 export JumpProblem
 export flatten
 export connect, domain_connect, @connector, Connection, AnalysisPoint, Flow, Stream,
-       instream
+    instream
 export @component, @mtkcompile, @mtkbuild
 export isinput, isoutput, getbounds, hasbounds, getguess, hasguess, isdisturbance,
-       istunable, getdist, hasdist,
-       tunable_parameters, isirreducible, getdescription, hasdescription,
-       hasunit, getunit, hasconnect, getconnect,
-       hasmisc, getmisc, state_priority,
-       subset_tunables
+    istunable, getdist, hasdist,
+    tunable_parameters, isirreducible, getdescription, hasdescription,
+    hasunit, getunit, hasconnect, getconnect,
+    hasmisc, getmisc, state_priority,
+    subset_tunables
 export liouville_transform, change_independent_variable,
-       add_accumulations, noise_to_brownians, Girsanov_transform, change_of_variables,
-       fractional_to_ordinary, linear_fractional_to_ordinary
+    add_accumulations, noise_to_brownians, Girsanov_transform, change_of_variables,
+    fractional_to_ordinary, linear_fractional_to_ordinary
 export respecialize
 export PDESystem
 export Differential, expand_derivatives, @derivatives
@@ -266,14 +266,14 @@ export Equation
 export Term
 export SymScope, LocalScope, ParentScope, GlobalScope
 export independent_variable, equations, observed, full_equations, jumps, cost,
-       brownians
+    brownians
 export initialization_equations, guesses, bindings, initial_conditions, hierarchy
 export mtkcompile, expand_connections, structural_simplify
 export solve
 export Pre
 
 export calculate_jacobian, generate_jacobian, generate_rhs, generate_custom_function,
-       generate_W, calculate_hessian
+    generate_W, calculate_hessian
 export calculate_control_jacobian, generate_control_jacobian
 export calculate_tgrad, generate_tgrad
 export generate_cost, calculate_cost_gradient, generate_cost_gradient
@@ -295,7 +295,7 @@ export alg_equations, diff_equations, has_alg_equations, has_diff_equations
 export get_alg_eqs, get_diff_eqs, has_alg_eqs, has_diff_eqs
 
 export @variables, @parameters, @independent_variables, @constants, @brownians, @brownian,
-       @discretes
+    @discretes
 export @named, @nonamespace, @namespace, extend, compose, complete, toggle_namespacing
 export debug_system
 
@@ -316,9 +316,9 @@ include("systems/optimal_control_interface.jl")
 
 using SciMLBase: AbstractDynamicOptProblem
 export AbstractDynamicOptProblem, JuMPDynamicOptProblem, InfiniteOptDynamicOptProblem,
-       CasADiDynamicOptProblem, PyomoDynamicOptProblem
+    CasADiDynamicOptProblem, PyomoDynamicOptProblem
 export AbstractCollocation, JuMPCollocation, InfiniteOptCollocation,
-       CasADiCollocation, PyomoCollocation
+    CasADiCollocation, PyomoCollocation
 export DynamicOptSolution
 
 const set_scalar_metadata = setmetadata
@@ -351,7 +351,7 @@ function __init__()
     SU.hashcons(COMMON_TRUE, true)
     SU.hashcons(COMMON_FALSE, true)
     SU.hashcons(COMMON_SENTINEL, true)
-    SU.hashcons(COMMON_INF, true)
+    return SU.hashcons(COMMON_INF, true)
 end
 
 include("precompile.jl")

--- a/lib/ModelingToolkitBase/src/atomic_array_dict.jl
+++ b/lib/ModelingToolkitBase/src/atomic_array_dict.jl
@@ -12,7 +12,7 @@ struct AtomicArrayDict{V, D <: AbstractDict{SymbolicT, V}} <: AbstractDict{Symbo
         for k in keys(dict)
             validate_atomic_array_key(k)
         end
-        new{V, typeof(dict)}(dict)
+        return new{V, typeof(dict)}(dict)
     end
 end
 
@@ -29,19 +29,21 @@ struct IndexedArrayKeyError <: Exception
 end
 
 function Base.showerror(io::IO, err::IndexedArrayKeyError)
-    print(io, """
-    `AtomicArrayDict` treats symbolic arrays as atomic. It does not allow keys to be \
-    indexed array symbolics. Got key $(err.k).
-    """)
+    return print(
+        io, """
+        `AtomicArrayDict` treats symbolic arrays as atomic. It does not allow keys to be \
+        indexed array symbolics. Got key $(err.k).
+        """
+    )
 end
 
 function validate_atomic_array_key(k::SymbolicT)
-    split_indexed_var(k)[2] && throw(IndexedArrayKeyError(k))
+    return split_indexed_var(k)[2] && throw(IndexedArrayKeyError(k))
 end
 
 Base.copy(dd::AtomicArrayDict) = AtomicArrayDict(copy(dd.dict))
 function Base.empty(dd::AtomicArrayDict, ::Type{K}, ::Type{V}) where {K, V}
-    AtomicArrayDict(empty(dd.dict, K, V))
+    return AtomicArrayDict(empty(dd.dict, K, V))
 end
 
 Base.get(def::Base.Callable, dd::AtomicArrayDict, k) = def()
@@ -58,7 +60,7 @@ Base.getindex(dd::AtomicArrayDict, k) = dd.dict[k]
 function Base.setindex!(dd::AtomicArrayDict, v, k)
     k = unwrap(k)
     validate_atomic_array_key(unwrap(k))
-    setindex!(dd.dict, v, k)
+    return setindex!(dd.dict, v, k)
 end
 
 Base.isempty(dd::AtomicArrayDict) = isempty(dd.dict)
@@ -158,7 +160,7 @@ struct AtomicArraySet{D <: AbstractDict{SymbolicT, Nothing}} <: AbstractSet{Symb
     dd::AtomicArrayDict{Nothing, D}
 
     function AtomicArraySet{D}(dd::AtomicArrayDict{Nothing, D}) where {D}
-        new{D}(dd)
+        return new{D}(dd)
     end
 end
 
@@ -187,7 +189,7 @@ end
 Add `item` to `x`. If `item` is an indexed array, add the array instead.
 """
 function push_as_atomic_array!(x::AtomicArraySet, item::SymbolicT)
-    push!(x, split_indexed_var(item)[1])
+    return push!(x, split_indexed_var(item)[1])
 end
 
 """
@@ -205,7 +207,7 @@ function as_atomic_array_set(::Type{D}, vars::Vector{SymbolicT}) where {D}
 end
 
 function contains_possibly_indexed_element(x::AtomicArraySet, k::SymbolicT)
-    has_possibly_indexed_key(x.dd, k)
+    return has_possibly_indexed_key(x.dd, k)
 end
 
 """
@@ -229,7 +231,7 @@ struct AtomicArrayDictSubstitutionWrapper{D} <: AbstractDict{SymbolicT, Symbolic
 end
 
 function AtomicArrayDictSubstitutionWrapper(d::AtomicArrayDict{SymbolicT, D}) where {D}
-    AtomicArrayDictSubstitutionWrapper{D}(d, COMMON_NOTHING)
+    return AtomicArrayDictSubstitutionWrapper{D}(d, COMMON_NOTHING)
 end
 
 const AADSubWrapper{D} = AtomicArrayDictSubstitutionWrapper{D}
@@ -250,10 +252,10 @@ end
 Base.get(dd::AADSubWrapper, k, default) = get(Returns(default), dd, k)
 
 function Base.haskey(dd::AADSubWrapper, k::SymbolicT)
-    has_possibly_indexed_key(dd, k)
+    return has_possibly_indexed_key(dd, k)
 end
 function Base.haskey(dd::AADSubWrapper, k::Union{Num, Arr, CallAndWrap})
-    haskey(dd, unwrap(k))
+    return haskey(dd, unwrap(k))
 end
 
 function Base.getindex(dd::AADSubWrapper, k)
@@ -263,7 +265,7 @@ function Base.getindex(dd::AADSubWrapper, k)
 end
 
 function Base.setindex!(dd::AADSubWrapper, v, k)
-    write_possibly_indexed_array!(dd.dict, k, v, dd.default)
+    return write_possibly_indexed_array!(dd.dict, k, v, dd.default)
 end
 
 Base.isempty(dd::AADSubWrapper) = isempty(dd.dict)

--- a/lib/ModelingToolkitBase/src/constants.jl
+++ b/lib/ModelingToolkitBase/src/constants.jl
@@ -3,7 +3,7 @@ Test whether `x` is a constant-type Sym.
 """
 function isconstant(x)
     x = unwrap(x)
-    x isa SymbolicT && !getmetadata(x, VariableTunable, true)
+    return x isa SymbolicT && !getmetadata(x, VariableTunable, true)
 end
 
 """
@@ -13,7 +13,7 @@ Maps the parameter to a constant. The parameter must have a default.
 """
 function toconstant(s)
     s = toparam(s)
-    setmetadata(s, VariableTunable, false)
+    return setmetadata(s, VariableTunable, false)
 end
 
 toconstant(s::Union{Num, Symbolics.Arr}) = wrap(toconstant(value(s)))
@@ -26,8 +26,10 @@ Define one or more constants.
 See also [`@independent_variables`](@ref), [`@parameters`](@ref) and [`@variables`](@ref).
 """
 macro constants(xs...)
-    Symbolics.parse_vars(:constants,
+    return Symbolics.parse_vars(
+        :constants,
         Real,
         xs,
-        toconstant)
+        toconstant
+    )
 end

--- a/lib/ModelingToolkitBase/src/debugging.jl
+++ b/lib/ModelingToolkitBase/src/debugging.jl
@@ -7,9 +7,9 @@ struct LoggedFun{F}
     error_nonfinite::Bool
 end
 function LoggedFunctionException(lf::LoggedFun, args, msg)
-    LoggedFunctionException(
+    return LoggedFunctionException(
         "Function $(lf.f)($(join(lf.args, ", "))) " * msg * " with input" *
-        join("\n  " .* string.(lf.args .=> args)) # one line for each "var => val" for readability
+            join("\n  " .* string.(lf.args .=> args)) # one line for each "var => val" for readability
     )
 end
 Base.showerror(io::IO, err::LoggedFunctionException) = print(io, err.msg)
@@ -29,18 +29,18 @@ end
 
 function logged_fun(f, args...; error_nonfinite = true) # remember to update error_nonfinite in debug_system() docstring
     # Currently we don't really support complex numbers
-    term(LoggedFun(f, args, error_nonfinite), args..., type = Real)
+    return term(LoggedFun(f, args, error_nonfinite), args..., type = Real)
 end
 
 function debug_sub(eq::Equation, funcs; kw...)
-    debug_sub(eq.lhs, funcs; kw...) ~ debug_sub(eq.rhs, funcs; kw...)
+    return debug_sub(eq.lhs, funcs; kw...) ~ debug_sub(eq.rhs, funcs; kw...)
 end
 function debug_sub(ex, funcs; kw...)
     iscall(ex) || return ex
     f = operation(ex)
     args = map(ex -> debug_sub(ex, funcs; kw...), arguments(ex))
-    f in funcs ? logged_fun(f, args...; kw...) :
-    maketerm(typeof(ex), f, args, metadata(ex))
+    return f in funcs ? logged_fun(f, args...; kw...) :
+        maketerm(typeof(ex), f, args, metadata(ex))
 end
 
 """
@@ -49,7 +49,7 @@ end
 A function which returns `NaN` if `condition` fails, and `0.0` otherwise.
 """
 function _nan_condition(condition::Bool)
-    condition ? 0.0 : NaN
+    return condition ? 0.0 : NaN
 end
 
 @register_symbolic _nan_condition(condition::Bool)

--- a/lib/ModelingToolkitBase/src/deprecations.jl
+++ b/lib/ModelingToolkitBase/src/deprecations.jl
@@ -1,12 +1,17 @@
 @deprecate structural_simplify(sys; kwargs...) mtkcompile(sys; kwargs...)
 @deprecate structural_simplify(sys, io; kwargs...) mtkcompile(
-    sys; inputs = io[1], outputs = io[2], kwargs...)
+    sys; inputs = io[1], outputs = io[2], kwargs...
+)
 
 macro mtkbuild(exprs...)
     return quote
         Base.depwarn("`@mtkbuild` is deprecated. Use `@mtkcompile` instead.", :mtkbuild)
-        $(Expr(:macrocall, var"@mtkcompile",
-            LineNumberNode(@__LINE__, @__FILE__), exprs...))
+        $(
+            Expr(
+                :macrocall, var"@mtkcompile",
+                LineNumberNode(@__LINE__, @__FILE__), exprs...
+            )
+        )
     end |> esc
 end
 
@@ -15,7 +20,8 @@ const ODESystem = IntermediateDeprecationSystem
 function IntermediateDeprecationSystem(args...; kwargs...)
     Base.depwarn(
         "`ODESystem(args...; kwargs...)` is deprecated. Use `System(args...; kwargs...) instead`.",
-        :ODESystem)
+        :ODESystem
+    )
 
     return System(args...; kwargs...)
 end
@@ -24,19 +30,21 @@ for T in [:NonlinearSystem, :DiscreteSystem, :ImplicitDiscreteSystem]
     @eval @deprecate $T(args...; kwargs...) System(args...; kwargs...)
 end
 
-for T in [:ODEProblem, :DDEProblem, :SDEProblem, :SDDEProblem, :DAEProblem,
-    :BVProblem, :DiscreteProblem, :ImplicitDiscreteProblem]
+for T in [
+        :ODEProblem, :DDEProblem, :SDEProblem, :SDDEProblem, :DAEProblem,
+        :BVProblem, :DiscreteProblem, :ImplicitDiscreteProblem,
+    ]
     for (pType, pCanonical) in [
-            (AbstractDict, :p),
-            (AbstractArray{<:Pair}, :(Dict(p))),
-            (AbstractArray, :(isempty(p) ? Dict() : Dict(parameters(sys) .=> p)))
-        ],
-        (uType, uCanonical) in [
-            (Nothing, :(Dict())),
-            (AbstractDict, :u0),
-            (AbstractArray{<:Pair}, :(Dict(u0))),
-            (AbstractArray, :(isempty(u0) ? Dict() : Dict(unknowns(sys) .=> u0)))
-        ]
+                (AbstractDict, :p),
+                (AbstractArray{<:Pair}, :(Dict(p))),
+                (AbstractArray, :(isempty(p) ? Dict() : Dict(parameters(sys) .=> p))),
+            ],
+            (uType, uCanonical) in [
+                (Nothing, :(Dict())),
+                (AbstractDict, :u0),
+                (AbstractArray{<:Pair}, :(Dict(u0))),
+                (AbstractArray, :(isempty(u0) ? Dict() : Dict(unknowns(sys) .=> u0))),
+            ]
 
         @eval function SciMLBase.$T(sys::System, u0::$uType, tspan, p::$pType; kw...)
             ctor = string($T)
@@ -46,10 +54,11 @@ for T in [:ODEProblem, :DDEProblem, :SDEProblem, :SDDEProblem, :DAEProblem,
             `$ctor(sys, u0, tspan, p; kw...)` is deprecated. Use
             `$ctor(sys, merge($uCan, $pCan), tspan)` instead.
             """
-            SciMLBase.$T(sys, merge($uCanonical, $pCanonical), tspan; kw...)
+            return SciMLBase.$T(sys, merge($uCanonical, $pCanonical), tspan; kw...)
         end
         @eval function SciMLBase.$T{iip}(
-                sys::System, u0::$uType, tspan, p::$pType; kw...) where {iip}
+                sys::System, u0::$uType, tspan, p::$pType; kw...
+            ) where {iip}
             ctor = string($T{iip})
             uCan = string($(QuoteNode(uCanonical)))
             pCan = string($(QuoteNode(pCanonical)))
@@ -60,7 +69,8 @@ for T in [:ODEProblem, :DDEProblem, :SDEProblem, :SDDEProblem, :DAEProblem,
             return SciMLBase.$T{iip}(sys, merge($uCanonical, $pCanonical), tspan; kw...)
         end
         @eval function SciMLBase.$T{iip, spec}(
-                sys::System, u0::$uType, tspan, p::$pType; kw...) where {iip, spec}
+                sys::System, u0::$uType, tspan, p::$pType; kw...
+            ) where {iip, spec}
             ctor = string($T{iip, spec})
             uCan = string($(QuoteNode(uCanonical)))
             pCan = string($(QuoteNode(pCanonical)))
@@ -81,10 +91,11 @@ for T in [:ODEProblem, :DDEProblem, :SDEProblem, :SDDEProblem, :DAEProblem,
             `$ctor(sys, u0, tspan, p::$pT; kw...)` is deprecated. Use
             `$ctor(sys, u0, tspan)` instead.
             """
-            $T(sys, u0, tspan; kw...)
+            return $T(sys, u0, tspan; kw...)
         end
         @eval function SciMLBase.$T{iip}(
-                sys::System, u0::$uType, tspan, p::$pType; kw...) where {iip}
+                sys::System, u0::$uType, tspan, p::$pType; kw...
+            ) where {iip}
             ctor = string($T{iip})
             pT = string($(QuoteNode(pType)))
             @warn """
@@ -94,7 +105,8 @@ for T in [:ODEProblem, :DDEProblem, :SDEProblem, :SDDEProblem, :DAEProblem,
             return $T{iip}(sys, u0, tspan; kw...)
         end
         @eval function SciMLBase.$T{iip, spec}(
-                sys::System, u0::$uType, tspan, p::$pType; kw...) where {iip, spec}
+                sys::System, u0::$uType, tspan, p::$pType; kw...
+            ) where {iip, spec}
             ctor = string($T{iip, spec})
             pT = string($(QuoteNode(pType)))
             @warn """
@@ -106,19 +118,21 @@ for T in [:ODEProblem, :DDEProblem, :SDEProblem, :SDDEProblem, :DAEProblem,
     end
 end
 
-for T in [:NonlinearProblem, :NonlinearLeastSquaresProblem,
-    :SCCNonlinearProblem, :OptimizationProblem, :SteadyStateProblem]
+for T in [
+        :NonlinearProblem, :NonlinearLeastSquaresProblem,
+        :SCCNonlinearProblem, :OptimizationProblem, :SteadyStateProblem,
+    ]
     for (pType, pCanonical) in [
-            (AbstractDict, :p),
-            (AbstractArray{<:Pair}, :(Dict(p))),
-            (AbstractArray, :(isempty(p) ? Dict() : Dict(parameters(sys) .=> p)))
-        ],
-        (uType, uCanonical) in [
-            (Nothing, :(Dict())),
-            (AbstractDict, :u0),
-            (AbstractArray{<:Pair}, :(Dict(u0))),
-            (AbstractArray, :(isempty(u0) ? Dict() : Dict(unknowns(sys) .=> u0)))
-        ]
+                (AbstractDict, :p),
+                (AbstractArray{<:Pair}, :(Dict(p))),
+                (AbstractArray, :(isempty(p) ? Dict() : Dict(parameters(sys) .=> p))),
+            ],
+            (uType, uCanonical) in [
+                (Nothing, :(Dict())),
+                (AbstractDict, :u0),
+                (AbstractArray{<:Pair}, :(Dict(u0))),
+                (AbstractArray, :(isempty(u0) ? Dict() : Dict(unknowns(sys) .=> u0))),
+            ]
 
         @eval function SciMLBase.$T(sys::System, u0::$uType, p::$pType; kw...)
             ctor = string($T)
@@ -128,10 +142,11 @@ for T in [:NonlinearProblem, :NonlinearLeastSquaresProblem,
             `$ctor(sys, u0, p; kw...)` is deprecated. Use `$ctor(sys, merge($uCan, $pCan))`
             instead.
             """
-            $T(sys, merge($uCanonical, $pCanonical); kw...)
+            return $T(sys, merge($uCanonical, $pCanonical); kw...)
         end
         @eval function SciMLBase.$T{iip}(
-                sys::System, u0::$uType, p::$pType; kw...) where {iip}
+                sys::System, u0::$uType, p::$pType; kw...
+            ) where {iip}
             ctor = string($T{iip})
             uCan = string($(QuoteNode(uCanonical)))
             pCan = string($(QuoteNode(pCanonical)))
@@ -142,7 +157,8 @@ for T in [:NonlinearProblem, :NonlinearLeastSquaresProblem,
             return $T{iip}(sys, merge($uCanonical, $pCanonical); kw...)
         end
         @eval function SciMLBase.$T{iip, spec}(
-                sys::System, u0::$uType, p::$pType; kw...) where {iip, spec}
+                sys::System, u0::$uType, p::$pType; kw...
+            ) where {iip, spec}
             ctor = string($T{iip, spec})
             uCan = string($(QuoteNode(uCanonical)))
             pCan = string($(QuoteNode(pCanonical)))
@@ -161,10 +177,11 @@ for T in [:NonlinearProblem, :NonlinearLeastSquaresProblem,
             @warn """
             `$ctor(sys, u0, p::$pT; kw...)` is deprecated. Use `$ctor(sys, u0)` instead
             """
-            $T(sys, u0; kw...)
+            return $T(sys, u0; kw...)
         end
         @eval function SciMLBase.$T{iip}(
-                sys::System, u0::$uType, p::$pType; kw...) where {iip}
+                sys::System, u0::$uType, p::$pType; kw...
+            ) where {iip}
             ctor = string($T{iip})
             pT = string($(QuoteNode(pType)))
             @warn """
@@ -173,7 +190,8 @@ for T in [:NonlinearProblem, :NonlinearLeastSquaresProblem,
             return $T{iip}(sys, u0; kw...)
         end
         @eval function SciMLBase.$T{iip, spec}(
-                sys::System, u0::$uType, p::$pType; kw...) where {iip, spec}
+                sys::System, u0::$uType, p::$pType; kw...
+            ) where {iip, spec}
             ctor = string($T{iip, spec})
             pT = string($(QuoteNode(pType)))
             @warn """
@@ -187,7 +205,8 @@ end
 macro brownian(xs...)
     return quote
         Base.depwarn(
-            "`@brownian` is deprecated. Use `@brownians` instead", :brownian_macro)
+            "`@brownian` is deprecated. Use `@brownians` instead", :brownian_macro
+        )
         $(@__MODULE__).@brownians $(xs...)
     end |> esc
 end

--- a/lib/ModelingToolkitBase/src/derivative_dict.jl
+++ b/lib/ModelingToolkitBase/src/derivative_dict.jl
@@ -18,7 +18,7 @@ DerivativeDict{K}(args...) where {K} = DerivativeDict(Dict{K, SymbolicT}(args...
 
 Base.copy(dd::DerivativeDict) = DerivativeDict(copy(dd.dict))
 function Base.empty(dd::DerivativeDict, ::Type{K}, ::Type{V}) where {K, V}
-    DerivativeDict(empty(dd.dict, K, V))
+    return DerivativeDict(empty(dd.dict, K, V))
 end
 
 struct __DDSentinel end
@@ -27,7 +27,7 @@ const DD_SENTINEL = __DDSentinel()
 function Base.get(def::Base.Callable, dd::DerivativeDict, k::SymbolicT)
     res = get(dd.dict, k, DD_SENTINEL)
     res === DD_SENTINEL || return res
-    Moshi.Match.@match k begin
+    return Moshi.Match.@match k begin
         BSImpl.Term(; f, args) && if f isa Differential && f.order::Int > 1 end => begin
             order = f.order::Int
             res = get(dd.dict, Differential(f.x, 1)(args[1]), DD_SENTINEL)

--- a/lib/ModelingToolkitBase/src/discretedomain.jl
+++ b/lib/ModelingToolkitBase/src/discretedomain.jl
@@ -31,11 +31,11 @@ Base.nameof(::Shift) = :Shift
 SymbolicUtils.isbinop(::Shift) = false
 
 function (D::Shift)(x::Equation, allow_zero = false)
-    D(x.lhs, allow_zero) ~ D(x.rhs, allow_zero)
+    return D(x.lhs, allow_zero) ~ D(x.rhs, allow_zero)
 end
 function (D::Shift)(x, allow_zero = false)
     !allow_zero && D.steps == 0 && return x
-    term(D, x; type = symtype(x), shape = SU.shape(x))
+    return term(D, x; type = symtype(x), shape = SU.shape(x))
 end
 function (D::Shift)(x::Union{Num, Symbolics.Arr}, allow_zero = false)
     !allow_zero && D.steps == 0 && return x
@@ -50,7 +50,7 @@ function (D::Shift)(x::Union{Num, Symbolics.Arr}, allow_zero = false)
             end
         end
     end
-    wrap(D(vt, allow_zero))
+    return wrap(D(vt, allow_zero))
 end
 SymbolicUtils.promote_symtype(::Shift, ::Type{T}) where {T} = T
 SymbolicUtils.promote_shape(::Shift, @nospecialize(x::SU.ShapeT)) = x
@@ -65,9 +65,11 @@ Base.literal_pow(f::typeof(^), D::Shift, ::Val{n}) where {n} = Shift(D.t, D.step
 
 function validate_operator(op::Shift, args, iv; context = nothing)
     isequal(op.t, iv) || throw(OperatorIndepvarMismatchError(op, iv, context))
-    op.steps <= 0 || error("""
-    Only non-positive shifts are allowed. Found shift of $(op.steps) in $context.
-    """)
+    return op.steps <= 0 || error(
+        """
+        Only non-positive shifts are allowed. Found shift of $(op.steps) in $context.
+        """
+    )
 end
 
 hasshift(eq::Equation) = hasshift(eq.lhs) || hasshift(eq.rhs)
@@ -142,7 +144,7 @@ function (xn::Num)(k::ShiftIndex)
     if steps == 0
         return xn # x(k) needs no shift operator if the step of k is 0
     end
-    Shift(t, steps)(xn) # a shift of k steps
+    return Shift(t, steps)(xn) # a shift of k steps
 end
 
 function (xn::Symbolics.Arr)(k::ShiftIndex)
@@ -172,7 +174,7 @@ function (xn::Symbolics.Arr)(k::ShiftIndex)
     if steps == 0
         return xn # x(k) needs no shift operator if the step of k is 0
     end
-    Shift(t, steps)(xn) # a shift of k steps
+    return Shift(t, steps)(xn) # a shift of k steps
 end
 
 Base.:+(k::ShiftIndex, i::Int) = ShiftIndex(k.clock, k.steps + i)
@@ -248,10 +250,14 @@ function validate_operator(op::Sample, args, iv; context = nothing)
     if !is_variable_floatingpoint(arg)
         throw(ContinuousOperatorDiscreteArgumentError(op, arg, context))
     end
-    if isparameter(arg)
-        throw(ArgumentError("""
-        Expected argument of $op to be an unknown, found $arg which is a parameter.
-        """))
+    return if isparameter(arg)
+        throw(
+            ArgumentError(
+                """
+                Expected argument of $op to be an unknown, found $arg which is a parameter.
+                """
+            )
+        )
     end
 end
 
@@ -301,7 +307,8 @@ function ZeroCrossing(expr; name = gensym(), up = true, down = true, kwargs...)
     return SymbolicContinuousCallback(
         [expr ~ 0], up ? ImperativeAffect(Returns(nothing)) : nothing;
         affect_neg = down ? ImperativeAffect(Returns(nothing)) : nothing,
-        kwargs..., zero_crossing_id = name)
+        kwargs..., zero_crossing_id = name
+    )
 end
 
 function SciMLBase.Clocks.EventClock(cb::SymbolicContinuousCallback)

--- a/lib/ModelingToolkitBase/src/discretes.jl
+++ b/lib/ModelingToolkitBase/src/discretes.jl
@@ -1,14 +1,16 @@
 function todiscrete_validate(s::SymbolicT)
     if !iscall(s)
-        error("""
-        `@discretes` cannot create time-independent variables. Encountered $s. Use \
-        `@parameters` for this purpose.
-        """)
+        error(
+            """
+            `@discretes` cannot create time-independent variables. Encountered $s. Use \
+            `@parameters` for this purpose.
+            """
+        )
     end
-    toparam(s)
+    return toparam(s)
 end
 function todiscrete_validate(s::Union{Num, Symbolics.Arr, Symbolics.CallAndWrap})
-    typeof(s)(todiscrete_validate(unwrap(s)))
+    return typeof(s)(todiscrete_validate(unwrap(s)))
 end
 
 """
@@ -20,9 +22,10 @@ symbolics declare with this macro must be dependent variables.
 See also [`@independent_variables`](@ref), [`@variables`](@ref) and [`@constants`](@ref).
 """
 macro discretes(xs...)
-    Symbolics.parse_vars(:discretes,
+    return Symbolics.parse_vars(
+        :discretes,
         Real,
         xs,
-        todiscrete_validate)
+        todiscrete_validate
+    )
 end
-

--- a/lib/ModelingToolkitBase/src/independent_variables.jl
+++ b/lib/ModelingToolkitBase/src/independent_variables.jl
@@ -7,10 +7,12 @@ Define one or more independent variables. For example:
     @variables x(t)
 """
 macro independent_variables(ts...)
-    Symbolics.parse_vars(:independent_variables,
+    return Symbolics.parse_vars(
+        :independent_variables,
         Real,
         ts,
-        toiv)
+        toiv
+    )
 end
 
 toiv(s::SymbolicT) = GlobalScope(setmetadata(s, MTKVariableTypeCtx, PARAMETER))

--- a/lib/ModelingToolkitBase/src/modelingtoolkitize/nonlinearproblem.jl
+++ b/lib/ModelingToolkitBase/src/modelingtoolkitize/nonlinearproblem.jl
@@ -18,7 +18,8 @@ All other keyword arguments are forwarded to the created `System`.
 """
 function modelingtoolkitize(
         prob::Union{NonlinearProblem, NonlinearLeastSquaresProblem};
-        u_names = nothing, p_names = nothing, kwargs...)
+        u_names = nothing, p_names = nothing, kwargs...
+    )
     p = prob.p
     has_p = !(p isa Union{DiffEqBase.NullParameters, Nothing})
 
@@ -43,8 +44,10 @@ function modelingtoolkitize(
     filter!(x -> !iscall(x) || !(operation(x) isa Initial), params)
     filter!(x -> !iscall(x[1]) || !(operation(x[1]) isa Initial), initial_conditions)
 
-    return System(eqs, sts, params;
+    return System(
+        eqs, sts, params;
         initial_conditions,
         name = gensym(:MTKizedNonlin),
-        kwargs...)
+        kwargs...
+    )
 end

--- a/lib/ModelingToolkitBase/src/modelingtoolkitize/odeproblem.jl
+++ b/lib/ModelingToolkitBase/src/modelingtoolkitize/odeproblem.jl
@@ -16,8 +16,10 @@ Convert an `ODEProblem` to a `ModelingToolkitBase.System`.
 
 All other keyword arguments are forwarded to the created `System`.
 """
-function modelingtoolkitize(prob::ODEProblem; u_names = nothing, p_names = nothing,
-        return_symbolic_u0_p = false, kwargs...)
+function modelingtoolkitize(
+        prob::ODEProblem; u_names = nothing, p_names = nothing,
+        return_symbolic_u0_p = false, kwargs...
+    )
     if prob.f isa DiffEqBase.AbstractParameterizedFunction
         return prob.f.sys
     end
@@ -46,10 +48,12 @@ function modelingtoolkitize(prob::ODEProblem; u_names = nothing, p_names = nothi
     filter!(x -> !iscall(x) || !(operation(x) isa Initial), params)
     filter!(x -> !iscall(x[1]) || !(operation(x[1]) isa Initial), initial_conditions)
 
-    sys = System(eqs, t, sts, params;
+    sys = System(
+        eqs, t, sts, params;
         initial_conditions,
         name = gensym(:MTKizedODE),
-        kwargs...)
+        kwargs...
+    )
 
     if return_symbolic_u0_p
         return sys, vars, _params

--- a/lib/ModelingToolkitBase/src/modelingtoolkitize/optimizationproblem.jl
+++ b/lib/ModelingToolkitBase/src/modelingtoolkitize/optimizationproblem.jl
@@ -17,7 +17,8 @@ All other keyword arguments are forwarded to the created `System`.
 """
 function modelingtoolkitize(
         prob::OptimizationProblem; u_names = nothing, p_names = nothing,
-        kwargs...)
+        kwargs...
+    )
     num_cons = isnothing(prob.lcons) ? 0 : length(prob.lcons)
     p = prob.p
     has_p = !(p isa Union{DiffEqBase.NullParameters, Nothing})
@@ -68,7 +69,7 @@ function modelingtoolkitize(
         end
 
         if (isnothing(prob.lcons) || all(isinf, prob.lcons)) &&
-           (isnothing(prob.ucons) || all(isinf, prob.ucons))
+                (isnothing(prob.ucons) || all(isinf, prob.ucons))
             throw(ArgumentError("Constraints passed have no proper bounds defined.
             Ensure you pass equal bounds (the scalar that the constraint should evaluate to) for equality constraints
             or pass the lower and upper bounds for inequality constraints."))
@@ -87,9 +88,11 @@ function modelingtoolkitize(
     filter!(x -> !iscall(x[1]) || !(operation(x[1]) isa Initial), initial_conditions)
 
     sts = vec(collect(vars))
-    sys = OptimizationSystem(objective, sts, params;
+    return sys = OptimizationSystem(
+        objective, sts, params;
         initial_conditions,
         constraints = cons,
         name = gensym(:MTKizedOpt),
-        kwargs...)
+        kwargs...
+    )
 end

--- a/lib/ModelingToolkitBase/src/modelingtoolkitize/sdeproblem.jl
+++ b/lib/ModelingToolkitBase/src/modelingtoolkitize/sdeproblem.jl
@@ -16,7 +16,8 @@ Convert an `SDEProblem` to a `ModelingToolkitBase.System`.
 All other keyword arguments are forwarded to the created `System`.
 """
 function modelingtoolkitize(
-        prob::SDEProblem; u_names = nothing, p_names = nothing, kwargs...)
+        prob::SDEProblem; u_names = nothing, p_names = nothing, kwargs...
+    )
     if prob.f isa DiffEqBase.AbstractParameterizedFunction
         return prob.f.sys
     end
@@ -24,12 +25,14 @@ function modelingtoolkitize(
     # just create the equivalent ODEProblem, `modelingtoolkitize` that
     # and add on the noise
     odefn = ODEFunction{SciMLBase.isinplace(prob)}(
-        prob.f.f; mass_matrix = prob.f.mass_matrix, sys = prob.f.sys)
+        prob.f.f; mass_matrix = prob.f.mass_matrix, sys = prob.f.sys
+    )
     odeprob = ODEProblem(odefn, prob.u0, prob.tspan, prob.p)
     sys, vars,
-    params = modelingtoolkitize(
+        params = modelingtoolkitize(
         odeprob; u_names, p_names, return_symbolic_u0_p = true,
-        name = gensym(:MTKizedSDE), kwargs...)
+        name = gensym(:MTKizedSDE), kwargs...
+    )
     t = get_iv(sys)
 
     if SciMLBase.isinplace(prob)

--- a/lib/ModelingToolkitBase/src/parameter_bindings_graph.jl
+++ b/lib/ModelingToolkitBase/src/parameter_bindings_graph.jl
@@ -101,8 +101,10 @@ end
 
 Find the bound parameters used by `expr`.
 """
-function bound_parameters_used_by!(buffer::OrderedSet{SymbolicT}, sys::AbstractSystem, expr;
-                                   bgraph::ParameterBindingsGraph = get_parameter_bindings_graph(sys))
+function bound_parameters_used_by!(
+        buffer::OrderedSet{SymbolicT}, sys::AbstractSystem, expr;
+        bgraph::ParameterBindingsGraph = get_parameter_bindings_graph(sys)
+    )
     # No point searching if we've already included all of them.
     if issubset(bgraph.bound_ps, buffer)
         return buffer
@@ -126,8 +128,10 @@ end
 
 Topologically sort the bound parameters `bound_ps`.
 """
-function sort_bound_parameters!(bound_ps::OrderedSet{SymbolicT}, sys::AbstractSystem;
-                                bgraph::ParameterBindingsGraph = get_parameter_bindings_graph(sys))
+function sort_bound_parameters!(
+        bound_ps::OrderedSet{SymbolicT}, sys::AbstractSystem;
+        bgraph::ParameterBindingsGraph = get_parameter_bindings_graph(sys)
+    )
     sort!(bound_ps; by = Base.Fix1(getindex, bgraph.bound_par_idx))
     return bound_ps
 end
@@ -137,11 +141,14 @@ struct CyclicBindingsError <: Exception
 end
 
 function Base.showerror(io::IO, err::CyclicBindingsError)
-    println(io, """
-    The bindings for parameters were found to have at least one cycle involving the \
-    follow parameters:
-    """)
+    println(
+        io, """
+        The bindings for parameters were found to have at least one cycle involving the \
+        follow parameters:
+        """
+    )
     for p in err.cycle_ps
         println(io, p)
     end
+    return
 end

--- a/lib/ModelingToolkitBase/src/parameters.jl
+++ b/lib/ModelingToolkitBase/src/parameters.jl
@@ -46,7 +46,7 @@ end
 Maps the variable to a parameter.
 """
 function toparam(s)
-    if s isa Symbolics.Arr
+    return if s isa Symbolics.Arr
         Symbolics.wrap(toparam(Symbolics.unwrap(s)))
     elseif s isa AbstractArray
         map(toparam, s)
@@ -66,15 +66,17 @@ tovar(s::Union{Num, Symbolics.Arr}) = wrap(tovar(unwrap(s)))
 
 function toparam_validate(s::SymbolicT)
     if iscall(s)
-        error("""
-        `@parameters` cannot create time-dependent parameters. Encountered $s. Use \
-        `@discretes` for this purpose.
-        """)
+        error(
+            """
+            `@parameters` cannot create time-dependent parameters. Encountered $s. Use \
+            `@discretes` for this purpose.
+            """
+        )
     end
-    toparam(s)
+    return toparam(s)
 end
 function toparam_validate(s::Union{Num, Symbolics.Arr, Symbolics.CallAndWrap})
-    typeof(s)(toparam_validate(unwrap(s)))
+    return typeof(s)(toparam_validate(unwrap(s)))
 end
 
 """
@@ -86,10 +88,12 @@ in the model.
 See also [`@independent_variables`](@ref), [`@variables`](@ref) and [`@constants`](@ref).
 """
 macro parameters(xs...)
-    Symbolics.parse_vars(:parameters,
+    return Symbolics.parse_vars(
+        :parameters,
         Real,
         xs,
-        toparam_validate)
+        toparam_validate
+    )
 end
 
 function find_types(array)
@@ -129,9 +133,13 @@ function subset_tunables(sys, new_tunables)
     diff_params = setdiff(cur_tunables, new_tunables)
 
     if !isempty(setdiff(new_tunables, cur_tunables))
-        throw(ArgumentError("""New tunable parameters must be a subset of the current tunable parameters. Found tunable parameters not in the system: $(setdiff(new_tunables, cur_tunables)).
-        Note that array parameters can only be set as tunable or non-tunable, not partially tunable. They should be specified in the un-scalarized form.
-        """))
+        throw(
+            ArgumentError(
+                """New tunable parameters must be a subset of the current tunable parameters. Found tunable parameters not in the system: $(setdiff(new_tunables, cur_tunables)).
+                Note that array parameters can only be set as tunable or non-tunable, not partially tunable. They should be specified in the un-scalarized form.
+                """
+            )
+        )
     end
     cur_ps = copy(get_ps(sys))
     const_ps = toconstant.(diff_params)
@@ -145,5 +153,5 @@ function subset_tunables(sys, new_tunables)
         end
     end
     @set! sys.ps = cur_ps
-    complete(sys)
+    return complete(sys)
 end

--- a/lib/ModelingToolkitBase/src/precompile.jl
+++ b/lib/ModelingToolkitBase/src/precompile.jl
@@ -1,87 +1,87 @@
 PrecompileTools.@compile_workload begin
-        fold1 = Val{false}()
-        using SymbolicUtils
-        using SymbolicUtils: shape
-        using Symbolics
-        @syms x y f(t) q[1:5]
-        SymbolicUtils.Sym{SymReal}(:a; type = Real, shape = SymbolicUtils.ShapeVecT())
-        x + y
-        x * y
-        x / y
-        x ^ y
-        x ^ 5
-        6 ^ x
-        x - y
-        x * x * q[1]
-        -y
-        2y
-        z = 2
-        dict = SymbolicUtils.ACDict{VartypeT}()
-        dict[x] = 1
-        dict[y] = 1
-        type::typeof(DataType) = rand() < 0.5 ? Real : Float64
-        nt = (; type, shape, unsafe = true)
-        Base.pairs(nt)
-        BSImpl.AddMul{VartypeT}(1, dict, SymbolicUtils.AddMulVariant.MUL; type, shape = SymbolicUtils.ShapeVecT(), unsafe = true)
-        *(y, z)
-        *(z, y)
-        SymbolicUtils.symtype(y)
-        f(x)
-        (5x / 5)
-        expand((x + y) ^ 2)
-        simplify(x ^ (1//2) + (sin(x) ^ 2 + cos(x) ^ 2) + 2(x + y) - x - y)
-        ex = x + 2y + sin(x)
-        rules1 = Dict(x => y)
-        rules2 = Dict(x => 1)
-        Dx = Differential(x)
-        Differential(y)(ex)
-        uex = unwrap(ex)
-        Symbolics.executediff(Dx, uex)
-        # Running `fold = Val(true)` invalidates the precompiled statements
-        # for `fold = Val(false)` and itself doesn't precompile anyway.
-        # substitute(ex, rules1)
-        substitute(ex, rules1; fold = fold1)
-        substitute(ex, rules2; fold = fold1)
-        @variables foo
-        f(foo)
-        @variables x y f(::Real) q[1:5]
-        x + y
-        x * y
-        x / y
-        x ^ y
-        x ^ 5
-        # 6 ^ x
-        x - y
-        -y
-        2y
-        symtype(y)
-        z = 2
-        *(y, z)
-        *(z, y)
-        f(x)
-        (5x / 5)
-        [x, y]
-        [x, f, f]
-        promote_type(Int, Num)
-        promote_type(Real, Num)
-        promote_type(Float64, Num)
-        # expand((x + y) ^ 2)
-        # simplify(x ^ (1//2) + (sin(x) ^ 2 + cos(x) ^ 2) + 2(x + y) - x - y)
-        ex = x + 2y + sin(x)
-        rules1 = Dict(x => y)
-        # rules2 = Dict(x => 1)
-        # Running `fold = Val(true)` invalidates the precompiled statements
-        # for `fold = Val(false)` and itself doesn't precompile anyway.
-        # substitute(ex, rules1)
-        substitute(ex, rules1; fold = fold1)
-        Symbolics.linear_expansion(ex, y)
-        # substitute(ex, rules2; fold = fold1)
-        # substitute(ex, rules2)
-        # substitute(ex, rules1; fold = fold2)
-        # substitute(ex, rules2; fold = fold2)
-        q[1]
-        q'q
-     using ModelingToolkitBase
+    fold1 = Val{false}()
+    using SymbolicUtils
+    using SymbolicUtils: shape
+    using Symbolics
+    @syms x y f(t) q[1:5]
+    SymbolicUtils.Sym{SymReal}(:a; type = Real, shape = SymbolicUtils.ShapeVecT())
+    x + y
+    x * y
+    x / y
+    x^y
+    x^5
+    6^x
+    x - y
+    x * x * q[1]
+    -y
+    2y
+    z = 2
+    dict = SymbolicUtils.ACDict{VartypeT}()
+    dict[x] = 1
+    dict[y] = 1
+    type::typeof(DataType) = rand() < 0.5 ? Real : Float64
+    nt = (; type, shape, unsafe = true)
+    Base.pairs(nt)
+    BSImpl.AddMul{VartypeT}(1, dict, SymbolicUtils.AddMulVariant.MUL; type, shape = SymbolicUtils.ShapeVecT(), unsafe = true)
+    *(y, z)
+    *(z, y)
+    SymbolicUtils.symtype(y)
+    f(x)
+    (5x / 5)
+    expand((x + y)^2)
+    simplify(x^(1 // 2) + (sin(x)^2 + cos(x)^2) + 2(x + y) - x - y)
+    ex = x + 2y + sin(x)
+    rules1 = Dict(x => y)
+    rules2 = Dict(x => 1)
+    Dx = Differential(x)
+    Differential(y)(ex)
+    uex = unwrap(ex)
+    Symbolics.executediff(Dx, uex)
+    # Running `fold = Val(true)` invalidates the precompiled statements
+    # for `fold = Val(false)` and itself doesn't precompile anyway.
+    # substitute(ex, rules1)
+    substitute(ex, rules1; fold = fold1)
+    substitute(ex, rules2; fold = fold1)
+    @variables foo
+    f(foo)
+    @variables x y f(::Real) q[1:5]
+    x + y
+    x * y
+    x / y
+    x^y
+    x^5
+    # 6 ^ x
+    x - y
+    -y
+    2y
+    symtype(y)
+    z = 2
+    *(y, z)
+    *(z, y)
+    f(x)
+    (5x / 5)
+    [x, y]
+    [x, f, f]
+    promote_type(Int, Num)
+    promote_type(Real, Num)
+    promote_type(Float64, Num)
+    # expand((x + y) ^ 2)
+    # simplify(x ^ (1//2) + (sin(x) ^ 2 + cos(x) ^ 2) + 2(x + y) - x - y)
+    ex = x + 2y + sin(x)
+    rules1 = Dict(x => y)
+    # rules2 = Dict(x => 1)
+    # Running `fold = Val(true)` invalidates the precompiled statements
+    # for `fold = Val(false)` and itself doesn't precompile anyway.
+    # substitute(ex, rules1)
+    substitute(ex, rules1; fold = fold1)
+    Symbolics.linear_expansion(ex, y)
+    # substitute(ex, rules2; fold = fold1)
+    # substitute(ex, rules2)
+    # substitute(ex, rules1; fold = fold2)
+    # substitute(ex, rules2; fold = fold2)
+    q[1]
+    q'q
+    using ModelingToolkitBase
     @parameters g
     @variables x(ModelingToolkitBase.t_nounits)
     @variables y(ModelingToolkitBase.t_nounits) [state_priority = 10]

--- a/lib/ModelingToolkitBase/src/problems/bvproblem.jl
+++ b/lib/ModelingToolkitBase/src/problems/bvproblem.jl
@@ -3,7 +3,8 @@
         check_compatibility = true, cse = true,
         checkbounds = false, eval_expression = false, eval_module = @__MODULE__,
         expression = Val{false}, guesses = Dict(), callback = nothing,
-        kwargs...) where {iip, spec}
+        kwargs...
+    ) where {iip, spec}
     check_complete(sys, BVProblem)
     check_compatibility && check_compatible_system(BVProblem, sys)
     isnothing(callback) || error("BVP solvers do not support callbacks.")
@@ -15,17 +16,19 @@
     _op = has_alg_eqs(sys) ? op : merge(Dict(op), Dict(guesses))
 
     fode, u0,
-    p = process_SciMLProblem(
+        p = process_SciMLProblem(
         ODEFunction{iip, spec}, sys, _op; guesses,
         t = tspan !== nothing ? tspan[1] : tspan, check_compatibility = false, cse,
-        checkbounds, time_dependent_init = false, expression, kwargs...)
+        checkbounds, time_dependent_init = false, expression, kwargs...
+    )
 
     stidxmap = Dict([v => i for (i, v) in enumerate(dvs)])
     u0_idxs = has_alg_eqs(sys) ? collect(1:length(dvs)) :
-              [stidxmap[k] for (k, v) in op if haskey(stidxmap, k)]
+        [stidxmap[k] for (k, v) in op if haskey(stidxmap, k)]
     fbc = generate_boundary_conditions(
         sys, u0, u0_idxs, tspan[1]; expression = Val{false},
-        wrap_gfw = Val{true}, cse, checkbounds)
+        wrap_gfw = Val{true}, cse, checkbounds
+    )
 
     if (length(constraints(sys)) + length(op) > length(dvs))
         @warn "The BVProblem is overdetermined. The total number of conditions (# constraints + # fixed initial values given by op) exceeds the total number of states. The BVP solvers will default to doing a nonlinear least-squares optimization."
@@ -45,7 +48,7 @@ function check_compatible_system(T::Type{BVProblem}, sys::System)
     check_no_noise(sys, T)
     check_is_continuous(sys, T)
 
-    if !isempty(discrete_events(sys)) || !isempty(continuous_events(sys))
+    return if !isempty(discrete_events(sys)) || !isempty(continuous_events(sys))
         throw(SystemCompatibilityError("BVP solvers do not support events."))
     end
 end

--- a/lib/ModelingToolkitBase/src/problems/compatibility.jl
+++ b/lib/ModelingToolkitBase/src/problems/compatibility.jl
@@ -12,107 +12,147 @@ end
 function Base.showerror(io::IO, err::SystemCompatibilityError)
     println(io, err.msg)
     println(io)
-    print(io, "To disable this check, pass `check_compatibility = false`.")
+    return print(io, "To disable this check, pass `check_compatibility = false`.")
 end
 
 function check_time_dependent(sys::System, T)
-    if !is_time_dependent(sys)
-        throw(SystemCompatibilityError("""
-        `$T` requires a time-dependent system.
-        """))
+    return if !is_time_dependent(sys)
+        throw(
+            SystemCompatibilityError(
+                """
+                `$T` requires a time-dependent system.
+                """
+            )
+        )
     end
 end
 
 function check_time_independent(sys::System, T)
-    if is_time_dependent(sys)
-        throw(SystemCompatibilityError("""
-        `$T` requires a time-independent system.
-        """))
+    return if is_time_dependent(sys)
+        throw(
+            SystemCompatibilityError(
+                """
+                `$T` requires a time-independent system.
+                """
+            )
+        )
     end
 end
 
 function check_is_dde(sys::System)
     altT = get_noise_eqs(sys) === nothing ? ODEProblem : SDEProblem
-    if !is_dde(sys)
-        throw(SystemCompatibilityError("""
-        The system does not have delays. Consider an `$altT` instead.
-        """))
+    return if !is_dde(sys)
+        throw(
+            SystemCompatibilityError(
+                """
+                The system does not have delays. Consider an `$altT` instead.
+                """
+            )
+        )
     end
 end
 
 function check_not_dde(sys::System)
     altT = get_noise_eqs(sys) === nothing ? DDEProblem : SDDEProblem
-    if is_dde(sys)
-        throw(SystemCompatibilityError("""
-        The system has delays. Consider a `$altT` instead.
-        """))
+    return if is_dde(sys)
+        throw(
+            SystemCompatibilityError(
+                """
+                The system has delays. Consider a `$altT` instead.
+                """
+            )
+        )
     end
 end
 
 function check_no_cost(sys::System, T)
     cost = ModelingToolkitBase.cost(sys)
-    if !_iszero(cost)
-        throw(SystemCompatibilityError("""
-        `$T` will not optimize solutions of systems that have associated cost \
-        functions. Solvers for optimal control problems are forthcoming.
-        """))
+    return if !_iszero(cost)
+        throw(
+            SystemCompatibilityError(
+                """
+                `$T` will not optimize solutions of systems that have associated cost \
+                functions. Solvers for optimal control problems are forthcoming.
+                """
+            )
+        )
     end
 end
 
 function check_has_cost(sys::System, T)
     cost = ModelingToolkitBase.cost(sys)
-    if _iszero(cost)
-        throw(SystemCompatibilityError("""
-        A system without cost cannot be used to construct a `$T`.
-        """))
+    return if _iszero(cost)
+        throw(
+            SystemCompatibilityError(
+                """
+                A system without cost cannot be used to construct a `$T`.
+                """
+            )
+        )
     end
 end
 
 function check_no_constraints(sys::System, T)
-    if !isempty(constraints(sys))
-        throw(SystemCompatibilityError("""
-        A system with constraints cannot be used to construct a `$T`.
-        """))
+    return if !isempty(constraints(sys))
+        throw(
+            SystemCompatibilityError(
+                """
+                A system with constraints cannot be used to construct a `$T`.
+                """
+            )
+        )
     end
 end
 
 function check_has_constraints(sys::System, T)
-    if isempty(constraints(sys))
-        throw(SystemCompatibilityError("""
-        A system without constraints cannot be used to construct a `$T`. Consider an \
-        `ODEProblem` instead.
-        """))
+    return if isempty(constraints(sys))
+        throw(
+            SystemCompatibilityError(
+                """
+                A system without constraints cannot be used to construct a `$T`. Consider an \
+                `ODEProblem` instead.
+                """
+            )
+        )
     end
 end
 
 function check_no_jumps(sys::System, T)
-    if !isempty(jumps(sys))
-        throw(SystemCompatibilityError("""
-        A system with jumps cannot be used to construct a `$T`. Consider a \
-        `JumpProblem` instead.
-        """))
+    return if !isempty(jumps(sys))
+        throw(
+            SystemCompatibilityError(
+                """
+                A system with jumps cannot be used to construct a `$T`. Consider a \
+                `JumpProblem` instead.
+                """
+            )
+        )
     end
 end
 
 function check_has_jumps(sys::System, T)
-    if isempty(jumps(sys))
+    return if isempty(jumps(sys))
         throw(SystemCompatibilityError("`$T` requires a system with jumps."))
     end
 end
 
 function check_no_noise(sys::System, T)
     altT = is_dde(sys) ? SDDEProblem : SDEProblem
-    if get_noise_eqs(sys) !== nothing
-        throw(SystemCompatibilityError("""
-        A system with noise cannot be used to construct a `$T`. Consider an \
-        `$altT` instead.
-        """))
+    return if get_noise_eqs(sys) !== nothing
+        throw(
+            SystemCompatibilityError(
+                """
+                A system with noise cannot be used to construct a `$T`. Consider an \
+                `$altT` instead.
+                """
+            )
+        )
     end
 end
 
 function check_has_noise(sys::System, T)
     altT = is_dde(sys) ? DDEProblem : ODEProblem
-    if get_noise_eqs(sys) === nothing
+    return if get_noise_eqs(sys) === nothing
         msg = """
         A system without noise cannot be used to construct a `$T`. Consider an \
         `$altT` instead.
@@ -128,53 +168,77 @@ function check_has_noise(sys::System, T)
 end
 
 function check_is_discrete(sys::System, T)
-    if !is_discrete_system(sys)
-        throw(SystemCompatibilityError("""
-        `$T` expects a discrete system. Consider an `ODEProblem` instead. If your system \
-        is discrete, ensure `mtkcompile` has been run on it.
-        """))
+    return if !is_discrete_system(sys)
+        throw(
+            SystemCompatibilityError(
+                """
+                `$T` expects a discrete system. Consider an `ODEProblem` instead. If your system \
+                is discrete, ensure `mtkcompile` has been run on it.
+                """
+            )
+        )
     end
 end
 
 function check_is_continuous(sys::System, T)
     altT = has_alg_equations(sys) ? ImplicitDiscreteProblem : DiscreteProblem
-    if is_discrete_system(sys)
-        throw(SystemCompatibilityError("""
-        A discrete system cannot be used to construct a `$T`. Consider a `$altT` instead.
-        """))
+    return if is_discrete_system(sys)
+        throw(
+            SystemCompatibilityError(
+                """
+                A discrete system cannot be used to construct a `$T`. Consider a `$altT` instead.
+                """
+            )
+        )
     end
 end
 
 function check_is_explicit(sys::System, T, altT)
-    if has_alg_equations(sys)
-        throw(SystemCompatibilityError("""
-        `$T` expects an explicit system. Consider a `$altT` instead.
-        """))
+    return if has_alg_equations(sys)
+        throw(
+            SystemCompatibilityError(
+                """
+                `$T` expects an explicit system. Consider a `$altT` instead.
+                """
+            )
+        )
     end
 end
 
 function check_is_implicit(sys::System, T, altT)
-    if !has_alg_equations(sys)
-        throw(SystemCompatibilityError("""
-        `$T` expects an implicit system. Consider a `$altT` instead.
-        """))
+    return if !has_alg_equations(sys)
+        throw(
+            SystemCompatibilityError(
+                """
+                `$T` expects an implicit system. Consider a `$altT` instead.
+                """
+            )
+        )
     end
 end
 
 function check_no_equations(sys::System, T)
-    if !isempty(equations(sys))
-        throw(SystemCompatibilityError("""
-        A system with equations cannot be used to construct a `$T`. Consider turning the
-        equations into constraints instead.
-        """))
+    return if !isempty(equations(sys))
+        throw(
+            SystemCompatibilityError(
+                """
+                A system with equations cannot be used to construct a `$T`. Consider turning the
+                equations into constraints instead.
+                """
+            )
+        )
     end
 end
 
 function check_affine(sys::System, T)
-    if !isaffine(sys)
-        throw(SystemCompatibilityError("""
-        A non-affine system cannot be used to construct a `$T`. Consider a
-        `NonlinearProblem` instead.
-        """))
+    return if !isaffine(sys)
+        throw(
+            SystemCompatibilityError(
+                """
+                A non-affine system cannot be used to construct a `$T`. Consider a
+                `NonlinearProblem` instead.
+                """
+            )
+        )
     end
 end

--- a/lib/ModelingToolkitBase/src/problems/daeproblem.jl
+++ b/lib/ModelingToolkitBase/src/problems/daeproblem.jl
@@ -3,13 +3,16 @@
         t = nothing, eval_expression = false, eval_module = @__MODULE__, sparse = false,
         steady_state = false, checkbounds = false, sparsity = false, analytic = nothing,
         simplify = false, cse = true, initialization_data = nothing,
-        expression = Val{false}, check_compatibility = true, kwargs...) where {iip, spec}
+        expression = Val{false}, check_compatibility = true, kwargs...
+    ) where {iip, spec}
     check_complete(sys, DAEFunction)
     check_compatibility && check_compatible_system(DAEFunction, sys)
 
-    f = generate_rhs(sys; expression, wrap_gfw = Val{true},
+    f = generate_rhs(
+        sys; expression, wrap_gfw = Val{true},
         implicit_dae = true, eval_expression, eval_module, checkbounds = checkbounds, cse,
-        kwargs...)
+        kwargs...
+    )
 
     if spec === SciMLBase.FunctionWrapperSpecialize && iip
         if u0 === nothing || p === nothing || t === nothing
@@ -23,15 +26,18 @@
     end
 
     if jac
-        _jac = generate_dae_jacobian(sys; expression,
+        _jac = generate_dae_jacobian(
+            sys; expression,
             wrap_gfw = Val{true}, simplify, sparse, cse, eval_expression, eval_module,
-            checkbounds, kwargs...)
+            checkbounds, kwargs...
+        )
     else
         _jac = nothing
     end
 
     observedfun = ObservedFunctionCache(
-        sys; expression, steady_state, eval_expression, eval_module, checkbounds, cse)
+        sys; expression, steady_state, eval_expression, eval_module, checkbounds, cse
+    )
 
     jac_prototype = if sparse
         uElType = u0 === nothing ? Float64 : eltype(u0)
@@ -53,7 +59,8 @@
         jac_prototype = jac_prototype,
         observed = observedfun,
         analytic = analytic,
-        initialization_data)
+        initialization_data,
+    )
     args = (; f)
 
     return maybe_codegen_scimlfn(expression, DAEFunction{iip, spec}, args; kwargs...)
@@ -63,18 +70,23 @@ end
         sys::System, op, tspan;
         callback = nothing, check_length = true, eval_expression = false,
         eval_module = @__MODULE__, check_compatibility = true,
-        expression = Val{false}, kwargs...) where {iip, spec}
+        expression = Val{false}, kwargs...
+    ) where {iip, spec}
     check_complete(sys, DAEProblem)
     check_compatibility && check_compatible_system(DAEProblem, sys)
 
     f, du0,
-    u0,
-    p = process_SciMLProblem(DAEFunction{iip, spec}, sys, op;
+        u0,
+        p = process_SciMLProblem(
+        DAEFunction{iip, spec}, sys, op;
         t = tspan !== nothing ? tspan[1] : tspan, check_length, eval_expression,
-        eval_module, check_compatibility, implicit_dae = true, expression, kwargs...)
+        eval_module, check_compatibility, implicit_dae = true, expression, kwargs...
+    )
 
-    kwargs = process_kwargs(sys; expression, callback, eval_expression, eval_module,
-        op, kwargs...)
+    kwargs = process_kwargs(
+        sys; expression, callback, eval_expression, eval_module,
+        op, kwargs...
+    )
 
     diffvars = collect_differential_variables(sys)
     sts = unknowns(sys)

--- a/lib/ModelingToolkitBase/src/problems/ddeproblem.jl
+++ b/lib/ModelingToolkitBase/src/problems/ddeproblem.jl
@@ -2,13 +2,16 @@
         sys::System; u0 = nothing, p = nothing, eval_expression = false,
         eval_module = @__MODULE__, expression = Val{false}, checkbounds = false,
         initialization_data = nothing, cse = true, check_compatibility = true,
-        sparse = false, simplify = false, analytic = nothing, kwargs...) where {iip, spec}
+        sparse = false, simplify = false, analytic = nothing, kwargs...
+    ) where {iip, spec}
     check_complete(sys, DDEFunction)
     check_compatibility && check_compatible_system(DDEFunction, sys)
 
-    f = generate_rhs(sys; expression, wrap_gfw = Val{true},
+    f = generate_rhs(
+        sys; expression, wrap_gfw = Val{true},
         eval_expression, eval_module, checkbounds = checkbounds, cse,
-        kwargs...)
+        kwargs...
+    )
 
     if spec === SciMLBase.FunctionWrapperSpecialize && iip
         if u0 === nothing || p === nothing || t === nothing
@@ -25,14 +28,16 @@
     _M = concrete_massmatrix(M; sparse, u0)
 
     observedfun = ObservedFunctionCache(
-        sys; expression, eval_expression, eval_module, checkbounds, cse)
+        sys; expression, eval_expression, eval_module, checkbounds, cse
+    )
 
     kwargs = (;
         sys = sys,
         mass_matrix = _M,
         observed = observedfun,
         analytic = analytic,
-        initialization_data)
+        initialization_data,
+    )
     args = (; f)
 
     return maybe_codegen_scimlfn(expression, DDEFunction{iip, spec}, args; kwargs...)
@@ -42,19 +47,23 @@ end
         sys::System, op, tspan;
         callback = nothing, check_length = true, cse = true, checkbounds = false,
         eval_expression = false, eval_module = @__MODULE__, check_compatibility = true,
-        u0_constructor = identity, expression = Val{false}, kwargs...) where {iip, spec}
+        u0_constructor = identity, expression = Val{false}, kwargs...
+    ) where {iip, spec}
     check_complete(sys, DDEProblem)
     check_compatibility && check_compatible_system(DDEProblem, sys)
 
     f, u0,
-    p = process_SciMLProblem(DDEFunction{iip, spec}, sys, op;
+        p = process_SciMLProblem(
+        DDEFunction{iip, spec}, sys, op;
         t = tspan !== nothing ? tspan[1] : tspan, check_length, cse, checkbounds,
         eval_expression, eval_module, check_compatibility, symbolic_u0 = true,
-        expression, u0_constructor, kwargs...)
+        expression, u0_constructor, kwargs...
+    )
 
     h = generate_history(
         sys, u0; expression, wrap_gfw = Val{true}, cse, eval_expression, eval_module,
-        checkbounds)
+        checkbounds
+    )
 
     if expression == Val{true}
         if u0 !== nothing
@@ -67,7 +76,8 @@ end
     end
 
     kwargs = process_kwargs(
-        sys; expression, callback, eval_expression, eval_module, op, kwargs...)
+        sys; expression, callback, eval_expression, eval_module, op, kwargs...
+    )
     args = (; f, u0, h, tspan, p)
 
     return maybe_codegen_scimlproblem(expression, DDEProblem{iip}, args; kwargs...)
@@ -80,5 +90,5 @@ function check_compatible_system(T::Union{Type{DDEFunction}, Type{DDEProblem}}, 
     check_no_constraints(sys, T)
     check_no_jumps(sys, T)
     check_no_noise(sys, T)
-    check_is_continuous(sys, T)
+    return check_is_continuous(sys, T)
 end

--- a/lib/ModelingToolkitBase/src/problems/discreteproblem.jl
+++ b/lib/ModelingToolkitBase/src/problems/discreteproblem.jl
@@ -3,13 +3,16 @@
         eval_expression = false, eval_module = @__MODULE__, expression = Val{false},
         checkbounds = false, analytic = nothing, simplify = false, cse = true,
         initialization_data = nothing, check_compatibility = true,
-        kwargs...) where {iip, spec}
+        kwargs...
+    ) where {iip, spec}
     check_complete(sys, DiscreteFunction)
     check_compatibility && check_compatible_system(DiscreteFunction, sys)
 
-    f = generate_rhs(sys; expression, wrap_gfw = Val{true},
+    f = generate_rhs(
+        sys; expression, wrap_gfw = Val{true},
         eval_expression, eval_module, checkbounds = checkbounds, cse,
-        kwargs...)
+        kwargs...
+    )
 
     if spec === SciMLBase.FunctionWrapperSpecialize && iip
         if u0 === nothing || p === nothing || t === nothing
@@ -24,13 +27,15 @@
 
     observedfun = ObservedFunctionCache(
         sys; steady_state = false, expression, eval_expression, eval_module, checkbounds,
-        cse)
+        cse
+    )
 
     kwargs = (;
         sys = sys,
         observed = observedfun,
         analytic = analytic,
-        initialization_data)
+        initialization_data,
+    )
     args = (; f)
 
     return maybe_codegen_scimlfn(expression, DiscreteFunction{iip, spec}, args; kwargs...)
@@ -38,7 +43,8 @@ end
 
 @fallback_iip_specialize function SciMLBase.DiscreteProblem{iip, spec}(
         sys::System, op, tspan;
-        check_compatibility = true, expression = Val{false}, kwargs...) where {iip, spec}
+        check_compatibility = true, expression = Val{false}, kwargs...
+    ) where {iip, spec}
     check_complete(sys, DiscreteProblem)
     check_compatibility && check_compatible_system(DiscreteProblem, sys)
 
@@ -46,9 +52,11 @@ end
     op = to_varmap(op, dvs)
     add_toterms!(op; replace = true)
     f, u0,
-    p = process_SciMLProblem(DiscreteFunction{iip, spec}, sys, op;
+        p = process_SciMLProblem(
+        DiscreteFunction{iip, spec}, sys, op;
         t = tspan !== nothing ? tspan[1] : tspan, check_compatibility, expression,
-        kwargs...)
+        kwargs...
+    )
 
     if expression == Val{true}
         u0 = :(f($u0, p, tspan[1]))
@@ -63,7 +71,8 @@ end
 end
 
 function check_compatible_system(
-        T::Union{Type{DiscreteFunction}, Type{DiscreteProblem}}, sys::System)
+        T::Union{Type{DiscreteFunction}, Type{DiscreteProblem}}, sys::System
+    )
     check_time_dependent(sys, T)
     check_not_dde(sys)
     check_no_cost(sys, T)
@@ -71,7 +80,7 @@ function check_compatible_system(
     check_no_jumps(sys, T)
     check_no_noise(sys, T)
     check_is_discrete(sys, T)
-    check_is_explicit(sys, T, ImplicitDiscreteProblem)
+    return check_is_explicit(sys, T, ImplicitDiscreteProblem)
 end
 
 function shift_u0map_forward(sys::System, u0map, defs)

--- a/lib/ModelingToolkitBase/src/problems/docs.jl
+++ b/lib/ModelingToolkitBase/src/problems/docs.jl
@@ -81,7 +81,7 @@ $INTERNAL_INITIALIZEPROB_KWARGS
 """
 
 function problem_ctors(prob, istd)
-    if istd
+    return if istd
         """
             SciMLBase.$prob(sys::System, op, tspan::NTuple{2}; kwargs...)
             SciMLBase.$prob{iip}(sys::System, op, tspan::NTuple{2}; kwargs...)
@@ -107,8 +107,10 @@ function prob_fun_common_kwargs(T, istd)
     """
 end
 
-function problem_docstring(prob, func, istd; init = true, extra_body = "",
-        extra_kwargs = "", extra_kwargs_desc = "")
+function problem_docstring(
+        prob, func, istd; init = true, extra_body = "",
+        extra_kwargs = "", extra_kwargs_desc = ""
+    )
     if func isa DataType
         func = "`$func`"
     end
@@ -193,21 +195,23 @@ If the `System` has algebraic equations, like `x(t)^2 + y(t)^2`, the resulting
 """
 
 for (mod, prob, func, istd, kws) in [
-    (SciMLBase, :ODEProblem, ODEFunction, true, (;)),
-    (SciMLBase, :SteadyStateProblem, ODEFunction, false, (;)),
-    (SciMLBase, :BVProblem, ODEFunction, true,
-        (; init = false, extra_body = BV_EXTRA_BODY)),
-    (SciMLBase, :DAEProblem, DAEFunction, true, (;)),
-    (SciMLBase, :DDEProblem, DDEFunction, true, (;)),
-    (SciMLBase, :SDEProblem, SDEFunction, true, (;)),
-    (SciMLBase, :SDDEProblem, SDDEFunction, true, (;)),
-    (JumpProcesses, :JumpProblem, "inner SciMLFunction", true, (; init = false)),
-    (SciMLBase, :DiscreteProblem, DiscreteFunction, true, (;)),
-    (SciMLBase, :ImplicitDiscreteProblem, ImplicitDiscreteFunction, true, (;)),
-    (SciMLBase, :NonlinearProblem, NonlinearFunction, false, (;)),
-    (SciMLBase, :NonlinearLeastSquaresProblem, NonlinearFunction, false, (;)),
-    (SciMLBase, :OptimizationProblem, OptimizationFunction, false, (; init = false)),
-]
+        (SciMLBase, :ODEProblem, ODEFunction, true, (;)),
+        (SciMLBase, :SteadyStateProblem, ODEFunction, false, (;)),
+        (
+            SciMLBase, :BVProblem, ODEFunction, true,
+            (; init = false, extra_body = BV_EXTRA_BODY),
+        ),
+        (SciMLBase, :DAEProblem, DAEFunction, true, (;)),
+        (SciMLBase, :DDEProblem, DDEFunction, true, (;)),
+        (SciMLBase, :SDEProblem, SDEFunction, true, (;)),
+        (SciMLBase, :SDDEProblem, SDDEFunction, true, (;)),
+        (JumpProcesses, :JumpProblem, "inner SciMLFunction", true, (; init = false)),
+        (SciMLBase, :DiscreteProblem, DiscreteFunction, true, (;)),
+        (SciMLBase, :ImplicitDiscreteProblem, ImplicitDiscreteFunction, true, (;)),
+        (SciMLBase, :NonlinearProblem, NonlinearFunction, false, (;)),
+        (SciMLBase, :NonlinearLeastSquaresProblem, NonlinearFunction, false, (;)),
+        (SciMLBase, :OptimizationProblem, OptimizationFunction, false, (; init = false)),
+    ]
     kwexpr = Expr(:parameters)
     for (k, v) in pairs(kws)
         push!(kwexpr.args, Expr(:kw, k, v))
@@ -216,7 +220,8 @@ for (mod, prob, func, istd, kws) in [
 end
 
 function function_docstring(
-        func, istd, optionals; extra_body = "", extra_kwargs = "", extra_kwargs_desc = "")
+        func, istd, optionals; extra_body = "", extra_kwargs = "", extra_kwargs_desc = ""
+    )
     return """
         $func(sys::System; kwargs...)
         $func{iip}(sys::System; kwargs...)
@@ -340,22 +345,22 @@ function process_optional_function_kwargs(choices::Vector{Symbol})
     if !isdisjoint(choices, CONS_SPARSITY_OPTIONALS)
         push!(choices, :cons_sparse)
     end
-    join(map(Base.Fix1(getindex, OPTIONAL_FN_KWARGS_DICT), choices), "\n")
+    return join(map(Base.Fix1(getindex, OPTIONAL_FN_KWARGS_DICT), choices), "\n")
 end
 
 for (mod, func, istd, optionals, kws) in [
-    (SciMLBase, :ODEFunction, true, [:jac, :tgrad], (;)),
-    (SciMLBase, :ODEInputFunction, true, [:inputfn, :jac, :tgrad, :controljac], (;)),
-    (SciMLBase, :DAEFunction, true, [:jac, :tgrad], (;)),
-    (SciMLBase, :DDEFunction, true, Symbol[], (;)),
-    (SciMLBase, :SDEFunction, true, [:jac, :tgrad], (;)),
-    (SciMLBase, :SDDEFunction, true, Symbol[], (;)),
-    (SciMLBase, :DiscreteFunction, true, Symbol[], (;)),
-    (SciMLBase, :ImplicitDiscreteFunction, true, Symbol[], (;)),
-    (SciMLBase, :NonlinearFunction, false, [:resid_prototype, :jac], (;)),
-    (SciMLBase, :IntervalNonlinearFunction, false, Symbol[], (;)),
-    (SciMLBase, :OptimizationFunction, false, [:jac, :grad, :hess, :cons_h, :cons_j], (;)),
-]
+        (SciMLBase, :ODEFunction, true, [:jac, :tgrad], (;)),
+        (SciMLBase, :ODEInputFunction, true, [:inputfn, :jac, :tgrad, :controljac], (;)),
+        (SciMLBase, :DAEFunction, true, [:jac, :tgrad], (;)),
+        (SciMLBase, :DDEFunction, true, Symbol[], (;)),
+        (SciMLBase, :SDEFunction, true, [:jac, :tgrad], (;)),
+        (SciMLBase, :SDDEFunction, true, Symbol[], (;)),
+        (SciMLBase, :DiscreteFunction, true, Symbol[], (;)),
+        (SciMLBase, :ImplicitDiscreteFunction, true, Symbol[], (;)),
+        (SciMLBase, :NonlinearFunction, false, [:resid_prototype, :jac], (;)),
+        (SciMLBase, :IntervalNonlinearFunction, false, Symbol[], (;)),
+        (SciMLBase, :OptimizationFunction, false, [:jac, :grad, :hess, :cons_h, :cons_j], (;)),
+    ]
     kwexpr = Expr(:parameters)
     for (k, v) in pairs(kws)
         push!(kwexpr.args, Expr(:kw, k, v))

--- a/lib/ModelingToolkitBase/src/problems/implicitdiscreteproblem.jl
+++ b/lib/ModelingToolkitBase/src/problems/implicitdiscreteproblem.jl
@@ -2,16 +2,20 @@
         sys::System; u0 = nothing, p = nothing, t = nothing, eval_expression = false,
         eval_module = @__MODULE__, expression = Val{false},
         checkbounds = false, analytic = nothing, simplify = false, cse = true,
-        initialization_data = nothing, check_compatibility = true, kwargs...) where {
-        iip, spec}
+        initialization_data = nothing, check_compatibility = true, kwargs...
+    ) where {
+        iip, spec,
+    }
     check_complete(sys, ImplicitDiscreteFunction)
     check_compatibility && check_compatible_system(ImplicitDiscreteFunction, sys)
 
     iv = get_iv(sys)
     dvs = unknowns(sys)
-    f = generate_rhs(sys; expression, wrap_gfw = Val{true},
+    f = generate_rhs(
+        sys; expression, wrap_gfw = Val{true},
         implicit_dae = true, eval_expression, eval_module, checkbounds = checkbounds, cse,
-        override_discrete = true, kwargs...)
+        override_discrete = true, kwargs...
+    )
 
     if spec === SciMLBase.FunctionWrapperSpecialize && iip
         if u0 === nothing || p === nothing || t === nothing
@@ -27,7 +31,8 @@
     end
 
     observedfun = ObservedFunctionCache(
-        sys; steady_state = false, expression, eval_expression, eval_module, checkbounds, cse)
+        sys; steady_state = false, expression, eval_expression, eval_module, checkbounds, cse
+    )
 
     args = (; f)
     kwargs = (;
@@ -35,15 +40,18 @@
         observed = observedfun,
         analytic = analytic,
         initialization_data,
-        resid_prototype)
+        resid_prototype,
+    )
 
     return maybe_codegen_scimlfn(
-        expression, ImplicitDiscreteFunction{iip, spec}, args; kwargs...)
+        expression, ImplicitDiscreteFunction{iip, spec}, args; kwargs...
+    )
 end
 
 @fallback_iip_specialize function SciMLBase.ImplicitDiscreteProblem{iip, spec}(
         sys::System, op, tspan;
-        check_compatibility = true, expression = Val{false}, kwargs...) where {iip, spec}
+        check_compatibility = true, expression = Val{false}, kwargs...
+    ) where {iip, spec}
     check_complete(sys, ImplicitDiscreteProblem)
     check_compatibility && check_compatible_system(ImplicitDiscreteProblem, sys)
 
@@ -51,24 +59,27 @@ end
     op = to_varmap(op, dvs)
     add_toterms!(op; replace = true)
     f, u0,
-    p = process_SciMLProblem(
+        p = process_SciMLProblem(
         ImplicitDiscreteFunction{iip, spec}, sys, op;
         t = tspan !== nothing ? tspan[1] : tspan, check_compatibility,
-        expression, kwargs...)
+        expression, kwargs...
+    )
 
     kwargs = process_kwargs(sys; kwargs...)
     args = (; f, u0, tspan, p)
     return maybe_codegen_scimlproblem(
-        expression, ImplicitDiscreteProblem{iip}, args; kwargs...)
+        expression, ImplicitDiscreteProblem{iip}, args; kwargs...
+    )
 end
 
 function check_compatible_system(
-        T::Union{Type{ImplicitDiscreteFunction}, Type{ImplicitDiscreteProblem}}, sys::System)
+        T::Union{Type{ImplicitDiscreteFunction}, Type{ImplicitDiscreteProblem}}, sys::System
+    )
     check_time_dependent(sys, T)
     check_not_dde(sys)
     check_no_cost(sys, T)
     check_no_constraints(sys, T)
     check_no_jumps(sys, T)
     check_no_noise(sys, T)
-    check_is_discrete(sys, T)
+    return check_is_discrete(sys, T)
 end

--- a/lib/ModelingToolkitBase/src/problems/initializationproblem.jl
+++ b/lib/ModelingToolkitBase/src/problems/initializationproblem.jl
@@ -31,7 +31,8 @@ All other keyword arguments are forwarded to the wrapped nonlinear problem const
         algebraic_only = false,
         time_dependent_init = is_time_dependent(sys),
         initsys_mtkcompile_kwargs = (;),
-        kwargs...) where {iip, specialize}
+        kwargs...
+    ) where {iip, specialize}
     if !iscomplete(sys)
         error("A completed system is required. Call `complete` or `mtkcompile` on the system before creating an `ODEProblem`")
     end
@@ -48,12 +49,14 @@ All other keyword arguments are forwarded to the wrapped nonlinear problem const
     elseif !has_u0_ics && get_initializesystem(sys) === nothing
         isys = generate_initializesystem(
             sys; initialization_eqs, check_units, op, guesses, algebraic_only,
-            fast_path)
+            fast_path
+        )
         simplify_system = true
     else
         isys = generate_initializesystem(
             sys; op, initialization_eqs, check_units, time_dependent_init,
-            guesses, algebraic_only, fast_path)
+            guesses, algebraic_only, fast_path
+        )
         simplify_system = true
     end
 
@@ -104,13 +107,15 @@ All other keyword arguments are forwarded to the wrapped nonlinear problem const
         op[get_iv(sys)] = t
     end
     filter!(!Base.Fix2(===, COMMON_MISSING) ∘ last, op)
-    TProb = get_initialization_problem_type(sys, isys; warn_initialize_determined,
-                                            kwargs...)
+    TProb = get_initialization_problem_type(
+        sys, isys; warn_initialize_determined,
+        kwargs...
+    )
     TProb{iip}(isys, op; kwargs..., build_initializeprob = false, is_initializeprob = true)
 end
 
 function overdetermined_initialization_message(neqs::Integer, nunknown::Integer, extra::AbstractString)
-    """
+    return """
     Initialization system is overdetermined. $neqs equations for $nunknown unknowns. \
     Initialization will default to using least squares. $(extra)
 
@@ -120,7 +125,7 @@ function overdetermined_initialization_message(neqs::Integer, nunknown::Integer,
 end
 
 function underdetermined_initialization_message(neqs::Integer, nunknown::Integer, extra::AbstractString)
-    """
+    return """
     Initialization system is underdetermined. $neqs equations for $nunknown unknowns. \
     Initialization will default to using least squares. $(extra)
 
@@ -135,8 +140,10 @@ end
 Get the type of the initialization problem (Nonlinear problem) to use, given the system
 `sys`, initialization system `isys` and arbitrary keyword arguments.
 """
-function get_initialization_problem_type(sys::AbstractSystem, isys::AbstractSystem;
-                                         warn_initialize_determined = true, kwargs...)
+function get_initialization_problem_type(
+        sys::AbstractSystem, isys::AbstractSystem;
+        warn_initialize_determined = true, kwargs...
+    )
     neqs = length(equations(isys))
     nunknown = length(unknowns(isys))
 
@@ -147,7 +154,7 @@ function get_initialization_problem_type(sys::AbstractSystem, isys::AbstractSyst
         @warn underdetermined_initialization_message(neqs, nunknown, "")
     end
 
-    if neqs == nunknown
+    return if neqs == nunknown
         NonlinearProblem
     else
         NonlinearLeastSquaresProblem
@@ -162,10 +169,10 @@ Return a list of possibly singular variables, given `get_tearing_state(sys)`.
 singular_check(::Nothing) = SymbolicT[]
 
 const INCOMPLETE_INITIALIZATION_MESSAGE = """
-                                Initialization incomplete. Not all of the state variables of the
-                                DAE system can be determined by the initialization. Missing
-                                variables:
-                                """
+Initialization incomplete. Not all of the state variables of the
+DAE system can be determined by the initialization. Missing
+variables:
+"""
 
 struct IncompleteInitializationError <: Exception
     uninit::Any
@@ -174,5 +181,5 @@ end
 
 function Base.showerror(io::IO, e::IncompleteInitializationError)
     println(io, INCOMPLETE_INITIALIZATION_MESSAGE)
-    println(io, underscore_to_D(collect(e.uninit), e.sys))
+    return println(io, underscore_to_D(collect(e.uninit), e.sys))
 end

--- a/lib/ModelingToolkitBase/src/problems/intervalnonlinearproblem.jl
+++ b/lib/ModelingToolkitBase/src/problems/intervalnonlinearproblem.jl
@@ -2,31 +2,38 @@ function SciMLBase.IntervalNonlinearFunction(
         sys::System; u0 = nothing, p = nothing, eval_expression = false,
         eval_module = @__MODULE__, expression = Val{false}, checkbounds = false,
         analytic = nothing, cse = true, initialization_data = nothing,
-        check_compatibility = true, kwargs...)
+        check_compatibility = true, kwargs...
+    )
     check_complete(sys, IntervalNonlinearFunction)
     check_compatibility && check_compatible_system(IntervalNonlinearFunction, sys)
 
-    f = generate_rhs(sys; expression, wrap_gfw = Val{true},
-        scalar = true, eval_expression, eval_module, checkbounds, cse, kwargs...)
+    f = generate_rhs(
+        sys; expression, wrap_gfw = Val{true},
+        scalar = true, eval_expression, eval_module, checkbounds, cse, kwargs...
+    )
 
     observedfun = ObservedFunctionCache(
         sys; steady_state = false, expression, eval_expression, eval_module, checkbounds,
-        cse)
+        cse
+    )
 
     args = (; f)
     kwargs = (;
         sys = sys,
         observed = observedfun,
         analytic = analytic,
-        initialization_data)
+        initialization_data,
+    )
 
     return maybe_codegen_scimlfn(
-        expression, IntervalNonlinearFunction{false}, args; kwargs...)
+        expression, IntervalNonlinearFunction{false}, args; kwargs...
+    )
 end
 
 function SciMLBase.IntervalNonlinearProblem(
         sys::System, uspan::NTuple{2}, parammap = SciMLBase.NullParameters();
-        check_compatibility = true, expression = Val{false}, kwargs...)
+        check_compatibility = true, expression = Val{false}, kwargs...
+    )
     check_complete(sys, IntervalNonlinearProblem)
     check_compatibility && check_compatible_system(IntervalNonlinearProblem, sys)
 
@@ -34,8 +41,10 @@ function SciMLBase.IntervalNonlinearProblem(
     op = anydict([unknowns(sys)[1] => uspan[1]])
     merge!(op, to_varmap(parammap, parameters(sys)))
     f, u0,
-    p = process_SciMLProblem(IntervalNonlinearFunction, sys, op;
-        check_compatibility, expression, kwargs...)
+        p = process_SciMLProblem(
+        IntervalNonlinearFunction, sys, op;
+        check_compatibility, expression, kwargs...
+    )
 
     kwargs = process_kwargs(sys; kwargs...)
     args = (; f, uspan, p)
@@ -43,21 +52,30 @@ function SciMLBase.IntervalNonlinearProblem(
 end
 
 function check_compatible_system(
-        T::Union{Type{IntervalNonlinearFunction}, Type{IntervalNonlinearProblem}}, sys::System)
+        T::Union{Type{IntervalNonlinearFunction}, Type{IntervalNonlinearProblem}}, sys::System
+    )
     check_time_independent(sys, T)
     if !isone(length(unknowns(sys)))
-        throw(SystemCompatibilityError("""
-            `$T` requires a system with a single unknown. Found `$(unknowns(sys))`.
-        """))
+        throw(
+            SystemCompatibilityError(
+                """
+                    `$T` requires a system with a single unknown. Found `$(unknowns(sys))`.
+                """
+            )
+        )
     end
     if !isone(length(equations(sys)))
-        throw(SystemCompatibilityError("""
-            `$T` requires a system with a single equation. Found `$(equations(sys))`.
-        """))
+        throw(
+            SystemCompatibilityError(
+                """
+                    `$T` requires a system with a single equation. Found `$(equations(sys))`.
+                """
+            )
+        )
     end
     check_not_dde(sys)
     check_no_cost(sys, T)
     check_no_constraints(sys, T)
     check_no_jumps(sys, T)
-    check_no_noise(sys, T)
+    return check_no_noise(sys, T)
 end

--- a/lib/ModelingToolkitBase/src/problems/jumpproblem.jl
+++ b/lib/ModelingToolkitBase/src/problems/jumpproblem.jl
@@ -2,7 +2,8 @@
         sys::System, op, tspan::Union{Tuple, Nothing};
         check_compatibility = true, eval_expression = false, eval_module = @__MODULE__,
         checkbounds = false, cse = true, aggregator = JumpProcesses.NullAggregator(),
-        callback = nothing, rng = nothing, kwargs...) where {iip, spec}
+        callback = nothing, rng = nothing, kwargs...
+    ) where {iip, spec}
     check_complete(sys, JumpProblem)
     check_compatibility && check_compatible_system(JumpProblem, sys)
 
@@ -15,34 +16,45 @@
             prob = SDEProblem{iip, spec}(
                 sys, op, tspan; check_compatibility = false,
                 build_initializeprob = false, checkbounds, cse, check_length = false,
-                kwargs...)
+                kwargs...
+            )
         elseif has_eqs
             prob = ODEProblem{iip, spec}(
                 sys, op, tspan; check_compatibility = false,
                 build_initializeprob = false, checkbounds, cse, check_length = false,
-                kwargs...)
+                kwargs...
+            )
         else
             _, u0,
-            p = process_SciMLProblem(EmptySciMLFunction{iip}, sys, op;
+                p = process_SciMLProblem(
+                EmptySciMLFunction{iip}, sys, op;
                 t = tspan === nothing ? nothing : tspan[1],
-                check_length = false, build_initializeprob = false, kwargs...)
-            observedfun = ObservedFunctionCache(sys; eval_expression, eval_module,
-                checkbounds, cse)
+                check_length = false, build_initializeprob = false, kwargs...
+            )
+            observedfun = ObservedFunctionCache(
+                sys; eval_expression, eval_module,
+                checkbounds, cse
+            )
             f = (du, u, p, t) -> (du .= 0; nothing)
             df = ODEFunction{true, spec}(f; sys, observed = observedfun)
             prob = ODEProblem{true}(df, u0, tspan, p; kwargs...)
         end
     else
         _f, u0,
-        p = process_SciMLProblem(EmptySciMLFunction{iip}, sys, op;
-            t = tspan === nothing ? nothing : tspan[1], check_length = false, build_initializeprob = false, cse, kwargs...)
+            p = process_SciMLProblem(
+            EmptySciMLFunction{iip}, sys, op;
+            t = tspan === nothing ? nothing : tspan[1], check_length = false, build_initializeprob = false, cse, kwargs...
+        )
         f = DiffEqBase.DISCRETE_INPLACE_DEFAULT
 
         observedfun = ObservedFunctionCache(
-            sys; eval_expression, eval_module, checkbounds, cse)
+            sys; eval_expression, eval_module, checkbounds, cse
+        )
 
-        df = DiscreteFunction{true, true}(f; sys = sys, observed = observedfun,
-            initialization_data = get(_f.kwargs, :initialization_data, nothing))
+        df = DiscreteFunction{true, true}(
+            f; sys = sys, observed = observedfun,
+            initialization_data = get(_f.kwargs, :initialization_data, nothing)
+        )
         prob = DiscreteProblem(df, u0, tspan, p; kwargs...)
     end
 
@@ -59,22 +71,26 @@
     _crjs = Vector{ConstantRateJump}(filter(x -> x isa ConstantRateJump, js))
     vrjs = Vector{VariableRateJump}(filter(x -> x isa VariableRateJump, js))
     majs = isempty(_majs) ? nothing : assemble_maj(_majs, unknowntoid, majpmapper)
-    crjs = ConstantRateJump[assemble_crj(sys, j, unknowntoid; eval_expression, eval_module)
-                            for j in _crjs]
-    vrjs = VariableRateJump[assemble_vrj(sys, j, unknowntoid; eval_expression, eval_module)
-                            for j in vrjs]
+    crjs = ConstantRateJump[
+        assemble_crj(sys, j, unknowntoid; eval_expression, eval_module)
+            for j in _crjs
+    ]
+    vrjs = VariableRateJump[
+        assemble_vrj(sys, j, unknowntoid; eval_expression, eval_module)
+            for j in vrjs
+    ]
     jset = JumpSet(Tuple(vrjs), Tuple(crjs), nothing, majs)
 
     # dep graphs are only for constant rate jumps
     nonvrjs = ArrayPartition(_majs, _crjs)
     if needs_vartojumps_map(aggregator) || needs_depgraph(aggregator) ||
-       (aggregator isa JumpProcesses.NullAggregator)
+            (aggregator isa JumpProcesses.NullAggregator)
         jdeps = asgraph(sys; eqs = nonvrjs)
         vdeps = variable_dependencies(sys; eqs = nonvrjs)
         vtoj = jdeps.badjlist
         jtov = vdeps.badjlist
         jtoj = needs_depgraph(aggregator) ? eqeq_dependencies(jdeps, vdeps).fadjlist :
-               nothing
+            nothing
     else
         vtoj = nothing
         jtov = nothing
@@ -83,14 +99,17 @@
 
     # handle events, making sure to reset aggregators in the generated affect functions
     cbs = process_events(
-        sys; callback, eval_expression, eval_module, op, reset_jumps = true)
+        sys; callback, eval_expression, eval_module, op, reset_jumps = true
+    )
 
     if rng !== nothing
         kwargs = (; kwargs..., rng)
     end
-    return JumpProblem(prob, aggregator, jset; dep_graph = jtoj, vartojumps_map = vtoj,
+    return JumpProblem(
+        prob, aggregator, jset; dep_graph = jtoj, vartojumps_map = vtoj,
         jumptovars_map = jtov, scale_rates = false, nocopy = true,
-        callback = cbs, kwargs...)
+        callback = cbs, kwargs...
+    )
 end
 
 function check_compatible_system(T::Union{Type{JumpProblem}}, sys::System)
@@ -99,7 +118,7 @@ function check_compatible_system(T::Union{Type{JumpProblem}}, sys::System)
     check_no_cost(sys, T)
     check_no_constraints(sys, T)
     check_has_jumps(sys, T)
-    check_is_continuous(sys, T)
+    return check_is_continuous(sys, T)
 end
 
 ###################### parameter mapper ###########################
@@ -115,59 +134,83 @@ function JumpSysMajParamMapper(js::System, p; jseqs = nothing, rateconsttype = F
     paramexprs = [maj.scaled_rates for maj in majs]
     psyms = reduce(vcat, reorder_parameters(js); init = SymbolicT[])
     paramdict = Dict(unwrap(k) => unwrap(v) for (k, v) in zip(psyms, reduce(vcat, p; init = rateconsttype[])))
-    JumpSysMajParamMapper{typeof(paramexprs), typeof(psyms), rateconsttype}(paramexprs,
+    return JumpSysMajParamMapper{typeof(paramexprs), typeof(psyms), rateconsttype}(
+        paramexprs,
         psyms,
-        paramdict)
+        paramdict
+    )
 end
 
-function updateparams!(ratemap::JumpSysMajParamMapper{U, V, W},
-        params) where {U <: AbstractArray, V <: AbstractArray, W}
+function updateparams!(
+        ratemap::JumpSysMajParamMapper{U, V, W},
+        params
+    ) where {U <: AbstractArray, V <: AbstractArray, W}
     for (i, p) in enumerate(params)
         sympar = ratemap.sympars[i]
         ratemap.subdict[sympar] = p
     end
-    nothing
+    return nothing
 end
 
-function updateparams!(ratemap::JumpSysMajParamMapper{U, V, W},
-        params::MTKParameters) where {U <: AbstractArray, V <: AbstractArray, W}
+function updateparams!(
+        ratemap::JumpSysMajParamMapper{U, V, W},
+        params::MTKParameters
+    ) where {U <: AbstractArray, V <: AbstractArray, W}
     for (i, p) in enumerate(ArrayPartition(params...))
         sympar = ratemap.sympars[i]
         ratemap.subdict[sympar] = p
     end
-    nothing
+    return nothing
 end
 
-function updateparams!(::JumpSysMajParamMapper{U, V, W},
-        params::Nothing) where {U <: AbstractArray, V <: AbstractArray, W}
-    nothing
+function updateparams!(
+        ::JumpSysMajParamMapper{U, V, W},
+        params::Nothing
+    ) where {U <: AbstractArray, V <: AbstractArray, W}
+    return nothing
 end
 
 # update a maj with parameter vectors
-function (ratemap::JumpSysMajParamMapper{U, V, W})(maj::MassActionJump, newparams;
+function (ratemap::JumpSysMajParamMapper{U, V, W})(
+        maj::MassActionJump, newparams;
         scale_rates,
-        kwargs...) where {U <: AbstractArray,
-        V <: AbstractArray, W}
+        kwargs...
+    ) where {
+        U <: AbstractArray,
+        V <: AbstractArray, W,
+    }
     updateparams!(ratemap, newparams)
     for i in 1:get_num_majumps(maj)
-        maj.scaled_rates[i] = convert(W,
-            value(substitute(ratemap.paramexprs[i],
-                ratemap.subdict; fold = Val(true))))
+        maj.scaled_rates[i] = convert(
+            W,
+            value(
+                substitute(
+                    ratemap.paramexprs[i],
+                    ratemap.subdict; fold = Val(true)
+                )
+            )
+        )
     end
     scale_rates && JumpProcesses.scalerates!(maj.scaled_rates, maj.reactant_stoch)
-    nothing
+    return nothing
 end
 
 # create the initial parameter vector for use in a MassActionJump
-function (ratemap::JumpSysMajParamMapper{
-        U,
-        V,
-        W
-})(params) where {U <: AbstractArray,
-        V <: AbstractArray, W}
+function (
+        ratemap::JumpSysMajParamMapper{
+            U,
+            V,
+            W,
+        }
+    )(params) where {
+        U <: AbstractArray,
+        V <: AbstractArray, W,
+    }
     updateparams!(ratemap, params)
-    [convert(W, value(substitute(paramexpr, ratemap.subdict; fold = Val(true))))
-     for paramexpr in ratemap.paramexprs]
+    return [
+        convert(W, value(substitute(paramexpr, ratemap.subdict; fold = Val(true))))
+            for paramexpr in ratemap.paramexprs
+    ]
 end
 
 ##### MTK dispatches for Symbolic jumps #####
@@ -183,8 +226,10 @@ function collect_vars!(unknowns::OrderedSet{SymbolicT}, parameters::OrderedSet{S
 end
 
 eqtype_supports_collect_vars(j::Union{ConstantRateJump, VariableRateJump}) = true
-function collect_vars!(unknowns::OrderedSet{SymbolicT}, parameters::OrderedSet{SymbolicT}, j::Union{ConstantRateJump, VariableRateJump},
-        iv::Union{SymbolicT, Nothing}, ::Type{op} = Differential; depth = 0) where {op}
+function collect_vars!(
+        unknowns::OrderedSet{SymbolicT}, parameters::OrderedSet{SymbolicT}, j::Union{ConstantRateJump, VariableRateJump},
+        iv::Union{SymbolicT, Nothing}, ::Type{op} = Differential; depth = 0
+    ) where {op}
     collect_vars!(unknowns, parameters, j.rate, iv, op; depth)
     for eq in j.affect!
         (eq isa Equation) && collect_vars!(unknowns, parameters, eq, iv, op; depth)
@@ -196,7 +241,7 @@ end
 function SU.search_variables!(dep, jump::Union{ConstantRateJump, VariableRateJump}; kw...)
     jr = unwrap(jump.rate)
     (jr isa SymbolicT) && SU.search_variables!(dep, jr; kw...)
-    dep
+    return dep
 end
 
 function SU.search_variables!(dep, jump::MassActionJump; is_atomic = SU.default_is_atomic, kw...)
@@ -207,7 +252,7 @@ function SU.search_variables!(dep, jump::MassActionJump; is_atomic = SU.default_
         var isa SymbolicT || continue
         is_atomic(var) && push!(dep, var)
     end
-    dep
+    return dep
 end
 
 ### Functions to determine which unknowns are modified by a given jump
@@ -223,12 +268,12 @@ function modified_unknowns!(munknowns, jump::Union{ConstantRateJump, VariableRat
         st = eq.lhs
         any(isequal(st), sts) && push!(munknowns, st)
     end
-    munknowns
+    return munknowns
 end
 
 function modified_unknowns!(munknowns, jump::MassActionJump, sts)
     for (unknown, stoich) in jump.net_stoch
         any(isequal(unknown), sts) && push!(munknowns, unknown)
     end
-    munknowns
+    return munknowns
 end

--- a/lib/ModelingToolkitBase/src/problems/linearproblem.jl
+++ b/lib/ModelingToolkitBase/src/problems/linearproblem.jl
@@ -7,18 +7,24 @@ end
 function LinearFunction{iip}(
         sys::System; expression = Val{false}, check_compatibility = true,
         sparse = false, eval_expression = false, eval_module = @__MODULE__,
-        checkbounds = false, cse = true, kwargs...) where {iip}
+        checkbounds = false, cse = true, kwargs...
+    ) where {iip}
     check_complete(sys, LinearProblem)
     check_compatibility && check_compatible_system(LinearProblem, sys)
 
     A, b = calculate_A_b(sys; sparse)
-    update_A = generate_update_A(sys, A; expression, wrap_gfw = Val{true}, eval_expression,
-        eval_module, checkbounds, cse, kwargs...)
-    update_b = generate_update_b(sys, b; expression, wrap_gfw = Val{true}, eval_expression,
-        eval_module, checkbounds, cse, kwargs...)
+    update_A = generate_update_A(
+        sys, A; expression, wrap_gfw = Val{true}, eval_expression,
+        eval_module, checkbounds, cse, kwargs...
+    )
+    update_b = generate_update_b(
+        sys, b; expression, wrap_gfw = Val{true}, eval_expression,
+        eval_module, checkbounds, cse, kwargs...
+    )
     observedfun = ObservedFunctionCache(
         sys; steady_state = false, expression, eval_expression, eval_module, checkbounds,
-        cse)
+        cse
+    )
 
     if expression == Val{true}
         symbolic_interface = quote
@@ -27,37 +33,41 @@ function LinearFunction{iip}(
             sys = $sys
             observedfun = $observedfun
             $(SciMLBase.SymbolicLinearInterface)(
-                update_A, update_b, sys, observedfun, nothing)
+                update_A, update_b, sys, observedfun, nothing
+            )
         end
     else
         symbolic_interface = SciMLBase.SymbolicLinearInterface(
-            update_A, update_b, sys, observedfun, nothing)
+            update_A, update_b, sys, observedfun, nothing
+        )
     end
 
     return LinearFunction{iip, typeof(symbolic_interface)}(symbolic_interface, A, b)
 end
 
 function SciMLBase.LinearProblem(sys::System, op; kwargs...)
-    SciMLBase.LinearProblem{true}(sys, op; kwargs...)
+    return SciMLBase.LinearProblem{true}(sys, op; kwargs...)
 end
 
 function SciMLBase.LinearProblem(sys::System, op::StaticArray; kwargs...)
-    SciMLBase.LinearProblem{false}(sys, op; kwargs...)
+    return SciMLBase.LinearProblem{false}(sys, op; kwargs...)
 end
 
 function SciMLBase.LinearProblem{iip}(
         sys::System, op; check_length = true, expression = Val{false},
         check_compatibility = true, sparse = false, eval_expression = false,
         eval_module = @__MODULE__, u0_constructor = identity, u0_eltype = nothing,
-        kwargs...) where {iip}
+        kwargs...
+    ) where {iip}
     check_complete(sys, LinearProblem)
     check_compatibility && check_compatible_system(LinearProblem, sys)
 
     f, u0,
-    p = process_SciMLProblem(
+        p = process_SciMLProblem(
         LinearFunction{iip}, sys, op; check_length, expression,
         build_initializeprob = false, symbolic_u0 = true, u0_constructor, u0_eltype,
-        kwargs...)
+        kwargs...
+    )
 
     if any(x -> symbolic_type(x) != NotSymbolic(), u0)
         u0 = nothing
@@ -74,8 +84,9 @@ function SciMLBase.LinearProblem{iip}(
     u0_constructor = get_p_constructor(u0_constructor, u0Type, u0_eltype)
     symbolic_interface = f.interface
     A,
-    b = get_A_b_from_LinearFunction(
-        sys, f, p; eval_expression, eval_module, expression, u0_constructor, sparse)
+        b = get_A_b_from_LinearFunction(
+        sys, f, p; eval_expression, eval_module, expression, u0_constructor, sparse
+    )
 
     kwargs = (; u0, process_kwargs(sys; kwargs...)..., f = symbolic_interface)
     args = (; A, b, p)
@@ -86,13 +97,16 @@ end
 function get_A_b_from_LinearFunction(
         sys::System, f::LinearFunction, p; eval_expression = false,
         eval_module = @__MODULE__, expression = Val{false}, u0_constructor = identity,
-        u0_eltype = float, sparse = false)
+        u0_eltype = float, sparse = false
+    )
     @unpack A, b, interface = f
     if expression == Val{true}
         get_A = build_explicit_observed_function(
-            sys, A; param_only = true, eval_expression, eval_module)
+            sys, A; param_only = true, eval_expression, eval_module
+        )
         get_b = build_explicit_observed_function(
-            sys, b; param_only = true, eval_expression, eval_module)
+            sys, b; param_only = true, eval_expression, eval_module
+        )
         A = u0_constructor(u0_eltype.(get_A(p)))
         b = u0_constructor(u0_eltype.(get_b(p)))
     else
@@ -108,7 +122,8 @@ end
 
 # For remake
 function SciMLBase.get_new_A_b(
-        sys::AbstractSystem, f::SciMLBase.SymbolicLinearInterface, p, A, b; kw...)
+        sys::AbstractSystem, f::SciMLBase.SymbolicLinearInterface, p, A, b; kw...
+    )
     if ArrayInterface.ismutable(A)
         f.update_A!(A, p)
         f.update_b!(b, p)
@@ -127,5 +142,5 @@ function check_compatible_system(T::Type{LinearProblem}, sys::System)
     check_no_cost(sys, T)
     check_no_constraints(sys, T)
     check_no_jumps(sys, T)
-    check_no_noise(sys, T)
+    return check_no_noise(sys, T)
 end

--- a/lib/ModelingToolkitBase/src/problems/nonlinearproblem.jl
+++ b/lib/ModelingToolkitBase/src/problems/nonlinearproblem.jl
@@ -4,13 +4,16 @@
         checkbounds = false, sparsity = false, analytic = nothing,
         simplify = false, cse = true, initialization_data = nothing,
         resid_prototype = nothing, check_compatibility = true, expression = Val{false},
-        kwargs...) where {iip, spec}
+        kwargs...
+    ) where {iip, spec}
     check_complete(sys, NonlinearFunction)
     check_compatibility && check_compatible_system(NonlinearFunction, sys)
 
-    f = generate_rhs(sys; expression, wrap_gfw = Val{true},
+    f = generate_rhs(
+        sys; expression, wrap_gfw = Val{true},
         eval_expression, eval_module, checkbounds = checkbounds, cse,
-        kwargs...)
+        kwargs...
+    )
 
     if spec === SciMLBase.FunctionWrapperSpecialize && iip
         if u0 === nothing || p === nothing
@@ -24,16 +27,19 @@
     end
 
     if jac
-        _jac = generate_jacobian(sys; expression,
+        _jac = generate_jacobian(
+            sys; expression,
             wrap_gfw = Val{true}, simplify, sparse, cse, eval_expression, eval_module,
-            checkbounds, kwargs...)
+            checkbounds, kwargs...
+        )
     else
         _jac = nothing
     end
 
     observedfun = ObservedFunctionCache(
         sys; steady_state = false, expression, eval_expression, eval_module, checkbounds,
-        cse)
+        cse
+    )
 
     if sparse
         jac_prototype = similar(calculate_jacobian(sys; sparse), eltype(u0))
@@ -48,7 +54,8 @@
         analytic = analytic,
         jac_prototype,
         resid_prototype,
-        initialization_data)
+        initialization_data,
+    )
     args = (; f)
 
     return maybe_codegen_scimlfn(expression, NonlinearFunction{iip, spec}, args; kwargs...)
@@ -56,7 +63,8 @@ end
 
 @fallback_iip_specialize function SciMLBase.NonlinearProblem{iip, spec}(
         sys::System, op; expression = Val{false},
-        check_length = true, check_compatibility = true, kwargs...) where {iip, spec}
+        check_length = true, check_compatibility = true, kwargs...
+    ) where {iip, spec}
     check_complete(sys, NonlinearProblem)
     if is_time_dependent(sys)
         sys = NonlinearSystem(sys)
@@ -64,8 +72,10 @@ end
     check_compatibility && check_compatible_system(NonlinearProblem, sys)
 
     f, u0,
-    p = process_SciMLProblem(NonlinearFunction{iip, spec}, sys, op;
-        check_length, check_compatibility, expression, kwargs...)
+        p = process_SciMLProblem(
+        NonlinearFunction{iip, spec}, sys, op;
+        check_length, check_compatibility, expression, kwargs...
+    )
 
     kwargs = process_kwargs(sys; kwargs...)
     ptype = getmetadata(sys, ProblemTypeCtx, StandardNonlinearProblem())
@@ -76,30 +86,37 @@ end
 
 @fallback_iip_specialize function SciMLBase.NonlinearLeastSquaresProblem{iip, spec}(
         sys::System, op; check_length = false,
-        check_compatibility = true, expression = Val{false}, kwargs...) where {iip, spec}
+        check_compatibility = true, expression = Val{false}, kwargs...
+    ) where {iip, spec}
     check_complete(sys, NonlinearLeastSquaresProblem)
     check_compatibility && check_compatible_system(NonlinearLeastSquaresProblem, sys)
 
     f, u0,
-    p = process_SciMLProblem(NonlinearFunction{iip}, sys, op;
-        check_length, expression, kwargs...)
+        p = process_SciMLProblem(
+        NonlinearFunction{iip}, sys, op;
+        check_length, expression, kwargs...
+    )
 
     kwargs = process_kwargs(sys; kwargs...)
     args = (; f, u0, p)
 
     return maybe_codegen_scimlproblem(
-        expression, NonlinearLeastSquaresProblem{iip}, args; kwargs...)
+        expression, NonlinearLeastSquaresProblem{iip}, args; kwargs...
+    )
 end
 
 function check_compatible_system(
-        T::Union{Type{NonlinearFunction}, Type{NonlinearProblem},
-            Type{NonlinearLeastSquaresProblem}}, sys::System)
+        T::Union{
+            Type{NonlinearFunction}, Type{NonlinearProblem},
+            Type{NonlinearLeastSquaresProblem},
+        }, sys::System
+    )
     check_time_independent(sys, T)
     check_not_dde(sys)
     check_no_cost(sys, T)
     check_no_constraints(sys, T)
     check_no_jumps(sys, T)
-    check_no_noise(sys, T)
+    return check_no_noise(sys, T)
 end
 
 function calculate_resid_prototype(N, u0, p)
@@ -107,7 +124,8 @@ function calculate_resid_prototype(N, u0, p)
     if SciMLStructures.isscimlstructure(p)
         u0ElType = promote_type(
             eltype(SciMLStructures.canonicalize(SciMLStructures.Tunable(), p)[1]),
-            u0ElType)
+            u0ElType
+        )
     end
     return zeros(u0ElType, N)
 end

--- a/lib/ModelingToolkitBase/src/problems/odeproblem.jl
+++ b/lib/ModelingToolkitBase/src/problems/odeproblem.jl
@@ -6,10 +6,12 @@ if called without ModelingToolkit loaded. The actual implementation is provided 
 ModelingToolkit when it is loaded.
 """
 function generate_ODENLStepData(sys, u0, p, mm, nlstep_compile, nlstep_scc)
-    error("""
+    error(
+        """
         `nlstep=true` requires ModelingToolkit.jl to be loaded.
         Please add `using ModelingToolkit` to your code before creating an ODEProblem with `nlstep=true`.
-        """)
+        """
+    )
 end
 
 @fallback_iip_specialize function SciMLBase.ODEFunction{iip, spec}(
@@ -18,13 +20,16 @@ end
         steady_state = false, checkbounds = false, sparsity = false, analytic = nothing,
         simplify = false, cse = true, initialization_data = nothing, expression = Val{false},
         check_compatibility = true, nlstep = false, nlstep_compile = true, nlstep_scc = false,
-        kwargs...) where {iip, spec}
+        kwargs...
+    ) where {iip, spec}
     check_complete(sys, ODEFunction)
     check_compatibility && check_compatible_system(ODEFunction, sys)
 
-    f = generate_rhs(sys; expression, wrap_gfw = Val{true},
+    f = generate_rhs(
+        sys; expression, wrap_gfw = Val{true},
         eval_expression, eval_module, checkbounds = checkbounds, cse,
-        kwargs...)
+        kwargs...
+    )
 
     if spec === SciMLBase.FunctionWrapperSpecialize && iip
         if u0 === nothing || p === nothing || t === nothing
@@ -40,7 +45,8 @@ end
     if tgrad
         _tgrad = generate_tgrad(
             sys; expression, wrap_gfw = Val{true},
-            simplify, cse, eval_expression, eval_module, checkbounds, kwargs...)
+            simplify, cse, eval_expression, eval_module, checkbounds, kwargs...
+        )
     else
         _tgrad = nothing
     end
@@ -48,7 +54,8 @@ end
     if jac
         _jac = generate_jacobian(
             sys; expression, wrap_gfw = Val{true},
-            simplify, sparse, cse, eval_expression, eval_module, checkbounds, kwargs...)
+            simplify, sparse, cse, eval_expression, eval_module, checkbounds, kwargs...
+        )
     else
         _jac = nothing
     end
@@ -63,7 +70,8 @@ end
     end
 
     observedfun = ObservedFunctionCache(
-        sys; expression, steady_state, eval_expression, eval_module, checkbounds, cse)
+        sys; expression, steady_state, eval_expression, eval_module, checkbounds, cse
+    )
 
     _W_sparsity = W_sparsity(sys)
     W_prototype = calculate_W_prototype(_W_sparsity; u0, sparse)
@@ -79,7 +87,8 @@ end
         sparsity = sparsity ? _W_sparsity : nothing,
         analytic = analytic,
         initialization_data,
-        nlstep_data = ode_nlstep)
+        nlstep_data = ode_nlstep,
+    )
 
     maybe_codegen_scimlfn(expression, ODEFunction{iip, spec}, args; kwargs...)
 end
@@ -88,17 +97,21 @@ end
         sys::System, op, tspan;
         callback = nothing, check_length = true, eval_expression = false,
         expression = Val{false}, eval_module = @__MODULE__, check_compatibility = true,
-        kwargs...) where {iip, spec}
+        kwargs...
+    ) where {iip, spec}
     check_complete(sys, ODEProblem)
     check_compatibility && check_compatible_system(ODEProblem, sys)
 
     f, u0,
-    p = process_SciMLProblem(ODEFunction{iip, spec}, sys, op;
+        p = process_SciMLProblem(
+        ODEFunction{iip, spec}, sys, op;
         t = tspan !== nothing ? tspan[1] : tspan, check_length, eval_expression,
-        eval_module, expression, check_compatibility, kwargs...)
+        eval_module, expression, check_compatibility, kwargs...
+    )
 
     kwargs = process_kwargs(
-        sys; expression, callback, eval_expression, eval_module, op, kwargs...)
+        sys; expression, callback, eval_expression, eval_module, op, kwargs...
+    )
 
     ptype = getmetadata(sys, ProblemTypeCtx, StandardODEProblem())
     args = (; f, u0, tspan, p, ptype)
@@ -107,14 +120,17 @@ end
 
 @fallback_iip_specialize function DiffEqBase.SteadyStateProblem{iip, spec}(
         sys::System, op; check_length = true, check_compatibility = true,
-        expression = Val{false}, kwargs...) where {iip, spec}
+        expression = Val{false}, kwargs...
+    ) where {iip, spec}
     check_complete(sys, SteadyStateProblem)
     check_compatibility && check_compatible_system(SteadyStateProblem, sys)
 
     f, u0,
-    p = process_SciMLProblem(ODEFunction{iip}, sys, op;
+        p = process_SciMLProblem(
+        ODEFunction{iip}, sys, op;
         steady_state = true, check_length, check_compatibility, expression,
-        time_dependent_init = false, kwargs...)
+        time_dependent_init = false, kwargs...
+    )
 
     kwargs = process_kwargs(sys; expression, kwargs...)
     args = (; f, u0, p)
@@ -123,14 +139,17 @@ end
 end
 
 function check_compatible_system(
-        T::Union{Type{ODEFunction}, Type{ODEProblem}, Type{DAEFunction},
-            Type{DAEProblem}, Type{SteadyStateProblem}},
-        sys::System)
+        T::Union{
+            Type{ODEFunction}, Type{ODEProblem}, Type{DAEFunction},
+            Type{DAEProblem}, Type{SteadyStateProblem},
+        },
+        sys::System
+    )
     check_time_dependent(sys, T)
     check_not_dde(sys)
     check_no_cost(sys, T)
     check_no_constraints(sys, T)
     check_no_jumps(sys, T)
     check_no_noise(sys, T)
-    check_is_continuous(sys, T)
+    return check_is_continuous(sys, T)
 end

--- a/lib/ModelingToolkitBase/src/problems/sddeproblem.jl
+++ b/lib/ModelingToolkitBase/src/problems/sddeproblem.jl
@@ -2,14 +2,19 @@
         sys::System; u0 = nothing, p = nothing, expression = Val{false},
         eval_expression = false, eval_module = @__MODULE__, checkbounds = false,
         initialization_data = nothing, cse = true, check_compatibility = true,
-        sparse = false, simplify = false, analytic = nothing, kwargs...) where {iip, spec}
+        sparse = false, simplify = false, analytic = nothing, kwargs...
+    ) where {iip, spec}
     check_complete(sys, SDDEFunction)
     check_compatibility && check_compatible_system(SDDEFunction, sys)
 
-    f = generate_rhs(sys; expression, wrap_gfw = Val{true},
-        eval_expression, eval_module, checkbounds = checkbounds, cse, kwargs...)
-    g = generate_diffusion_function(sys; expression,
-        wrap_gfw = Val{true}, eval_expression, eval_module, checkbounds, cse, kwargs...)
+    f = generate_rhs(
+        sys; expression, wrap_gfw = Val{true},
+        eval_expression, eval_module, checkbounds = checkbounds, cse, kwargs...
+    )
+    g = generate_diffusion_function(
+        sys; expression,
+        wrap_gfw = Val{true}, eval_expression, eval_module, checkbounds, cse, kwargs...
+    )
 
     if spec === SciMLBase.FunctionWrapperSpecialize && iip
         if u0 === nothing || p === nothing || t === nothing
@@ -26,14 +31,16 @@
     _M = concrete_massmatrix(M; sparse, u0)
 
     observedfun = ObservedFunctionCache(
-        sys; expression, eval_expression, eval_module, checkbounds, cse)
+        sys; expression, eval_expression, eval_module, checkbounds, cse
+    )
 
     kwargs = (;
         sys = sys,
         mass_matrix = _M,
         observed = observedfun,
         analytic = analytic,
-        initialization_data)
+        initialization_data,
+    )
     args = (; f, g)
 
     return maybe_codegen_scimlfn(expression, SDDEFunction{iip, spec}, args; kwargs...)
@@ -44,19 +51,23 @@ end
         callback = nothing, check_length = true, cse = true, checkbounds = false,
         eval_expression = false, eval_module = @__MODULE__, check_compatibility = true,
         u0_constructor = identity, sparse = false, sparsenoise = sparse,
-        expression = Val{false}, kwargs...) where {iip, spec}
+        expression = Val{false}, kwargs...
+    ) where {iip, spec}
     check_complete(sys, SDDEProblem)
     check_compatibility && check_compatible_system(SDDEProblem, sys)
 
     f, u0,
-    p = process_SciMLProblem(SDDEFunction{iip, spec}, sys, op;
+        p = process_SciMLProblem(
+        SDDEFunction{iip, spec}, sys, op;
         t = tspan !== nothing ? tspan[1] : tspan, check_length, cse, checkbounds,
         eval_expression, eval_module, check_compatibility, sparse, symbolic_u0 = true,
-        expression, u0_constructor, kwargs...)
+        expression, u0_constructor, kwargs...
+    )
 
     h = generate_history(
         sys, u0; expression, wrap_gfw = Val{true}, cse, eval_expression, eval_module,
-        checkbounds)
+        checkbounds
+    )
 
     if expression == Val{true}
         if u0 !== nothing
@@ -83,12 +94,13 @@ end
 end
 
 function check_compatible_system(
-        T::Union{Type{SDDEFunction}, Type{SDDEProblem}}, sys::System)
+        T::Union{Type{SDDEFunction}, Type{SDDEProblem}}, sys::System
+    )
     check_time_dependent(sys, T)
     check_is_dde(sys)
     check_no_cost(sys, T)
     check_no_constraints(sys, T)
     check_no_jumps(sys, T)
     check_has_noise(sys, T)
-    check_is_continuous(sys, T)
+    return check_is_continuous(sys, T)
 end

--- a/lib/ModelingToolkitBase/src/problems/sdeproblem.jl
+++ b/lib/ModelingToolkitBase/src/problems/sdeproblem.jl
@@ -3,15 +3,20 @@
         t = nothing, eval_expression = false, eval_module = @__MODULE__, sparse = false,
         steady_state = false, checkbounds = false, sparsity = false, analytic = nothing,
         simplify = false, cse = true, initialization_data = nothing,
-        check_compatibility = true, expression = Val{false}, kwargs...) where {iip, spec}
+        check_compatibility = true, expression = Val{false}, kwargs...
+    ) where {iip, spec}
     check_complete(sys, SDEFunction)
     check_compatibility && check_compatible_system(SDEFunction, sys)
 
-    f = generate_rhs(sys; expression, wrap_gfw = Val{true},
+    f = generate_rhs(
+        sys; expression, wrap_gfw = Val{true},
         eval_expression, eval_module, checkbounds = checkbounds, cse,
-        kwargs...)
-    g = generate_diffusion_function(sys; expression,
-        wrap_gfw = Val{true}, eval_expression, eval_module, checkbounds, cse, kwargs...)
+        kwargs...
+    )
+    g = generate_diffusion_function(
+        sys; expression,
+        wrap_gfw = Val{true}, eval_expression, eval_module, checkbounds, cse, kwargs...
+    )
 
     if spec === SciMLBase.FunctionWrapperSpecialize && iip
         if u0 === nothing || p === nothing || t === nothing
@@ -25,17 +30,21 @@
     end
 
     if tgrad
-        _tgrad = generate_tgrad(sys; expression,
+        _tgrad = generate_tgrad(
+            sys; expression,
             wrap_gfw = Val{true}, simplify, cse, eval_expression, eval_module, checkbounds,
-            kwargs...)
+            kwargs...
+        )
     else
         _tgrad = nothing
     end
 
     if jac
-        _jac = generate_jacobian(sys; expression,
+        _jac = generate_jacobian(
+            sys; expression,
             wrap_gfw = Val{true}, simplify, sparse, cse, eval_expression, eval_module,
-            checkbounds, kwargs...)
+            checkbounds, kwargs...
+        )
     else
         _jac = nothing
     end
@@ -44,7 +53,8 @@
     _M = concrete_massmatrix(M; sparse, u0)
 
     observedfun = ObservedFunctionCache(
-        sys; expression, steady_state, eval_expression, eval_module, checkbounds, cse)
+        sys; expression, steady_state, eval_expression, eval_module, checkbounds, cse
+    )
 
     _W_sparsity = W_sparsity(sys)
     W_prototype = calculate_W_prototype(_W_sparsity; u0, sparse)
@@ -58,7 +68,8 @@
         observed = observedfun,
         sparsity = sparsity ? _W_sparsity : nothing,
         analytic = analytic,
-        initialization_data)
+        initialization_data,
+    )
     args = (; f, g)
 
     return maybe_codegen_scimlfn(expression, SDEFunction{iip, spec}, args; kwargs...)
@@ -68,14 +79,17 @@ end
         sys::System, op, tspan;
         callback = nothing, check_length = true, eval_expression = false,
         eval_module = @__MODULE__, check_compatibility = true, sparse = false,
-        sparsenoise = sparse, expression = Val{false}, kwargs...) where {iip, spec}
+        sparsenoise = sparse, expression = Val{false}, kwargs...
+    ) where {iip, spec}
     check_complete(sys, SDEProblem)
     check_compatibility && check_compatible_system(SDEProblem, sys)
 
     f, u0,
-    p = process_SciMLProblem(SDEFunction{iip, spec}, sys, op;
+        p = process_SciMLProblem(
+        SDEFunction{iip, spec}, sys, op;
         t = tspan !== nothing ? tspan[1] : tspan, check_length, eval_expression,
-        eval_module, check_compatibility, sparse, expression, kwargs...)
+        eval_module, check_compatibility, sparse, expression, kwargs...
+    )
 
     # Only calculate noise and noise_rate_prototype if not provided by user
     if !haskey(kwargs, :noise) && !haskey(kwargs, :noise_rate_prototype)
@@ -91,8 +105,10 @@ end
         noise_rate_prototype = kwargs[:noise_rate_prototype]
     end
 
-    kwargs = process_kwargs(sys; expression, callback, eval_expression, eval_module,
-        op, kwargs...)
+    kwargs = process_kwargs(
+        sys; expression, callback, eval_expression, eval_module,
+        op, kwargs...
+    )
 
     args = (; f, u0, tspan, p)
     kwargs = (; noise, noise_rate_prototype, kwargs...)
@@ -107,7 +123,7 @@ function check_compatible_system(T::Union{Type{SDEFunction}, Type{SDEProblem}}, 
     check_no_constraints(sys, T)
     check_no_jumps(sys, T)
     check_has_noise(sys, T)
-    check_is_continuous(sys, T)
+    return check_is_continuous(sys, T)
 end
 
 function calculate_noise_and_rate_prototype(sys::System, u0; sparsenoise = false)
@@ -134,8 +150,10 @@ end
 __default_wiener_process() = __default_wiener_process(nothing)
 
 function __default_wiener_process(_)
-    error("""
-    Generating code for this problem requires loading DiffEqNoiseProcess.jl. Please run
-    `import DiffEqNoiseProcess` to proceed.
-    """)
+    error(
+        """
+        Generating code for this problem requires loading DiffEqNoiseProcess.jl. Please run
+        `import DiffEqNoiseProcess` to proceed.
+        """
+    )
 end

--- a/lib/ModelingToolkitBase/src/systems/connectiongraph.jl
+++ b/lib/ModelingToolkitBase/src/systems/connectiongraph.jl
@@ -45,7 +45,8 @@ Create a `ConnectionVertex` given
 use for this connection.
 """
 function ConnectionVertex(
-        namespace::Vector{Symbol}, var::Union{SymbolicT, AbstractSystem}, isouter::Bool)
+        namespace::Vector{Symbol}, var::Union{SymbolicT, AbstractSystem}, isouter::Bool
+    )
     if var isa SymbolicT
         name = getname(var)
     else
@@ -74,7 +75,8 @@ Create a connection vertex for the given path `name` using the provided `isouter
 `type`. `alias` denotes whether `name` can be stored by this vertex without copying.
 """
 function ConnectionVertex(
-        name::Vector{Symbol}, isouter::Bool, type::DataType; alias = false)
+        name::Vector{Symbol}, isouter::Bool, type::DataType; alias = false
+    )
     if !alias
         name = copy(name)
     end
@@ -94,9 +96,11 @@ function Base.:(==)(a::ConnectionVertex, b::ConnectionVertex)
     a.isouter == b.isouter || return false
     a.type == b.type || return false
     if a.hash != b.hash
-        error("""
-        This should never happen. Please open an issue in ModelingToolkitBase.jl with an MWE.
-        """)
+        error(
+            """
+            This should never happen. Please open an issue in ModelingToolkitBase.jl with an MWE.
+            """
+        )
     end
     return true
 end
@@ -105,7 +109,7 @@ function Base.show(io::IO, vert::ConnectionVertex)
     for name in @view(vert.name[1:(end - 1)])
         print(io, name, ".")
     end
-    print(io, vert.name[end], "::", vert.isouter ? "outer" : "inner")
+    return print(io, vert.name[end], "::", vert.isouter ? "outer" : "inner")
 end
 
 const ConnectionGraph = HyperGraph{ConnectionVertex}
@@ -119,7 +123,7 @@ function BipartiteGraphs.print_hyperedge_hint(io::IO, ::Type{ConnectionVertex}, 
         # otherwise it prints `ModelingToolkitBase.Equality`
         type = "Equality"
     end
-    printstyled(io, type; bold = true, color = :yellow)
+    return printstyled(io, type; bold = true, color = :yellow)
 end
 
 const ConnectionGraphEdge = BipartiteGraphs.HyperGraphEdge{ConnectionVertex}
@@ -170,7 +174,7 @@ function Base.show(io::IO, state::AbstractConnectionState)
     println(io, "And")
     println(io)
     ctx2 = IOContext(io, :cgraph_name => "Domain Network", :compact => true)
-    show(ctx2, state.domain_connection_graph)
+    return show(ctx2, state.domain_connection_graph)
 end
 
 """
@@ -234,7 +238,7 @@ end
 Create an empty `NegativeConnectionState` with empty graphs.
 """
 function NegativeConnectionState()
-    NegativeConnectionState(ConnectionGraph(), ConnectionGraph(), Int[], Int[])
+    return NegativeConnectionState(ConnectionGraph(), ConnectionGraph(), Int[], Int[])
 end
 
 """
@@ -258,7 +262,8 @@ Add the given edge to the domain network. Does not affect the connection network
 that the first vertex in `edge` is the input.
 """
 function add_domain_connection_edge!(
-        state::NegativeConnectionState, edge::ConnectionGraphEdge)
+        state::NegativeConnectionState, edge::ConnectionGraphEdge
+    )
     i = Graphs.add_edge!(state.domain_connection_graph, edge)
     j = state.domain_connection_graph.labels[first(edge)]
     push!(state.domain_hyperedge_inputs, j)
@@ -282,7 +287,8 @@ ordering of vertices, and thus all comparisons should be done by comparing the
 `ConnectionVertex`.
 """
 function remove_negative_connections!(
-        graph::ConnectionGraph, neg_graph::ConnectionGraph, neg_edge_inputs::Vector{Int})
+        graph::ConnectionGraph, neg_graph::ConnectionGraph, neg_edge_inputs::Vector{Int}
+    )
     # _i means index in neg_graph
     # _j means index in graph
 
@@ -343,6 +349,7 @@ function remove_negative_connections!(
             Graphs.rem_edge!(graph.graph, edge_j, vert_j)
         end
     end
+    return
 end
 
 """
@@ -352,12 +359,16 @@ Remove negative hyperedges given by `neg_state` from the connection and domain n
 `state`.
 """
 function remove_negative_connections!(
-        state::ConnectionState, neg_state::NegativeConnectionState)
-    remove_negative_connections!(state.connection_graph, neg_state.connection_graph,
-        neg_state.connection_hyperedge_inputs)
+        state::ConnectionState, neg_state::NegativeConnectionState
+    )
     remove_negative_connections!(
+        state.connection_graph, neg_state.connection_graph,
+        neg_state.connection_hyperedge_inputs
+    )
+    return remove_negative_connections!(
         state.domain_connection_graph, neg_state.domain_connection_graph,
-        neg_state.domain_hyperedge_inputs)
+        neg_state.domain_hyperedge_inputs
+    )
 end
 
 """
@@ -375,5 +386,5 @@ Return the connection sets of the connection graph and domain network.
 """
 function connectionsets(state::ConnectionState)
     return connectionsets(state.connection_graph),
-    connectionsets(state.domain_connection_graph)
+        connectionsets(state.domain_connection_graph)
 end

--- a/lib/ModelingToolkitBase/src/systems/dependency_graphs.jl
+++ b/lib/ModelingToolkitBase/src/systems/dependency_graphs.jl
@@ -36,8 +36,10 @@ equation_dependencies(jumpsys)
 equation_dependencies(jumpsys, variables = parameters(jumpsys))
 ```
 """
-function equation_dependencies(sys::AbstractSystem; variables = unknowns(sys),
-        eqs = equations(sys))
+function equation_dependencies(
+        sys::AbstractSystem; variables = unknowns(sys),
+        eqs = equations(sys)
+    )
     deps = Set()
     depeqs_to_vars = Vector{Vector}(undef, length(eqs))
 
@@ -47,7 +49,7 @@ function equation_dependencies(sys::AbstractSystem; variables = unknowns(sys),
         empty!(deps)
     end
 
-    depeqs_to_vars
+    return depeqs_to_vars
 end
 
 """
@@ -84,7 +86,7 @@ function asgraph(eqdeps, vtois)
         ne += length(vidxs)
     end
 
-    BipartiteGraph(ne, fadjlist, badjlist)
+    return BipartiteGraph(ne, fadjlist, badjlist)
 end
 
 # could be made to directly generate graph and save memory
@@ -113,10 +115,12 @@ Continuing the example started in [`equation_dependencies`](@ref)
 digr = asgraph(jumpsys)
 ```
 """
-function asgraph(sys::AbstractSystem; variables = unknowns(sys),
+function asgraph(
+        sys::AbstractSystem; variables = unknowns(sys),
         variablestoids = Dict(v => i for (i, v) in enumerate(variables)),
-        eqs = equations(sys))
-    asgraph(equation_dependencies(sys; variables, eqs), variablestoids)
+        eqs = equations(sys)
+    )
+    return asgraph(equation_dependencies(sys; variables, eqs), variablestoids)
 end
 
 """
@@ -141,10 +145,12 @@ Continuing the example of [`equation_dependencies`](@ref)
 variable_dependencies(jumpsys)
 ```
 """
-function variable_dependencies(sys::AbstractSystem; variables = unknowns(sys),
-        variablestoids = nothing, eqs = equations(sys))
+function variable_dependencies(
+        sys::AbstractSystem; variables = unknowns(sys),
+        variablestoids = nothing, eqs = equations(sys)
+    )
     vtois = isnothing(variablestoids) ? Dict(v => i for (i, v) in enumerate(variables)) :
-            variablestoids
+        variablestoids
 
     deps = Set()
     badjlist = Vector{Vector{Int}}(undef, length(eqs))
@@ -161,7 +167,7 @@ function variable_dependencies(sys::AbstractSystem; variables = unknowns(sys),
         ne += length(vidxs)
     end
 
-    BipartiteGraph(ne, fadjlist, badjlist)
+    return BipartiteGraph(ne, fadjlist, badjlist)
 end
 
 """
@@ -192,8 +198,10 @@ Continuing the example in [`asgraph`](@ref)
 dg = asdigraph(digr, jumpsys)
 ```
 """
-function asdigraph(g::BipartiteGraph, sys::AbstractSystem; variables = unknowns(sys),
-        equationsfirst = true, eqs = equations(sys))
+function asdigraph(
+        g::BipartiteGraph, sys::AbstractSystem; variables = unknowns(sys),
+        equationsfirst = true, eqs = equations(sys)
+    )
     neqs = length(eqs)
     nvars = length(variables)
     fadjlist = deepcopy(g.fadjlist)
@@ -209,7 +217,7 @@ function asdigraph(g::BipartiteGraph, sys::AbstractSystem; variables = unknowns(
     append!(fadjlist, [Vector{Int}() for i in 1:(equationsfirst ? nvars : neqs)])
     prepend!(badjlist, [Vector{Int}() for i in 1:(equationsfirst ? neqs : nvars)])
 
-    SimpleDiGraph(g.ne, fadjlist, badjlist)
+    return SimpleDiGraph(g.ne, fadjlist, badjlist)
 end
 
 """
@@ -234,8 +242,10 @@ Continuing the example of `equation_dependencies`
 eqeqdep = eqeq_dependencies(asgraph(jumpsys), variable_dependencies(jumpsys))
 ```
 """
-function eqeq_dependencies(eqdeps::BipartiteGraph{T},
-        vardeps::BipartiteGraph{T}) where {T <: Integer}
+function eqeq_dependencies(
+        eqdeps::BipartiteGraph{T},
+        vardeps::BipartiteGraph{T}
+    ) where {T <: Integer}
     g = SimpleDiGraph{T}(length(eqdeps.fadjlist))
 
     for (eqidx, sidxs) in enumerate(vardeps.badjlist)
@@ -246,7 +256,7 @@ function eqeq_dependencies(eqdeps::BipartiteGraph{T},
         end
     end
 
-    g
+    return g
 end
 
 """
@@ -273,7 +283,9 @@ Continuing the example of `equation_dependencies`
 varvardep = varvar_dependencies(asgraph(jumpsys), variable_dependencies(jumpsys))
 ```
 """
-function varvar_dependencies(eqdeps::BipartiteGraph{T},
-        vardeps::BipartiteGraph{T}) where {T <: Integer}
-    eqeq_dependencies(vardeps, eqdeps)
+function varvar_dependencies(
+        eqdeps::BipartiteGraph{T},
+        vardeps::BipartiteGraph{T}
+    ) where {T <: Integer}
+    return eqeq_dependencies(vardeps, eqdeps)
 end

--- a/lib/ModelingToolkitBase/src/systems/imperative_affect.jl
+++ b/lib/ModelingToolkitBase/src/systems/imperative_affect.jl
@@ -1,4 +1,3 @@
-
 """
     ImperativeAffect(f::Function; modified::NamedTuple, observed::NamedTuple, ctx)
 
@@ -38,47 +37,62 @@ struct ImperativeAffect
     skip_checks::Bool
 end
 
-function ImperativeAffect(f;
+function ImperativeAffect(
+        f;
         observed::NamedTuple = NamedTuple{()}(()),
         modified::NamedTuple = NamedTuple{()}(()),
         ctx = nothing,
-        skip_checks = false)
-    ImperativeAffect(f,
+        skip_checks = false
+    )
+    return ImperativeAffect(
+        f,
         collect(values(observed)), collect(keys(observed)),
         collect(values(modified)), collect(keys(modified)),
-        ctx, skip_checks)
-end
-function ImperativeAffect(f, modified::NamedTuple;
-        observed::NamedTuple = NamedTuple{()}(()), ctx = nothing, skip_checks = false)
-    ImperativeAffect(
-        f, observed = observed, modified = modified, ctx = ctx, skip_checks = skip_checks)
+        ctx, skip_checks
+    )
 end
 function ImperativeAffect(
-        f, modified::NamedTuple, observed::NamedTuple; ctx = nothing, skip_checks = false)
-    ImperativeAffect(
-        f, observed = observed, modified = modified, ctx = ctx, skip_checks = skip_checks)
+        f, modified::NamedTuple;
+        observed::NamedTuple = NamedTuple{()}(()), ctx = nothing, skip_checks = false
+    )
+    return ImperativeAffect(
+        f, observed = observed, modified = modified, ctx = ctx, skip_checks = skip_checks
+    )
 end
 function ImperativeAffect(
-        f, modified::NamedTuple, observed::NamedTuple, ctx; skip_checks = false)
-    ImperativeAffect(
-        f, observed = observed, modified = modified, ctx = ctx, skip_checks = skip_checks)
+        f, modified::NamedTuple, observed::NamedTuple; ctx = nothing, skip_checks = false
+    )
+    return ImperativeAffect(
+        f, observed = observed, modified = modified, ctx = ctx, skip_checks = skip_checks
+    )
+end
+function ImperativeAffect(
+        f, modified::NamedTuple, observed::NamedTuple, ctx; skip_checks = false
+    )
+    return ImperativeAffect(
+        f, observed = observed, modified = modified, ctx = ctx, skip_checks = skip_checks
+    )
 end
 function ImperativeAffect(; f, kwargs...)
-    ImperativeAffect(f; kwargs...)
+    return ImperativeAffect(f; kwargs...)
 end
 
 function (s::SymbolicUtils.Substituter)(aff::ImperativeAffect)
-    ImperativeAffect(aff.f, s(aff.obs), aff.obs_syms,
-        s(aff.modified), aff.mod_syms, aff.ctx, aff.skip_checks)
-    
+    return ImperativeAffect(
+        aff.f, s(aff.obs), aff.obs_syms,
+        s(aff.modified), aff.mod_syms, aff.ctx, aff.skip_checks
+    )
+
 end
 
 function Base.show(io::IO, mfa::ImperativeAffect)
     obs_vals = join(map((ob, nm) -> "$ob => $nm", mfa.obs, mfa.obs_syms), ", ")
     mod_vals = join(map((md, nm) -> "$md => $nm", mfa.modified, mfa.mod_syms), ", ")
     affect = mfa.f
-    print(io,
-        "ImperativeAffect(observed: [$obs_vals], modified: [$mod_vals], affect:$affect)")
+    return print(
+        io,
+        "ImperativeAffect(observed: [$obs_vals], modified: [$mod_vals], affect:$affect)"
+    )
 end
 func(f::ImperativeAffect) = f.f
 context(a::ImperativeAffect) = a.ctx
@@ -100,7 +114,7 @@ modified(a::ImperativeAffect) = a.modified
 modified_syms(a::ImperativeAffect) = a.mod_syms
 
 function Base.:(==)(a1::ImperativeAffect, a2::ImperativeAffect)
-    isequal(a1.f, a2.f) && isequal(a1.obs, a2.obs) && isequal(a1.modified, a2.modified) &&
+    return isequal(a1.f, a2.f) && isequal(a1.obs, a2.obs) && isequal(a1.modified, a2.modified) &&
         isequal(a1.obs_syms, a2.obs_syms) && isequal(a1.mod_syms, a2.mod_syms) &&
         isequal(a1.ctx, a2.ctx)
 end
@@ -111,7 +125,7 @@ function Base.hash(a::ImperativeAffect, s::UInt)
     s = hash(a.obs_syms, s)
     s = hash(a.modified, s)
     s = hash(a.mod_syms, s)
-    hash(a.ctx, s)
+    return hash(a.ctx, s)
 end
 
 namespace_affects(af::ImperativeAffect, s) = namespace_affect(af, s)
@@ -128,31 +142,40 @@ function namespace_affect(affect::ImperativeAffect, s)
             push!(rmn, renamespace(s, modded))
         end
     end
-    ImperativeAffect(func(affect),
+    return ImperativeAffect(
+        func(affect),
         namespace_expr.(observed(affect), (s,)),
         observed_syms(affect),
         rmn,
         modified_syms(affect),
         context(affect),
-        affect.skip_checks)
+        affect.skip_checks
+    )
 end
 
 function invalid_variables(sys, expr)
-    setdiff!(SU.search_variables(expr), all_symbols(sys))
+    return setdiff!(SU.search_variables(expr), all_symbols(sys))
 end
 
 function unassignable_variables(sys, expr)
     assignable_syms = reduce(
-        vcat, Symbolics.scalarize.(vcat(
-            unknowns(sys), parameters(sys; initial_parameters = true)));
-        init = [])
+        vcat, Symbolics.scalarize.(
+            vcat(
+                unknowns(sys), parameters(sys; initial_parameters = true)
+            )
+        );
+        init = []
+    )
     written = reduce(vcat, Symbolics.scalarize.(collect(SU.search_variables(expr))); init = [])
     return filter(
-        x -> !any(isequal(x), assignable_syms), written)
+        x -> !any(isequal(x), assignable_syms), written
+    )
 end
 
-@generated function _generated_writeback(integ, setters::NamedTuple{NS1, <:Tuple},
-        values::NamedTuple{NS2, <:Tuple}) where {NS1, NS2}
+@generated function _generated_writeback(
+        integ, setters::NamedTuple{NS1, <:Tuple},
+        values::NamedTuple{NS2, <:Tuple}
+    ) where {NS1, NS2}
     setter_exprs = []
     for name in NS2
         if !(name in NS1)
@@ -161,13 +184,15 @@ end
         end
         push!(setter_exprs, :(setters.$name(integ, values.$name)))
     end
-    return :(begin
-        $(setter_exprs...)
-    end)
+    return :(
+        begin
+            $(setter_exprs...)
+        end
+    )
 end
 
 function check_assignable(sys, sym)
-    if symbolic_type(sym) == ScalarSymbolic()
+    return if symbolic_type(sym) == ScalarSymbolic()
         is_variable(sys, sym) || is_parameter(sys, sym)
     elseif symbolic_type(sym) == ArraySymbolic()
         is_variable(sys, sym) || is_parameter(sys, sym) ||
@@ -180,7 +205,8 @@ function check_assignable(sys, sym)
 end
 
 function compile_functional_affect(
-        affect::ImperativeAffect, sys; reset_jumps = false, kwargs...)
+        affect::ImperativeAffect, sys; reset_jumps = false, kwargs...
+    )
     #=
     Implementation sketch:
         generate observed function (oop), should save to a component array under obs_syms
@@ -241,14 +267,15 @@ function compile_functional_affect(
 
     # sanity checks done! now build the data and update function for observed values
     mkzero(sz) =
-        if sz === ()
-            0.0
-        else
-            zeros(sz)
-        end
+    if sz === ()
+        0.0
+    else
+        zeros(sz)
+    end
     obs_fun = build_explicit_observed_function(
         sys, Symbolics.scalarize.(obs_exprs);
-        mkarray = (es, _) -> MakeTuple(es))
+        mkarray = (es, _) -> MakeTuple(es)
+    )
     obs_sym_tuple = (obs_syms...,)
 
     # okay so now to generate the stuff to assign it back into the system
@@ -256,19 +283,23 @@ function compile_functional_affect(
     mod_names = (mod_syms...,)
     mod_og_val_fun = build_explicit_observed_function(
         sys, Symbolics.scalarize.(first.(mod_pairs));
-        mkarray = (es, _) -> MakeTuple(es))
+        mkarray = (es, _) -> MakeTuple(es)
+    )
 
     upd_funs = NamedTuple{mod_names}((setu.((sys,), first.(mod_pairs))...,))
 
-    let user_affect = func(affect), ctx = context(affect), reset_jumps = reset_jumps
+    return let user_affect = func(affect), ctx = context(affect), reset_jumps = reset_jumps
         @inline function (integ)
             # update the to-be-mutated values; this ensures that if you do a no-op then nothing happens
             modvals = mod_og_val_fun(integ.u, integ.p, integ.t)
             upd_component_array = NamedTuple{mod_names}(modvals)
 
             # update the observed values
-            obs_component_array = NamedTuple{obs_sym_tuple}(obs_fun(
-                integ.u, integ.p, integ.t))
+            obs_component_array = NamedTuple{obs_sym_tuple}(
+                obs_fun(
+                    integ.u, integ.p, integ.t
+                )
+            )
 
             # let the user do their thing
             upd_vals = user_affect(upd_component_array, obs_component_array, ctx, integ)
@@ -278,7 +309,7 @@ function compile_functional_affect(
                 _generated_writeback(integ, upd_funs, upd_vals)
             end
 
-            reset_jumps && reset_aggregated_jumps!(integ)
+            return reset_jumps && reset_aggregated_jumps!(integ)
         end
     end
 end
@@ -291,4 +322,5 @@ function SU.search_variables!(vars, aff::ImperativeAffect; kwargs...)
             SU.search_variables!(vars, v; kwargs...)
         end
     end
+    return
 end

--- a/lib/ModelingToolkitBase/src/systems/pde/pdesystem.jl
+++ b/lib/ModelingToolkitBase/src/systems/pde/pdesystem.jl
@@ -89,7 +89,8 @@ struct PDESystem <: AbstractSystem
     Metadata for MTK GUI.
     """
     gui_metadata::Union{Nothing, GUIMetadata}
-    @add_kwonly function PDESystem(eqs, bcs, domain, ivs, dvs,
+    @add_kwonly function PDESystem(
+            eqs, bcs, domain, ivs, dvs,
             ps = SciMLBase.NullParameters();
             initial_conditions = Dict(),
             systems = [],
@@ -101,7 +102,8 @@ struct PDESystem <: AbstractSystem
             eval_module = @__MODULE__,
             checks::Union{Bool, Int} = true,
             description = "",
-            name)
+            name
+        )
         if checks == true || (checks & CheckUnits) > 0
             u = __get_unit_type(dvs, ivs, ps)
             check_units(u, eqs)
@@ -121,8 +123,11 @@ struct PDESystem <: AbstractSystem
                     p = ps isa SciMLBase.NullParameters ? [] : ps
                     args = vcat(DestructuredArgs(p), args)
                     ex = Func(args, [], eq.rhs) |> toexpr
-                    eq.lhs => drop_expr(RuntimeGeneratedFunction(
-                        eval_module, eval_module, ex))
+                    eq.lhs => drop_expr(
+                        RuntimeGeneratedFunction(
+                            eval_module, eval_module, ex
+                        )
+                    )
                 end
             end
         end
@@ -131,8 +136,10 @@ struct PDESystem <: AbstractSystem
             analytic_func = analytic_func isa Dict ? analytic_func : analytic_func |> Dict
         end
 
-        new(eqs, bcs, domain, ivs, dvs, ps, initial_conditions, connector_type, systems, analytic,
-            analytic_func, name, description, metadata, gui_metadata)
+        new(
+            eqs, bcs, domain, ivs, dvs, ps, initial_conditions, connector_type, systems, analytic,
+            analytic_func, name, description, metadata, gui_metadata
+        )
     end
 end
 
@@ -141,13 +148,15 @@ function Base.getproperty(x::PDESystem, sym::Symbol)
         return getfield(x, :ivs)
         Base.depwarn(
             "`sys.indvars` is deprecated, please use `get_ivs(sys)`", :getproperty,
-            force = true)
+            force = true
+        )
 
     elseif sym == :depvars
         return getfield(x, :dvs)
         Base.depwarn(
             "`sys.depvars` is deprecated, please use `get_dvs(sys)`", :getproperty,
-            force = true)
+            force = true
+        )
 
     else
         return getfield(x, sym)

--- a/lib/ModelingToolkitBase/src/systems/system.jl
+++ b/lib/ModelingToolkitBase/src/systems/system.jl
@@ -7,7 +7,7 @@ struct Schedule
 end
 
 function Base.copy(sched::Schedule)
-    Schedule(copy(sched.var_sccs), copy(sched.dummy_sub))
+    return Schedule(copy(sched.var_sccs), copy(sched.dummy_sub))
 end
 
 const MetadataT = Base.ImmutableDict{DataType, Any}
@@ -281,12 +281,17 @@ struct System <: IntermediateDeprecationSystem
             ignored_connections = nothing,
             preface = nothing, parent = nothing, initializesystem = nothing,
             is_initializesystem = false, is_discrete = false, isscheduled = false,
-            schedule = nothing; checks::Union{Bool, Int} = true)
+            schedule = nothing; checks::Union{Bool, Int} = true
+        )
         if is_initializesystem && iv !== nothing
-            throw(ArgumentError("""
-            Expected initialization system to be time-independent. Found independent
-            variable $iv.
-            """))
+            throw(
+                ArgumentError(
+                    """
+                    Expected initialization system to be time-independent. Found independent
+                    variable $iv.
+                    """
+                )
+            )
         end
         @assert iv === nothing || symtype(iv) === Real
         if (checks isa Bool && checks === true || checks isa Int && (checks & CheckComponents) > 0) && iv !== nothing
@@ -320,7 +325,8 @@ struct System <: IntermediateDeprecationSystem
             end
             isempty(constraints) || check_units(u, constraints)
         end
-        new(tag, eqs, noise_eqs, jumps, constraints, costs,
+        return new(
+            tag, eqs, noise_eqs, jumps, constraints, costs,
             consolidate, unknowns, ps, brownians, iv,
             observed, var_to_name, name, description, bindings, initial_conditions,
             guesses, systems, initialization_eqs, continuous_events, discrete_events,
@@ -328,7 +334,8 @@ struct System <: IntermediateDeprecationSystem
             tstops, inputs, outputs, tearing_state, namespacing,
             complete, index_cache, parameter_bindings_graph, ignored_connections,
             preface, parent, initializesystem, is_initializesystem, is_discrete,
-            isscheduled, schedule)
+            isscheduled, schedule
+        )
     end
 end
 
@@ -377,7 +384,8 @@ for time-independent systems, unknowns `dvs`, parameters `ps` and brownian varia
 All other keyword arguments are named identically to the corresponding fields in
 [`System`](@ref).
 """
-function System(eqs::Vector{Equation}, iv, dvs, ps, brownians = SymbolicT[];
+function System(
+        eqs::Vector{Equation}, iv, dvs, ps, brownians = SymbolicT[];
         constraints = Union{Equation, Inequality}[], noise_eqs = nothing, jumps = JumpType[],
         costs = SymbolicT[], consolidate = default_consolidate,
         observed = Equation[], bindings = SymmapT(), initial_conditions = SymmapT(),
@@ -390,14 +398,17 @@ function System(eqs::Vector{Equation}, iv, dvs, ps, brownians = SymbolicT[];
         ignored_connections = nothing, parent = nothing,
         description = "", name = nothing, discover_from_metadata = true,
         initializesystem = nothing, is_initializesystem = false, is_discrete = false,
-        @nospecialize(preface = nothing), checks = true, __legacy_defaults__ = nothing)
+        @nospecialize(preface = nothing), checks = true, __legacy_defaults__ = nothing
+    )
     name === nothing && throw(NoNameError())
 
     if __legacy_defaults__ !== nothing
-        Base.depwarn("""
+        Base.depwarn(
+            """
             The `@mtkmodel` macro is deprecated. Please use the functional form with \
             `@components` instead.
-            """, :mtkmodel)
+            """, :mtkmodel
+        )
         initial_conditions = __legacy_defaults__
     end
 
@@ -448,19 +459,23 @@ function System(eqs::Vector{Equation}, iv, dvs, ps, brownians = SymbolicT[];
     if iv === nothing
         for k in keys(bindings)
             k in all_dvs || continue
-            throw(ArgumentError("""
-            Bindings for variables are enforced during initialization. Since \
-            time-independent systems only perform parameter initialization, \
-            bindings for variables in such systems are invalid. $k was found to have \
-            a binding in the system $name.
-            """))
+            throw(
+                ArgumentError(
+                    """
+                    Bindings for variables are enforced during initialization. Since \
+                    time-independent systems only perform parameter initialization, \
+                    bindings for variables in such systems are invalid. $k was found to have \
+                    a binding in the system $name.
+                    """
+                )
+            )
         end
     end
     let initial_conditions = discover_from_metadata ? initial_conditions : SymmapT(),
-        bindings = discover_from_metadata ? bindings : SymmapT(),
-        guesses = discover_from_metadata ? guesses : SymmapT(),
-        inputs = discover_from_metadata ? inputs : OrderedSet{SymbolicT}(),
-        outputs = discover_from_metadata ? outputs : OrderedSet{SymbolicT}()
+            bindings = discover_from_metadata ? bindings : SymmapT(),
+            guesses = discover_from_metadata ? guesses : SymmapT(),
+            inputs = discover_from_metadata ? inputs : OrderedSet{SymbolicT}(),
+            outputs = discover_from_metadata ? outputs : OrderedSet{SymbolicT}()
 
         process_variables!(var_to_name, initial_conditions, bindings, guesses, dvs)
         process_variables!(var_to_name, initial_conditions, bindings, guesses, ps)
@@ -504,8 +519,9 @@ function System(eqs::Vector{Equation}, iv, dvs, ps, brownians = SymbolicT[];
         nonunique_subsystems(systems)
     end
     continuous_events,
-    discrete_events = create_symbolic_events(
-        continuous_events, discrete_events)
+        discrete_events = create_symbolic_events(
+        continuous_events, discrete_events
+    )
 
     if iv === nothing && (!isempty(continuous_events) || !isempty(discrete_events))
         throw(EventsInTimeIndependentSystemError(continuous_events, discrete_events))
@@ -534,13 +550,15 @@ function System(eqs::Vector{Equation}, iv, dvs, ps, brownians = SymbolicT[];
     end
     metadata = refreshed_metadata(metadata)
     jumps = Vector{JumpType}(jumps)
-    System(Threads.atomic_add!(SYSTEM_COUNT, UInt(1)), eqs, noise_eqs, jumps, constraints,
+    return System(
+        Threads.atomic_add!(SYSTEM_COUNT, UInt(1)), eqs, noise_eqs, jumps, constraints,
         costs, consolidate, dvs, ps, brownians, iv, observed,
         var_to_name, name, description, bindings, initial_conditions, guesses, systems, initialization_eqs,
         continuous_events, discrete_events, connector_type, assertions, metadata, gui_metadata, is_dde,
         tstops, inputs, outputs, tearing_state, true, false,
         nothing, nothing, ignored_connections, preface, parent,
-        initializesystem, is_initializesystem, is_discrete; checks)
+        initializesystem, is_initializesystem, is_discrete; checks
+    )
 end
 
 @noinline function nonunique_subsystems(systems)
@@ -558,7 +576,7 @@ Create a time-independent [`System`](@ref) with the given equations `eqs`, unkno
 and parameters `ps`.
 """
 function System(eqs::Vector{Equation}, dvs, ps; kwargs...)
-    System(eqs, nothing, dvs, ps; kwargs...)
+    return System(eqs, nothing, dvs, ps; kwargs...)
 end
 
 """
@@ -582,10 +600,14 @@ function System(eqs::Vector{Equation}, iv; kwargs...)
         if iscall(eq.lhs) && operation(eq.lhs) isa Differential
             var, _ = var_from_nested_derivative(eq.lhs)
             if var in diffvars
-                throw(ArgumentError("""
-                    The differential variable $var is not unique in the system of \
-                    equations.
-                """))
+                throw(
+                    ArgumentError(
+                        """
+                            The differential variable $var is not unique in the system of \
+                        equations.
+                        """
+                    )
+                )
             end
             # this check ensures var is correctly scoped, since `collect_vars!` won't pick
             # it up if it belongs to an ancestor system.
@@ -646,7 +668,8 @@ function System(eqs::Vector{Equation}, iv; kwargs...)
     end
 
     return System(
-        eqs, iv, collect(allunknowns), collect(new_ps), collect(brownians); kwargs...)
+        eqs, iv, collect(allunknowns), collect(new_ps), collect(brownians); kwargs...
+    )
 end
 
 """
@@ -716,7 +739,8 @@ end
 Process variables in constraints of the (ODE) System.
 """
 function process_constraint_system(
-        constraints::Vector{Union{Equation, Inequality}}, sts, ps, iv; validate = true)
+        constraints::Vector{Union{Equation, Inequality}}, sts, ps, iv; validate = true
+    )
     isempty(constraints) && return OrderedSet{SymbolicT}(), OrderedSet{SymbolicT}()
 
     constraintsts = OrderedSet{SymbolicT}()
@@ -745,7 +769,7 @@ function process_costs(costs::Vector, sts, ps, iv)
     end
 
     validate_vars_and_find_ps!(coststs, costps, sts, iv)
-    coststs, costps
+    return coststs, costps
 end
 
 """
@@ -762,8 +786,10 @@ function validate_vars_and_find_ps!(auxvars, auxps, sysvars, iv)
 
     for var in auxvars
         if !iscall(var)
-            SU.query(isequal(iv), var) && (var ∈ sts ||
-             throw(ArgumentError("Time-dependent variable $var is not an unknown of the system.")))
+            SU.query(isequal(iv), var) && (
+                var ∈ sts ||
+                    throw(ArgumentError("Time-dependent variable $var is not an unknown of the system."))
+            )
         elseif length(arguments(var)) > 1
             throw(ArgumentError("Too many arguments for variable $var."))
         elseif length(arguments(var)) == 1
@@ -783,6 +809,7 @@ function validate_vars_and_find_ps!(auxvars, auxps, sysvars, iv)
                 @warn "Variable $var has no argument. It will be interpreted as $var($iv), and the constraint will apply to the entire interval."
         end
     end
+    return
 end
 
 """
@@ -793,7 +820,7 @@ callbacks, so checking if any LHS is shifted is sufficient. If a variable is shi
 the input equations there _will_ be a `Shift` equation in the simplified system.
 """
 function is_discrete_system(sys::System)
-    get_is_discrete(sys) || any(eq -> isoperator(eq.lhs, Shift), equations(sys))
+    return get_is_discrete(sys) || any(eq -> isoperator(eq.lhs, Shift), equations(sys))
 end
 
 SymbolicIndexingInterface.is_time_dependent(sys::System) = get_iv(sys) !== nothing
@@ -836,7 +863,8 @@ function flatten(sys::System, noeqs = false)
     # connection expansion inherently requires the hierarchy structure. If the system
     # is being flattened, then we no longer want to expand connections (or have already
     # done so) and thus don't care about `ignored_connections`.
-    return System(noeqs ? Equation[] : equations(sys), get_iv(sys), unknowns(sys),
+    return System(
+        noeqs ? Equation[] : equations(sys), get_iv(sys), unknowns(sys),
         parameters(sys; initial_parameters = true), brownians(sys);
         jumps = jumps(sys), constraints = constraints(sys), costs = costs,
         consolidate = default_consolidate, observed = observed(sys),
@@ -852,7 +880,8 @@ function flatten(sys::System, noeqs = false)
         # retain `initial_conditions(sys)` as-is.
         discover_from_metadata = false, metadata = get_metadata(sys),
         gui_metadata = get_gui_metadata(sys),
-        description = description(sys), name = nameof(sys))
+        description = description(sys), name = nameof(sys)
+    )
 end
 
 has_massactionjumps(js::System) = any(x -> x isa MassActionJump, jumps(js))
@@ -925,12 +954,12 @@ metadata values.
 function SymbolicUtils.setmetadata(sys::AbstractSystem, k::DataType, v)
     meta = get_metadata(sys)
     meta = Base.ImmutableDict(meta, k => v)::MetadataT
-    @set sys.metadata = meta
+    return @set sys.metadata = meta
 end
 
 function SymbolicUtils.hasmetadata(sys::AbstractSystem, k::DataType)
     meta = get_metadata(sys)
-    haskey(meta, k)
+    return haskey(meta, k)
 end
 
 """
@@ -947,7 +976,7 @@ struct ProblemTypeCtx end
     $(TYPEDSIGNATURES)
 """
 function check_complete(sys::System, obj)
-    iscomplete(sys) || throw(SystemNotCompleteError(obj))
+    return iscomplete(sys) || throw(SystemNotCompleteError(obj))
 end
 
 """
@@ -986,11 +1015,13 @@ function NonlinearSystem(sys::System)
     if iscomplete(sys)
         append!(new_ps, collect(bound_parameters(sys)))
     end
-    nsys = System(eqs, unknowns(sys), new_ps;
+    nsys = System(
+        eqs, unknowns(sys), new_ps;
         bindings = merge(bindings(sys), Dict(get_iv(sys) => Inf)),
         initial_conditions = initial_conditions(sys), guesses = guesses(sys),
         initialization_eqs = initialization_equations(sys), name = nameof(sys),
-        observed = obs, systems = map(NonlinearSystem, get_systems(sys)))
+        observed = obs, systems = map(NonlinearSystem, get_systems(sys))
+    )
     if iscomplete(sys)
         nsys = complete(nsys; split = is_split(sys))
     end
@@ -1108,8 +1139,10 @@ will automatically perform this conversion.
 
 All keyword arguments are the same as those of the [`System`](@ref) constructor.
 """
-function SDESystem(eqs::Vector{Equation}, noise, iv; is_scalar_noise = false,
-        kwargs...)
+function SDESystem(
+        eqs::Vector{Equation}, noise, iv; is_scalar_noise = false,
+        kwargs...
+    )
     if is_scalar_noise
         if !(noise isa Vector)
             throw(ArgumentError("Expected noise to be a vector if `is_scalar_noise`"))
@@ -1128,7 +1161,8 @@ Identical to the 3-argument `SDESystem` constructor, but uses the explicitly pro
 """
 function SDESystem(
         eqs::Vector{Equation}, noise, iv, dvs, ps; is_scalar_noise = false,
-        kwargs...)
+        kwargs...
+    )
     if is_scalar_noise
         if !(noise isa Vector)
             throw(ArgumentError("Expected noise to be a vector if `is_scalar_noise`"))
@@ -1144,7 +1178,7 @@ end
 Attach the given noise matrix `noise` to the system `sys`.
 """
 function SDESystem(sys::System, noise; kwargs...)
-    SDESystem(equations(sys), noise, get_iv(sys); kwargs...)
+    return SDESystem(equations(sys), noise, get_iv(sys); kwargs...)
 end
 
 struct SystemNotCompleteError <: Exception
@@ -1152,10 +1186,12 @@ struct SystemNotCompleteError <: Exception
 end
 
 function Base.showerror(io::IO, err::SystemNotCompleteError)
-    print(io, """
-    A completed system is required. Call `complete` or `mtkcompile` on the \
-    system before creating a `$(err.obj)`.
-    """)
+    return print(
+        io, """
+        A completed system is required. Call `complete` or `mtkcompile` on the \
+        system before creating a `$(err.obj)`.
+        """
+    )
 end
 
 struct IllFormedNoiseEquationsError <: Exception
@@ -1164,17 +1200,21 @@ struct IllFormedNoiseEquationsError <: Exception
 end
 
 function Base.showerror(io::IO, err::IllFormedNoiseEquationsError)
-    print(io, """
-    Noise equations are ill-formed. The number of rows must match the number of drift \
-    equations. `size(neqs, 1) == $(err.noise_eqs_rows) != length(eqs) == \
-    $(err.eqs_length)`.
-    """)
+    return print(
+        io, """
+        Noise equations are ill-formed. The number of rows must match the number of drift \
+        equations. `size(neqs, 1) == $(err.noise_eqs_rows) != length(eqs) == \
+        $(err.eqs_length)`.
+        """
+    )
 end
 
 function NoNameError()
-    ArgumentError("""
-    The `name` keyword must be provided. Please consider using the `@named` macro.
-    """)
+    return ArgumentError(
+        """
+        The `name` keyword must be provided. Please consider using the `@named` macro.
+        """
+    )
 end
 
 struct NonUniqueSubsystemsError <: Exception
@@ -1194,6 +1234,7 @@ function Base.showerror(io::IO, err::NonUniqueSubsystemsError)
     for n in dupes
         println(io, "  ", n)
     end
+    return
 end
 
 struct EventsInTimeIndependentSystemError <: Exception
@@ -1202,22 +1243,23 @@ struct EventsInTimeIndependentSystemError <: Exception
 end
 
 function Base.showerror(io::IO, err::EventsInTimeIndependentSystemError)
-    println(
+    return println(
         io, """
-Events are not supported in time-independent systems. Provide an independent variable to \
-make the system time-dependent or remove the events.
+        Events are not supported in time-independent systems. Provide an independent variable to \
+        make the system time-dependent or remove the events.
 
-The following continuous events were provided:
-$(err.cevents)
+        The following continuous events were provided:
+        $(err.cevents)
 
-The following discrete events were provided:
-$(err.devents)
-""")
+        The following discrete events were provided:
+        $(err.devents)
+        """
+    )
 end
 
 function supports_initialization(sys::System)
     return isempty(get_systems(sys)) && isempty(jumps(sys)) &&
-           isempty(get_costs(sys)) && isempty(get_constraints(sys))
+        isempty(get_costs(sys)) && isempty(get_constraints(sys))
 end
 
 safe_eachrow(::Nothing) = nothing
@@ -1239,34 +1281,35 @@ If this returns `false`, the systems are very likely to be different.
 function Base.isapprox(sysa::System, sysb::System)
     sysa === sysb && return true
     return nameof(sysa) == nameof(sysb) &&
-           isequal(get_iv(sysa), get_iv(sysb)) &&
-           issetequal(get_eqs(sysa), get_eqs(sysb)) &&
-           safe_issetequal(
-               safe_eachrow(get_noise_eqs(sysa)), safe_eachrow(get_noise_eqs(sysb))) &&
-           issetequal(get_jumps(sysa), get_jumps(sysb)) &&
-           issetequal(get_constraints(sysa), get_constraints(sysb)) &&
-           issetequal(get_costs(sysa), get_costs(sysb)) &&
-           isequal(get_consolidate(sysa), get_consolidate(sysb)) &&
-           issetequal(get_unknowns(sysa), get_unknowns(sysb)) &&
-           issetequal(get_ps(sysa), get_ps(sysb)) &&
-           issetequal(get_brownians(sysa), get_brownians(sysb)) &&
-           issetequal(get_observed(sysa), get_observed(sysb)) &&
-           isequal(get_description(sysa), get_description(sysb)) &&
-           isequal(get_bindings(sysa), get_bindings(sysb)) &&
-           isequal(get_initial_conditions(sysa), get_initial_conditions(sysb)) &&
-           isequal(get_guesses(sysa), get_guesses(sysb)) &&
-           issetequal(get_initialization_eqs(sysa), get_initialization_eqs(sysb)) &&
-           issetequal(get_continuous_events(sysa), get_continuous_events(sysb)) &&
-           issetequal(get_discrete_events(sysa), get_discrete_events(sysb)) &&
-           isequal(get_connector_type(sysa), get_connector_type(sysb)) &&
-           isequal(get_assertions(sysa), get_assertions(sysb)) &&
-           isequal(get_metadata(sysa), get_metadata(sysb)) &&
-           isequal(get_is_dde(sysa), get_is_dde(sysb)) &&
-           issetequal(get_tstops(sysa), get_tstops(sysb)) &&
-           issetequal(get_inputs(sysa), get_inputs(sysb)) &&
-           issetequal(get_outputs(sysa), get_outputs(sysb)) &&
-           safe_issetequal(get_ignored_connections(sysa), get_ignored_connections(sysb)) &&
-           isequal(get_is_initializesystem(sysa), get_is_initializesystem(sysb)) &&
-           isequal(get_is_discrete(sysa), get_is_discrete(sysb)) &&
-           isequal(get_isscheduled(sysa), get_isscheduled(sysb))
+        isequal(get_iv(sysa), get_iv(sysb)) &&
+        issetequal(get_eqs(sysa), get_eqs(sysb)) &&
+        safe_issetequal(
+        safe_eachrow(get_noise_eqs(sysa)), safe_eachrow(get_noise_eqs(sysb))
+    ) &&
+        issetequal(get_jumps(sysa), get_jumps(sysb)) &&
+        issetequal(get_constraints(sysa), get_constraints(sysb)) &&
+        issetequal(get_costs(sysa), get_costs(sysb)) &&
+        isequal(get_consolidate(sysa), get_consolidate(sysb)) &&
+        issetequal(get_unknowns(sysa), get_unknowns(sysb)) &&
+        issetequal(get_ps(sysa), get_ps(sysb)) &&
+        issetequal(get_brownians(sysa), get_brownians(sysb)) &&
+        issetequal(get_observed(sysa), get_observed(sysb)) &&
+        isequal(get_description(sysa), get_description(sysb)) &&
+        isequal(get_bindings(sysa), get_bindings(sysb)) &&
+        isequal(get_initial_conditions(sysa), get_initial_conditions(sysb)) &&
+        isequal(get_guesses(sysa), get_guesses(sysb)) &&
+        issetequal(get_initialization_eqs(sysa), get_initialization_eqs(sysb)) &&
+        issetequal(get_continuous_events(sysa), get_continuous_events(sysb)) &&
+        issetequal(get_discrete_events(sysa), get_discrete_events(sysb)) &&
+        isequal(get_connector_type(sysa), get_connector_type(sysb)) &&
+        isequal(get_assertions(sysa), get_assertions(sysb)) &&
+        isequal(get_metadata(sysa), get_metadata(sysb)) &&
+        isequal(get_is_dde(sysa), get_is_dde(sysb)) &&
+        issetequal(get_tstops(sysa), get_tstops(sysb)) &&
+        issetequal(get_inputs(sysa), get_inputs(sysb)) &&
+        issetequal(get_outputs(sysa), get_outputs(sysb)) &&
+        safe_issetequal(get_ignored_connections(sysa), get_ignored_connections(sysb)) &&
+        isequal(get_is_initializesystem(sysa), get_is_initializesystem(sysb)) &&
+        isequal(get_is_discrete(sysa), get_is_discrete(sysb)) &&
+        isequal(get_isscheduled(sysa), get_isscheduled(sysb))
 end

--- a/lib/ModelingToolkitBase/src/systems/unit_check.jl
+++ b/lib/ModelingToolkitBase/src/systems/unit_check.jl
@@ -11,13 +11,14 @@ struct PleaseImportDynamicQuantities end
 global t::Union{PleaseImportDynamicQuantities, Num} = PleaseImportDynamicQuantities()
 
 function Base.show(io::IO, ::PleaseImportDynamicQuantities)
-    __import_dynamic_quantities()
+    return __import_dynamic_quantities()
 end
 
 function __import_dynamic_quantities(_...)
-    error("""
-    Please import DynamicQuantites.jl to use this `t` and `D`.
-    """)
+    error(
+        """
+        Please import DynamicQuantites.jl to use this `t` and `D`.
+        """
+    )
 end
 global D::Union{typeof(__import_dynamic_quantities), Differential} = __import_dynamic_quantities
-

--- a/lib/ModelingToolkitBase/test/accessor_functions.jl
+++ b/lib/ModelingToolkitBase/test/accessor_functions.jl
@@ -4,9 +4,9 @@
 using ModelingToolkitBase, Test
 using ModelingToolkitBase: t_nounits as t, D_nounits as D
 import ModelingToolkitBase: get_ps, get_unknowns, get_observed, get_eqs, get_continuous_events,
-                        get_discrete_events, namespace_equations
+    get_discrete_events, namespace_equations
 import ModelingToolkitBase: parameters_toplevel, unknowns_toplevel, equations_toplevel,
-                        continuous_events_toplevel, discrete_events_toplevel
+    continuous_events_toplevel, discrete_events_toplevel
 
 # Creates helper functions.
 function all_sets_equal(args...)
@@ -37,33 +37,38 @@ let
     eqs_top = [
         D(X_top) ~ p_top - d * X_top,
         D(Y) ~ log(X_top) - Y^2 + 3.0,
-        O ~ (p_top + d) * X_top + Y
+        O ~ (p_top + d) * X_top + Y,
     ]
     eqs_mid1 = [
         D(X_mid1) ~ p_mid1 - d * X_mid1^2,
         D(Y) ~ D(X_mid1) - Y^3,
-        O ~ (p_mid1 + d) * X_mid1 + Y
+        O ~ (p_mid1 + d) * X_mid1 + Y,
     ]
     eqs_mid2 = [
         D(X_mid2) ~ p_mid2 - d * X_mid2,
         X_mid2^3 ~ log(X_mid2 + Y) - Y^2 + 3.0,
-        O ~ (p_mid2 + d) * X_mid2 + Y
+        O ~ (p_mid2 + d) * X_mid2 + Y,
     ]
     eqs_bot = [
         D(X_bot) ~ p_bot - d * X_bot,
         D(Y) ~ -Y^3,
-        O ~ (p_bot + d) * X_bot + Y
+        O ~ (p_bot + d) * X_bot + Y,
     ]
     cevs = [[t ~ 1.0] => [Y ~ Pre(Y) + 2.0]]
     devs = [(t == 2.0) => [Y ~ Pre(Y) + 2.0]]
     @named sys_bot = System(
-        eqs_bot, t; systems = [], continuous_events = cevs, discrete_events = devs)
+        eqs_bot, t; systems = [], continuous_events = cevs, discrete_events = devs
+    )
     @named sys_mid2 = System(
-        eqs_mid2, t; systems = [], continuous_events = cevs, discrete_events = devs)
+        eqs_mid2, t; systems = [], continuous_events = cevs, discrete_events = devs
+    )
     @named sys_mid1 = System(
-        eqs_mid1, t; systems = [sys_bot], continuous_events = cevs, discrete_events = devs)
-    @named sys_top = System(eqs_top, t; systems = [sys_mid1, sys_mid2],
-        continuous_events = cevs, discrete_events = devs)
+        eqs_mid1, t; systems = [sys_bot], continuous_events = cevs, discrete_events = devs
+    )
+    @named sys_top = System(
+        eqs_top, t; systems = [sys_mid1, sys_mid2],
+        continuous_events = cevs, discrete_events = devs
+    )
     sys_bot_comp = complete(sys_bot)
     sys_mid2_comp = complete(sys_mid2)
     sys_mid1_comp = complete(sys_mid1)
@@ -75,92 +80,136 @@ let
 
     # Checks `parameters1.
     @test all_sets_equal(parameters.([sys_bot, sys_bot_comp, sys_bot_ss])..., [d, p_bot])
-    @test all_sets_equal(parameters.([sys_mid1, sys_mid1_comp, sys_mid1_ss])...,
-        [d, p_mid1, sys_bot.d, sys_bot.p_bot])
     @test all_sets_equal(
-        parameters.([sys_mid2, sys_mid2_comp, sys_mid2_ss])..., [d, p_mid2])
-    @test all_sets_equal(parameters.([sys_top, sys_top_comp, sys_top_ss])...,
-        [d, p_top, sys_mid1.d, sys_mid1.p_mid1, sys_mid1.sys_bot.d,
-            sys_mid1.sys_bot.p_bot, sys_mid2.d, sys_mid2.p_mid2])
+        parameters.([sys_mid1, sys_mid1_comp, sys_mid1_ss])...,
+        [d, p_mid1, sys_bot.d, sys_bot.p_bot]
+    )
+    @test all_sets_equal(
+        parameters.([sys_mid2, sys_mid2_comp, sys_mid2_ss])..., [d, p_mid2]
+    )
+    @test all_sets_equal(
+        parameters.([sys_top, sys_top_comp, sys_top_ss])...,
+        [
+            d, p_top, sys_mid1.d, sys_mid1.p_mid1, sys_mid1.sys_bot.d,
+            sys_mid1.sys_bot.p_bot, sys_mid2.d, sys_mid2.p_mid2,
+        ]
+    )
 
     # Checks `parameters_toplevel`. Compares to known parameters and also checks that
     # these are subset of what `get_ps` returns.
     @test all_sets_equal(
-        parameters_toplevel.([sys_bot, sys_bot_comp, sys_bot_ss])..., [d, p_bot])
+        parameters_toplevel.([sys_bot, sys_bot_comp, sys_bot_ss])..., [d, p_bot]
+    )
     @test all_sets_equal(
         parameters_toplevel.([sys_mid1, sys_mid1_comp, sys_mid1_ss])...,
-        [d, p_mid1])
+        [d, p_mid1]
+    )
     @test all_sets_equal(
         parameters_toplevel.([sys_mid2, sys_mid2_comp, sys_mid2_ss])...,
-        [d, p_mid2])
+        [d, p_mid2]
+    )
     @test all_sets_equal(
-        parameters_toplevel.([sys_top, sys_top_comp, sys_top_ss])..., [d, p_top])
-    @test all(sym_issubset(parameters_toplevel(sys), get_ps(sys))
-    for sys in [sys_bot, sys_mid2, sys_mid1, sys_top])
+        parameters_toplevel.([sys_top, sys_top_comp, sys_top_ss])..., [d, p_top]
+    )
+    @test all(
+        sym_issubset(parameters_toplevel(sys), get_ps(sys))
+            for sys in [sys_bot, sys_mid2, sys_mid1, sys_top]
+    )
 
     # Checks `unknowns`. O(t) is eliminated by `mtkcompile` and
     # must be considered separately.
     @test all_sets_equal(unknowns.([sys_bot, sys_bot_comp])..., [O, Y, X_bot])
-    @test all_sets_equal(unknowns.([sys_mid1, sys_mid1_comp])...,
-        [O, Y, X_mid1, sys_bot.Y, sys_bot.O, sys_bot.X_bot])
+    @test all_sets_equal(
+        unknowns.([sys_mid1, sys_mid1_comp])...,
+        [O, Y, X_mid1, sys_bot.Y, sys_bot.O, sys_bot.X_bot]
+    )
     @test all_sets_equal(unknowns.([sys_mid2, sys_mid2_comp])..., [O, Y, X_mid2])
-    @test all_sets_equal(unknowns.([sys_top, sys_top_comp])...,
-        [O, Y, X_top, sys_mid1.O, sys_mid1.Y, sys_mid1.X_mid1,
+    @test all_sets_equal(
+        unknowns.([sys_top, sys_top_comp])...,
+        [
+            O, Y, X_top, sys_mid1.O, sys_mid1.Y, sys_mid1.X_mid1,
             sys_mid1.sys_bot.O, sys_mid1.sys_bot.Y, sys_mid1.sys_bot.X_bot,
-            sys_mid2.O, sys_mid2.Y, sys_mid2.X_mid2])
+            sys_mid2.O, sys_mid2.Y, sys_mid2.X_mid2,
+        ]
+    )
     if @isdefined(ModelingToolkit)
         @test all_sets_equal(unknowns.([sys_bot_ss])..., [Y, X_bot])
         @test all_sets_equal(unknowns.([sys_mid1_ss])..., [Y, X_mid1, sys_bot.Y, sys_bot.X_bot])
         @test all_sets_equal(unknowns.([sys_mid2_ss])..., [Y, X_mid2])
-        @test all_sets_equal(unknowns.([sys_top_ss])...,
-            [Y, X_top, sys_mid1.Y, sys_mid1.X_mid1, sys_mid1.sys_bot.Y,
-                sys_mid1.sys_bot.X_bot, sys_mid2.Y, sys_mid2.X_mid2])
+        @test all_sets_equal(
+            unknowns.([sys_top_ss])...,
+            [
+                Y, X_top, sys_mid1.Y, sys_mid1.X_mid1, sys_mid1.sys_bot.Y,
+                sys_mid1.sys_bot.X_bot, sys_mid2.Y, sys_mid2.X_mid2,
+            ]
+        )
     end
 
     # Checks `unknowns_toplevel`. Note that O is not eliminated here (as we go back
     # to original parent system). Also checks that outputs are subsets of what `get_unknowns` returns.
     @test all_sets_equal(
-        unknowns_toplevel.([sys_bot, sys_bot_comp, sys_bot_ss])..., [O, Y, X_bot])
+        unknowns_toplevel.([sys_bot, sys_bot_comp, sys_bot_ss])..., [O, Y, X_bot]
+    )
     @test all_sets_equal(
-        unknowns_toplevel.([sys_mid1, sys_mid1_comp])..., [O, Y, X_mid1])
+        unknowns_toplevel.([sys_mid1, sys_mid1_comp])..., [O, Y, X_mid1]
+    )
     @test all_sets_equal(
-        unknowns_toplevel.([sys_mid2, sys_mid2_comp])..., [O, Y, X_mid2])
+        unknowns_toplevel.([sys_mid2, sys_mid2_comp])..., [O, Y, X_mid2]
+    )
     @test all_sets_equal(
-        unknowns_toplevel.([sys_top, sys_top_comp])..., [O, Y, X_top])
-    @test all(sym_issubset(unknowns_toplevel(sys), get_unknowns(sys))
-    for sys in [sys_bot, sys_mid1, sys_mid2, sys_top])
+        unknowns_toplevel.([sys_top, sys_top_comp])..., [O, Y, X_top]
+    )
+    @test all(
+        sym_issubset(unknowns_toplevel(sys), get_unknowns(sys))
+            for sys in [sys_bot, sys_mid1, sys_mid2, sys_top]
+    )
 
     # Checks `equations`. Do not check ss equations as these might potentially
     # be structurally simplified to new equations.
     @test all_sets_equal(equations.([sys_bot, sys_bot_comp])..., eqs_bot)
     @test all_sets_equal(
-        equations.([sys_mid1, sys_mid1_comp])..., [eqs_mid1; namespace_equations(sys_bot)])
+        equations.([sys_mid1, sys_mid1_comp])..., [eqs_mid1; namespace_equations(sys_bot)]
+    )
     @test all_sets_equal(equations.([sys_mid2, sys_mid2_comp])..., eqs_mid2)
-    @test all_sets_equal(equations.([sys_top, sys_top_comp])...,
-        [eqs_top; namespace_equations(sys_mid1); namespace_equations(sys_mid2)])
+    @test all_sets_equal(
+        equations.([sys_top, sys_top_comp])...,
+        [eqs_top; namespace_equations(sys_mid1); namespace_equations(sys_mid2)]
+    )
 
     # Checks `equations_toplevel`. Do not check ss equations directly as these
     # might potentially be structurally simplified to new equations. Do not check
     @test all_sets_equal(equations_toplevel.([sys_bot])..., eqs_bot)
     @test all_sets_equal(
-        equations_toplevel.([sys_mid1])..., eqs_mid1)
+        equations_toplevel.([sys_mid1])..., eqs_mid1
+    )
     @test all_sets_equal(
-        equations_toplevel.([sys_mid2])..., eqs_mid2)
+        equations_toplevel.([sys_mid2])..., eqs_mid2
+    )
     @test all_sets_equal(equations_toplevel.([sys_top])..., eqs_top)
-    @test all(sym_issubset(equations_toplevel(sys), get_eqs(sys))
-    for sys in [sys_bot, sys_mid2, sys_mid1, sys_top])
+    @test all(
+        sym_issubset(equations_toplevel(sys), get_eqs(sys))
+            for sys in [sys_bot, sys_mid2, sys_mid1, sys_top]
+    )
 
     # Checks `continuous_events_toplevel` and  `discrete_events_toplevel` (straightforward
     # as I stored the same single event in all systems). Don't check for non-toplevel cases as
     # technically not needed for these tests and name spacing the events is a mess.
     @test all_sets_equal(
-        continuous_events_toplevel.([sys_bot, sys_bot_comp, sys_bot_ss])...)
+        continuous_events_toplevel.([sys_bot, sys_bot_comp, sys_bot_ss])...
+    )
     @test all_sets_equal(
         discrete_events_toplevel.(
-        [sys_mid1, sys_mid1_comp, sys_mid1_ss])...)
-    @test all(sym_issubset(
-                  continuous_events_toplevel(sys), get_continuous_events(sys))
-    for sys in [sys_bot, sys_mid2, sys_mid1, sys_top])
-    @test all(sym_issubset(discrete_events_toplevel(sys), get_discrete_events(sys))
-    for sys in [sys_bot, sys_mid2, sys_mid1, sys_top])
+            [sys_mid1, sys_mid1_comp, sys_mid1_ss]
+        )...
+    )
+    @test all(
+        sym_issubset(
+                continuous_events_toplevel(sys), get_continuous_events(sys)
+            )
+            for sys in [sys_bot, sys_mid2, sys_mid1, sys_top]
+    )
+    @test all(
+        sym_issubset(discrete_events_toplevel(sys), get_discrete_events(sys))
+            for sys in [sys_bot, sys_mid2, sys_mid1, sys_top]
+    )
 end

--- a/lib/ModelingToolkitBase/test/bigsystem.jl
+++ b/lib/ModelingToolkitBase/test/bigsystem.jl
@@ -20,8 +20,10 @@ const X = reshape([i for i in 1:N for j in 1:N], N, N)
 const Y = reshape([j for i in 1:N for j in 1:N], N, N)
 const α₁ = 1.0 .* (X .>= 4 * N / 5)
 
-const Mx = Tridiagonal([1.0 for i in 1:(N - 1)], [-2.0 for i in 1:N],
-    [1.0 for i in 1:(N - 1)])
+const Mx = Tridiagonal(
+    [1.0 for i in 1:(N - 1)], [-2.0 for i in 1:N],
+    [1.0 for i in 1:(N - 1)]
+)
 const My = copy(Mx)
 Mx[2, 1] = 2.0
 Mx[end - 1, end] = 2.0
@@ -47,13 +49,17 @@ function f(du, u, p, t)
     @. DA = _DD * (MyA + AMx)
     @. dA = DA + α₁ - β₁ * A - r₁ * A * B + r₂ * C
     @. dB = α₂ - β₂ * B - r₁ * A * B + r₂ * C
-    @. dC = α₃ - β₃ * C + r₁ * A * B - r₂ * C
+    return @. dC = α₃ - β₃ * C + r₁ * A * B - r₂ * C
 end
 
 f(du, u, nothing, 0.0)
 
-multithreadedf = eval(ModelingToolkitBase.build_function(du, u, fillzeros = true,
-    parallel = ModelingToolkitBase.MultithreadedForm())[2])
+multithreadedf = eval(
+    ModelingToolkitBase.build_function(
+        du, u, fillzeros = true,
+        parallel = ModelingToolkitBase.MultithreadedForm()
+    )[2]
+)
 
 MyA = zeros(N, N);
 AMx = zeros(N, N);

--- a/lib/ModelingToolkitBase/test/binding_semantics.jl
+++ b/lib/ModelingToolkitBase/test/binding_semantics.jl
@@ -22,9 +22,11 @@ end
 @testset "Prefer keyword over metadata" begin
     @variables x(t) = 1 y(t) = x
     @parameters p = 1 q = p
-    @named sys = System([D(x) ~ p * x, D(y) ~ q * y], t;
-                        bindings = [x => y, p => q, y => nothing, q => nothing],
-                        initial_conditions = [y => 2, q => 2, x => nothing, p => nothing])
+    @named sys = System(
+        [D(x) ~ p * x, D(y) ~ q * y], t;
+        bindings = [x => y, p => q, y => nothing, q => nothing],
+        initial_conditions = [y => 2, q => 2, x => nothing, p => nothing]
+    )
     @test isequal(bindings(sys), Dict(x => y, p => q))
     @test isequal(initial_conditions(sys), Dict(y => SConst(2), q => SConst(2)))
 end
@@ -70,21 +72,21 @@ end
 
 function SubComp(; k, name)
     @parameters k = k
-    System(Equation[], t, [], [k]; name)
+    return System(Equation[], t, [], [k]; name)
 end
 
 function Comp(; name)
     @parameters k
     @variables x(t)
     @named sub = SubComp(; k)
-    System([D(x) ~ sub.k * x + k], t; systems = [sub], name)
+    return System([D(x) ~ sub.k * x + k], t; systems = [sub], name)
 end
 
 function BadComp(; name)
     @parameters k
     @variables x(t)
     @named sub = SubComp(; k = x)
-    System([D(x) ~ sub.k * x + k], t; systems = [sub], name)
+    return System([D(x) ~ sub.k * x + k], t; systems = [sub], name)
 end
 
 

--- a/lib/ModelingToolkitBase/test/bvproblem.jl
+++ b/lib/ModelingToolkitBase/test/bvproblem.jl
@@ -1,4 +1,4 @@
-### TODO: update when BoundaryValueDiffEqAscher is updated to use the normal boundary condition conventions 
+### TODO: update when BoundaryValueDiffEqAscher is updated to use the normal boundary condition conventions
 using OrdinaryDiffEq
 using BoundaryValueDiffEqMIRK, BoundaryValueDiffEqAscher
 using ModelingToolkitBase
@@ -6,16 +6,18 @@ using SciMLBase
 using ModelingToolkitBase: t_nounits as t, D_nounits as D
 using Test
 
-### Test Collocation solvers on simple problems 
+### Test Collocation solvers on simple problems
 solvers = [MIRK4]
 daesolvers = [Ascher2, Ascher4, Ascher6]
 
 @testset "Lotka-Volterra" begin
-    @parameters α=7.5 β=4.0 γ=8.0 δ=5.0
-    @variables x(t)=1.0 y(t)=2.0
+    @parameters α = 7.5 β = 4.0 γ = 8.0 δ = 5.0
+    @variables x(t) = 1.0 y(t) = 2.0
 
-    eqs = [D(x) ~ α * x - β * x * y,
-        D(y) ~ -γ * y + δ * x * y]
+    eqs = [
+        D(x) ~ α * x - β * x * y,
+        D(y) ~ -γ * y + δ * x * y,
+    ]
 
     u0map = [x => 1.0, y => 2.0]
     parammap = [α => 7.5, β => 4, γ => 8.0, δ => 5.0]
@@ -26,7 +28,8 @@ daesolvers = [Ascher2, Ascher4, Ascher6]
     osol = solve(op, Vern9())
 
     bvp = SciMLBase.BVProblem{true, SciMLBase.AutoSpecialize}(
-        lotkavolterra, [u0map; parammap], tspan)
+        lotkavolterra, [u0map; parammap], tspan
+    )
 
     for solver in solvers
         sol = solve(bvp, solver(), dt = 0.01)
@@ -36,7 +39,8 @@ daesolvers = [Ascher2, Ascher4, Ascher6]
 
     # Test out of place
     bvp2 = SciMLBase.BVProblem{false, SciMLBase.AutoSpecialize}(
-        lotkavolterra, [u0map; parammap], tspan)
+        lotkavolterra, [u0map; parammap], tspan
+    )
 
     for solver in solvers
         sol = solve(bvp2, solver(), dt = 0.01)
@@ -47,11 +51,13 @@ end
 
 ### Testing on pendulum
 @testset "Pendulum" begin
-    @parameters g=9.81 L=1.0
-    @variables θ(t)=π / 2 θ_t(t)
+    @parameters g = 9.81 L = 1.0
+    @variables θ(t) = π / 2 θ_t(t)
 
-    eqs = [D(θ) ~ θ_t
-           D(θ_t) ~ -(g / L) * sin(θ)]
+    eqs = [
+        D(θ) ~ θ_t
+        D(θ_t) ~ -(g / L) * sin(θ)
+    ]
 
     @mtkcompile pend = System(eqs, t)
 
@@ -63,7 +69,8 @@ end
     osol = solve(op, Vern9())
 
     bvp = SciMLBase.BVProblem{true, SciMLBase.AutoSpecialize}(
-        pend, [u0map; parammap], tspan)
+        pend, [u0map; parammap], tspan
+    )
     for solver in solvers
         sol = solve(bvp, solver(), dt = 0.01)
         @test isapprox(sol.u[end], osol.u[end]; atol = 0.01)
@@ -72,7 +79,8 @@ end
 
     # Test out-of-place
     bvp2 = SciMLBase.BVProblem{false, SciMLBase.FullSpecialize}(
-        pend, [u0map; parammap], tspan)
+        pend, [u0map; parammap], tspan
+    )
 
     for solver in solvers
         sol = solve(bvp2, solver(), dt = 0.01)
@@ -87,10 +95,12 @@ end
 
 # Test generation of boundary condition function using `generate_function_bc`. Compare solutions to manually written boundary conditions
 @testset "Boundary Condition Compilation" begin
-    @parameters α=1.5 β=1.0 γ=3.0 δ=1.0
+    @parameters α = 1.5 β = 1.0 γ = 3.0 δ = 1.0
     @variables x(..) y(..)
-    eqs = [D(x(t)) ~ α * x(t) - β * x(t) * y(t),
-        D(y(t)) ~ -γ * y(t) + δ * x(t) * y(t)]
+    eqs = [
+        D(x(t)) ~ α * x(t) - β * x(t) * y(t),
+        D(y(t)) ~ -γ * y(t) + δ * x(t) * y(t),
+    ]
 
     tspan = (0.0, 1.0)
     @mtkcompile lksys = System(eqs, t)
@@ -122,9 +132,11 @@ end
     bvpi1 = SciMLBase.BVProblem(lotkavolterra!, bc!, u0, tspan, p)
     bvpi2 = SciMLBase.BVProblem(lotkavolterra, bc, u0, tspan, p)
     bvpi3 = SciMLBase.BVProblem{true, SciMLBase.AutoSpecialize}(
-        lksys, [x(t) => 1.0], tspan; guesses = [y(t) => 1.0])
+        lksys, [x(t) => 1.0], tspan; guesses = [y(t) => 1.0]
+    )
     bvpi4 = SciMLBase.BVProblem{false, SciMLBase.FullSpecialize}(
-        lksys, [x(t) => 1.0], tspan; guesses = [y(t) => 1.0])
+        lksys, [x(t) => 1.0], tspan; guesses = [y(t) => 1.0]
+    )
 
     sol1 = solve(bvpi1, MIRK4(), dt = 0.01)
     sol2 = solve(bvpi2, MIRK4(), dt = 0.01)
@@ -136,7 +148,8 @@ end
 end
 
 function test_solvers(
-        solvers, prob, u0map, constraints, equations = []; dt = 0.05, atol = 1e-2)
+        solvers, prob, u0map, constraints, equations = []; dt = 0.05, atol = 1.0e-2
+    )
     for solver in solvers
         println("Solver: $solver")
         sol = solve(prob, solver(), dt = dt, abstol = atol)
@@ -167,15 +180,18 @@ function test_solvers(
             @test sol[eq] ≈ 0
         end
     end
+    return
 end
 
 # Simple System with BVP constraints.
 @testset "ODE with constraints" begin
-    @parameters α=1.5 β=1.0 γ=3.0 δ=1.0
+    @parameters α = 1.5 β = 1.0 γ = 3.0 δ = 1.0
     @variables x(..) y(..)
 
-    eqs = [D(x(t)) ~ α * x(t) - β * x(t) * y(t),
-        D(y(t)) ~ -γ * y(t) + δ * x(t) * y(t)]
+    eqs = [
+        D(x(t)) ~ α * x(t) - β * x(t) * y(t),
+        D(y(t)) ~ -γ * y(t) + δ * x(t) * y(t),
+    ]
 
     u0map = []
     tspan = (0.0, 1.0)
@@ -184,20 +200,23 @@ end
     @mtkcompile lksys = System(eqs, t; constraints = constr)
 
     bvp = SciMLBase.BVProblem{true, SciMLBase.AutoSpecialize}(
-        lksys, u0map, tspan; guesses = guess)
+        lksys, u0map, tspan; guesses = guess
+    )
     test_solvers(solvers, bvp, u0map, constr; dt = 0.05)
 
     # Testing that more complicated constraints give correct solutions.
     constr = [y(0.2) + x(0.8) ~ 3.0, y(0.3) ~ 2.0]
     @mtkcompile lksys = System(eqs, t; constraints = constr)
     bvp = SciMLBase.BVProblem{false, SciMLBase.FullSpecialize}(
-        lksys, u0map, tspan; guesses = guess)
+        lksys, u0map, tspan; guesses = guess
+    )
     test_solvers(solvers, bvp, u0map, constr; dt = 0.05)
 
     constr = [α * β - x(0.6) ~ 0.0, y(0.2) ~ 3.0]
     @mtkcompile lksys = System(eqs, t; constraints = constr)
     bvp = SciMLBase.BVProblem{true, SciMLBase.AutoSpecialize}(
-        lksys, u0map, tspan; guesses = guess)
+        lksys, u0map, tspan; guesses = guess
+    )
     test_solvers(solvers, bvp, u0map, constr)
 end
 
@@ -210,37 +229,37 @@ end
 #            D(D(y)) ~ λ * y - g
 #            x^2 + y^2 ~ 1]
 #     @mtkcompile pend = System(eqs, t)
-# 
+#
 #     tspan = (0.0, 1.5)
 #     u0map = [x => 1, y => 0]
 #     pmap = [g => 1]
 #     guess = [λ => 1]
-# 
+#
 #     prob = ODEProblem(pend, u0map, tspan, pmap; guesses = guess)
 #     osol = solve(prob, Rodas5P())
-# 
+#
 #     zeta = [0., 0., 0., 0., 0.]
 #     bvp = SciMLBase.BVProblem{true, SciMLBase.AutoSpecialize}(pend, u0map, tspan, parammap; guesses = guess)
-#     
+#
 #     for solver in solvers
 #         sol = solve(bvp, solver(zeta), dt = 0.001)
 #         @test isapprox(sol.u[end], osol.u[end]; atol = 0.01)
 #         conditions = getfield.(equations(pend)[3:end], :rhs)
 #         @test isapprox([sol[conditions][1]; sol[x][1] - 1; sol[y][1]], zeros(5), atol = 0.001)
 #     end
-# 
+#
 #     bvp2 = SciMLBase.BVProblem{false, SciMLBase.FullSpecialize}(pend, u0map, tspan, parammap)
 #     for solver in solvers
 #         sol = solve(bvp, solver(zeta), dt = 0.01)
 #         @test isapprox(sol.u[end], osol.u[end]; atol = 0.01)
 #         conditions = getfield.(equations(pend)[3:end], :rhs)
-#         @test [sol[conditions][1]; sol[x][1] - 1; sol[y][1]] ≈ 0 
+#         @test [sol[conditions][1]; sol[x][1] - 1; sol[y][1]] ≈ 0
 #     end
 # end
 
 # Adding a midpoint boundary constraint.
 # Solve using BVDAE solvers.
-# let 
+# let
 #     @parameters g
 #     @variables x(..) y(t) [state_priority = 10] λ(t)
 #     eqs = [D(D(x(t))) ~ λ * x(t)
@@ -248,28 +267,28 @@ end
 #            x(t)^2 + y^2 ~ 1]
 #     constr = [x(0.5) ~ 1]
 #     @mtkcompile pend = System(eqs, t; constr)
-# 
+#
 #     tspan = (0.0, 1.5)
 #     u0map = [x(t) => 0.6, y => 0.8]
 #     parammap = [g => 1]
 #     guesses = [λ => 1]
-# 
+#
 #     bvp = SciMLBase.BVProblem{true, SciMLBase.AutoSpecialize}(pend, u0map, tspan, parammap; guesses, check_length = false)
 #     test_solvers(daesolvers, bvp, u0map, constr)
-# 
+#
 #     bvp2 = SciMLBase.BVProblem{false, SciMLBase.FullSpecialize}(pend, u0map, tspan, parammap)
 #     test_solvers(daesolvers, bvp2, u0map, constr, get_alg_eqs(pend))
-# 
+#
 #     # More complicated constr.
 #     u0map = [x(t) => 0.6]
 #     guesses = [λ => 1, y(t) => 0.8]
-# 
-#     constr = [x(0.5) ~ 1, 
+#
+#     constr = [x(0.5) ~ 1,
 #                    x(0.3)^3 + y(0.6)^2 ~ 0.5]
 #     @mtkcompile pend = System(eqs, t; constr)
 #     bvp = SciMLBase.BVProblem{true, SciMLBase.AutoSpecialize}(pend, u0map, tspan, parammap; guesses, check_length = false)
 #     test_solvers(daesolvers, bvp, u0map, constr, get_alg_eqs(pend))
-# 
+#
 #     constr = [x(0.4) * g ~ y(0.2),
 #                    y(0.7) ~ 0.3]
 #     @mtkcompile pend = System(eqs, t; constr)
@@ -278,12 +297,14 @@ end
 # end
 
 @testset "Cost function compilation" begin
-    @parameters α=1.5 β=1.0 γ=3.0 δ=1.0
+    @parameters α = 1.5 β = 1.0 γ = 3.0 δ = 1.0
     @variables x(..) y(..)
     t = ModelingToolkitBase.t_nounits
 
-    eqs = [D(x(t)) ~ α * x(t) - β * x(t) * y(t),
-        D(y(t)) ~ -γ * y(t) + δ * x(t) * y(t)]
+    eqs = [
+        D(x(t)) ~ α * x(t) - β * x(t) * y(t),
+        D(y(t)) ~ -γ * y(t) + δ * x(t) * y(t),
+    ]
 
     tspan = (0.0, 1.0)
     u0map = [x(t) => 4.0, y(t) => 2.0]
@@ -293,11 +314,13 @@ end
     @mtkcompile lksys = System(eqs, t; costs, consolidate)
 
     @test_throws ModelingToolkitBase.SystemCompatibilityError ODEProblem(
-        lksys, [u0map; parammap], tspan)
+        lksys, [u0map; parammap], tspan
+    )
     prob = ODEProblem(lksys, [u0map; parammap], tspan; check_compatibility = false)
     sol = solve(prob, Tsit5())
     costfn = ModelingToolkitBase.generate_cost(
-        lksys; expression = Val{false}, wrap_gfw = Val{true})
+        lksys; expression = Val{false}, wrap_gfw = Val{true}
+    )
     _t = tspan[2]
     @test costfn(sol, prob.p, _t) ≈ (sol(0.6; idxs = x(t)) + 3)^2 + sol(0.3; idxs = x(t))^2
 
@@ -311,7 +334,8 @@ end
     prob = ODEProblem(lksys, [u0map; parammap], tspan; check_compatibility = false)
     sol = solve(prob, Tsit5())
     costfn = ModelingToolkitBase.generate_cost(
-        lksys; expression = Val{false}, wrap_gfw = Val{true})
+        lksys; expression = Val{false}, wrap_gfw = Val{true}
+    )
     @test costfn(sol, prob.p, _t) ≈
-          log(sol(0.56; idxs = y(t)) + sol(0.0; idxs = x(t))) - sol(0.4; idxs = x(t))^2
+        log(sol(0.56; idxs = y(t)) + sol(0.0; idxs = x(t))) - sol(0.4; idxs = x(t))^2
 end

--- a/lib/ModelingToolkitBase/test/causal_variables_connection.jl
+++ b/lib/ModelingToolkitBase/test/causal_variables_connection.jl
@@ -33,8 +33,10 @@ end
     @named P = FirstOrder(k = 1, T = 1)
     @named C = Gain(; k = -1)
 
-    eqs = [connect(P.output.u, C.input.u)
-           connect(C.output.u, P.input.u)]
+    eqs = [
+        connect(P.output.u, C.input.u)
+        connect(C.output.u, P.input.u)
+    ]
     sys1 = System(eqs, t, systems = [P, C], name = :hej)
     sys = expand_connections(sys1)
     @test any(isequal(C.input.u ~ P.output.u), equations(sys))
@@ -60,7 +62,7 @@ if @isdefined(ModelingToolkit)
             ("inner", sys, sys.plant_input),
             ("nested", nested_sys, nested_sys.hej.plant_input),
             ("inner - Symbol", sys, :plant_input),
-            ("nested - Symbol", nested_sys, nameof(sys.plant_input))
+            ("nested - Symbol", nested_sys, nameof(sys.plant_input)),
         ]
 
         @testset "get_sensitivity - $name" for (name, sys, ap) in test_cases
@@ -108,7 +110,7 @@ end
         end
 
         equations = Equation[
-            y ~ x
+            y ~ x,
         ]
 
         return System(equations, t, vars, pars; name, systems)
@@ -137,7 +139,11 @@ end
     @named sys = Outer()
     ss = toggle_namespacing(sys, false)
     eqs = equations(expand_connections(sys))
-    @test issetequal(eqs, [ss.inner.x ~ ss.u
-                           ss.inner.y ~ ss.inner.x
-                           ss.v ~ ss.inner.y])
+    @test issetequal(
+        eqs, [
+            ss.inner.x ~ ss.u
+            ss.inner.y ~ ss.inner.x
+            ss.v ~ ss.inner.y
+        ]
+    )
 end

--- a/lib/ModelingToolkitBase/test/ccompile.jl
+++ b/lib/ModelingToolkitBase/test/ccompile.jl
@@ -3,10 +3,14 @@ using ModelingToolkitBase: t_nounits as t, D_nounits as D
 
 @parameters a
 @variables x y
-eqs = [D(x) ~ a * x - x * y,
-    D(y) ~ -3y + x * y]
-f = build_function([x.rhs for x in eqs], [x, y], [a], t, expression = Val{false},
-    target = ModelingToolkitBase.CTarget())
+eqs = [
+    D(x) ~ a * x - x * y,
+    D(y) ~ -3y + x * y,
+]
+f = build_function(
+    [x.rhs for x in eqs], [x, y], [a], t, expression = Val{false},
+    target = ModelingToolkitBase.CTarget()
+)
 f2 = eval(build_function([x.rhs for x in eqs], [x, y], [a], t)[2])
 du = rand(2);
 du2 = rand(2);

--- a/lib/ModelingToolkitBase/test/changeofvariables.jl
+++ b/lib/ModelingToolkitBase/test/changeofvariables.jl
@@ -17,7 +17,7 @@ eqs = [D(D(z)) ~ ones(2, 2)]
 @parameters α
 @variables x(t)
 D = Differential(t)
-eqs = [D(x) ~ α*x]
+eqs = [D(x) ~ α * x]
 
 tspan = (0.0, 1.0)
 def = [x => 1.0, α => -0.5]
@@ -35,22 +35,23 @@ new_sys = change_of_variables(sys, t, forward_subs, backward_subs)
 new_prob = ODEProblem(new_sys, [], tspan)
 new_sol = solve(new_prob, common_alg)
 
-@test isapprox(new_sol[x][end], sol[x][end], atol = 1e-4)
+@test isapprox(new_sol[x][end], sol[x][end], atol = 1.0e-4)
 
 # Riccati equation
 @parameters α
 @variables x(t)
 D = Differential(t)
 eqs = [D(x) ~ t^2 + α - x^2]
-def = [x=>1.0, α => 1.0]
-@mtkcompile sys = System(eqs, t; initial_conditions  = def)
+def = [x => 1.0, α => 1.0]
+@mtkcompile sys = System(eqs, t; initial_conditions = def)
 
 @variables z(t)
-forward_subs = [t + α/(x+t) => z]
-backward_subs = [x => α/(z-t) - t]
+forward_subs = [t + α / (x + t) => z]
+backward_subs = [x => α / (z - t) - t]
 
 new_sys = change_of_variables(
-    sys, t, forward_subs, backward_subs; simplify = true, t0 = 0.0)
+    sys, t, forward_subs, backward_subs; simplify = true, t0 = 0.0
+)
 # output should be equivalent to
 # t^2 + α - z^2 + 2   (but this simplification is not found automatically)
 
@@ -61,14 +62,14 @@ new_prob = ODEProblem(new_sys, [], tspan)
 sol = solve(prob, Tsit5())
 new_sol = solve(new_prob, common_alg)
 
-@test isapprox(sol[x][end], new_sol[x][end], rtol = 1e-4)
+@test isapprox(sol[x][end], new_sol[x][end], rtol = 1.0e-4)
 
 # Linear transformation to diagonal system
 @independent_variables t
 @variables x(t)[1:3]
 D = Differential(t)
 A = [0.0 -1.0 0.0; -0.5 0.5 0.0; 0.0 0.0 -1.0]
-right = A*x
+right = A * x
 eqs = [D(x) ~ right]
 
 tspan = (0.0, 10.0)
@@ -83,8 +84,8 @@ T_inv = inv(T)
 
 @variables z(t)[1:3]
 z = reshape(z, 3, 1)
-forward_subs = vec(collect(T_inv*x) .=> collect(z))
-backward_subs = vec(collect(x) .=> collect(T*z))
+forward_subs = vec(collect(T_inv * x) .=> collect(z))
+backward_subs = vec(collect(x) .=> collect(T * z))
 
 new_sys = change_of_variables(sys, t, forward_subs, backward_subs; simplify = true)
 
@@ -98,9 +99,9 @@ if @isdefined(ModelingToolkit)
     A = diagm(eigen(A).values)
     A = sortslices(A, dims = 1)
     new_A = sortslices(new_A, dims = 1)
-    @test isapprox(A, new_A, rtol = 1e-10)
+    @test isapprox(A, new_A, rtol = 1.0e-10)
 end
-@test isapprox(new_sol[x[1]][end], sol[x[1]][end], rtol = 1e-4)
+@test isapprox(new_sol[x[1]][end], sol[x[1]][end], rtol = 1.0e-4)
 
 # Change of variables for sde
 noise_eqs = ModelingToolkitBase.get_noise_eqs
@@ -111,14 +112,14 @@ value = ModelingToolkitBase.value
 @parameters μ σ
 @variables x(t) y(t)
 D = Differential(t)
-eqs = [D(x) ~ μ*x + σ*x*B]
+eqs = [D(x) ~ μ * x + σ * x * B]
 
-def = [x=>0.0, μ => 2.0, σ=>1.0]
+def = [x => 0.0, μ => 2.0, σ => 1.0]
 @mtkcompile sys = System(eqs, t; initial_conditions = def)
 forward_subs = [log(x) => y]
 backward_subs = [x => exp(y)]
 new_sys = change_of_variables(sys, t, forward_subs, backward_subs)
-@test equations(new_sys)[1] == (D(y) ~ μ - 1/2*σ^2)
+@test equations(new_sys)[1] == (D(y) ~ μ - 1 / 2 * σ^2)
 @test noise_eqs(new_sys)[1] === value(σ)
 
 #Multiple Brownian and equations
@@ -127,29 +128,29 @@ new_sys = change_of_variables(sys, t, forward_subs, backward_subs)
 @parameters μ σ α
 @variables x(t) y(t) z(t) w(t) u(t) v(t)
 D = Differential(t)
-eqs = [D(x) ~ μ*x + σ*x*Bx, D(y) ~ α*By, D(u) ~ μ*u + σ*u*Bx + α*u*By]
-def = [x=>0.0, y => 0.0, u=>0.0, μ => 2.0, σ=>1.0, α=>3.0]
+eqs = [D(x) ~ μ * x + σ * x * Bx, D(y) ~ α * By, D(u) ~ μ * u + σ * u * Bx + α * u * By]
+def = [x => 0.0, y => 0.0, u => 0.0, μ => 2.0, σ => 1.0, α => 3.0]
 forward_subs = [log(x) => z, y^2 => w, log(u) => v]
 backward_subs = [x => exp(z), y => w^0.5, u => exp(v)]
 
 @mtkcompile sys = System(eqs, t; initial_conditions = def)
 new_sys = change_of_variables(sys, t, forward_subs, backward_subs)
-@test equations(new_sys)[1] == (D(z) ~ μ - 1/2*σ^2)
+@test equations(new_sys)[1] == (D(z) ~ μ - 1 / 2 * σ^2)
 @test equations(new_sys)[2] == (D(w) ~ α^2)
-@test equations(new_sys)[3] == (D(v) ~ μ - 1/2*(α^2 + σ^2))
+@test equations(new_sys)[3] == (D(v) ~ μ - 1 / 2 * (α^2 + σ^2))
 col1 = isequal(noise_eqs(new_sys)[1, 1], unwrap(σ))::Bool ? 1 : 2
 col2 = 3 - col1
 @test value(noise_eqs(new_sys)[1, col1]) === value(σ)
-@test value(noise_eqs(new_sys)[1,  col2]) === value(0)
-@test value(noise_eqs(new_sys)[2,  col1]) === value(0)
-@test isequal(noise_eqs(new_sys)[2, col2], simplify(substitute(2*α*y, backward_subs[2])))
+@test value(noise_eqs(new_sys)[1, col2]) === value(0)
+@test value(noise_eqs(new_sys)[2, col1]) === value(0)
+@test isequal(noise_eqs(new_sys)[2, col2], simplify(substitute(2 * α * y, backward_subs[2])))
 @test value(noise_eqs(new_sys)[3, col1]) === value(σ)
 @test value(noise_eqs(new_sys)[3, col2]) === value(α)
 
 # Test for  Brownian instead of noise
 @named sys = System(eqs, t; initial_conditions = def)
 new_sys = change_of_variables(sys, t, forward_subs, backward_subs; simplify = false)
-@test simplify(equations(new_sys)[1]) == simplify((D(z) ~ μ - 1/2*σ^2 + σ*Bx))
-@test simplify(equations(new_sys)[2]) == simplify((D(w) ~ α^2 + 2*α*w^0.5*By))
+@test simplify(equations(new_sys)[1]) == simplify((D(z) ~ μ - 1 / 2 * σ^2 + σ * Bx))
+@test simplify(equations(new_sys)[2]) == simplify((D(w) ~ α^2 + 2 * α * w^0.5 * By))
 @test simplify(equations(new_sys)[3]) ==
-      simplify((D(v) ~ μ - 1/2*(α^2 + σ^2) + σ*Bx + α*By))
+    simplify((D(v) ~ μ - 1 / 2 * (α^2 + σ^2) + σ * Bx + α * By))

--- a/lib/ModelingToolkitBase/test/code_generation.jl
+++ b/lib/ModelingToolkitBase/test/code_generation.jl
@@ -4,23 +4,26 @@ using Test
 
 @testset "`generate_custom_function`" begin
     @variables x(t) y(t)[1:3]
-    @parameters p1=1.0 p2[1:3]=[1.0, 2.0, 3.0] p3::Int=1 p4::Bool=false
+    @parameters p1 = 1.0 p2[1:3] = [1.0, 2.0, 3.0] p3::Int = 1 p4::Bool = false
 
     sys = complete(System(Equation[], t, [x; y], [p1, p2, p3, p4]; name = :sys))
     u0 = [1.0, 2.0, 3.0, 4.0]
     p = ModelingToolkitBase.MTKParameters(sys, [])
 
     fn1 = generate_custom_function(
-        sys, x + y[1] + p1 + p2[1] + p3 * t; expression = Val(false))
+        sys, x + y[1] + p1 + p2[1] + p3 * t; expression = Val(false)
+    )
     @test fn1(u0, p, 0.0) == 5.0
 
     fn2 = generate_custom_function(
-        sys, x + y[1] + p1 + p2[1] + p3 * t, [x], [p1, p2, p3]; expression = Val(false))
+        sys, x + y[1] + p1 + p2[1] + p3 * t, [x], [p1, p2, p3]; expression = Val(false)
+    )
     @test fn1(u0, p, 0.0) == 5.0
 
     fn3_oop,
-    fn3_iip = generate_custom_function(
-        sys, [x + y[2], y[3] + p2[2], p1 + p3, 3t]; expression = Val(false))
+        fn3_iip = generate_custom_function(
+        sys, [x + y[2], y[3] + p2[2], p1 + p3, 3t]; expression = Val(false)
+    )
 
     buffer = zeros(4)
     fn3_iip(buffer, u0, p, 1.0)
@@ -40,12 +43,14 @@ using Test
     @test fn1(u0, p) == 6.0
 
     fn2 = generate_custom_function(
-        sys, x + y[1] + p1 + p2[1] + p3, [x], [p1, p2, p3]; expression = Val(false))
+        sys, x + y[1] + p1 + p2[1] + p3, [x], [p1, p2, p3]; expression = Val(false)
+    )
     @test fn1(u0, p) == 6.0
 
     fn3_oop,
-    fn3_iip = generate_custom_function(
-        sys, [x + y[2], y[3] + p2[2], p1 + p3]; expression = Val(false))
+        fn3_iip = generate_custom_function(
+        sys, [x + y[2], y[3] + p2[2], p1 + p3]; expression = Val(false)
+    )
 
     buffer = zeros(3)
     fn3_iip(buffer, u0, p)
@@ -89,11 +94,13 @@ end
         val[] = 0
         @variables z(t)[1:2]
         @mtkcompile sys = System(
-            [D(y) ~ foo(x), D(x) ~ sum(y), zeros(2) ~ foo(prod(z))], t)
+            [D(y) ~ foo(x), D(x) ~ sum(y), zeros(2) ~ foo(prod(z))], t
+        )
         @test length(equations(sys)) == 5
         @test length(ModelingToolkitBase.observed(sys)) == 0
         prob = ODEProblem(
-            sys, [y => ones(2), z => 2ones(2), x => 3.0, foo => _tmp_fn2], (0.0, 1.0))
+            sys, [y => ones(2), z => 2ones(2), x => 3.0, foo => _tmp_fn2], (0.0, 1.0)
+        )
         val[] = 0
         @test_nowarn prob.f(prob.u0, prob.p, 0.0)
         @test val[] == 2

--- a/lib/ModelingToolkitBase/test/complex.jl
+++ b/lib/ModelingToolkitBase/test/complex.jl
@@ -33,7 +33,7 @@ end
     eqs = [
         D(x) ~ y - x,
         D(y) ~ -x * z + b * abs(z),
-        D(z) ~ x * y - a
+        D(z) ~ x * y - a,
     ]
     @named modlorenz = System(eqs, t)
     sys = mtkcompile(modlorenz)

--- a/lib/ModelingToolkitBase/test/constants.jl
+++ b/lib/ModelingToolkitBase/test/constants.jl
@@ -15,15 +15,17 @@ prob = ODEProblem(complete(sys), [x => 0], [0.0, 1.0])
 sol = solve(prob, Tsit5())
 
 # Test mtkcompile substitutions & observed values
-eqs = [D(x) ~ 1,
-    w ~ a]
+eqs = [
+    D(x) ~ 1,
+    w ~ a,
+]
 @named sys = System(eqs, t)
 # Now eliminate the constants first
 simp = mtkcompile(sys)
 @test equations(simp) == [D(x) ~ 1.0]
 
 #Constant with units
-@constants β=1 [unit = u"m/s"]
+@constants β = 1 [unit = u"m/s"]
 MT.get_unit(β)
 @test MT.isconstant(β)
 @test !MT.istunable(β)

--- a/lib/ModelingToolkitBase/test/dae_jacobian.jl
+++ b/lib/ModelingToolkitBase/test/dae_jacobian.jl
@@ -7,7 +7,7 @@ using ModelingToolkitBase: t_nounits as t, D_nounits as D
 
 function testjac(res, du, u, p, t) #System of equations
     res[1] = du[1] - 1.5 * u[1] + 1.0 * u[1] * u[2]
-    res[2] = du[2] + 3 * u[2] - u[1] * u[2]
+    return res[2] = du[2] + 3 * u[2] - u[1] * u[2]
 end
 
 function testjac_jac(J, du, u, p, gamma, t) #Explicit Jacobian
@@ -15,17 +15,21 @@ function testjac_jac(J, du, u, p, gamma, t) #Explicit Jacobian
     J[1, 2] = 1.0 * u[1]
     J[2, 1] = -1 * u[2]
     J[2, 2] = gamma + 3 - u[1]
-    nothing
+    return nothing
 end
 
-testjac_f = DAEFunction(testjac, jac = testjac_jac,
-    jac_prototype = sparse([1, 2, 1, 2], [1, 1, 2, 2], zeros(4)))
+testjac_f = DAEFunction(
+    testjac, jac = testjac_jac,
+    jac_prototype = sparse([1, 2, 1, 2], [1, 1, 2, 2], zeros(4))
+)
 
-prob1 = DAEProblem(testjac_f,
+prob1 = DAEProblem(
+    testjac_f,
     [0.5, -2.0],
     ones(2),
     (0.0, 10.0),
-    differential_vars = [true, true])
+    differential_vars = [true, true]
+)
 sol1 = solve(prob1, IDA(linear_solver = :KLU))
 
 # Now MTK style solution with generated Jacobian
@@ -33,22 +37,28 @@ sol1 = solve(prob1, IDA(linear_solver = :KLU))
 @variables u1(t) u2(t)
 @parameters p1 p2
 
-eqs = [D(u1) ~ p1 * u1 - u1 * u2,
-    D(u2) ~ u1 * u2 - p2 * u2]
+eqs = [
+    D(u1) ~ p1 * u1 - u1 * u2,
+    D(u2) ~ u1 * u2 - p2 * u2,
+]
 
 @named sys = System(eqs, t)
 
-u0 = [u1 => 1.0,
-    u2 => 1.0]
+u0 = [
+    u1 => 1.0,
+    u2 => 1.0,
+]
 
 tspan = (0.0, 10.0)
 
 du0 = [D(u1) => 0.5, D(u2) => -2.0]
 
-p = [p1 => 1.5,
-    p2 => 3.0]
+p = [
+    p1 => 1.5,
+    p2 => 3.0,
+]
 
 prob = DAEProblem(complete(sys), [du0; p], tspan, jac = true, sparse = true)
 sol = solve(prob, IDA(linear_solver = :KLU))
 
-@test maximum(sol - sol1) < 2e-12
+@test maximum(sol - sol1) < 2.0e-12

--- a/lib/ModelingToolkitBase/test/dde.jl
+++ b/lib/ModelingToolkitBase/test/dde.jl
@@ -18,8 +18,8 @@ tau = 1;
 function bc_model(du, u, h, p, t)
     du[1] = (v0 / (1 + beta0 * (h(p, t - tau)[3]^2))) * (p0 - q0) * u[1] - d0 * u[1]
     du[2] = (v0 / (1 + beta0 * (h(p, t - tau)[3]^2))) * (1 - p0 + q0) * u[1] +
-            (v1 / (1 + beta1 * (h(p, t - tau)[3]^2))) * (p1 - q1) * u[2] - d1 * u[2]
-    du[3] = (v1 / (1 + beta1 * (h(p, t - tau)[3]^2))) * (1 - p1 + q1) * u[2] - d2 * u[3]
+        (v1 / (1 + beta1 * (h(p, t - tau)[3]^2))) * (p1 - q1) * u[2] - d1 * u[2]
+    return du[3] = (v1 / (1 + beta1 * (h(p, t - tau)[3]^2))) * (1 - p1 + q1) * u[2] - d2 * u[3]
 end
 lags = [tau]
 h(p, t) = ones(3)
@@ -28,32 +28,38 @@ tspan = (0.0, 10.0)
 u0 = [1.0, 1.0, 1.0]
 prob = DDEProblem(bc_model, u0, h, tspan, constant_lags = lags)
 alg = MethodOfSteps(Vern9())
-sol = solve(prob, alg, reltol = 1e-7, abstol = 1e-10)
+sol = solve(prob, alg, reltol = 1.0e-7, abstol = 1.0e-10)
 prob2 = DDEProblem(bc_model, u0, h2, tspan, constant_lags = lags)
-sol2 = solve(prob2, alg, reltol = 1e-7, abstol = 1e-10)
+sol2 = solve(prob2, alg, reltol = 1.0e-7, abstol = 1.0e-10)
 
-@parameters p0=0.2 p1=0.2 q0=0.3 q1=0.3 v0=1 v1=1 d0=5 d1=1 d2=1 beta0=1 beta1=1
+@parameters p0 = 0.2 p1 = 0.2 q0 = 0.3 q1 = 0.3 v0 = 1 v1 = 1 d0 = 5 d1 = 1 d2 = 1 beta0 = 1 beta1 = 1
 @variables x₀(t) x₁(t) x₂(..)
 tau = 1
-eqs = [D(x₀) ~ (v0 / (1 + beta0 * (x₂(t - tau)^2))) * (p0 - q0) * x₀ - d0 * x₀
-       D(x₁) ~
-       (v0 / (1 + beta0 * (x₂(t - tau)^2))) * (1 - p0 + q0) * x₀ +
-       (v1 / (1 + beta1 * (x₂(t - tau)^2))) * (p1 - q1) * x₁ - d1 * x₁
-       D(x₂(t)) ~ (v1 / (1 + beta1 * (x₂(t - tau)^2))) * (1 - p1 + q1) * x₁ - d2 * x₂(t)]
+eqs = [
+    D(x₀) ~ (v0 / (1 + beta0 * (x₂(t - tau)^2))) * (p0 - q0) * x₀ - d0 * x₀
+    D(x₁) ~
+        (v0 / (1 + beta0 * (x₂(t - tau)^2))) * (1 - p0 + q0) * x₀ +
+        (v1 / (1 + beta1 * (x₂(t - tau)^2))) * (p1 - q1) * x₁ - d1 * x₁
+    D(x₂(t)) ~ (v1 / (1 + beta1 * (x₂(t - tau)^2))) * (1 - p1 + q1) * x₁ - d2 * x₂(t)
+]
 @mtkcompile sys = System(eqs, t)
 @test ModelingToolkitBase.is_dde(sys)
 @test !is_markovian(sys)
-prob = DDEProblem(sys,
+prob = DDEProblem(
+    sys,
     [x₀ => 1.0, x₁ => 1.0, x₂(t) => 1.0],
     tspan,
-    constant_lags = [tau])
-sol_mtk = solve(prob, alg, reltol = 1e-7, abstol = 1e-10)
+    constant_lags = [tau]
+)
+sol_mtk = solve(prob, alg, reltol = 1.0e-7, abstol = 1.0e-10)
 @test sol_mtk[[x₀, x₁, x₂(t)]][end] ≈ sol.u[end]
-prob2 = DDEProblem(sys,
+prob2 = DDEProblem(
+    sys,
     [x₀ => 1.0 - t * q1 * 10, x₁ => 1.0 - t * q1 * 10, x₂(t) => 1.0 - t * q1 * 10],
     tspan,
-    constant_lags = [tau])
-sol2_mtk = solve(prob2, alg, reltol = 1e-7, abstol = 1e-10)
+    constant_lags = [tau]
+)
+sol2_mtk = solve(prob2, alg, reltol = 1.0e-7, abstol = 1.0e-10)
 @test sol2_mtk[[x₀, x₁, x₂(t)]][end] ≈ sol2.u[end]
 @test_nowarn sol2_mtk[[x₀, x₁, x₂(t)]]
 @test_nowarn sol2_mtk[[x₀, x₁, x₂(t - 0.1)]]
@@ -61,25 +67,29 @@ sol2_mtk = solve(prob2, alg, reltol = 1e-7, abstol = 1e-10)
 using StochasticDelayDiffEq
 function hayes_modelf(du, u, h, p, t)
     τ, a, b, c, α, β, γ = p
-    du .= a .* u .+ b .* h(p, t - τ) .+ c
+    return du .= a .* u .+ b .* h(p, t - τ) .+ c
 end
 function hayes_modelg(du, u, h, p, t)
     τ, a, b, c, α, β, γ = p
-    du .= α .* u .+ γ
+    return du .= α .* u .+ γ
 end
 h(p, t) = (ones(1) .+ t);
 tspan = (0.0, 10.0)
 
-pmul = [1.0,
+pmul = [
+    1.0,
     -4.0, -2.0, 10.0,
-    -1.3, -1.2, 1.1]
+    -1.3, -1.2, 1.1,
+]
 
-prob = SDDEProblem(hayes_modelf, hayes_modelg, [1.0], h, tspan, pmul;
-    constant_lags = (pmul[1],));
+prob = SDDEProblem(
+    hayes_modelf, hayes_modelg, [1.0], h, tspan, pmul;
+    constant_lags = (pmul[1],)
+);
 sol = solve(prob, RKMil(), seed = 100)
 
 @variables x(..) delx(t)
-@parameters a=-4.0 b=-2.0 c=10.0 α=-1.3 β=-1.2 γ=1.1
+@parameters a = -4.0 b = -2.0 c = 10.0 α = -1.3 β = -1.2 γ = 1.1
 @brownians η
 τ = 1.0
 eqs = [D(x(t)) ~ a * x(t) + b * x(t - τ) + c + (α * x(t) + γ) * η, delx ~ x(t - τ)]
@@ -99,17 +109,20 @@ prob_mtk = SDDEProblem(sys, [x(t) => 1.0 + t], tspan; constant_lags = (τ,));
 @test_nowarn sol_mtk = solve(prob_mtk, RKMil(), seed = 100)
 
 prob_sa = SDDEProblem(
-    sys, [x(t) => 1.0 + t], tspan; constant_lags = (τ,), u0_constructor = SVector{1})
+    sys, [x(t) => 1.0 + t], tspan; constant_lags = (τ,), u0_constructor = SVector{1}
+)
 @test prob_sa.u0 isa SVector{1, Float64}
 
 @parameters x(..) a
 
 function oscillator(; name, k = 1.0, τ = 0.01)
-    @parameters k=k τ=τ
-    @variables x(..)=0.1 y(t)=0.1 jcn(t) delx(t)
-    eqs = [D(x(t)) ~ y,
+    @parameters k = k τ = τ
+    @variables x(..) = 0.1 y(t) = 0.1 jcn(t) delx(t)
+    eqs = [
+        D(x(t)) ~ y,
         D(y) ~ -k * x(t - τ) + jcn,
-        delx ~ x(t - τ)]
+        delx ~ x(t - τ),
+    ]
     return System(eqs, t; name = name)
 end
 
@@ -117,8 +130,10 @@ systems = @named begin
     osc1 = oscillator(k = 1.0, τ = 0.01)
     osc2 = oscillator(k = 2.0, τ = 0.04)
 end
-eqs = [osc1.jcn ~ osc2.delx,
-    osc2.jcn ~ osc1.delx]
+eqs = [
+    osc1.jcn ~ osc2.delx,
+    osc2.jcn ~ osc1.delx,
+]
 @named coupledOsc = System(eqs, t)
 @named coupledOsc = compose(coupledOsc, systems)
 @test ModelingToolkitBase.is_dde(coupledOsc)
@@ -137,14 +152,17 @@ sys = mtkcompile(coupledOsc)
 prob = DDEProblem(sys, [], (0.0, 10.0); constant_lags = [sys.osc1.τ, sys.osc2.τ])
 sol = solve(prob, MethodOfSteps(@isdefined(ModelingToolkit) ? Tsit5() : Rodas5P()))
 obsfn = ModelingToolkitBase.build_explicit_observed_function(
-    sys, [sys.osc1.delx, sys.osc2.delx])
+    sys, [sys.osc1.delx, sys.osc2.delx]
+)
 @test_nowarn sol[[sys.osc1.delx, sys.osc2.delx]]
 mask = sol.t .>= 0.01
-@test sol[sys.osc1.delx][mask] ≈ sol(sol.t[mask] .- 0.01; idxs = sys.osc1.x).u rtol=1e-3
+@test sol[sys.osc1.delx][mask] ≈ sol(sol.t[mask] .- 0.01; idxs = sys.osc1.x).u rtol = 1.0e-3
 
 N = length(unknowns(sys))
-prob_sa = DDEProblem(sys, [], (0.0, 10.0); constant_lags = [sys.osc1.τ, sys.osc2.τ],
-    u0_constructor = x -> SVector{length(x)}(x))
+prob_sa = DDEProblem(
+    sys, [], (0.0, 10.0); constant_lags = [sys.osc1.τ, sys.osc2.τ],
+    u0_constructor = x -> SVector{length(x)}(x)
+)
 @test prob_sa.u0 isa SVector{N, Float64}
 
 if @isdefined(ModelingToolkit)
@@ -161,9 +179,11 @@ if @isdefined(ModelingToolkit)
                 lag_opening(t)
                 snap_opening(t)
             end
-            eqs = [D(opening(t)) ~ Kp * (open - opening(t))
-                   lag_opening ~ opening(t - τ)
-                   snap_opening ~ clamp(Ksnap * lag_opening - 1 / Ksnap, 0, 1)]
+            eqs = [
+                D(opening(t)) ~ Kp * (open - opening(t))
+                lag_opening ~ opening(t - τ)
+                snap_opening ~ clamp(Ksnap * lag_opening - 1 / Ksnap, 0, 1)
+            ]
             return System(eqs, t; name = name)
         end
 
@@ -176,28 +196,31 @@ if @isdefined(ModelingToolkit)
         end
 
         @mtkcompile ssys = System(
-            Equation[], t; systems = [valve(name = :valve), veccy(name = :vvecs)])
+            Equation[], t; systems = [valve(name = :valve), veccy(name = :vvecs)]
+        )
         prob = DDEProblem(ssys, [ssys.valve.opening => 1.0], (0.0, 1.0))
         sol = solve(prob, MethodOfSteps(Tsit5()))
         obsval = @test_nowarn sol[ssys.valve.lag_opening + sum(ssys.vvecs.x)]
         @test obsval ≈
-              sol(sol.t .- prob.ps[ssys.valve.τ]; idxs = ssys.valve.opening).u .+
-              sum.(sol[ssys.vvecs.x])
+            sol(sol.t .- prob.ps[ssys.valve.τ]; idxs = ssys.valve.opening).u .+
+            sum.(sol[ssys.vvecs.x])
     end
 end
 
 @testset "Issue#3165 DDEs with non-tunables" begin
     @variables x(..) = 1.0
-    @parameters w=1.0 [tunable=false] τ=0.5
+    @parameters w = 1.0 [tunable = false] τ = 0.5
     eqs = [D(x(t)) ~ -w * x(t - τ)]
 
     @named sys = System(eqs, t)
     sys = mtkcompile(sys)
 
-    prob = DDEProblem(sys,
+    prob = DDEProblem(
+        sys,
         [],
         (0.0, 10.0),
-        constant_lags = [τ])
+        constant_lags = [τ]
+    )
 
     alg = MethodOfSteps(Vern7())
     @test_nowarn solve(prob, alg)
@@ -206,10 +229,12 @@ end
     eqs = [D(x(t)) ~ -w * x(t - τ) + r]
     @named sys = System(eqs, t)
     sys = mtkcompile(sys)
-    prob = SDDEProblem(sys,
+    prob = SDDEProblem(
+        sys,
         [],
         (0.0, 10.0),
-        constant_lags = [τ])
+        constant_lags = [τ]
+    )
 
     @test_nowarn solve(prob, RKMil())
 end

--- a/lib/ModelingToolkitBase/test/debugging.jl
+++ b/lib/ModelingToolkitBase/test/debugging.jl
@@ -14,7 +14,8 @@ SEED = 42
 
 @testset "assertions are present in generated `f`" begin
     @testset "$(Problem)" for (Problem, sys, alg) in [
-        (ODEProblem, sys_ode, Tsit5()), (SDEProblem, sys_sde, ImplicitEM())]
+            (ODEProblem, sys_ode, Tsit5()), (SDEProblem, sys_sde, ImplicitEM()),
+        ]
         kwargs = Problem == SDEProblem ? (; seed = SEED) : (;)
         @test !is_parameter(sys, ASSERTION_LOG_VARIABLE)
         prob = Problem(sys, [x => 0.1], (0.0, 5.0); kwargs...)
@@ -26,32 +27,34 @@ end
 
 @testset "`debug_system` adds logging" begin
     @testset "$(Problem)" for (Problem, sys, alg) in [
-        (ODEProblem, sys_ode, Tsit5()), (SDEProblem, sys_sde, ImplicitEM())]
+            (ODEProblem, sys_ode, Tsit5()), (SDEProblem, sys_sde, ImplicitEM()),
+        ]
         kwargs = Problem == SDEProblem ? (; seed = SEED) : (;)
         dsys = debug_system(sys; functions = [])
         @test is_parameter(dsys, ASSERTION_LOG_VARIABLE)
         prob = Problem(dsys, [x => 0.1], (0.0, 5.0); kwargs...)
-        sol = @test_logs (:error, r"ohno") match_mode=:any solve(prob, alg)
+        sol = @test_logs (:error, r"ohno") match_mode = :any solve(prob, alg)
         @test !SciMLBase.successful_retcode(sol)
         prob.ps[ASSERTION_LOG_VARIABLE] = false
-        sol = @test_logs min_level=Logging.Error solve(prob, alg)
+        sol = @test_logs min_level = Logging.Error solve(prob, alg)
         @test !SciMLBase.successful_retcode(sol)
     end
 end
 
 @testset "Hierarchical system" begin
     @testset "$(Problem)" for (ctor, Problem, inner, alg) in [
-        (System, ODEProblem, inner_ode, Tsit5()),
-        (System, SDEProblem, inner_sde, ImplicitEM())]
+            (System, ODEProblem, inner_ode, Tsit5()),
+            (System, SDEProblem, inner_sde, ImplicitEM()),
+        ]
         kwargs = Problem == SDEProblem ? (; seed = SEED) : (;)
         @mtkcompile outer = ctor(Equation[], t; systems = [inner])
         dsys = debug_system(outer; functions = [])
         @test is_parameter(dsys, ASSERTION_LOG_VARIABLE)
         prob = Problem(dsys, [inner.x => 0.1], (0.0, 5.0); kwargs...)
-        sol = @test_logs (:error, r"ohno") match_mode=:any solve(prob, alg)
+        sol = @test_logs (:error, r"ohno") match_mode = :any solve(prob, alg)
         @test !SciMLBase.successful_retcode(sol)
         prob.ps[ASSERTION_LOG_VARIABLE] = false
-        sol = @test_logs min_level=Logging.Error solve(prob, alg)
+        sol = @test_logs min_level = Logging.Error solve(prob, alg)
         @test !SciMLBase.successful_retcode(sol)
     end
 end

--- a/lib/ModelingToolkitBase/test/dep_graphs.jl
+++ b/lib/ModelingToolkitBase/test/dep_graphs.jl
@@ -43,7 +43,7 @@ using Symbolics: SymbolicT
         eq_eq_ne = 6,
         # var to vars that depend on them
         var_vardeps = [[1, 2, 3], [1, 2, 3], [3]],
-        var_var_ne = 3
+        var_var_ne = 3,
     )
     # testing when ignoring VariableRateJumps
     test_case_2 = (;
@@ -66,11 +66,12 @@ using Symbolics: SymbolicT
         eq_eq_ne = 5,
         # var to vars that depend on them
         var_vardeps = [[1, 2, 3], [1, 2, 3], [3]],
-        var_var_ne = 3
+        var_var_ne = 3,
     )
 
     @testset "Case $i" for (i, test_case) in enumerate([test_case_1, test_case_2])
-        (;         # filter out vrjs in making graphs
+        (;
+            # filter out vrjs in making graphs
             eqs,         # eq to vars they depend on
             eq_sdeps,
             eq_sidepsf,
@@ -84,7 +85,7 @@ using Symbolics: SymbolicT
             eq_eqdeps,
             eq_eq_ne,         # var to vars that depend on them
             var_vardeps,
-            var_var_ne
+            var_var_ne,
         ) = test_case
         deps = equation_dependencies(js; eqs)
         @test length(deps) == length(eq_sdeps)
@@ -133,9 +134,11 @@ end
 @testset "ODEs, SDEs" begin
     @parameters k1 k2
     @variables S(t) I(t) R(t)
-    eqs = [D(S) ~ k1 - k1 * S - k2 * S * I - k1 * k2 / (1 + t) * S
-           D(I) ~ k2 * S * I
-           D(R) ~ -k2 * S^2 * R / 2 + k1 * I + k1 * k2 * S / (1 + t)]
+    eqs = [
+        D(S) ~ k1 - k1 * S - k2 * S * I - k1 * k2 / (1 + t) * S
+        D(I) ~ k2 * S * I
+        D(R) ~ -k2 * S^2 * R / 2 + k1 * I + k1 * k2 * S / (1 + t)
+    ]
     @named os = System(eqs, t, [S, I, R], [k1, k2])
     deps = equation_dependencies(os)
     S = value(S)
@@ -163,9 +166,11 @@ end
     @variables x y z
     @parameters σ ρ β
 
-    eqs = [0 ~ σ * (y - x),
+    eqs = [
+        0 ~ σ * (y - x),
         0 ~ ρ - y,
-        0 ~ y - β * z]
+        0 ~ y - β * z,
+    ]
     @named ns = System(eqs, [x, y, z], [σ, ρ, β])
     deps = equation_dependencies(ns)
     eq_sdeps = [[x, y], [y], [y, z]]

--- a/lib/ModelingToolkitBase/test/distributed.jl
+++ b/lib/ModelingToolkitBase/test/distributed.jl
@@ -9,9 +9,11 @@ addprocs(2)
 @everywhere @parameters σ ρ β
 @everywhere @variables x(t) y(t) z(t)
 
-@everywhere eqs = [D(x) ~ σ * (y - x),
+@everywhere eqs = [
+    D(x) ~ σ * (y - x),
     D(y) ~ x * (ρ - z) - y,
-    D(z) ~ x * y - β * z]
+    D(z) ~ x * y - β * z,
+]
 
 @everywhere @named de = System(eqs, t)
 @everywhere de = complete(de)

--- a/lib/ModelingToolkitBase/test/dq_units.jl
+++ b/lib/ModelingToolkitBase/test/dq_units.jl
@@ -16,8 +16,10 @@ const unitless = MT.get_unit(0.5)
 @test MT.get_unit(γ) == unitless
 @test MT.get_unit(MT.SciMLBase.NullParameters()) == unitless
 
-eqs = [D(E) ~ P - E / τ
-       0 ~ P]
+eqs = [
+    D(E) ~ P - E / τ
+    0 ~ P
+]
 @test MT.validate(eqs)
 @named sys = System(eqs, t)
 
@@ -27,33 +29,45 @@ eqs = [D(E) ~ P - E / τ
 # Disabling unit validation/checks selectively
 @test_throws MT.ArgumentError System(eqs, t, [E, P, t], [τ], name = :sys)
 System(eqs, t, [E, P, t], [τ], name = :sys, checks = MT.CheckUnits)
-eqs = [D(E) ~ P - E / τ
-       0 ~ P + E * τ]
+eqs = [
+    D(E) ~ P - E / τ
+    0 ~ P + E * τ
+]
 @test_throws MT.ValidationError System(eqs, t, name = :sys, checks = MT.CheckAll)
 @test_throws MT.ValidationError System(eqs, t, name = :sys, checks = true)
 System(eqs, t, name = :sys, checks = MT.CheckNone)
 System(eqs, t, name = :sys, checks = false)
-@test_throws MT.ValidationError System(eqs, t, name = :sys,
-    checks = MT.CheckComponents | MT.CheckUnits)
+@test_throws MT.ValidationError System(
+    eqs, t, name = :sys,
+    checks = MT.CheckComponents | MT.CheckUnits
+)
 @named sys = System(eqs, t, checks = MT.CheckComponents)
-@test_throws MT.ValidationError System(eqs, t, [E, P, t], [τ], name = :sys,
-    checks = MT.CheckUnits)
+@test_throws MT.ValidationError System(
+    eqs, t, [E, P, t], [τ], name = :sys,
+    checks = MT.CheckUnits
+)
 
 # connection validation
 @connector function Pin(; name)
-    sts = @variables(v(t)=1.0, [unit=u"V"],
-        i(t)=1.0, [unit=u"A", connect=Flow])
+    sts = @variables(
+        v(t) = 1.0, [unit = u"V"],
+        i(t) = 1.0, [unit = u"A", connect = Flow]
+    )
     System(Equation[], t, sts, []; name = name)
 end
 @connector function OtherPin(; name)
-    sts = @variables(v(t)=1.0, [unit=u"mV"],
-        i(t)=1.0, [unit=u"mA", connect=Flow])
+    sts = @variables(
+        v(t) = 1.0, [unit = u"mV"],
+        i(t) = 1.0, [unit = u"mA", connect = Flow]
+    )
     System(Equation[], t, sts, []; name = name)
 end
 @connector function LongPin(; name)
-    sts = @variables(v(t)=1.0, [unit=u"V"],
-        i(t)=1.0, [unit=u"A", connect=Flow],
-        x(t)=1.0)
+    sts = @variables(
+        v(t) = 1.0, [unit = u"V"],
+        i(t) = 1.0, [unit = u"A", connect = Flow],
+        x(t) = 1.0
+    )
     System(Equation[], t, sts, []; name = name)
 end
 @named p1 = Pin()
@@ -73,7 +87,7 @@ good_eqs = [connect(op, op2)]
 
 # Array variables
 @variables x(t)[1:3] [unit = u"m"]
-@parameters v[1:3]=[1, 2, 3] [unit = u"m/s"]
+@parameters v[1:3] = [1, 2, 3] [unit = u"m/s"]
 eqs = [D(x) ~ v]
 System(eqs, t, name = :sys)
 
@@ -81,62 +95,80 @@ System(eqs, t, name = :sys)
 @parameters a [unit = u"kg"^-1]
 @variables x [unit = u"kg"]
 eqs = [
-    0 ~ a * x
+    0 ~ a * x,
 ]
 @named nls = System(eqs, [x], [a])
 
 # SDE test w/ noise vector
 @parameters τ [unit = u"s"] Q [unit = u"W"]
 @variables E(t) [unit = u"J"] P(t) [unit = u"W"]
-eqs = [D(E) ~ P - E / τ
-       P ~ Q]
+eqs = [
+    D(E) ~ P - E / τ
+    P ~ Q
+]
 
-noiseeqs = [0.1us"W",
-    0.1us"W"]
+noiseeqs = [
+    0.1us"W",
+    0.1us"W",
+]
 @named sys = SDESystem(eqs, noiseeqs, t, [P, E], [τ, Q])
 
-noiseeqs = [0.1u"W",
-    0.1u"W"]
+noiseeqs = [
+    0.1u"W",
+    0.1u"W",
+]
 @test_throws MT.ValidationError @named sys = SDESystem(eqs, noiseeqs, t, [P, E], [τ, Q])
 
 # With noise matrix
-noiseeqs = [0.1us"W" 0.1us"W"
-            0.1us"W" 0.1us"W"]
+noiseeqs = [
+    0.1us"W" 0.1us"W"
+    0.1us"W" 0.1us"W"
+]
 @named sys = SDESystem(eqs, noiseeqs, t, [P, E], [τ, Q])
 
 # Invalid noise matrix
-noiseeqs = [0.1us"W" 0.1us"W"
-            0.1us"W" 0.1us"s"]
+noiseeqs = [
+    0.1us"W" 0.1us"W"
+    0.1us"W" 0.1us"s"
+]
 @test !MT.validate(eqs, noiseeqs)
 
 # Non-trivial simplifications
 @variables V(t) [unit = u"m"^3] L(t) [unit = u"m"]
 @parameters v [unit = u"m/s"] r [unit = u"m"^3 / u"s"]
-eqs = [D(L) ~ v,
-    V ~ L^3]
+eqs = [
+    D(L) ~ v,
+    V ~ L^3,
+]
 @named sys = System(eqs, t)
 sys_simple = mtkcompile(sys)
 
-eqs = [D(V) ~ r,
-    V ~ L^3]
+eqs = [
+    D(V) ~ r,
+    V ~ L^3,
+]
 @named sys = System(eqs, t)
 sys_simple = mtkcompile(sys)
 
 @variables V [unit = u"m"^3] L [unit = u"m"]
 @parameters v [unit = u"m/s"] r [unit = u"m"^3 / u"s"]
-eqs = [V ~ r * t,
-    V ~ L^3]
+eqs = [
+    V ~ r * t,
+    V ~ L^3,
+]
 @named sys = System(eqs, [V, L], [t, r])
 sys_simple = mtkcompile(sys)
 
-eqs = [L ~ v * t,
-    V ~ L^3]
+eqs = [
+    L ~ v * t,
+    V ~ L^3,
+]
 @named sys = System(eqs, [V, L], [t, r, v])
 sys_simple = mtkcompile(sys)
 
 #Jump System
 @parameters β [unit = u"(mol^2*s)^-1"] γ [unit = u"(mol*s)^-1"] jumpmol [
-    unit = u"mol"
+    unit = u"mol",
 ]
 @variables S(t) [unit = u"mol"] I(t) [unit = u"mol"] R(t) [unit = u"mol"]
 rate₁ = β * S * I
@@ -200,7 +232,8 @@ maj2 = MassActionJump(γ, [S => 1], [S => -1])
     p = [pend.g => 1.0, pend.L => 1.0]
     guess = [pend.λ => 0.0]
     @test prob = ODEProblem(
-        pend, [u0; p], (0.0, 1.0); guesses = guess, check_units = false) isa Any
+        pend, [u0; p], (0.0, 1.0); guesses = guess, check_units = false
+    ) isa Any
 end
 
 @parameters p [unit = u"L/s"] d [unit = u"s^(-1)"]

--- a/lib/ModelingToolkitBase/test/equation_type_accessors.jl
+++ b/lib/ModelingToolkitBase/test/equation_type_accessors.jl
@@ -36,20 +36,26 @@ eq8 = -0.1 ~ D(Z) + X
 @test is_diff_equation(eq8)
 
 # Creates systems.
-eqs1 = [X * Y + a ~ Z^3 - X * log(b + Y)
-        X ~ Z * Y * X + a + b
-        c * sin(X) + sin(Y) ~ d * (a + X * (b + Y * (c + Z)))]
-eqs2 = [X + Y + c ~ b * X^(X + Z + a)
-        D(X) ~ a * Y + b * X + c * Z
-        D(Z) + Z * Y ~ X - log(Z)]
-eqs3 = [D(X) ~ sqrt(X + b) + sqrt(Z + c)
-        2Z * (Z + Y) ~ D(Y) * log(a)
-        D(Z) + c * X ~ b / (X + Y^d) + D(Z)]
+eqs1 = [
+    X * Y + a ~ Z^3 - X * log(b + Y)
+    X ~ Z * Y * X + a + b
+    c * sin(X) + sin(Y) ~ d * (a + X * (b + Y * (c + Z)))
+]
+eqs2 = [
+    X + Y + c ~ b * X^(X + Z + a)
+    D(X) ~ a * Y + b * X + c * Z
+    D(Z) + Z * Y ~ X - log(Z)
+]
+eqs3 = [
+    D(X) ~ sqrt(X + b) + sqrt(Z + c)
+    2Z * (Z + Y) ~ D(Y) * log(a)
+    D(Z) + c * X ~ b / (X + Y^d) + D(Z)
+]
 @named osys1 = System(eqs1, t)
 @named osys2 = System(eqs2, t)
 @named osys3 = System(eqs3, t)
 
-# Test `has...` for non-composed systems. 
+# Test `has...` for non-composed systems.
 @test has_alg_equations(osys1)
 @test has_alg_equations(osys2)
 @test !has_alg_equations(osys3)

--- a/lib/ModelingToolkitBase/test/error_handling.jl
+++ b/lib/ModelingToolkitBase/test/error_handling.jl
@@ -11,10 +11,10 @@ function UnderdefinedConstantVoltage(; name, V = 1.0)
     @named n = Pin()
     @parameters V
     eqs = [
-        V ~ p.v - n.v        # Remove equation
-    # 0 ~ p.i + n.i
+        V ~ p.v - n.v,        # Remove equation
+        # 0 ~ p.i + n.i
     ]
-    System(eqs, t, [], [V], systems = [p, n], initial_conditions = Dict(V => val), name = name)
+    return System(eqs, t, [], [V], systems = [p, n], initial_conditions = Dict(V => val), name = name)
 end
 
 function OverdefinedConstantVoltage(; name, V = 1.0, I = 1.0)
@@ -23,12 +23,16 @@ function OverdefinedConstantVoltage(; name, V = 1.0, I = 1.0)
     @named p = Pin()
     @named n = Pin()
     @parameters V I
-    eqs = [V ~ p.v - n.v
-           # Overdefine p.i and n.i
-           n.i ~ I
-           p.i ~ I]
-    System(eqs, t, [], [V, I], systems = [p, n], initial_conditions = Dict(V => val, I => val2),
-        name = name)
+    eqs = [
+        V ~ p.v - n.v
+        # Overdefine p.i and n.i
+        n.i ~ I
+        p.i ~ I
+    ]
+    return System(
+        eqs, t, [], [V, I], systems = [p, n], initial_conditions = Dict(V => val, I => val2),
+        name = name
+    )
 end
 
 R = 1.0
@@ -38,17 +42,21 @@ V = 1.0
 @named capacitor = Capacitor(C = C)
 @named source = UnderdefinedConstantVoltage(V = V)
 
-rc_eqs = [connect(source.p, resistor.p)
-          connect(resistor.n, capacitor.p)
-          connect(capacitor.n, source.n)]
+rc_eqs = [
+    connect(source.p, resistor.p)
+    connect(resistor.n, capacitor.p)
+    connect(capacitor.n, source.n)
+]
 
 @named rc_model = System(rc_eqs, t, systems = [resistor, capacitor, source])
 @test_throws ModelingToolkitBase.ExtraVariablesSystemException mtkcompile(rc_model)
 
 @named source2 = OverdefinedConstantVoltage(V = V, I = V / R)
-rc_eqs2 = [connect(source2.p, resistor.p)
-           connect(resistor.n, capacitor.p)
-           connect(capacitor.n, source2.n)]
+rc_eqs2 = [
+    connect(source2.p, resistor.p)
+    connect(resistor.n, capacitor.p)
+    connect(capacitor.n, source2.n)
+]
 
 @named rc_model2 = System(rc_eqs2, t, systems = [resistor, capacitor, source2])
 @test_throws ModelingToolkitBase.ExtraEquationsSystemException mtkcompile(rc_model2)

--- a/lib/ModelingToolkitBase/test/extensions/ad.jl
+++ b/lib/ModelingToolkitBase/test/extensions/ad.jl
@@ -15,12 +15,18 @@ using ChainRulesTestUtils: test_rrule, rand_tangent
 
 @variables x(t)[1:3] y(t)
 @parameters p[1:3, 1:3] q
-eqs = [D(x) ~ p * x
-       D(y) ~ sum(p) + q * y]
-u0 = [x => zeros(3),
-    y => 1.0]
-ps = [p => zeros(3, 3),
-    q => 1.0]
+eqs = [
+    D(x) ~ p * x
+    D(y) ~ sum(p) + q * y
+]
+u0 = [
+    x => zeros(3),
+    y => 1.0,
+]
+ps = [
+    p => zeros(3, 3),
+    q => 1.0,
+]
 tspan = (0.0, 10.0)
 @mtkcompile sys = System(eqs, t)
 prob = ODEProblem(sys, [u0; ps], tspan)
@@ -38,7 +44,8 @@ end
 @testset "Issue#2997" begin
     pars = @parameters y0 mh Tγ0 Th0 h ργ0
     vars = @variables x(t)
-    @named sys = System([D(x) ~ y0],
+    @named sys = System(
+        [D(x) ~ y0],
         t,
         vars,
         pars;
@@ -46,8 +53,9 @@ end
             y0 => mh * 3.1 / (2.3 * Th0),
             mh => 123.4,
             Th0 => (4 / 11)^(1 / 3) * Tγ0,
-            Tγ0 => (15 / π^2 * ργ0 * (2 * h)^2 / 7)^(1 / 4) / 5
-        ])
+            Tγ0 => (15 / π^2 * ργ0 * (2 * h)^2 / 7)^(1 / 4) / 5,
+        ]
+    )
     sys = mtkcompile(sys)
 
     function x_at_0(θ)
@@ -61,29 +69,37 @@ end
 @parameters a b[1:3] c(t) d::Integer e[1:3] f[1:3, 1:3]::Int g::Vector{AbstractFloat} h::String
 @named sys = System(
     Equation[], t, [], [a, b, c, d, e, f, g, h],
-    continuous_events = [ModelingToolkitBase.SymbolicContinuousCallback(
-        [a ~ 0] => [c ~ 0], discrete_parameters = c, iv = t)])
+    continuous_events = [
+        ModelingToolkitBase.SymbolicContinuousCallback(
+            [a ~ 0] => [c ~ 0], discrete_parameters = c, iv = t
+        ),
+    ]
+)
 sys = complete(sys)
 
-ivs = Dict(c => 3a, b => ones(3), a => 1.0, d => 4, e => [5.0, 6.0, 7.0],
-    f => ones(Int, 3, 3), g => [0.1, 0.2, 0.3], h => "foo")
+ivs = Dict(
+    c => 3a, b => ones(3), a => 1.0, d => 4, e => [5.0, 6.0, 7.0],
+    f => ones(Int, 3, 3), g => [0.1, 0.2, 0.3], h => "foo"
+)
 
 ps = MTKParameters(sys, ivs)
 
-varmap = Dict(a => 1.0f0, b => 3ones(Float32, 3), c => 2.0,
-    e => Float32[0.4, 0.5, 0.6], g => ones(Float32, 4))
+varmap = Dict(
+    a => 1.0f0, b => 3ones(Float32, 3), c => 2.0,
+    e => Float32[0.4, 0.5, 0.6], g => ones(Float32, 4)
+)
 get_values = getp(sys, [a, b..., c, e...])
 get_g = getp(sys, g)
 for (_idxs, vals) in [
-    # all portions
-    (collect(keys(varmap)), collect(values(varmap))),
-    # non-arrays
-    (keys(varmap), values(varmap)),
-    # tunable only
-    ([a], [varmap[a]]),
-    ([a, b], (varmap[a], varmap[b])),
-    ([a, b[2]], (varmap[a], varmap[b][2]))
-]
+        # all portions
+        (collect(keys(varmap)), collect(values(varmap))),
+        # non-arrays
+        (keys(varmap), values(varmap)),
+        # tunable only
+        ([a], [varmap[a]]),
+        ([a, b], (varmap[a], varmap[b])),
+        ([a, b[2]], (varmap[a], varmap[b][2])),
+    ]
     for idxs in [_idxs, map(i -> parameter_index(sys, i), collect(_idxs))]
         loss = function (p)
             newps = remake_buffer(sys, ps, idxs, p)
@@ -152,7 +168,7 @@ end
         end
 
         equations = Equation[
-            D(x) ~ -α * x
+            D(x) ~ -α * x,
         ]
 
         return System(equations, t, vars, pars; name, systems)
@@ -165,7 +181,7 @@ end
     data = (;
         t = solution.t,
         # [[y, x], :]
-        measurements = Array(solution)
+        measurements = Array(solution),
     )
     data.measurements .+= 0.05 * randn(rng, size(data.measurements))
 
@@ -179,11 +195,11 @@ end
         end
     end
 
-    # Check 0.0031677344878386607 
+    # Check 0.0031677344878386607
     @test_nowarn objective(p0, data)
 
     fd = ForwardDiff.gradient(Base.Fix2(objective, data), p0)
     zg = Zygote.gradient(Base.Fix2(objective, data), p0)
 
-    @test fd≈zg[1] atol=1e-6
+    @test fd ≈ zg[1] atol = 1.0e-6
 end

--- a/lib/ModelingToolkitBase/test/extensions/bifurcationkit.jl
+++ b/lib/ModelingToolkitBase/test/extensions/bifurcationkit.jl
@@ -6,21 +6,25 @@ if @isdefined(ModelingToolkit)
     # Creates model.
     @variables x(t) y(t)
     @parameters μ α
-    eqs = [0 ~ μ * x - x^3 + α * y,
-        0 ~ -y]
+    eqs = [
+        0 ~ μ * x - x^3 + α * y,
+        0 ~ -y,
+    ]
     @named nsys = System(eqs, [x, y], [μ, α])
     nsys = complete(nsys)
-    # Creates BifurcationProblem 
+    # Creates BifurcationProblem
     bif_par = μ
     p_start = [μ => -1.0, α => 1.0]
     u0_guess = [x => 1.0, y => 1.0]
     plot_var = x
-    bprob = BifurcationProblem(nsys,
+    bprob = BifurcationProblem(
+        nsys,
         u0_guess,
         p_start,
         bif_par;
         plot_var = plot_var,
-        jac = false)
+        jac = false
+    )
 
     # Conputes bifurcation diagram.
     p_span = (-4.0, 6.0)
@@ -33,16 +37,20 @@ if @isdefined(ModelingToolkit)
         μ, α = p
         return [μ * x - x^3 + α * y, -y]
     end
-    bprob_BK = BifurcationProblem(f_BK,
+    bprob_BK = BifurcationProblem(
+        f_BK,
         [1.0, 1.0],
         [-1.0, 1.0],
         (BifurcationKit.@optic _[1]);
-        record_from_solution = (x, p; k...) -> x[1])
-    bif_dia_BK = bifurcationdiagram(bprob_BK,
+        record_from_solution = (x, p; k...) -> x[1]
+    )
+    bif_dia_BK = bifurcationdiagram(
+        bprob_BK,
         PALC(),
         2,
         (args...) -> opts_br;
-        bothside = true)
+        bothside = true
+    )
 
     # Compares results.
     @test getfield.(bif_dia.γ.branch, :x) ≈ getfield.(bif_dia_BK.γ.branch, :x)
@@ -58,26 +66,32 @@ let
     # Creates a Lotka–Volterra model.
     @parameters α a b
     @variables x(t) y(t) z(t)
-    eqs = [D(x) ~ -x + a * y + x^2 * y,
-        D(y) ~ b - a * y - x^2 * y]
+    eqs = [
+        D(x) ~ -x + a * y + x^2 * y,
+        D(y) ~ b - a * y - x^2 * y,
+    ]
     @named sys = System(eqs, t)
     sys = complete(sys)
     # Creates BifurcationProblem
-    bprob = BifurcationProblem(sys,
+    bprob = BifurcationProblem(
+        sys,
         [x => 1.5, y => 1.0],
         [a => 0.1, b => 0.5],
         b;
-        plot_var = x)
+        plot_var = x
+    )
 
     # Computes bifurcation diagram.
     p_span = (0.0, 2.0)
-    opt_newton = NewtonPar(tol = 1e-9, max_iterations = 2000)
-    opts_br = ContinuationPar(dsmax = 0.05,
+    opt_newton = NewtonPar(tol = 1.0e-9, max_iterations = 2000)
+    opts_br = ContinuationPar(
+        dsmax = 0.05,
         max_steps = 500,
         newton_options = opt_newton,
         p_min = p_span[1],
         p_max = p_span[2],
-        n_inversion = 4)
+        n_inversion = 4
+    )
     bif_dia = bifurcationdiagram(bprob, PALC(), 2, (args...) -> opts_br; bothside = true)
 
     # Tests that the diagram has the correct values (x = b)
@@ -85,9 +99,12 @@ let
 
     # Tests that we get two Hopf bifurcations at the correct positions.
     hopf_points = sort(
-        getfield.(filter(sp -> sp.type == :hopf, bif_dia.γ.specialpoint),
-            :x);
-        by = x -> x[1])
+        getfield.(
+            filter(sp -> sp.type == :hopf, bif_dia.γ.specialpoint),
+            :x
+        );
+        by = x -> x[1]
+    )
     @test length(hopf_points) == 2
     @test hopf_points[1] ≈ [0.41998733080424205, 1.5195495712453098]
     @test hopf_points[2] ≈ [0.7899715592573977, 1.0910379583813192]
@@ -98,11 +115,13 @@ end
 # Checks that observables (that depend on other observables, as in this case) are accounted for.
 if @isdefined(ModelingToolkit)
     # Creates model, and uses `mtkcompile` to generate observables.
-    @parameters μ p=2
+    @parameters μ p = 2
     @variables x(t) y(t) z(t)
-    eqs = [0 ~ μ - x^3 + 2x^2,
+    eqs = [
+        0 ~ μ - x^3 + 2x^2,
         0 ~ p * μ - y,
-        0 ~ y - z]
+        0 ~ y - z,
+    ]
     @named nsys = System(eqs, [x, y, z], [μ, p])
     nsys = mtkcompile(nsys)
 
@@ -115,21 +134,27 @@ if @isdefined(ModelingToolkit)
 
     # Computes bifurcation diagram.
     p_span = (-4.3, 12.0)
-    opt_newton = NewtonPar(tol = 1e-9, max_iterations = 20)
-    opts_br = ContinuationPar(dsmax = 0.05,
+    opt_newton = NewtonPar(tol = 1.0e-9, max_iterations = 20)
+    opts_br = ContinuationPar(
+        dsmax = 0.05,
         max_steps = 500,
         newton_options = opt_newton,
         p_min = p_span[1],
         p_max = p_span[2],
-        n_inversion = 4)
+        n_inversion = 4
+    )
     bif_dia = bifurcationdiagram(bprob, PALC(), 2, (args...) -> opts_br; bothside = true)
 
     # Tests that the diagram has the correct values (x = b)
     all([b.x ≈ 2 * b.param for b in bif_dia.γ.branch])
 
     # Tests that we get two fold bifurcations at the correct positions.
-    fold_points = sort(getfield.(filter(sp -> sp.type == :bp, bif_dia.γ.specialpoint),
-        :param))
+    fold_points = sort(
+        getfield.(
+            filter(sp -> sp.type == :bp, bif_dia.γ.specialpoint),
+            :param
+        )
+    )
     @test length(fold_points) == 2
     @test fold_points ≈ [-1.1851851706940317, -5.6734983580551894e-6] # test that they occur at the correct parameter values).
 end
@@ -164,17 +189,21 @@ if @isdefined(ModelingToolkit)
 
     bif_par = fol.τ
     bp = BifurcationProblem(fol, u0, par, bif_par)
-    opts_br = ContinuationPar(p_min = -1.0,
-        p_max = 1.0)
+    opts_br = ContinuationPar(
+        p_min = -1.0,
+        p_max = 1.0
+    )
     bf = bifurcationdiagram(bp, PALC(), 2, opts_br)
 
-    @test bf.γ.specialpoint[1].param≈0.1 atol=1e-4 rtol=1e-4
+    @test bf.γ.specialpoint[1].param ≈ 0.1 atol = 1.0e-4 rtol = 1.0e-4
 
     # Test with plot variable as observable
     pvar = ModelingToolkitBase.get_var_to_name(fol)[:RHS]
     bp = BifurcationProblem(fol, u0, par, bif_par; plot_var = pvar)
-    opts_br = ContinuationPar(p_min = -1.0,
-        p_max = 1.0)
+    opts_br = ContinuationPar(
+        p_min = -1.0,
+        p_max = 1.0
+    )
     bf = bifurcationdiagram(bp, PALC(), 2, opts_br)
-    @test bf.γ.specialpoint[1].param≈0.1 atol=1e-4 rtol=1e-4
+    @test bf.γ.specialpoint[1].param ≈ 0.1 atol = 1.0e-4 rtol = 1.0e-4
 end

--- a/lib/ModelingToolkitBase/test/extensions/dynamic_optimization.jl
+++ b/lib/ModelingToolkitBase/test/extensions/dynamic_optimization.jl
@@ -17,11 +17,13 @@ const ENABLE_CASADI = VERSION >= v"1.11"
 
 @testset "ODE Solution, no cost" begin
     # Test solving without anything attached.
-    @parameters α=1.5 β=1.0 γ=3.0 δ=1.0
+    @parameters α = 1.5 β = 1.0 γ = 3.0 δ = 1.0
     @variables x(..) y(..)
 
-    eqs = [D(x(t)) ~ α * x(t) - β * x(t) * y(t),
-        D(y(t)) ~ -γ * y(t) + δ * x(t) * y(t)]
+    eqs = [
+        D(x(t)) ~ α * x(t) - β * x(t) * y(t),
+        D(y(t)) ~ -γ * y(t) + δ * x(t) * y(t),
+    ]
 
     @mtkcompile sys = System(eqs, t)
     tspan = (0.0, 1.0)
@@ -55,7 +57,7 @@ const ENABLE_CASADI = VERSION >= v"1.11"
     if @isdefined(Pyomo)
         pprob = PyomoDynamicOptProblem(sys, [u0map; parammap], tspan, dt = 0.01)
         psol = solve(pprob, PyomoCollocation("ipopt", BackwardEuler()))
-        @test all([≈(psol.sol(t), osol2(t), rtol = 1e-2) for t in 0.0:0.01:1.0])
+        @test all([≈(psol.sol(t), osol2(t), rtol = 1.0e-2) for t in 0.0:0.01:1.0])
     end
 
     # With a constraint
@@ -65,14 +67,16 @@ const ENABLE_CASADI = VERSION >= v"1.11"
     @mtkcompile lksys = System(eqs, t; constraints = constr)
 
     jprob = JuMPDynamicOptProblem(
-        lksys, [u0map; parammap], tspan; guesses = guess, dt = 0.01)
+        lksys, [u0map; parammap], tspan; guesses = guess, dt = 0.01
+    )
     jsol = solve(jprob, JuMPCollocation(Ipopt.Optimizer, constructTsitouras5()))
     @test jsol.sol(0.6; idxs = x(t)) ≈ 3.5
     @test jsol.sol(0.3; idxs = x(t)) ≈ 7.0
 
     if ENABLE_CASADI
         cprob = CasADiDynamicOptProblem(
-            lksys, [u0map; parammap], tspan; guesses = guess, dt = 0.01)
+            lksys, [u0map; parammap], tspan; guesses = guess, dt = 0.01
+        )
         csol = solve(cprob, CasADiCollocation("ipopt", constructTsitouras5()))
         @test csol.sol(0.6; idxs = x(t)) ≈ 3.5
         @test csol.sol(0.3; idxs = x(t)) ≈ 7.0
@@ -80,16 +84,20 @@ const ENABLE_CASADI = VERSION >= v"1.11"
 
     if @isdefined(Pyomo)
         pprob = PyomoDynamicOptProblem(
-            lksys, [u0map; parammap], tspan; guesses = guess, dt = 0.01)
+            lksys, [u0map; parammap], tspan; guesses = guess, dt = 0.01
+        )
         psol = solve(pprob, PyomoCollocation("ipopt", LagrangeLegendre(3)))
         @test psol.sol(0.6; idxs = x(t)) ≈ 3.5
         @test psol.sol(0.3; idxs = x(t)) ≈ 7.0
     end
 
     iprob = InfiniteOptDynamicOptProblem(
-        lksys, [u0map; parammap], tspan; guesses = guess, dt = 0.01)
-    isol = solve(iprob,
-        InfiniteOptCollocation(Ipopt.Optimizer, InfiniteOpt.OrthogonalCollocation(3))) # 48.564 ms, 9.58 MiB
+        lksys, [u0map; parammap], tspan; guesses = guess, dt = 0.01
+    )
+    isol = solve(
+        iprob,
+        InfiniteOptCollocation(Ipopt.Optimizer, InfiniteOpt.OrthogonalCollocation(3))
+    ) # 48.564 ms, 9.58 MiB
     sol = isol.sol
     @test sol(0.6; idxs = x(t)) ≈ 3.5
     @test sol(0.3; idxs = x(t)) ≈ 7.0
@@ -98,43 +106,49 @@ const ENABLE_CASADI = VERSION >= v"1.11"
     constr = [x(t) ≳ 1, y(t) ≳ 1]
     @mtkcompile lksys = System(eqs, t; constraints = constr)
     iprob = InfiniteOptDynamicOptProblem(
-        lksys, [u0map; parammap], tspan; guesses = guess, dt = 0.01)
-    isol = solve(iprob,
-        InfiniteOptCollocation(Ipopt.Optimizer, InfiniteOpt.OrthogonalCollocation(3)))
+        lksys, [u0map; parammap], tspan; guesses = guess, dt = 0.01
+    )
+    isol = solve(
+        iprob,
+        InfiniteOptCollocation(Ipopt.Optimizer, InfiniteOpt.OrthogonalCollocation(3))
+    )
     @test all(u -> u > [1, 1], isol.sol.u)
 
     jprob = JuMPDynamicOptProblem(
-        lksys, [u0map; parammap], tspan; guesses = guess, dt = 0.01)
+        lksys, [u0map; parammap], tspan; guesses = guess, dt = 0.01
+    )
     jsol = solve(jprob, JuMPCollocation(Ipopt.Optimizer, constructRadauIA3()))
     @test all(u -> u > [1, 1], jsol.sol.u)
 
     if @isdefined(Pyomo)
         pprob = PyomoDynamicOptProblem(
-            lksys, [u0map; parammap], tspan; guesses = guess, dt = 0.01)
+            lksys, [u0map; parammap], tspan; guesses = guess, dt = 0.01
+        )
         psol = solve(pprob, PyomoCollocation("ipopt", MidpointEuler()))
         @test all(u -> u > [1, 1], psol.sol.u)
     end
 
     if ENABLE_CASADI
         cprob = CasADiDynamicOptProblem(
-            lksys, [u0map; parammap], tspan; guesses = guess, dt = 0.01)
+            lksys, [u0map; parammap], tspan; guesses = guess, dt = 0.01
+        )
         csol = solve(cprob, CasADiCollocation("ipopt", constructRadauIA3()))
         @test all(u -> u > [1, 1], csol.sol.u)
     end
 end
 
-function is_bangbang(input_sol, lbounds, ubounds, rtol = 1e-4)
+function is_bangbang(input_sol, lbounds, ubounds, rtol = 1.0e-4)
     for v in 1:(length(input_sol.u[1]) - 1)
         all(i -> ≈(i[v], bounds[v]; rtol) || ≈(i[v], bounds[u]; rtol), input_sol.u) ||
             return false
     end
-    true
+    return true
 end
 
 function ctrl_to_spline(inputsol, splineType)
     us = reduce(vcat, inputsol.u)
     ts = reduce(vcat, inputsol.t)
-    splineType(us, ts)
+    return splineType(us, ts)
 end
 
 @testset "Linear systems" begin
@@ -144,7 +158,8 @@ end
     constr = [v(1.0) ~ 0.0]
     cost = [-x(1.0)] # Maximize the final distance.
     @named block = System(
-        [D(x(t)) ~ v(t), D(v(t)) ~ u(t)], t; costs = cost, constraints = constr)
+        [D(x(t)) ~ v(t), D(v(t)) ~ u(t)], t; costs = cost, constraints = constr
+    )
     block = mtkcompile(block; inputs = [u(t)])
 
     u0map = [x(t) => 0.0, v(t) => 0.0]
@@ -152,18 +167,19 @@ end
     parammap = [u(t) => 0.0]
     jprob = JuMPDynamicOptProblem(block, [u0map; parammap], tspan; dt = 0.01)
     jsol = solve(
-        jprob, JuMPCollocation(Ipopt.Optimizer, constructVerner8()), verbose = true)
+        jprob, JuMPCollocation(Ipopt.Optimizer, constructVerner8()), verbose = true
+    )
     # Linear systems have bang-bang controls
     @test is_bangbang(jsol.input_sol, [-1.0], [1.0])
     # Test reached final position.
-    @test ≈(jsol.sol[x(t)][end], 0.25, rtol = 1e-5)
+    @test ≈(jsol.sol[x(t)][end], 0.25, rtol = 1.0e-5)
 
     if ENABLE_CASADI
         cprob = CasADiDynamicOptProblem(block, [u0map; parammap], tspan; dt = 0.01)
         csol = solve(cprob, CasADiCollocation("ipopt", constructVerner8()))
         @test is_bangbang(csol.input_sol, [-1.0], [1.0])
         # Test reached final position.
-        @test ≈(csol.sol[x(t)][end], 0.25, rtol = 1e-5)
+        @test ≈(csol.sol[x(t)][end], 0.25, rtol = 1.0e-5)
     end
 
     # Test dynamics
@@ -180,13 +196,13 @@ end
     iprob = InfiniteOptDynamicOptProblem(block, [u0map; parammap], tspan; dt = 0.01)
     isol = solve(iprob, InfiniteOptCollocation(Ipopt.Optimizer))
     @test is_bangbang(isol.input_sol, [-1.0], [1.0])
-    @test ≈(isol.sol[x(t)][end], 0.25, rtol = 1e-5)
+    @test ≈(isol.sol[x(t)][end], 0.25, rtol = 1.0e-5)
 
     if @isdefined(Pyomo)
         pprob = PyomoDynamicOptProblem(block, [u0map; parammap], tspan; dt = 0.01)
         psol = solve(pprob, PyomoCollocation("ipopt", BackwardEuler()))
         @test is_bangbang(psol.input_sol, [-1.0], [1.0])
-        @test ≈(psol.sol[x(t)][end], 0.25, rtol = 1e-3)
+        @test ≈(psol.sol[x(t)][end], 0.25, rtol = 1.0e-3)
         @test all([≈(psol.sol(t), osol(t), rtol = 0.05) for t in 0.0:0.01:1.0])
     end
 
@@ -202,8 +218,10 @@ end
     @parameters b c μ s ν
 
     tspan = (0, 4)
-    eqs = [D(w(t)) ~ -μ * w(t) + b * s * α * w(t),
-        D(q(t)) ~ -ν * q(t) + c * (1 - α) * s * w(t)]
+    eqs = [
+        D(w(t)) ~ -μ * w(t) + b * s * α * w(t),
+        D(q(t)) ~ -ν * q(t) + c * (1 - α) * s * w(t),
+    ]
     costs = [-q(tspan[2])]
 
     @named beesys = System(eqs, t; costs)
@@ -229,15 +247,21 @@ end
     end
 
     @parameters (α_interp::LinearInterpolation)(..)
-    eqs = [D(w(t)) ~ -μ * w(t) + b * s * α_interp(t) * w(t),
-        D(q(t)) ~ -ν * q(t) + c * (1 - α_interp(t)) * s * w(t)]
+    eqs = [
+        D(w(t)) ~ -μ * w(t) + b * s * α_interp(t) * w(t),
+        D(q(t)) ~ -ν * q(t) + c * (1 - α_interp(t)) * s * w(t),
+    ]
     @mtkcompile beesys_ode = System(eqs, t)
     u0map = [w(t) => 40, q(t) => 2]
     pmap = [b => 1, c => 1, μ => 1, s => 1, ν => 1]
-    oprob = ODEProblem(beesys_ode,
-        merge(Dict(u0map), Dict(pmap),
-            Dict(α_interp => ctrl_to_spline(jsol.input_sol, LinearInterpolation))),
-        tspan)
+    oprob = ODEProblem(
+        beesys_ode,
+        merge(
+            Dict(u0map), Dict(pmap),
+            Dict(α_interp => ctrl_to_spline(jsol.input_sol, LinearInterpolation))
+        ),
+        tspan
+    )
     osol = solve(oprob, Tsit5(); dt = 0.01, adaptive = false)
     @test ≈(osol.u, jsol.sol.u, rtol = 0.01)
     if ENABLE_CASADI
@@ -258,9 +282,11 @@ end
     drag(h, v) = D_c * v^2 * exp(-h_c * (h - h₀) / h₀)
     gravity(h) = g₀ * (h₀ / h)
 
-    eqs = [D(h) ~ v,
+    eqs = [
+        D(h) ~ v,
         D(v) ~ (T - drag(h, v)) / m - gravity(h),
-        D(m) ~ -T / c]
+        D(m) ~ -T / c,
+    ]
 
     (ts, te) = (0.0, 0.2)
     costs = [-EvalAt(te)(h)]
@@ -271,14 +297,16 @@ end
     u0map = [h => h₀, v => 0]
     pmap = [
         g₀ => 1, m₀ => 1.0, h_c => 500, c => 0.5 * √(g₀ * h₀), D_c => 0.5 * 620 * m₀ / g₀,
-        Tₘ => 3.5 * g₀ * m₀, T => 0.0, h₀ => 1, m_c => 0.6]
+        Tₘ => 3.5 * g₀ * m₀, T => 0.0, h₀ => 1, m_c => 0.6,
+    ]
     jprob = JuMPDynamicOptProblem(rocket, [u0map; pmap], (ts, te); dt = 0.001, cse = false)
     jsol = solve(jprob, JuMPCollocation(Ipopt.Optimizer, constructRadauIIA5()))
     @test jsol.sol[h][end] > 1.012
 
     if ENABLE_CASADI
         cprob = CasADiDynamicOptProblem(
-            rocket, [u0map; pmap], (ts, te); dt = 0.001, cse = false)
+            rocket, [u0map; pmap], (ts, te); dt = 0.001, cse = false
+        )
         csol = solve(cprob, CasADiCollocation("ipopt"))
         @test csol.sol[h][end] > 1.012
     end
@@ -295,15 +323,18 @@ end
 
     # Test solution
     @parameters (T_interp::CubicSpline)(..)
-    eqs = [D(h) ~ v,
+    eqs = [
+        D(h) ~ v,
         D(v) ~ (T_interp(t) - drag(h, v)) / m - gravity(h),
-        D(m) ~ -T_interp(t) / c]
+        D(m) ~ -T_interp(t) / c,
+    ]
     @mtkcompile rocket_ode = System(eqs, t)
     interpmap = Dict(T_interp => ctrl_to_spline(jsol.input_sol, CubicSpline))
     u0map = [h => h₀, v => 0]
     pmap = [
         g₀ => 1, m₀ => 1.0, h_c => 500, c => 0.5 * √(g₀ * h₀), D_c => 0.5 * 620 * m₀ / g₀,
-        h₀ => 1]
+        h₀ => 1,
+    ]
     oprob = ODEProblem(rocket_ode, merge(Dict(u0map), Dict(pmap), interpmap), (ts, te))
     osol = solve(oprob, RadauIIA5(); adaptive = false, dt = 0.001)
     @test ≈(jsol.sol.u, osol.u, rtol = 0.02)
@@ -339,25 +370,25 @@ end
     pmap = [u(t) => 0.0, tf => 8]
     jprob = JuMPDynamicOptProblem(rocket, [u0map; pmap], (0, tf); steps = 201)
     jsol = solve(jprob, JuMPCollocation(Ipopt.Optimizer, constructTsitouras5()))
-    @test isapprox(jsol.sol.t[end], 10.0, rtol = 1e-3)
+    @test isapprox(jsol.sol.t[end], 10.0, rtol = 1.0e-3)
     @test ≈(M.objective_value(jsol), -92.75, atol = 0.25)
 
     if ENABLE_CASADI
         cprob = CasADiDynamicOptProblem(rocket, [u0map; pmap], (0, tf); steps = 201)
         csol = solve(cprob, CasADiCollocation("ipopt", constructTsitouras5()))
-        @test isapprox(csol.sol.t[end], 10.0, rtol = 1e-3)
+        @test isapprox(csol.sol.t[end], 10.0, rtol = 1.0e-3)
         @test ≈(M.objective_value(csol), -92.75, atol = 0.25)
     end
 
     iprob = InfiniteOptDynamicOptProblem(rocket, [u0map; pmap], (0, tf); steps = 200)
     isol = solve(iprob, InfiniteOptCollocation(Ipopt.Optimizer))
-    @test isapprox(isol.sol.t[end], 10.0, rtol = 1e-3)
+    @test isapprox(isol.sol.t[end], 10.0, rtol = 1.0e-3)
     @test ≈(M.objective_value(isol), -92.75, atol = 0.25)
 
     if @isdefined(Pyomo)
         pprob = PyomoDynamicOptProblem(rocket, [u0map; pmap], (0, tf); steps = 201)
         psol = solve(pprob, PyomoCollocation("ipopt", BackwardEuler()))
-        @test isapprox(psol.sol.t[end], 10.0, rtol = 1e-3)
+        @test isapprox(psol.sol.t[end], 10.0, rtol = 1.0e-3)
         @test ≈(M.objective_value(psol), -92.75, atol = 0.1)
     end
 
@@ -368,7 +399,8 @@ end
     cost = [tf] # Minimize time
 
     @named block = System(
-        [D(x(t)) ~ v(t), D(v(t)) ~ u(t)], t; costs = cost, constraints = constr)
+        [D(x(t)) ~ v(t), D(v(t)) ~ u(t)], t; costs = cost, constraints = constr
+    )
     block = mtkcompile(block, inputs = [u(t)])
 
     u0map = [x(t) => 1.0, v(t) => 0.0]
@@ -376,22 +408,22 @@ end
     parammap = [u(t) => 1.0, tf => 1.0]
     jprob = JuMPDynamicOptProblem(block, [u0map; parammap], tspan; steps = 51)
     jsol = solve(jprob, JuMPCollocation(Ipopt.Optimizer, constructVerner8()))
-    @test isapprox(jsol.sol.t[end], 2.0, atol = 1e-5)
+    @test isapprox(jsol.sol.t[end], 2.0, atol = 1.0e-5)
 
     if ENABLE_CASADI
         cprob = CasADiDynamicOptProblem(block, [u0map; parammap], (0, tf); steps = 51)
         csol = solve(cprob, CasADiCollocation("ipopt", constructVerner8()))
-        @test isapprox(csol.sol.t[end], 2.0, atol = 1e-5)
+        @test isapprox(csol.sol.t[end], 2.0, atol = 1.0e-5)
     end
 
     iprob = InfiniteOptDynamicOptProblem(block, [u0map; parammap], tspan; steps = 51)
     isol = solve(iprob, InfiniteOptCollocation(Ipopt.Optimizer), verbose = true)
-    @test isapprox(isol.sol.t[end], 2.0, atol = 1e-5)
+    @test isapprox(isol.sol.t[end], 2.0, atol = 1.0e-5)
 
     if @isdefined(Pyomo)
         pprob = PyomoDynamicOptProblem(block, [u0map; parammap], tspan; steps = 51)
         psol = solve(pprob, PyomoCollocation("ipopt", BackwardEuler()))
-        @test isapprox(psol.sol.t[end], 2.0, atol = 1e-5)
+        @test isapprox(psol.sol.t[end], 2.0, atol = 1.0e-5)
     end
 end
 
@@ -404,10 +436,14 @@ end
 
     s = sin(θ(t))
     c = cos(θ(t))
-    H = [mₖ+mₚ mₚ*l*c
-         mₚ*l*c mₚ*l^2]
-    C = [0 -mₚ*D(θ(t))*l*s
-         0 0]
+    H = [
+        mₖ + mₚ mₚ * l * c
+        mₚ * l * c mₚ * l^2
+    ]
+    C = [
+        0 -mₚ * D(θ(t)) * l * s
+        0 0
+    ]
     qd = [D(x(t)), D(θ(t))]
     G = [0, mₚ * g * l * s]
     B = [1, 0]
@@ -437,8 +473,10 @@ end
     end
 
     iprob = InfiniteOptDynamicOptProblem(cartpole, [u0map; pmap], tspan; dt = 0.04)
-    isol = solve(iprob,
-        InfiniteOptCollocation(Ipopt.Optimizer, InfiniteOpt.OrthogonalCollocation(2)))
+    isol = solve(
+        iprob,
+        InfiniteOptCollocation(Ipopt.Optimizer, InfiniteOpt.OrthogonalCollocation(2))
+    )
     @test isol.sol[var_order][end] ≈ [π, 0, 0, 0]
 
     if @isdefined(Pyomo)
@@ -450,13 +488,15 @@ end
 
 @testset "Parameter defaults usage" begin
     # Test that parameter defaults are used when not explicitly provided in op
-    @parameters α=1.5 β=1.0 γ=3.0 δ=1.0
+    @parameters α = 1.5 β = 1.0 γ = 3.0 δ = 1.0
     @variables x(t) y(t)
 
-    eqs = [D(x) ~ α * x - β * x * y
-        D(y) ~ -γ * y + δ * x * y]
+    eqs = [
+        D(x) ~ α * x - β * x * y
+        D(y) ~ -γ * y + δ * x * y
+    ]
 
-    sys = mtkcompile(System(eqs, t, name=:sys))
+    sys = mtkcompile(System(eqs, t, name = :sys))
     tspan = (0.0, 1.0)
     u0map = [x => 4.0, y => 2.0]
 
@@ -472,7 +512,7 @@ end
 
     iprob = InfiniteOptDynamicOptProblem(sys, u0map, tspan, dt = 0.01)
     isol = solve(iprob, InfiniteOptCollocation(Ipopt.Optimizer, InfiniteOpt.OrthogonalCollocation(3)))
-    @test isol.sol.u ≈ osol.u rtol=1e-4
+    @test isol.sol.u ≈ osol.u rtol = 1.0e-4
 
     if ENABLE_CASADI
         cprob = CasADiDynamicOptProblem(sys, u0map, tspan, dt = 0.01)
@@ -484,16 +524,18 @@ end
         pprob = PyomoDynamicOptProblem(sys, u0map, tspan, dt = 0.01)
         psol = solve(pprob, PyomoCollocation("ipopt", BackwardEuler()))
 
-        @test psol.sol.u ≈ osol.u rtol=1e-2
+        @test psol.sol.u ≈ osol.u rtol = 1.0e-2
     end
 end
 
 @testset "Parameter estimation" begin
-    @parameters α = 1.5 β = 1.0 [tunable=false] γ = 3.0 δ = 1.0
+    @parameters α = 1.5 β = 1.0 [tunable = false] γ = 3.0 δ = 1.0
     @variables x(t) y(t)
 
-    eqs = [D(x) ~ α * x - β * x * y,
-        D(y) ~ -γ * y + δ * x * y]
+    eqs = [
+        D(x) ~ α * x - β * x * y,
+        D(y) ~ -γ * y + δ * x * y,
+    ]
 
     @mtkcompile sys0 = System(eqs, t)
     tspan = (0.0, 1.0)
@@ -502,61 +544,61 @@ end
 
     oprob = ODEProblem(sys0, [u0map; parammap], tspan)
     osol = solve(oprob, Tsit5())
-    ts = range(tspan..., length=51)
-    data = osol(ts, idxs=x).u
+    ts = range(tspan..., length = 51)
+    data = osol(ts, idxs = x).u
 
-    costs = [abs2(EvalAt(t)(x)-data[i]) for (i, t) in enumerate(ts)]
+    costs = [abs2(EvalAt(t)(x) - data[i]) for (i, t) in enumerate(ts)]
     consolidate(u, sub) = sum(u)
 
     @mtkcompile sys = System(eqs, t; costs, consolidate)
 
     sys′ = subset_tunables(sys, [δ, α])
-    jprob = JuMPDynamicOptProblem(sys′, u0map, tspan; dt=1/50, tune_parameters=true)
+    jprob = JuMPDynamicOptProblem(sys′, u0map, tspan; dt = 1 / 50, tune_parameters = true)
     jsol = solve(jprob, JuMPCollocation(Ipopt.Optimizer, constructTsitouras5()))
 
-    @test jsol.sol.ps[δ] ≈ 1.8 rtol=1e-4
-    @test jsol.sol.ps[α] ≈ 2.5 rtol=1e-4
+    @test jsol.sol.ps[δ] ≈ 1.8 rtol = 1.0e-4
+    @test jsol.sol.ps[α] ≈ 2.5 rtol = 1.0e-4
 
     # test with different time stepping
 
-    jprob = JuMPDynamicOptProblem(sys′, u0map, tspan; dt=1/120, tune_parameters=true)
+    jprob = JuMPDynamicOptProblem(sys′, u0map, tspan; dt = 1 / 120, tune_parameters = true)
     err_msg = "Found extra 40 collocation points."
     @test_throws err_msg solve(jprob, JuMPCollocation(Ipopt.Optimizer, constructTsitouras5()))
 
-    iprob = InfiniteOptDynamicOptProblem(sys′, u0map, tspan, dt = 1/50, tune_parameters=true)
+    iprob = InfiniteOptDynamicOptProblem(sys′, u0map, tspan, dt = 1 / 50, tune_parameters = true)
     isol = solve(iprob, InfiniteOptCollocation(Ipopt.Optimizer, InfiniteOpt.OrthogonalCollocation(3)))
 
-    @test isol.sol.ps[δ] ≈ 1.8 rtol=1e-3
-    @test isol.sol.ps[α] ≈ 2.5 rtol=1e-3
+    @test isol.sol.ps[δ] ≈ 1.8 rtol = 1.0e-3
+    @test isol.sol.ps[α] ≈ 2.5 rtol = 1.0e-3
 
     # test with different time stepping
 
-    iprob = InfiniteOptDynamicOptProblem(sys′, u0map, tspan, dt = 1/120, tune_parameters=true)
+    iprob = InfiniteOptDynamicOptProblem(sys′, u0map, tspan, dt = 1 / 120, tune_parameters = true)
     isol = solve(iprob, InfiniteOptCollocation(Ipopt.Optimizer, InfiniteOpt.OrthogonalCollocation(3)))
 
-    @test isol.sol.ps[δ] ≈ 1.8 rtol=1e-4
-    @test isol.sol.ps[α] ≈ 2.5 rtol=1e-4
+    @test isol.sol.ps[δ] ≈ 1.8 rtol = 1.0e-4
+    @test isol.sol.ps[α] ≈ 2.5 rtol = 1.0e-4
 
     if ENABLE_CASADI
-        cprob = CasADiDynamicOptProblem(sys′, u0map, tspan; dt = 1/50, tune_parameters=true)
+        cprob = CasADiDynamicOptProblem(sys′, u0map, tspan; dt = 1 / 50, tune_parameters = true)
         csol = solve(cprob, CasADiCollocation("ipopt", constructRK4()))
-        @test csol.sol.ps[δ] ≈ 1.8 rtol=1e-4
-        @test csol.sol.ps[α] ≈ 2.5 rtol=1e-4
+        @test csol.sol.ps[δ] ≈ 1.8 rtol = 1.0e-4
+        @test csol.sol.ps[α] ≈ 2.5 rtol = 1.0e-4
 
         # test with different time stepping
 
-        cprob = CasADiDynamicOptProblem(sys′, u0map, tspan; dt = 1/120, tune_parameters=true)
+        cprob = CasADiDynamicOptProblem(sys′, u0map, tspan; dt = 1 / 120, tune_parameters = true)
         csol = solve(cprob, CasADiCollocation("ipopt", constructRK4()))
-        @test csol.sol.ps[δ] ≈ 1.8 rtol=1e-4
-        @test csol.sol.ps[α] ≈ 2.5 rtol=1e-3
+        @test csol.sol.ps[δ] ≈ 1.8 rtol = 1.0e-4
+        @test csol.sol.ps[α] ≈ 2.5 rtol = 1.0e-3
     end
 
     if @isdefined(Pyomo)
-        pprob = PyomoDynamicOptProblem(sys′, u0map, tspan, dt = 1/50, tune_parameters=true)
+        pprob = PyomoDynamicOptProblem(sys′, u0map, tspan, dt = 1 / 50, tune_parameters = true)
         psol = solve(pprob, PyomoCollocation("ipopt", LagrangeLegendre(4)))
 
-        @test psol.sol.ps[δ] ≈ 1.8 rtol=1e-4
-        @test psol.sol.ps[α] ≈ 2.5 rtol=1e-4
+        @test psol.sol.ps[δ] ≈ 1.8 rtol = 1.0e-4
+        @test psol.sol.ps[α] ≈ 2.5 rtol = 1.0e-4
     end
     # test with different time stepping
 

--- a/lib/ModelingToolkitBase/test/extensions/labelledarrays.jl
+++ b/lib/ModelingToolkitBase/test/extensions/labelledarrays.jl
@@ -8,9 +8,11 @@ using ModelingToolkitBase: t_nounits as t, D_nounits as D
 @variables x(t) y(t) z(t)
 
 # Define a differential equation
-eqs = [D(x) ~ σ * (y - x),
+eqs = [
+    D(x) ~ σ * (y - x),
     D(y) ~ t * x * (ρ - z) - y,
-    D(z) ~ x * y - β * z]
+    D(z) ~ x * y - β * z,
+]
 
 @named de = System(eqs, t)
 de = complete(de)
@@ -69,7 +71,7 @@ function SIR!(du, u, p, t)
     du[1] = (μ * N - λ * S - μ * S + ω * R)
     du[2] = (λ * S - σ * I - μ * I)
     du[3] = (σ * I - μ * R - ω * R)
-    du[4] = (σ * I) # cumulative incidence
+    return du[4] = (σ * I) # cumulative incidence
 end
 
 # Solver settings
@@ -87,6 +89,8 @@ u0 = @LArray [9998.0, 1.0, 1.0, 1.0] (:S, :I, :R, :C)
 problem = ODEProblem(SIR!, u0, tspan, p)
 sys = complete(modelingtoolkitize(problem))
 
-@test all(any(isequal(x), parameters(sys))
-for x in ModelingToolkitBase.unwrap.(@variables(β, η, ω, φ, σ, μ)))
+@test all(
+    any(isequal(x), parameters(sys))
+        for x in ModelingToolkitBase.unwrap.(@variables(β, η, ω, φ, σ, μ))
+)
 @test all(isequal.(Symbol.(unknowns(sys)), Symbol.(@variables(S(t), I(t), R(t), C(t)))))

--- a/lib/ModelingToolkitBase/test/extensions/test_infiniteopt.jl
+++ b/lib/ModelingToolkitBase/test/extensions/test_infiniteopt.jl
@@ -34,7 +34,8 @@ inputs = [model.τ]
 outputs = [model.y]
 model = mtkcompile(model; inputs, outputs)
 f, dvs, psym, io_sys = ModelingToolkitBase.generate_control_function(
-    model, split = false)
+    model, split = false
+)
 
 f_obs = ModelingToolkitBase.build_explicit_observed_function(io_sys, outputs; inputs)
 
@@ -51,23 +52,31 @@ nu = length(inputs)
 ny = length(outputs)
 
 ##
-m = InfiniteModel(optimizer_with_attributes(Ipopt.Optimizer,
-    "print_level" => 0, "acceptable_tol" => 1e-3, "constr_viol_tol" => 1e-5, "max_iter" => 1000,
-    "tol" => 1e-5, "mu_strategy" => "monotone", "nlp_scaling_method" => "gradient-based",
-    "alpha_for_y" => "safer-min-dual-infeas", "bound_mult_init_method" => "mu-based", "print_user_options" => "yes"));
+m = InfiniteModel(
+    optimizer_with_attributes(
+        Ipopt.Optimizer,
+        "print_level" => 0, "acceptable_tol" => 1.0e-3, "constr_viol_tol" => 1.0e-5, "max_iter" => 1000,
+        "tol" => 1.0e-5, "mu_strategy" => "monotone", "nlp_scaling_method" => "gradient-based",
+        "alpha_for_y" => "safer-min-dual-infeas", "bound_mult_init_method" => "mu-based", "print_user_options" => "yes"
+    )
+);
 
-@infinite_parameter(m, τ in [0, 1], num_supports=51,
-    derivative_method=OrthogonalCollocation(4)) # Time variable
+@infinite_parameter(
+    m, τ in [0, 1], num_supports = 51,
+    derivative_method = OrthogonalCollocation(4)
+) # Time variable
 guess_xs = [t -> pi, t -> 0.1][permutation]
 guess_us = [t -> 0.1]
-InfiniteOpt.@variables(m,
-begin
-    # state variables
-    (lb[i] <= x[i = 1:nx] <= ub[i], Infinite(τ), start = guess_xs[i]) # state variables
-    -10 <= u[i = 1:nu] <= 10, Infinite(τ), (start = guess_us[i]) # control variables
-    0 <= tf <= 10, (start = 5) # Final time
-    0.2 <= L <= 0.6, (start = 0.4) # Length parameter
-end)
+InfiniteOpt.@variables(
+    m,
+    begin
+        # state variables
+        (lb[i] <= x[i = 1:nx] <= ub[i], Infinite(τ), start = guess_xs[i]) # state variables
+        -10 <= u[i = 1:nu] <= 10, Infinite(τ), (start = guess_us[i]) # control variables
+        0 <= tf <= 10, (start = 5) # Final time
+        0.2 <= L <= 0.6, (start = 0.4) # Length parameter
+    end
+)
 
 # Trace the dynamics
 x0 = ModelingToolkitBase.get_u0(io_sys, [model.θ => 0, model.ω => 0])
@@ -77,14 +86,20 @@ xp = f[1](x, u, p, τ)
 cp = f_obs(x, u, p, τ) # Test that it's possible to trace through an observed function
 
 @objective(m, Min, tf)
-@constraint(m, [i = 1:nx], x[i](0)==x0[i]) # Initial condition
-@constraint(m, [i = 1:nx], x[i](1)==xf[i]) # Terminal state
+@constraint(m, [i = 1:nx], x[i](0) == x0[i]) # Initial condition
+@constraint(m, [i = 1:nx], x[i](1) == xf[i]) # Terminal state
 
-x_scale = varmap_to_vars(Dict{Any, Any}([model.θ => 1
-                                         model.ω => 1]), dvs)
+x_scale = varmap_to_vars(
+    Dict{Any, Any}(
+        [
+            model.θ => 1
+            model.ω => 1
+        ]
+    ), dvs
+)
 
 # Add dynamics constraints
-@constraint(m, [i = 1:nx], (∂(x[i], τ) - tf * xp[i]) / x_scale[i]==0)
+@constraint(m, [i = 1:nx], (∂(x[i], τ) - tf * xp[i]) / x_scale[i] == 0)
 
 optimize!(m)
 
@@ -102,10 +117,10 @@ opt_L = value(L)
 # plot!(opt_time, opt_u[1], label = "τ", sp=3)
 
 using Test
-@test opt_x[1][end]≈pi atol=1e-3
-@test opt_x[2][end]≈0 atol=1e-3
+@test opt_x[1][end] ≈ pi atol = 1.0e-3
+@test opt_x[2][end] ≈ 0 atol = 1.0e-3
 
-@test opt_x[1][1]≈0 atol=1e-3
-@test opt_x[2][1]≈0 atol=1e-3
+@test opt_x[1][1] ≈ 0 atol = 1.0e-3
+@test opt_x[2][1] ≈ 0 atol = 1.0e-3
 
-@test opt_L≈0.2 atol=1e-3 # Smallest permissible length is optimal
+@test opt_L ≈ 0.2 atol = 1.0e-3 # Smallest permissible length is optimal

--- a/lib/ModelingToolkitBase/test/function_registration.jl
+++ b/lib/ModelingToolkitBase/test/function_registration.jl
@@ -6,47 +6,47 @@
 # TEST: Function registration in a module.
 # ------------------------------------------------
 module MyModule
-using ModelingToolkitBase, DiffEqBase, LinearAlgebra, Test
-using ModelingToolkitBase: t_nounits as t, D_nounits as Dt
-@parameters x
-@variables u(t)
+    using ModelingToolkitBase, DiffEqBase, LinearAlgebra, Test
+    using ModelingToolkitBase: t_nounits as t, D_nounits as Dt
+    @parameters x
+    @variables u(t)
 
-function do_something(a)
-    a + 10
-end
-@register_symbolic do_something(a)
+    function do_something(a)
+        return a + 10
+    end
+    @register_symbolic do_something(a)
 
-eq = Dt(u) ~ do_something(x) + MyModule.do_something(x)
-@named sys = System([eq], t, [u], [x])
-sys = complete(sys)
-fun = ODEFunction(sys)
+    eq = Dt(u) ~ do_something(x) + MyModule.do_something(x)
+    @named sys = System([eq], t, [u], [x])
+    sys = complete(sys)
+    fun = ODEFunction(sys)
 
-u0 = 5.0
-@test fun([0.5], u0, 0.0) == [do_something(u0) * 2]
+    u0 = 5.0
+    @test fun([0.5], u0, 0.0) == [do_something(u0) * 2]
 end
 
 # TEST: Function registration in a nested module.
 # ------------------------------------------------
 module MyModule2
-module MyNestedModule
-using ModelingToolkitBase, DiffEqBase, LinearAlgebra, Test
-using ModelingToolkitBase: t_nounits as t, D_nounits as Dt
-@parameters x
-@variables u(t)
+    module MyNestedModule
+        using ModelingToolkitBase, DiffEqBase, LinearAlgebra, Test
+        using ModelingToolkitBase: t_nounits as t, D_nounits as Dt
+        @parameters x
+        @variables u(t)
 
-function do_something_2(a)
-    a + 20
-end
-@register_symbolic do_something_2(a)
+        function do_something_2(a)
+            return a + 20
+        end
+        @register_symbolic do_something_2(a)
 
-eq = Dt(u) ~ do_something_2(x) + MyNestedModule.do_something_2(x)
-@named sys = System([eq], t, [u], [x])
-sys = complete(sys)
-fun = ODEFunction(sys)
+        eq = Dt(u) ~ do_something_2(x) + MyNestedModule.do_something_2(x)
+        @named sys = System([eq], t, [u], [x])
+        sys = complete(sys)
+        fun = ODEFunction(sys)
 
-u0 = 3.0
-@test fun([0.5], u0, 0.0) == [do_something_2(u0) * 2]
-end
+        u0 = 3.0
+        @test fun([0.5], u0, 0.0) == [do_something_2(u0) * 2]
+    end
 end
 
 # TEST: Function registration outside any modules.
@@ -57,7 +57,7 @@ using ModelingToolkitBase: t_nounits as t, D_nounits as Dt
 @variables u(t)
 
 function do_something_3(a)
-    a + 30
+    return a + 30
 end
 @register_symbolic do_something_3(a)
 
@@ -92,7 +92,7 @@ expr = value(foo(x, y))
 # Might be useful in cases where someone wants to define functions that build
 # up and use ODEFunctions given some parameters.
 function do_something_4(a)
-    a + 30
+    return a + 30
 end
 @register_symbolic do_something_4(a)
 function build_ode()
@@ -101,12 +101,12 @@ function build_ode()
     eq = Dt(u) ~ do_something_4(x) + (@__MODULE__).do_something_4(x)
     @named sys = System([eq], t, [u], [x])
     sys = complete(sys)
-    fun = ODEFunction(sys, eval_expression = false)
+    return fun = ODEFunction(sys, eval_expression = false)
 end
 function run_test()
     fun = build_ode()
     u0 = 10.0
-    @test fun([0.5], u0, 0.0) == [do_something_4(u0) * 2]
+    return @test fun([0.5], u0, 0.0) == [do_something_4(u0) * 2]
 end
 run_test()
 

--- a/lib/ModelingToolkitBase/test/guess_propagation.jl
+++ b/lib/ModelingToolkitBase/test/guess_propagation.jl
@@ -8,12 +8,12 @@ using Test
     @variables y(t)
     eqs = [D(x) ~ 1]
     initialization_eqs = [1 ~ exp(1 + x)]
-    
+
     @named sys = System(eqs, t; initialization_eqs, observed = [y ~ x])
     sys = complete(sys)
     tspan = (0.0, 0.2)
     prob = ODEProblem(sys, [], tspan)
-    
+
     @test prob.f.initializeprob[y] == 2.0
     @test prob.f.initializeprob[x] == 2.0
     sol = solve(prob.f.initializeprob; show_trace = Val(true))

--- a/lib/ModelingToolkitBase/test/index_cache.jl
+++ b/lib/ModelingToolkitBase/test/index_cache.jl
@@ -79,7 +79,8 @@ end
     sys = complete(sys)
     # and the arrays must have matching size
     @test_throws ArgumentError reorder_dimension_by_tunables!(
-        zeros(2, 4), sys, src, [p, q, r])
+        zeros(2, 4), sys, src, [p, q, r]
+    )
 
     ps = MTKParameters(sys, [p => 1.0, q => 3ones(3), r => 4ones(2, 2), s => 0.0])
     src = ps.tunable
@@ -111,8 +112,9 @@ end
 
     event1 = [1.0, 2, 3] => (f = update_affect!, modified = (; p_1))
 
-    @named sys = System([
-            ModelingToolkitBase.D_nounits(x) ~ p_1(x)
+    @named sys = System(
+        [
+            ModelingToolkitBase.D_nounits(x) ~ p_1(x),
         ],
         ModelingToolkitBase.t_nounits;
         discrete_events = [event1]

--- a/lib/ModelingToolkitBase/test/jumpsystem.jl
+++ b/lib/ModelingToolkitBase/test/jumpsystem.jl
@@ -29,13 +29,13 @@ mtjump2 = MT.assemble_vrj(js, j₂, unknowntoid)
 rate1(u, p, t) = (0.1 / 1000.0) * u[1] * u[2]
 function affect1!(integrator)
     integrator.u[1] -= 1
-    integrator.u[2] += 1
+    return integrator.u[2] += 1
 end
 jump1 = ConstantRateJump(rate1, affect1!)
 rate2(u, p, t) = 0.01u[2] + t
 function affect2!(integrator)
     integrator.u[2] -= 1
-    integrator.u[3] += 1
+    return integrator.u[3] += 1
 end
 jump2 = VariableRateJump(rate2, affect2!)
 
@@ -74,19 +74,21 @@ u₀ = [999, 1, 0];
 tspan = (0.0, 250.0);
 u₀map = [S => 999, I => 1, R => 0]
 parammap = [β => 0.1 / 1000, γ => 0.01]
-jprob = JumpProblem(js2, [u₀map; parammap], tspan; aggregator = Direct(),
-    save_positions = (false, false), rng)
+jprob = JumpProblem(
+    js2, [u₀map; parammap], tspan; aggregator = Direct(),
+    save_positions = (false, false), rng
+)
 p = parameter_values(jprob)
 @test jprob.prob isa DiscreteProblem
 Nsims = 1000
 function getmean(jprob, Nsims; use_stepper = true)
     m = 0.0
     for i in 1:Nsims
-        i%200 == 0 && @info i
+        i % 200 == 0 && @info i
         sol = use_stepper ? solve(jprob, SSAStepper()) : solve(jprob)
         m += sol[end, end]
     end
-    m / Nsims
+    return m / Nsims
 end
 m = getmean(jprob, Nsims)
 
@@ -99,15 +101,19 @@ mb = getmean(jprobb, Nsims; use_stepper = false)
 obs = [S2 ~ 2 * S]
 @named js2b = JumpSystem([j₁, j₃], t, [S, I, R], [β, γ, h], observed = obs)
 js2b = complete(js2b)
-jprob = JumpProblem(js2b, [u₀map; parammap], tspan; aggregator = Direct(),
-    save_positions = (false, false), rng)
+jprob = JumpProblem(
+    js2b, [u₀map; parammap], tspan; aggregator = Direct(),
+    save_positions = (false, false), rng
+)
 @test jprob.prob isa DiscreteProblem
 sol = solve(jprob, SSAStepper(); saveat = tspan[2] / 10)
 @test all(2 .* sol[S] .== sol[S2])
 
 # test save_positions is working
-jprob = JumpProblem(js2, [u₀map; parammap], tspan; aggregator = Direct(),
-    save_positions = (false, false), rng)
+jprob = JumpProblem(
+    js2, [u₀map; parammap], tspan; aggregator = Direct(),
+    save_positions = (false, false), rng
+)
 sol = solve(jprob, SSAStepper(); saveat = 1.0)
 @test all((sol.t) .== collect(0.0:tspan[2]))
 
@@ -134,13 +140,13 @@ prob = DiscreteProblem([999, 1, 0], (0.0, 250.0), p)
 r1(u, p, t) = (0.1 / 1000.0) * u[1] * u[2]
 function a1!(integrator)
     integrator.u[1] -= 1
-    integrator.u[2] += 1
+    return integrator.u[2] += 1
 end
 j1 = ConstantRateJump(r1, a1!)
 r2(u, p, t) = 0.01u[2]
 function a2!(integrator)
     integrator.u[2] -= 1
-    integrator.u[3] += 1
+    return integrator.u[3] += 1
 end
 j2 = ConstantRateJump(r2, a2!)
 jset = JumpSet((), (j1, j2), nothing, nothing)
@@ -178,7 +184,8 @@ maj2 = MassActionJump(γ, [S => 1], [S => -1])
 @named js4 = JumpSystem([maj1, maj2], t, [S], [β, γ])
 js4 = complete(js4)
 jprob = JumpProblem(
-    js4, [S => 999, β => 100.0, γ => 0.01], (0, 1000.0); aggregator = Direct(), rng)
+    js4, [S => 999, β => 100.0, γ => 0.01], (0, 1000.0); aggregator = Direct(), rng
+)
 @test jprob.prob isa DiscreteProblem
 m4 = getmean(jprob, Nsims)
 @test abs(m4 - 2.0 / 0.01) * 0.01 / 2.0 < 0.01
@@ -189,7 +196,8 @@ maj2 = MassActionJump(γ, [S => 2], [S => -1])
 @named js4 = JumpSystem([maj1, maj2], t, [S], [β, γ])
 js4 = complete(js4)
 jprob = JumpProblem(
-    js4, [S => 999, β => 100.0, γ => 0.01], (0, 1000.0); aggregator = Direct(), rng)
+    js4, [S => 999, β => 100.0, γ => 0.01], (0, 1000.0); aggregator = Direct(), rng
+)
 @test jprob.prob isa DiscreteProblem
 sol = solve(jprob, SSAStepper());
 
@@ -199,7 +207,8 @@ sol = solve(jprob, SSAStepper());
     sys2 = JumpSystem([maj1, maj2], t, [S], [β, γ], name = :sys1)
     @test_throws ModelingToolkitBase.NonUniqueSubsystemsError JumpSystem(
         [sys1.γ ~ sys2.γ], t, [], [],
-        systems = [sys1, sys2], name = :foo)
+        systems = [sys1, sys2], name = :foo
+    )
 end
 
 # test if param mapper is setup correctly for callbacks
@@ -214,7 +223,8 @@ end
     u₀ = [A => 100, B => 0]
     tspan = (0.0, 2000.0)
     jprob = JumpProblem(
-        js5, [u₀; p], tspan; aggregator = Direct(), save_positions = (false, false), rng)
+        js5, [u₀; p], tspan; aggregator = Direct(), save_positions = (false, false), rng
+    )
     @test jprob.prob isa DiscreteProblem
     @test all(jprob.massaction_jump.scaled_rates .== [1.0, 0.0])
 
@@ -246,10 +256,12 @@ end
     # B --> X
     # X --> B
     @variables A(t) X(t) B(t)
-    jumps = [MassActionJump(1.0, [A => 1, X => 2], [A => -1, X => 1]),
+    jumps = [
+        MassActionJump(1.0, [A => 1, X => 2], [A => -1, X => 1]),
         MassActionJump(1.0, [X => 3], [A => 1, X => -1]),
         MassActionJump(1.0, [B => 1], [B => -1, X => 1]),
-        MassActionJump(1.0, [X => 1], [B => 1, X => -1])]
+        MassActionJump(1.0, [X => 1], [B => 1, X => -1]),
+    ]
     @named js = JumpSystem(jumps, t, [A, X, B], [])
     jdeps = asgraph(js; eqs = MT.jumps(js))
     vdeps = variable_dependencies(js; eqs = MT.jumps(js))
@@ -322,7 +334,8 @@ end
     vrj = VariableRateJump(k * (sin(t) + 1), [A ~ Pre(A) + 1, C ~ Pre(C) + 2])
     js = complete(JumpSystem([vrj], t, [A, C], [k]; name = :js, observed = [B ~ C * A]))
     jprob = JumpProblem(
-        js, [A => 0, C => 0, k => 1], (0.0, 10.0); aggregator = Direct(), rng)
+        js, [A => 0, C => 0, k => 1], (0.0, 10.0); aggregator = Direct(), rng
+    )
     @test jprob.prob isa ODEProblem
     sol = solve(jprob, Tsit5())
 
@@ -515,7 +528,7 @@ end
     function Xf(t, p)
         local α, β, X₀, Y₀ = p
         return (α / β) + (α^2 / β^2) + α * (Y₀ - α / β) * t * exp(-β * t) +
-               (X₀ - α / β - α^2 / β^2) * exp(-β * t)
+            (X₀ - α / β - α^2 / β^2) * exp(-β * t)
     end
     Xact = [Xf(t, p) for t in times]
     Yact = [Yf(t, p) for t in times]
@@ -528,8 +541,10 @@ end
         (;)
     end
     cevents = [t ~ 0.2] => (; f = affect!)
-    @named jsys = JumpSystem([maj, crj, vrj, eqs[1]], t, [X, Y], [α, β];
-        continuous_events = cevents)
+    @named jsys = JumpSystem(
+        [maj, crj, vrj, eqs[1]], t, [X, Y], [α, β];
+        continuous_events = cevents
+    )
     jsys = complete(jsys)
     tspan = (0.0, 200.0)
     jprob = JumpProblem(jsys, [u0map; pmap], tspan; rng, save_positions = (false, false))
@@ -558,7 +573,8 @@ end
     # Works.
     @mtkcompile js = JumpSystem([j1, j2], t, [X], [p, d])
     jprob = JumpProblem(
-        js, [X => 15, p => 2.0, d => 0.5], (0.0, 10.0); aggregator = Direct(), u0_eltype = Int)
+        js, [X => 15, p => 2.0, d => 0.5], (0.0, 10.0); aggregator = Direct(), u0_eltype = Int
+    )
     sol = solve(jprob, SSAStepper())
     @test eltype(sol[X]) === Int64
 end
@@ -580,7 +596,7 @@ end
 @testset "Proper substitution in `JumpSysMajParamWrapper`" begin
     @variables X(t)
     @parameters p d
-    jump1 = MassActionJump(exp(p), Pair{Num,Real}[], [X => 1], nothing)
+    jump1 = MassActionJump(exp(p), Pair{Num, Real}[], [X => 1], nothing)
     jump2 = ConstantRateJump(d * exp(X) * X, [X ~ Pre(X) - 1])
     @named sys = JumpSystem([jump1, jump2], t, [X], [p, d])
     sys = complete(sys)

--- a/lib/ModelingToolkitBase/test/latexify.jl
+++ b/lib/ModelingToolkitBase/test/latexify.jl
@@ -24,24 +24,30 @@ using ModelingToolkitStandardLibrary.Blocks
 @parameters σ ρ β
 @variables x(t) y(t) z(t)
 
-eqs = [D(x) ~ σ * (y - x) * D(x - y) / D(z),
+eqs = [
+    D(x) ~ σ * (y - x) * D(x - y) / D(z),
     0 ~ σ * x * (ρ - z) / 10 - y,
-    D(z) ~ x * y^(2 // 3) - β * z]
+    D(z) ~ x * y^(2 // 3) - β * z,
+]
 
 # Latexify.@generate_test latexify(eqs)
 @test_reference "latexify/10.tex" latexify(eqs)
 
 @variables u(t)[1:3]
 @parameters p[1:3]
-eqs = [D(u[1]) ~ p[3] * (u[2] - u[1]),
+eqs = [
+    D(u[1]) ~ p[3] * (u[2] - u[1]),
     0 ~ p[2] * p[3] * u[1] * (p[1] - u[1]) / 10 - u[2],
-    D(u[3]) ~ u[1] * u[2]^(2 // 3) - p[3] * u[3]]
+    D(u[3]) ~ u[1] * u[2]^(2 // 3) - p[3] * u[3],
+]
 
 @test_reference "latexify/20.tex" latexify(eqs)
 
-eqs = [D(u[1]) ~ p[3] * (u[2] - u[1]),
+eqs = [
+    D(u[1]) ~ p[3] * (u[2] - u[1]),
     D(u[2]) ~ p[2] * p[3] * u[1] * (p[1] - u[1]) / 10 - u[2],
-    D(u[3]) ~ u[1] * u[2]^(2 // 3) - p[3] * u[3]]
+    D(u[3]) ~ u[1] * u[2]^(2 // 3) - p[3] * u[3],
+]
 
 @test_reference "latexify/30.tex" latexify(eqs)
 @variables x(t)
@@ -53,8 +59,10 @@ eqs = [D(x) ~ (1 + cos(t)) / (1 + 2 * x)]
 @named C = Gain(; k = -1)
 
 ap = AnalysisPoint(:plant_input)
-eqs = [connect(P.output, C.input)
-       connect(C.output, ap, P.input)]
+eqs = [
+    connect(P.output, C.input)
+    connect(C.output, ap, P.input)
+]
 sys_ap = System(eqs, t, systems = [P, C], name = :hej)
 
 @test_reference "latexify/50.tex" latexify(sys_ap)

--- a/lib/ModelingToolkitBase/test/linearity.jl
+++ b/lib/ModelingToolkitBase/test/linearity.jl
@@ -8,20 +8,26 @@ using Test
 @variables x(t) y(t) z(t)
 D = Differential(t)
 
-eqs = [D(x) ~ σ * (y - x),
+eqs = [
+    D(x) ~ σ * (y - x),
     D(y) ~ -z - y,
-    D(z) ~ y - β * z]
+    D(z) ~ y - β * z,
+]
 
 @test ModelingToolkitBase.islinear(@named sys = System(eqs, t))
 
-eqs2 = [D(x) ~ σ * (y - x),
+eqs2 = [
+    D(x) ~ σ * (y - x),
     D(y) ~ -z - 1 / y,
-    D(z) ~ y - β * z]
+    D(z) ~ y - β * z,
+]
 
 @test !ModelingToolkitBase.islinear(@named sys = System(eqs2, t))
 
-eqs3 = [D(x) ~ σ * (y - x),
+eqs3 = [
+    D(x) ~ σ * (y - x),
     D(y) ~ -z - y,
-    D(z) ~ y - β * z + 1]
+    D(z) ~ y - β * z + 1,
+]
 
 @test ModelingToolkitBase.isaffine(@named sys = System(eqs, t))

--- a/lib/ModelingToolkitBase/test/linearproblem.jl
+++ b/lib/ModelingToolkitBase/test/linearproblem.jl
@@ -41,7 +41,7 @@ ps = [p => A, q => b]
 
     sol = solve(prob)
     @test SciMLBase.successful_retcode(sol)
-    @test prob.A * sol.u - prob.b≈zeros(3) atol=1e-10
+    @test prob.A * sol.u - prob.b ≈ zeros(3) atol = 1.0e-10
 
     A2 = rand(3, 3)
     b2 = rand(3)
@@ -78,7 +78,7 @@ ps = [p => A, q => b]
 
         sol = solve(prob3)
         @test SciMLBase.successful_retcode(sol)
-        @test prob3.A * sol.u - prob3.b≈zeros(3) atol=1e-10
+        @test prob3.A * sol.u - prob3.b ≈ zeros(3) atol = 1.0e-10
     end
 end
 
@@ -110,7 +110,7 @@ end
     sol = solve(prob)
     # https://github.com/SciML/LinearSolve.jl/issues/532
     @test SciMLBase.successful_retcode(sol)
-    @test prob.A * sol.u - prob.b≈zeros(3) atol=1e-10
+    @test prob.A * sol.u - prob.b ≈ zeros(3) atol = 1.0e-10
 
     A2 = rand(3, 3)
     b2 = rand(3)
@@ -137,7 +137,7 @@ end
         sol = solve(prob3)
         # https://github.com/SciML/LinearSolve.jl/issues/532
         @test SciMLBase.successful_retcode(sol)
-        @test prob3.A * sol.u - prob3.b≈zeros(3) atol=1e-10
+        @test prob3.A * sol.u - prob3.b ≈ zeros(3) atol = 1.0e-10
     end
 end
 

--- a/lib/ModelingToolkitBase/test/mass_matrix.jl
+++ b/lib/ModelingToolkitBase/test/mass_matrix.jl
@@ -4,23 +4,27 @@ using ModelingToolkitBase: t_nounits as t, D_nounits as D, MTKParameters
 @variables y(t)[1:3]
 @parameters k[1:3]
 
-eqs = [D(y[1]) ~ -k[1] * y[1] + k[3] * y[2] * y[3],
+eqs = [
+    D(y[1]) ~ -k[1] * y[1] + k[3] * y[2] * y[3],
     D(y[2]) ~ k[1] * y[1] - k[3] * y[2] * y[3] - k[2] * y[2]^2,
-    0 ~ y[1] + y[2] + y[3] - 1]
+    0 ~ y[1] + y[2] + y[3] - 1,
+]
 
 @named sys = System(eqs, t, collect(y), [k])
 sys = complete(sys)
 @test_throws ModelingToolkitBase.OperatorIndepvarMismatchError System(eqs, y[1])
 M = calculate_massmatrix(sys)
 @test M isa Diagonal
-@test M == [1 0 0
-            0 1 0
-            0 0 0]
+@test M == [
+    1 0 0
+    0 1 0
+    0 0 0
+]
 
-prob_mm = ODEProblem(sys, [y => [1.0, 0.0, 0.0], k => [0.04, 3e7, 1e4]], (0.0, 1e5))
+prob_mm = ODEProblem(sys, [y => [1.0, 0.0, 0.0], k => [0.04, 3.0e7, 1.0e4]], (0.0, 1.0e5))
 @test prob_mm.f.mass_matrix isa Diagonal{Float64, Vector{Float64}}
-sol = solve(prob_mm, Rodas5(), reltol = 1e-8, abstol = 1e-8)
-prob_mm = ODEProblem(sys, SA[y => [1.0, 0.0, 0.0], k => [0.04, 3e7, 1e4]], (0.0, 1e5))
+sol = solve(prob_mm, Rodas5(), reltol = 1.0e-8, abstol = 1.0e-8)
+prob_mm = ODEProblem(sys, SA[y => [1.0, 0.0, 0.0], k => [0.04, 3.0e7, 1.0e4]], (0.0, 1.0e5))
 @test prob_mm.f.mass_matrix isa Diagonal{Float64, SVector{3, Float64}}
 
 function rober(du, u, p, t)
@@ -29,12 +33,14 @@ function rober(du, u, p, t)
     du[1] = -k₁ * y₁ + k₃ * y₂ * y₃
     du[2] = k₁ * y₁ - k₃ * y₂ * y₃ - k₂ * y₂^2
     du[3] = y₁ + y₂ + y₃ - 1
-    nothing
+    return nothing
 end
 f = ODEFunction(rober, mass_matrix = M)
-prob_mm2 = ODEProblem(f, [1.0, 0.0, 0.0], (0.0, 1e5), (0.04, 3e7, 1e4))
-sol2 = solve(prob_mm2, Rodas5(), reltol = 1e-8, abstol = 1e-8, tstops = sol.t,
-    adaptive = false)
+prob_mm2 = ODEProblem(f, [1.0, 0.0, 0.0], (0.0, 1.0e5), (0.04, 3.0e7, 1.0e4))
+sol2 = solve(
+    prob_mm2, Rodas5(), reltol = 1.0e-8, abstol = 1.0e-8, tstops = sol.t,
+    adaptive = false
+)
 
 # MTK expression are canonicalized, so the floating point numbers are slightly
 # different
@@ -48,15 +54,17 @@ eqs = [D(y[1]) ~ y[1], D(y[2]) ~ y[2], D(y[3]) ~ y[3]]
 @test calculate_massmatrix(sys) === I
 
 @testset "Mass matrix `isa Diagonal` for `SDEProblem`" begin
-    eqs = [D(y[1]) ~ -k[1] * y[1] + k[3] * y[2] * y[3],
+    eqs = [
+        D(y[1]) ~ -k[1] * y[1] + k[3] * y[2] * y[3],
         D(y[2]) ~ k[1] * y[1] - k[3] * y[2] * y[3] - k[2] * y[2]^2,
-        0 ~ y[1] + y[2] + y[3] - 1]
+        0 ~ y[1] + y[2] + y[3] - 1,
+    ]
 
     @named sys = System(eqs, t, collect(y), [k])
     @named sys = SDESystem(sys, [1, 1, 0])
     sys = complete(sys)
-    prob = SDEProblem(sys, [y => [1.0, 0.0, 0.0], k => [0.04, 3e7, 1e4]], (0.0, 1e5))
+    prob = SDEProblem(sys, [y => [1.0, 0.0, 0.0], k => [0.04, 3.0e7, 1.0e4]], (0.0, 1.0e5))
     @test prob.f.mass_matrix isa Diagonal{Float64, Vector{Float64}}
-    prob = SDEProblem(sys, SA[y => [1.0, 0.0, 0.0], k => [0.04, 3e7, 1e4]], (0.0, 1e5))
+    prob = SDEProblem(sys, SA[y => [1.0, 0.0, 0.0], k => [0.04, 3.0e7, 1.0e4]], (0.0, 1.0e5))
     @test prob.f.mass_matrix isa Diagonal{Float64, SVector{3, Float64}}
 end

--- a/lib/ModelingToolkitBase/test/namespacing.jl
+++ b/lib/ModelingToolkitBase/test/namespacing.jl
@@ -1,6 +1,6 @@
 using ModelingToolkitBase
 using ModelingToolkitBase: t_nounits as t, D_nounits as D, iscomplete, does_namespacing,
-                       renamespace
+    renamespace
 using Test
 
 @variables x(t)
@@ -25,7 +25,8 @@ nsys = toggle_namespacing(sys, false)
 @test !isequal(p, sys.p)
 
 @test_throws ["namespacing", "inner"] System(
-    Equation[], t; systems = [nsys], name = :a)
+    Equation[], t; systems = [nsys], name = :a
+)
 
 @testset "Variables of variables" begin
     @variables x(t) y(x)

--- a/lib/ModelingToolkitBase/test/parameter_bindings.jl
+++ b/lib/ModelingToolkitBase/test/parameter_bindings.jl
@@ -1,7 +1,7 @@
 using ModelingToolkitBase
 using Test
 using ModelingToolkitBase: t_nounits as t, D_nounits as D, SymbolicDiscreteCallback,
-                       SymbolicContinuousCallback
+    SymbolicContinuousCallback
 using OrdinaryDiffEq
 using StochasticDiffEq
 using JumpProcesses
@@ -52,7 +52,7 @@ import DiffEqNoiseProcess
 end
 
 @testset "vector parameter bindings" begin
-    @parameters p1[1:2]=[1.0, 2.0] p2[1:2]=2p1
+    @parameters p1[1:2] = [1.0, 2.0] p2[1:2] = 2p1
     @variables x(t) = 0
 
     @named sys = System(
@@ -70,14 +70,15 @@ end
 end
 
 @testset "extend" begin
-    @parameters p1=1.0 p2
+    @parameters p1 = 1.0 p2
     @variables x(t) = 0
 
     @mtkcompile sys1 = System(
         [D(x) ~ p1 * t + p2],
         t
     )
-    @named sys2 = System(Equation[],
+    @named sys2 = System(
+        Equation[],
         t, [], [];
         bindings = [p2 => 2p1]
     )
@@ -90,7 +91,7 @@ end
 end
 
 @testset "getu with parameter bindings" begin
-    @parameters p1=1.0 p2=2p1
+    @parameters p1 = 1.0 p2 = 2p1
     @variables x(t) = 0
 
     @named sys = System(
@@ -103,7 +104,7 @@ end
 end
 
 @testset "getu with vector parameter bindings" begin
-    @parameters p1[1:2]=[1.0, 2.0] p2[1:2]=2p1
+    @parameters p1[1:2] = [1.0, 2.0] p2[1:2] = 2p1
     @variables x(t) = 0
 
     @named sys = System(
@@ -116,7 +117,7 @@ end
 end
 
 @testset "composing systems with parameter bindings" begin
-    @parameters p1=1.0 p2
+    @parameters p1 = 1.0 p2
     @variables x(t) = 0
 
     @named sys1 = System(
@@ -161,7 +162,8 @@ end
     @parameters p1 = 1.0
     sys1 = System(
         Equation[], t, [], [p1];
-        bindings = [sys2.p2 => 2p1], name = :sys1, systems = [sys2])
+        bindings = [sys2.p2 => 2p1], name = :sys1, systems = [sys2]
+    )
 
     sys = mtkcompile(sys1)
 
@@ -171,11 +173,11 @@ end
 end
 
 @testset "Change Tunables" begin
-    @variables θ(t)=π/6 ω(t)=0.
-    @parameters g=9.81 L=1.0 b=0.1 errp=1
+    @variables θ(t) = π / 6 ω(t) = 0.0
+    @parameters g = 9.81 L = 1.0 b = 0.1 errp = 1
     eqs = [
         D(θ) ~ ω,
-        D(ω) ~ -(g/L)*sin(θ) - b*ω
+        D(ω) ~ -(g / L) * sin(θ) - b * ω,
     ]
     @named pendulum_sys = System(eqs, t, [θ, ω], [g, L, b])
     sys = mtkcompile(pendulum_sys)
@@ -210,7 +212,7 @@ end
 
 @testset "callable parameters" begin
     @variables y(t) = 1
-    @parameters p=2 (i::CallableFoo)(..)
+    @parameters p = 2 (i::CallableFoo)(..)
 
     eqs = [D(y) ~ i(t) + p]
     @named model = System(eqs, t, [y], [p, i]; bindings = [i => CallableFoo(p)])
@@ -226,13 +228,17 @@ end
     @parameters σ ρ β
     @variables x(t) y(t) z(t)
 
-    eqs = [D(x) ~ σ * (y - x),
+    eqs = [
+        D(x) ~ σ * (y - x),
         D(y) ~ x * (ρ - z) - y,
-        D(z) ~ x * y - β * z]
+        D(z) ~ x * y - β * z,
+    ]
 
-    noiseeqs = [0.1 * x,
+    noiseeqs = [
+        0.1 * x,
         0.1 * y,
-        0.1 * z]
+        0.1 * z,
+    ]
 
     @named sys = System(eqs, t)
     @named sdesys = SDESystem(sys, noiseeqs; bindings = [ρ => 2σ])
@@ -241,7 +247,8 @@ end
     @test ρ in Set(bound_parameters(sdesys))
 
     prob = SDEProblem(
-        sdesys, [x => 1.0, y => 0.0, z => 0.0, σ => 10.0, β => 2.33], (0.0, 100.0))
+        sdesys, [x => 1.0, y => 0.0, z => 0.0, σ => 10.0, β => 2.33], (0.0, 100.0)
+    )
     @test prob.ps[ρ] == 2prob.ps[σ]
     @test_nowarn solve(prob, SRIW1())
 end
@@ -258,7 +265,8 @@ end
     j₁ = ConstantRateJump(rate₁, affect₁)
     j₃ = ConstantRateJump(rate₃, affect₃)
     @named js2 = JumpSystem(
-        [j₃], t, [S, I, R], [β, γ, h]; bindings = [β => 0.01γ])
+        [j₃], t, [S, I, R], [β, γ, h]; bindings = [β => 0.01γ]
+    )
     @test issetequal(parameters(js2), [β, γ, h])
     js2 = complete(js2)
     @test issetequal(parameters(js2), [γ, h])
@@ -266,15 +274,17 @@ end
     tspan = (0.0, 250.0)
     u₀map = [S => 999, I => 1, R => 0]
     parammap = [γ => 0.01]
-    jprob = JumpProblem(js2, [u₀map; parammap], tspan; aggregator = Direct(),
-        save_positions = (false, false), rng = rng)
+    jprob = JumpProblem(
+        js2, [u₀map; parammap], tspan; aggregator = Direct(),
+        save_positions = (false, false), rng = rng
+    )
     @test jprob.ps[γ] == 0.01
     @test jprob.ps[β] == 0.0001
     @test_nowarn solve(jprob, SSAStepper())
 end
 
 @testset "NonlinearSystem" begin
-    @parameters p1=1.0 p2
+    @parameters p1 = 1.0 p2
     @variables x(t)
     eqs = [0 ~ p1 * x * exp(x) + p2]
     @mtkcompile sys = System(eqs; bindings = [p2 => 2p1])
@@ -290,7 +300,7 @@ end
 end
 
 @testset "SciMLStructures interface" begin
-    @parameters p1=1.0 p2
+    @parameters p1 = 1.0 p2
     @variables x(t)
     cb1 = [x ~ 2.0] => [p1 ~ 2.0] # triggers at t=-2+√6
     function affect1!(integ, u, p, ctx)

--- a/lib/ModelingToolkitBase/test/pdesystem.jl
+++ b/lib/ModelingToolkitBase/test/pdesystem.jl
@@ -7,11 +7,15 @@ using ModelingToolkitBase: t_nounits as t, D_nounits as Dt
 @variables u(..)
 Dxx = Differential(x)^2
 eq = Dt(u(t, x)) ~ h * Dxx(u(t, x))
-bcs = [u(0, x) ~ -h * x * (x - 1) * sin(x),
-    u(t, 0) ~ 0, u(t, 1) ~ 0]
+bcs = [
+    u(0, x) ~ -h * x * (x - 1) * sin(x),
+    u(t, 0) ~ 0, u(t, 1) ~ 0,
+]
 
-domains = [t ∈ (0.0, 1.0),
-    x ∈ (0.0, 1.0)]
+domains = [
+    t ∈ (0.0, 1.0),
+    x ∈ (0.0, 1.0),
+]
 
 analytic = [u(t, x) ~ -h * x * (x - 1) * sin(x) * exp(-2 * h * t)]
 analytic_function = (ps, t, x) -> -ps[1] * x * (x - 1) * sin(x) * exp(-2 * ps[1] * t)
@@ -25,5 +29,7 @@ dx = 0:0.1:1
 dt = 0:0.1:1
 
 # Test generated analytic_func
-@test all(pdesys.analytic_func[u(t, x)]([2], disct, discx) ≈
-          analytic_function([2], disct, discx) for disct in dt, discx in dx)
+@test all(
+    pdesys.analytic_func[u(t, x)]([2], disct, discx) ≈
+        analytic_function([2], disct, discx) for disct in dt, discx in dx
+)

--- a/lib/ModelingToolkitBase/test/precompile_test.jl
+++ b/lib/ModelingToolkitBase/test/precompile_test.jl
@@ -10,16 +10,18 @@ using Distributed
 using ODEPrecompileTest
 
 u = collect(1:3)
-p = ModelingToolkitBase.MTKParameters(ODEPrecompileTest.f_noeval_good.sys,
-    [:σ, :ρ, :β] .=> collect(4:6))
+p = ModelingToolkitBase.MTKParameters(
+    ODEPrecompileTest.f_noeval_good.sys,
+    [:σ, :ρ, :β] .=> collect(4:6)
+)
 
 # These cases do not work, because they get defined in the ModelingToolkitBase's RGF cache.
 @test parentmodule(typeof(ODEPrecompileTest.f_bad.f.f_iip).parameters[2]) == ModelingToolkitBase
 @test parentmodule(typeof(ODEPrecompileTest.f_bad.f.f_oop).parameters[2]) == ModelingToolkitBase
 @test parentmodule(typeof(ODEPrecompileTest.f_noeval_bad.f.f_iip).parameters[2]) ==
-      ModelingToolkitBase
+    ModelingToolkitBase
 @test parentmodule(typeof(ODEPrecompileTest.f_noeval_bad.f.f_oop).parameters[2]) ==
-      ModelingToolkitBase
+    ModelingToolkitBase
 @test_skip begin
     @test_throws KeyError ODEPrecompileTest.f_bad(u, p, 0.1)
     @test_throws KeyError ODEPrecompileTest.f_noeval_bad(u, p, 0.1)
@@ -27,17 +29,17 @@ end
 
 # This case works, because it gets defined with the appropriate cache and context tags.
 @test parentmodule(typeof(ODEPrecompileTest.f_noeval_good.f.f_iip).parameters[2]) ==
-      ODEPrecompileTest
+    ODEPrecompileTest
 @test parentmodule(typeof(ODEPrecompileTest.f_noeval_good.f.f_oop).parameters[2]) ==
-      ODEPrecompileTest
+    ODEPrecompileTest
 @test ODEPrecompileTest.f_noeval_good(u, p, 0.1) == [4, 0, -16]
 
 ODEPrecompileTest.f_eval_bad(u, p, 0.1)
 
 @test parentmodule(typeof(ODEPrecompileTest.f_eval_good.f.f_iip)) ==
-      ODEPrecompileTest
+    ODEPrecompileTest
 @test parentmodule(typeof(ODEPrecompileTest.f_eval_good.f.f_oop)) ==
-      ODEPrecompileTest
+    ODEPrecompileTest
 @test ODEPrecompileTest.f_eval_good(u, p, 0.1) == [4, 0, -16]
 
 @test_nowarn solve(ODEPrecompileTest.prob_eval)

--- a/lib/ModelingToolkitBase/test/precompile_test/ODEPrecompileTest.jl
+++ b/lib/ModelingToolkitBase/test/precompile_test/ODEPrecompileTest.jl
@@ -9,9 +9,11 @@ function system(; kwargs...)
     D = Differential(t)
 
     # Define a differential equation
-    eqs = [D(x) ~ σ * (y - x),
+    eqs = [
+        D(x) ~ σ * (y - x),
         D(y) ~ x * (ρ - z) - y,
-        D(z) ~ x * y - β * z]
+        D(z) ~ x * y - β * z,
+    ]
 
     @named de = System(eqs, t)
     de = complete(de)
@@ -45,13 +47,15 @@ function problem(; kwargs...)
     D = Differential(t)
 
     # Define a differential equation
-    eqs = [D(x) ~ σ * (y - x),
+    eqs = [
+        D(x) ~ σ * (y - x),
         D(y) ~ x * (ρ - z) - y,
-        D(z) ~ x * y - β * z]
+        D(z) ~ x * y - β * z,
+    ]
 
     @named de = System(eqs, t)
     de = complete(de)
-    return ODEProblem(de, [x => 1, y => 0, z => 0, σ => 10, ρ => 28, β => 8/3], (0.0, 5.0); kwargs...)
+    return ODEProblem(de, [x => 1, y => 0, z => 0, σ => 10, ρ => 28, β => 8 / 3], (0.0, 5.0); kwargs...)
 end
 
 const prob_eval = problem(; eval_expression = true, eval_module = @__MODULE__)

--- a/lib/ModelingToolkitBase/test/print_tree.jl
+++ b/lib/ModelingToolkitBase/test/print_tree.jl
@@ -7,19 +7,19 @@ io = IOBuffer()
 print_tree(io, rc_model)
 ser = String(take!(io))
 str = """rc_model
-      ├─ resistor
-      │  ├─ p
-      │  └─ n
-      ├─ capacitor
-      │  ├─ p
-      │  └─ n
-      ├─ shape
-      │  └─ output
-      ├─ source
-      │  ├─ p
-      │  ├─ n
-      │  └─ V
-      └─ ground
-         └─ g
-      """
+├─ resistor
+│  ├─ p
+│  └─ n
+├─ capacitor
+│  ├─ p
+│  └─ n
+├─ shape
+│  └─ output
+├─ source
+│  ├─ p
+│  ├─ n
+│  └─ V
+└─ ground
+   └─ g
+"""
 @test strip(ser) == strip(str)

--- a/lib/ModelingToolkitBase/test/runtests.jl
+++ b/lib/ModelingToolkitBase/test/runtests.jl
@@ -7,13 +7,13 @@ const GROUP = get(ENV, "GROUP", "All")
 function activate_extensions_env()
     Pkg.activate("extensions")
     Pkg.develop([PackageSpec(path = dirname(@__DIR__))])
-    Pkg.instantiate()
+    return Pkg.instantiate()
 end
 
 function activate_downstream_env()
     Pkg.activate("downstream")
     Pkg.develop([PackageSpec(path = dirname(@__DIR__))])
-    Pkg.instantiate()
+    return Pkg.instantiate()
 end
 
 @time begin
@@ -81,7 +81,7 @@ end
             @safetestset "LinearProblem Tests" include("linearproblem.jl")
         end
     end
-    
+
     if GROUP == "All" || GROUP == "SymbolicIndexingInterface"
         @safetestset "SymbolicIndexingInterface test" include("symbolic_indexing_interface.jl")
         @safetestset "SciML Problem Input Test" include("sciml_problem_inputs.jl")

--- a/lib/ModelingToolkitBase/test/sciml_problem_inputs.jl
+++ b/lib/ModelingToolkitBase/test/sciml_problem_inputs.jl
@@ -2,7 +2,7 @@
 
 # Fetch packages
 using ModelingToolkitBase, JumpProcesses, NonlinearSolve, OrdinaryDiffEq, StaticArrays,
-      SteadyStateDiffEq, StochasticDiffEq, SciMLBase, Test, SymbolicUtils
+    SteadyStateDiffEq, StochasticDiffEq, SciMLBase, Test, SymbolicUtils
 import DiffEqNoiseProcess
 using ModelingToolkitBase: t_nounits as t, D_nounits as D
 
@@ -16,17 +16,17 @@ seed = rand(rng, 1:100)
 # Prepares a models and initial conditions/parameters (of different forms) to be used as problem inputs.
 begin
     # Prepare system components.
-    @parameters kp kd k1 k2=0.5 Z0
-    @variables X(t) Y(t) Z(t)=Z0
+    @parameters kp kd k1 k2 = 0.5 Z0
+    @variables X(t) Y(t) Z(t) = Z0
     alg_eqs = [
         0 ~ kp - k1 * X + k2 * Y - kd * X,
         0 ~ -k1 * Y + k1 * X - k2 * Y + k2 * Z,
-        0 ~ k1 * Y - k2 * Z
+        0 ~ k1 * Y - k2 * Z,
     ]
     diff_eqs = [
         D(X) ~ kp - k1 * X + k2 * Y - kd * X,
         D(Y) ~ -k1 * Y + k1 * X - k2 * Y + k2 * Z,
-        D(Z) ~ k1 * Y - k2 * Z
+        D(Z) ~ k1 * Y - k2 * Z,
     ]
     noise_eqs = fill(0.01, 3, 6)
     jumps = [
@@ -35,13 +35,16 @@ begin
         MassActionJump(k1, [X => 1], [X => -1, Y => 1]),
         MassActionJump(k2, [Y => 1], [X => 1, Y => -1]),
         MassActionJump(k1, [Y => 1], [Y => -1, Z => 1]),
-        MassActionJump(k2, [Z => 1], [Y => 1, Z => -1])
+        MassActionJump(k2, [Z => 1], [Y => 1, Z => -1]),
     ]
 
     # Create systems (without mtkcompile, since that might modify systems to affect intended tests).
     osys = complete(System(diff_eqs, t; name = :osys))
-    ssys = complete(SDESystem(
-        diff_eqs, noise_eqs, t, [X, Y, Z], [kp, kd, k1, k2]; name = :ssys))
+    ssys = complete(
+        SDESystem(
+            diff_eqs, noise_eqs, t, [X, Y, Z], [kp, kd, k1, k2]; name = :ssys
+        )
+    )
     jsys = complete(JumpSystem(jumps, t, [X, Y, Z], [kp, kd, k1, k2]; name = :jsys))
     nsys = complete(System(alg_eqs; name = :nsys))
 
@@ -69,7 +72,7 @@ begin
         (osys.X => 4, osys.Y => 5),
         # Tuples providing default values.
         (X => 4, Y => 5, Z => 10),
-        (osys.X => 4, osys.Y => 5, osys.Z => 10)
+        (osys.X => 4, osys.Y => 5, osys.Z => 10),
     ]
     tspan = (0.0, 10.0)
     p_alts = [
@@ -90,14 +93,18 @@ begin
         Dict([osys.kp => 1.0, osys.kd => 0.1, osys.k1 => 0.25, osys.Z0 => 10]),
         # Dicts providing default values.
         Dict([kp => 1.0, kd => 0.1, k1 => 0.25, k2 => 0.5, Z0 => 10]),
-        Dict([osys.kp => 1.0, osys.kd => 0.1, osys.k1 => 0.25,
-            osys.k2 => 0.5, osys.Z0 => 10]),
+        Dict(
+            [
+                osys.kp => 1.0, osys.kd => 0.1, osys.k1 => 0.25,
+                osys.k2 => 0.5, osys.Z0 => 10,
+            ]
+        ),
         # Tuples not providing default values.
         (kp => 1.0, kd => 0.1, k1 => 0.25, Z0 => 10),
         (osys.kp => 1.0, osys.kd => 0.1, osys.k1 => 0.25, osys.Z0 => 10),
         # Tuples providing default values.
         (kp => 1.0, kd => 0.1, k1 => 0.25, k2 => 0.5, Z0 => 10),
-        (osys.kp => 1.0, osys.kd => 0.1, osys.k1 => 0.25, osys.k2 => 0.5, osys.Z0 => 10)
+        (osys.kp => 1.0, osys.kd => 0.1, osys.k1 => 0.25, osys.k2 => 0.5, osys.Z0 => 10),
     ]
 end
 
@@ -168,45 +175,45 @@ end
     @test_deprecated DiscreteSystem([x ~ x(k - 1) + x(k - 2)], t; name = :a)
     @mtkcompile discsys = System([x ~ x(k - 1) * p], t)
     @test_deprecated ImplicitDiscreteSystem([x ~ x(k - 1) + x(k - 2) * p * x], t; name = :a)
-    @mtkcompile idiscsys = System([x ~ x(k - 1) * p * x], t; guesses = [x(k-1) => 1.0])
+    @mtkcompile idiscsys = System([x ~ x(k - 1) * p * x], t; guesses = [x(k - 1) => 1.0])
     @mtkcompile optsys = OptimizationSystem(x^2 + p)
 
     u0s = [
         Dict(x => 1.0),
         [x => 1.0],
         [],
-        nothing
+        nothing,
     ]
     ps = [
         Dict(p => 1.0),
         [p => 1.0],
         [],
         nothing,
-        SciMLBase.NullParameters()
+        SciMLBase.NullParameters(),
     ]
     tspan = (0.0, 1.0)
 
     @testset "$ctor" for (sys, ctor) in [
-        (odesys, ODEProblem),
-        (odesys, ODEProblem{true}),
-        (odesys, ODEProblem{true, SciMLBase.FullSpecialize}), (odesys, BVProblem),
-        (odesys, BVProblem{true}),
-        (odesys, BVProblem{true, SciMLBase.FullSpecialize}), (sdesys, SDEProblem),
-        (sdesys, SDEProblem{true}),
-        (sdesys, SDEProblem{true, SciMLBase.FullSpecialize}), (ddesys, DDEProblem),
-        (ddesys, DDEProblem{true}),
-        (ddesys, DDEProblem{true, SciMLBase.FullSpecialize}), (sddesys, SDDEProblem),
-        (sddesys, SDDEProblem{true}),
-        (sddesys, SDDEProblem{true, SciMLBase.FullSpecialize}),
+            (odesys, ODEProblem),
+            (odesys, ODEProblem{true}),
+            (odesys, ODEProblem{true, SciMLBase.FullSpecialize}), (odesys, BVProblem),
+            (odesys, BVProblem{true}),
+            (odesys, BVProblem{true, SciMLBase.FullSpecialize}), (sdesys, SDEProblem),
+            (sdesys, SDEProblem{true}),
+            (sdesys, SDEProblem{true, SciMLBase.FullSpecialize}), (ddesys, DDEProblem),
+            (ddesys, DDEProblem{true}),
+            (ddesys, DDEProblem{true, SciMLBase.FullSpecialize}), (sddesys, SDDEProblem),
+            (sddesys, SDDEProblem{true}),
+            (sddesys, SDDEProblem{true, SciMLBase.FullSpecialize}),
 
-        # (discsys, DiscreteProblem),
-        # (discsys, DiscreteProblem{true}),
-        # (discsys, DiscreteProblem{true, SciMLBase.FullSpecialize}),
+            # (discsys, DiscreteProblem),
+            # (discsys, DiscreteProblem{true}),
+            # (discsys, DiscreteProblem{true, SciMLBase.FullSpecialize}),
 
-        (idiscsys, ImplicitDiscreteProblem),
-        (idiscsys, ImplicitDiscreteProblem{true}),
-        (idiscsys, ImplicitDiscreteProblem{true, SciMLBase.FullSpecialize})
-    ]
+            (idiscsys, ImplicitDiscreteProblem),
+            (idiscsys, ImplicitDiscreteProblem{true}),
+            (idiscsys, ImplicitDiscreteProblem{true, SciMLBase.FullSpecialize}),
+        ]
         @testset "$(typeof(u0)) - $(typeof(p))" for u0 in u0s, p in ps
 
             if u0 isa Vector{Float64} && ctor <: ImplicitDiscreteProblem
@@ -216,16 +223,18 @@ end
         end
     end
     @testset "$ctor" for (sys, ctor) in [
-        (nlsys, NonlinearProblem),
-        (nlsys, NonlinearProblem{true}),
-        (nlsys, NonlinearProblem{true, SciMLBase.FullSpecialize}), (
-            nlsys, NonlinearLeastSquaresProblem),
-        (nlsys, NonlinearLeastSquaresProblem{true}),
-        (nlsys, NonlinearLeastSquaresProblem{true, SciMLBase.FullSpecialize}), (
-            nlsys, SCCNonlinearProblem),
-        (nlsys, SCCNonlinearProblem{true}), (optsys, OptimizationProblem),
-        (optsys, OptimizationProblem{true})
-    ]
+            (nlsys, NonlinearProblem),
+            (nlsys, NonlinearProblem{true}),
+            (nlsys, NonlinearProblem{true, SciMLBase.FullSpecialize}), (
+                nlsys, NonlinearLeastSquaresProblem,
+            ),
+            (nlsys, NonlinearLeastSquaresProblem{true}),
+            (nlsys, NonlinearLeastSquaresProblem{true, SciMLBase.FullSpecialize}), (
+                nlsys, SCCNonlinearProblem,
+            ),
+            (nlsys, SCCNonlinearProblem{true}), (optsys, OptimizationProblem),
+            (optsys, OptimizationProblem{true}),
+        ]
         if !(ctor <: SCCNonlinearProblem) || @isdefined(ModelingToolkit)
             @testset "$(typeof(u0)) - $(typeof(p))" for u0 in u0s, p in ps
 

--- a/lib/ModelingToolkitBase/test/serialization.jl
+++ b/lib/ModelingToolkitBase/test/serialization.jl
@@ -6,9 +6,9 @@ using ModelingToolkitBase: t_nounits as t, D_nounits as D
 @named sys = System([D(x) ~ -0.5 * x], t, initial_conditions = Dict(x => 1.0))
 sys = complete(sys)
 for prob in [
-    eval(ModelingToolkitBase.ODEProblem{false}(sys, nothing, nothing)),
-    eval(ModelingToolkitBase.ODEProblem{false}(sys, nothing, nothing; expression = Val{true}))
-]
+        eval(ModelingToolkitBase.ODEProblem{false}(sys, nothing, nothing)),
+        eval(ModelingToolkitBase.ODEProblem{false}(sys, nothing, nothing; expression = Val{true})),
+    ]
     _fn = tempname()
 
     open(_fn, "w") do f
@@ -44,7 +44,7 @@ ss_exp = ModelingToolkitBase.toexpr(ss)
 ss_ = complete(eval(ss_exp))
 prob_ = ODEProblem(ss_, [capacitor.v => 0.0], (0, 0.1))
 sol_ = solve(prob_, ImplicitEuler())
-@test sol[all_obs] == sol_[all_obs] skip=!@isdefined(ModelingToolkit)
+@test sol[all_obs] == sol_[all_obs] skip = !@isdefined(ModelingToolkit)
 
 ## Check ODEProblemExpr with Observables -----------
 

--- a/lib/ModelingToolkitBase/test/static_arrays.jl
+++ b/lib/ModelingToolkitBase/test/static_arrays.jl
@@ -4,20 +4,24 @@ using ModelingToolkitBase: t_nounits as t, D_nounits as D
 @parameters σ ρ β
 @variables x(t) y(t) z(t)
 
-eqs = [D(D(x)) ~ σ * (y - x),
+eqs = [
+    D(D(x)) ~ σ * (y - x),
     D(y) ~ x * (ρ - z) - y,
-    D(z) ~ x * y - β * z]
+    D(z) ~ x * y - β * z,
+]
 
 @named sys = System(eqs, t)
 sys = mtkcompile(sys)
 
-ivs = @SVector [D(x) => 2.0,
+ivs = @SVector [
+    D(x) => 2.0,
     x => 1.0,
     y => 0.0,
     z => 0.0,
     σ => 28.0,
     ρ => 10.0,
-    β => 8 / 3]
+    β => 8 / 3,
+]
 
 tspan = (0.0, 100.0)
 prob_mtk = ODEProblem(sys, ivs, tspan)

--- a/lib/ModelingToolkitBase/test/steadystatesystems.jl
+++ b/lib/ModelingToolkitBase/test/steadystatesystems.jl
@@ -10,14 +10,14 @@ eqs = [D(x) ~ x^2 - r]
 @named de = System(eqs, t)
 de = complete(de)
 
-for factor in [1e-1, 1e0, 1e10],
-    u0_p in [(2.34, 2.676), (22.34, 1.632), (0.3, 15.676), (0.3, 0.006)]
+for factor in [1.0e-1, 1.0e0, 1.0e10],
+        u0_p in [(2.34, 2.676), (22.34, 1.632), (0.3, 15.676), (0.3, 0.006)]
 
     u0 = [x => factor * u0_p[1]]
     p = [r => factor * u0_p[2]]
     ss_prob = SteadyStateProblem(de, [u0; p])
     sol = solve(ss_prob, SSRootfind()).u[1]
-    @test abs(sol^2 - factor * u0_p[2]) < 1e-8
+    @test abs(sol^2 - factor * u0_p[2]) < 1.0e-8
     ss_prob = SteadyStateProblem(de, [u0; p])
     sol_expr = solve(ss_prob, SSRootfind()).u[1]
     @test all(x -> x == 0, sol - sol_expr)

--- a/lib/ModelingToolkitBase/test/stream_connectors.jl
+++ b/lib/ModelingToolkitBase/test/stream_connectors.jl
@@ -35,9 +35,11 @@ end
     System(eqs, t, vars, pars; name)
 end
 
-function MassFlowSource_h(; name,
-        h_in = 420e3,
-        m_flow_in = -0.01)
+function MassFlowSource_h(;
+        name,
+        h_in = 420.0e3,
+        m_flow_in = -0.01
+    )
     pars = @parameters begin
         h_in = h_in
         m_flow_in = m_flow_in
@@ -57,12 +59,14 @@ function MassFlowSource_h(; name,
     push!(eqns, port.m_flow ~ -m_flow_in)
     push!(eqns, port.h_outflow ~ h_in)
 
-    compose(System(eqns, t, vars, pars; name = name), subs)
+    return compose(System(eqns, t, vars, pars; name = name), subs)
 end
 
 # Simplified components.
-function AdiabaticStraightPipe(; name,
-        kwargs...)
+function AdiabaticStraightPipe(;
+        name,
+        kwargs...
+    )
     vars = []
     pars = []
 
@@ -75,12 +79,14 @@ function AdiabaticStraightPipe(; name,
 
     push!(eqns, connect(port_a, port_b))
     sys = System(eqns, t, vars, pars; name = name)
-    sys = compose(sys, subs)
+    return sys = compose(sys, subs)
 end
 
-function SmallBoundary_Ph(; name,
-        P_in = 1e6,
-        h_in = 400e3)
+function SmallBoundary_Ph(;
+        name,
+        P_in = 1.0e6,
+        h_in = 400.0e3
+    )
     vars = []
 
     pars = @parameters begin
@@ -97,14 +103,16 @@ function SmallBoundary_Ph(; name,
     push!(eqns, port1.P ~ P)
     push!(eqns, port1.h_outflow ~ h)
 
-    compose(System(eqns, t, vars, pars; name = name), subs)
+    return compose(System(eqns, t, vars, pars; name = name), subs)
 end
 
 # N1M1 model and test code.
-function N1M1(; name,
-        P_in = 1e6,
-        h_in = 400e3,
-        kwargs...)
+function N1M1(;
+        name,
+        P_in = 1.0e6,
+        h_in = 400.0e3,
+        kwargs...
+    )
     @named port_a = TwoPhaseFluidPort()
     @named source = SmallBoundary_Ph(P_in = P_in, h_in = h_in)
 
@@ -115,71 +123,91 @@ function N1M1(; name,
     push!(eqns, connect(source.port1, port_a))
 
     sys = System(eqns, t, [], [], name = name)
-    sys = compose(sys, subs)
+    return sys = compose(sys, subs)
 end
 
 @named fluid = TwoPhaseFluid(; R = 876, B = 1.2e9, V = 0.034)
 @named n1m1 = N1M1()
 @named pipe = AdiabaticStraightPipe()
-@named sink = MassFlowSource_h(m_flow_in = -0.01, h_in = 400e3)
+@named sink = MassFlowSource_h(m_flow_in = -0.01, h_in = 400.0e3)
 
-eqns = [connect(n1m1.port_a, pipe.port_a)
-        connect(pipe.port_b, sink.port)]
+eqns = [
+    connect(n1m1.port_a, pipe.port_a)
+    connect(pipe.port_b, sink.port)
+]
 
 @named sys = System(eqns, t; systems = [n1m1, pipe, sink])
 
-eqns = [domain_connect(fluid, n1m1.port_a)
-        connect(n1m1.port_a, pipe.port_a)
-        connect(pipe.port_b, sink.port)]
+eqns = [
+    domain_connect(fluid, n1m1.port_a)
+    connect(n1m1.port_a, pipe.port_a)
+    connect(pipe.port_b, sink.port)
+]
 
 @named n1m1Test = System(eqns, t, [], []; systems = [fluid, n1m1, pipe, sink])
 
 @test_nowarn mtkcompile(n1m1Test)
 @unpack source, port_a = n1m1
 ssort(eqs) = sort(eqs, by = string)
-@test ssort(equations(expand_connections(n1m1))) == ssort([0 ~ port_a.m_flow
-             0 ~ source.port1.m_flow - port_a.m_flow
-             source.port1.P ~ port_a.P
-             source.port1.P ~ source.P
-             port_a.h_outflow ~ source.port1.h_outflow
-             source.port1.h_outflow ~ source.h])
+@test ssort(equations(expand_connections(n1m1))) == ssort(
+    [
+        0 ~ port_a.m_flow
+        0 ~ source.port1.m_flow - port_a.m_flow
+        source.port1.P ~ port_a.P
+        source.port1.P ~ source.P
+        port_a.h_outflow ~ source.port1.h_outflow
+        source.port1.h_outflow ~ source.h
+    ]
+)
 @unpack port_a, port_b = pipe
 @test ssort(equations(expand_connections(pipe))) ==
-      ssort([0 ~ -port_a.m_flow - port_b.m_flow
-             0 ~ port_a.m_flow
-             0 ~ port_b.m_flow
-             port_a.P ~ port_b.P
-             port_a.h_outflow ~ instream(port_b.h_outflow)
-             port_b.h_outflow ~ instream(port_a.h_outflow)])
+    ssort(
+    [
+        0 ~ -port_a.m_flow - port_b.m_flow
+        0 ~ port_a.m_flow
+        0 ~ port_b.m_flow
+        port_a.P ~ port_b.P
+        port_a.h_outflow ~ instream(port_b.h_outflow)
+        port_b.h_outflow ~ instream(port_a.h_outflow)
+    ]
+)
 @test equations(expand_connections(sys)) ⊇
-      [0 ~ n1m1.port_a.m_flow + pipe.port_a.m_flow
-       0 ~ pipe.port_b.m_flow + sink.port.m_flow
-       n1m1.port_a.P ~ pipe.port_a.P
-       pipe.port_b.P ~ sink.port.P]
+    [
+    0 ~ n1m1.port_a.m_flow + pipe.port_a.m_flow
+    0 ~ pipe.port_b.m_flow + sink.port.m_flow
+    n1m1.port_a.P ~ pipe.port_a.P
+    pipe.port_b.P ~ sink.port.P
+]
 @test ssort(equations(expand_connections(n1m1Test))) ==
-      ssort([0 ~ -pipe.port_a.m_flow - pipe.port_b.m_flow
-             0 ~ n1m1.source.port1.m_flow - n1m1.port_a.m_flow
-             0 ~ n1m1.port_a.m_flow + pipe.port_a.m_flow
-             0 ~ pipe.port_b.m_flow + sink.port.m_flow
-             fluid.m_flow ~ 0
-             n1m1.port_a.P ~ pipe.port_a.P
-             n1m1.source.port1.P ~ n1m1.port_a.P
-             n1m1.source.port1.P ~ n1m1.source.P
-             n1m1.port_a.h_outflow ~ n1m1.source.port1.h_outflow
-             n1m1.source.port1.h_outflow ~ n1m1.source.h
-             pipe.port_a.P ~ pipe.port_b.P
-             pipe.port_a.h_outflow ~ sink.port.h_outflow
-             pipe.port_b.P ~ sink.port.P
-             pipe.port_b.h_outflow ~ n1m1.port_a.h_outflow
-             sink.port.P ~ sink.P
-             sink.port.h_outflow ~ sink.h_in
-             sink.port.m_flow ~ -sink.m_flow_in])
+    ssort(
+    [
+        0 ~ -pipe.port_a.m_flow - pipe.port_b.m_flow
+        0 ~ n1m1.source.port1.m_flow - n1m1.port_a.m_flow
+        0 ~ n1m1.port_a.m_flow + pipe.port_a.m_flow
+        0 ~ pipe.port_b.m_flow + sink.port.m_flow
+        fluid.m_flow ~ 0
+        n1m1.port_a.P ~ pipe.port_a.P
+        n1m1.source.port1.P ~ n1m1.port_a.P
+        n1m1.source.port1.P ~ n1m1.source.P
+        n1m1.port_a.h_outflow ~ n1m1.source.port1.h_outflow
+        n1m1.source.port1.h_outflow ~ n1m1.source.h
+        pipe.port_a.P ~ pipe.port_b.P
+        pipe.port_a.h_outflow ~ sink.port.h_outflow
+        pipe.port_b.P ~ sink.port.P
+        pipe.port_b.h_outflow ~ n1m1.port_a.h_outflow
+        sink.port.P ~ sink.P
+        sink.port.h_outflow ~ sink.h_in
+        sink.port.m_flow ~ -sink.m_flow_in
+    ]
+)
 
 # N1M2 model and test code.
-function N1M2(; name,
-        P_in = 1e6,
-        h_in = 400e3,
-        kwargs...)
+function N1M2(;
+        name,
+        P_in = 1.0e6,
+        h_in = 400.0e3,
+        kwargs...
+    )
     @named port_a = TwoPhaseFluidPort()
     @named port_b = TwoPhaseFluidPort()
 
@@ -193,15 +221,17 @@ function N1M2(; name,
     push!(eqns, connect(source.port1, port_b))
 
     sys = System(eqns, t, [], [], name = name)
-    sys = compose(sys, subs)
+    return sys = compose(sys, subs)
 end
 
 @named n1m2 = N1M2()
-@named sink1 = MassFlowSource_h(m_flow_in = -0.01, h_in = 400e3)
-@named sink2 = MassFlowSource_h(m_flow_in = -0.01, h_in = 400e3)
+@named sink1 = MassFlowSource_h(m_flow_in = -0.01, h_in = 400.0e3)
+@named sink2 = MassFlowSource_h(m_flow_in = -0.01, h_in = 400.0e3)
 
-eqns = [connect(n1m2.port_a, sink1.port)
-        connect(n1m2.port_b, sink2.port)]
+eqns = [
+    connect(n1m2.port_a, sink1.port)
+    connect(n1m2.port_b, sink2.port)
+]
 
 @named sys = System(eqns, t)
 @named n1m2Test = compose(sys, n1m2, sink1, sink2)
@@ -210,21 +240,25 @@ eqns = [connect(n1m2.port_a, sink1.port)
 @named n1m2 = N1M2()
 @named pipe1 = AdiabaticStraightPipe()
 @named pipe2 = AdiabaticStraightPipe()
-@named sink1 = MassFlowSource_h(m_flow_in = -0.01, h_in = 400e3)
-@named sink2 = MassFlowSource_h(m_flow_in = -0.01, h_in = 400e3)
+@named sink1 = MassFlowSource_h(m_flow_in = -0.01, h_in = 400.0e3)
+@named sink2 = MassFlowSource_h(m_flow_in = -0.01, h_in = 400.0e3)
 
-eqns = [connect(n1m2.port_a, pipe1.port_a)
-        connect(pipe1.port_b, sink1.port)
-        connect(n1m2.port_b, pipe2.port_a)
-        connect(pipe2.port_b, sink2.port)]
+eqns = [
+    connect(n1m2.port_a, pipe1.port_a)
+    connect(pipe1.port_b, sink1.port)
+    connect(n1m2.port_b, pipe2.port_a)
+    connect(pipe2.port_b, sink2.port)
+]
 
 @named sys = System(eqns, t)
 @named n1m2AltTest = compose(sys, n1m2, pipe1, pipe2, sink1, sink2)
 @test_nowarn mtkcompile(n1m2AltTest)
 
 # N2M2 model and test code.
-function N2M2(; name,
-        kwargs...)
+function N2M2(;
+        name,
+        kwargs...
+    )
     @named port_a = TwoPhaseFluidPort()
     @named port_b = TwoPhaseFluidPort()
     @named pipe = AdiabaticStraightPipe()
@@ -237,15 +271,17 @@ function N2M2(; name,
     push!(eqns, connect(pipe.port_b, port_b))
 
     sys = System(eqns, t, [], [], name = name)
-    sys = compose(sys, subs)
+    return sys = compose(sys, subs)
 end
 
 @named n2m2 = N2M2()
-@named source = MassFlowSource_h(m_flow_in = -0.01, h_in = 400e3)
-@named sink = SmallBoundary_Ph(P_in = 1e6, h_in = 400e3)
+@named source = MassFlowSource_h(m_flow_in = -0.01, h_in = 400.0e3)
+@named sink = SmallBoundary_Ph(P_in = 1.0e6, h_in = 400.0e3)
 
-eqns = [connect(source.port, n2m2.port_a)
-        connect(n2m2.port_b, sink.port1)]
+eqns = [
+    connect(source.port, n2m2.port_a)
+    connect(n2m2.port_b, sink.port1)
+]
 
 @named sys = System(eqns, t)
 @named n2m2Test = compose(sys, n2m2, source, sink)
@@ -256,16 +292,20 @@ eqns = [connect(source.port, n2m2.port_a)
 @named sp2 = TwoPhaseFluidPort()
 @named sys = System([connect(sp1, sp2)], t)
 sys_exp = expand_connections(compose(sys, [sp1, sp2]))
-@test ssort(equations(sys_exp)) == ssort([0 ~ -sp1.m_flow - sp2.m_flow
-             0 ~ sp1.m_flow
-             0 ~ sp2.m_flow
-             sp1.P ~ sp2.P
-             sp1.h_outflow ~ ModelingToolkitBase.instream(sp2.h_outflow)
-             sp2.h_outflow ~ ModelingToolkitBase.instream(sp1.h_outflow)])
+@test ssort(equations(sys_exp)) == ssort(
+    [
+        0 ~ -sp1.m_flow - sp2.m_flow
+        0 ~ sp1.m_flow
+        0 ~ sp2.m_flow
+        sp1.P ~ sp2.P
+        sp1.h_outflow ~ ModelingToolkitBase.instream(sp2.h_outflow)
+        sp2.h_outflow ~ ModelingToolkitBase.instream(sp1.h_outflow)
+    ]
+)
 
 # array var
 @connector function VecPin(; name)
-    sts = @variables v(t)[1:2]=[1.0, 0.0] i(t)[1:2]=ones(2) [connect=Flow]
+    sts = @variables v(t)[1:2] = [1.0, 0.0] i(t)[1:2] = ones(2) [connect = Flow]
     System(Equation[], t, [sts...;], []; name = name)
 end
 
@@ -275,16 +315,20 @@ end
 
 @named simple = System([connect(vp1, vp2, vp3)], t)
 sys = expand_connections(compose(simple, [vp1, vp2, vp3]))
-@test ssort(equations(sys)) == ssort([0 .~ collect(vp1.i)
-             0 .~ collect(vp2.i)
-             0 .~ collect(vp3.i)
-             vp1.v ~ vp2.v
-             vp1.v ~ vp3.v
-             0 ~ -vp1.i[1] - vp2.i[1] - vp3.i[1]
-             0 ~ -vp1.i[2] - vp2.i[2] - vp3.i[2]])
+@test ssort(equations(sys)) == ssort(
+    [
+        0 .~ collect(vp1.i)
+        0 .~ collect(vp2.i)
+        0 .~ collect(vp3.i)
+        vp1.v ~ vp2.v
+        vp1.v ~ vp3.v
+        0 ~ -vp1.i[1] - vp2.i[1] - vp3.i[1]
+        0 ~ -vp1.i[2] - vp2.i[2] - vp3.i[2]
+    ]
+)
 
 @connector function VectorHeatPort(; name, N = 100, T0 = 0.0, Q0 = 0.0)
-    @variables (T(t))[1:N]=T0 * ones(N) (Q(t))[1:N]=Q0 * ones(N) [connect=Flow]
+    @variables (T(t))[1:N] = T0 * ones(N) (Q(t))[1:N] = Q0 * ones(N) [connect = Flow]
     System(Equation[], t, [T; Q], []; name = name)
 end
 
@@ -333,7 +377,7 @@ end
 
     # equations ---------------------------
     eqs = [
-        dm ~ 0
+        dm ~ 0,
     ]
 
     System(eqs, t, vars, pars; name)
@@ -353,10 +397,10 @@ function StepSource(; P, name)
 
     # equations ---------------------------
     eqs = [
-        H.p ~ p_int * (t > 0.01)
+        H.p ~ p_int * (t > 0.01),
     ]
 
-    System(eqs, t, vars, pars; name, systems)
+    return System(eqs, t, vars, pars; name, systems)
 end
 
 function StaticVolume(; P, V, name)
@@ -380,13 +424,17 @@ function StaticVolume(; P, V, name)
     rho_0 = H.rho
 
     # equations ---------------------------
-    eqs = [D(vrho) ~ drho
-           vrho ~ rho_0 * (1 + p / H.bulk)
-           H.p ~ p
-           H.dm ~ drho * V]
+    eqs = [
+        D(vrho) ~ drho
+        vrho ~ rho_0 * (1 + p / H.bulk)
+        H.p ~ p
+        H.dm ~ drho * V
+    ]
 
-    System(eqs, t, vars, pars; name, systems,
-        initial_conditions = [vrho => rho_0 * (1 + p_int / H.bulk)])
+    return System(
+        eqs, t, vars, pars; name, systems,
+        initial_conditions = [vrho => rho_0 * (1 + p_int / H.bulk)]
+    )
 end
 
 function PipeBase(; P, R, name)
@@ -404,11 +452,13 @@ function PipeBase(; P, R, name)
     end
 
     # equations ---------------------------
-    eqs = [HA.p - HB.p ~ HA.dm * resistance / HA.viscosity
-           0 ~ HA.dm + HB.dm
-           domain_connect(HA, HB)]
+    eqs = [
+        HA.p - HB.p ~ HA.dm * resistance / HA.viscosity
+        0 ~ HA.dm + HB.dm
+        domain_connect(HA, HB)
+    ]
 
-    System(eqs, t, vars, pars; name, systems)
+    return System(eqs, t, vars, pars; name, systems)
 end
 
 function Pipe(; P, R, name)
@@ -427,10 +477,12 @@ function Pipe(; P, R, name)
         v2 = StaticVolume(; P = p_int, V = 0.01)
     end
 
-    eqs = [connect(v1.H, p12.HA, HA)
-           connect(v2.H, p12.HB, HB)]
+    eqs = [
+        connect(v1.H, p12.HA, HA)
+        connect(v2.H, p12.HB, HB)
+    ]
 
-    System(eqs, t, vars, pars; name, systems)
+    return System(eqs, t, vars, pars; name, systems)
 end
 
 function TwoFluidSystem(; name)
@@ -440,25 +492,27 @@ function TwoFluidSystem(; name)
     # nodes -------------------------------
     systems = @named begin
         fluid_a = Fluid(; R = 876, B = 1.2e9, V = 0.034)
-        source_a = StepSource(; P = 10e5)
-        pipe_a = Pipe(; P = 0, R = 1e6)
+        source_a = StepSource(; P = 10.0e5)
+        pipe_a = Pipe(; P = 0, R = 1.0e6)
         volume_a = StaticVolume(; P = 0, V = 0.1)
 
         fluid_b = Fluid(; R = 1000, B = 2.5e9, V = 0.00034)
-        source_b = StepSource(; P = 10e5)
-        pipe_b = Pipe(; P = 0, R = 1e6)
+        source_b = StepSource(; P = 10.0e5)
+        pipe_b = Pipe(; P = 0, R = 1.0e6)
         volume_b = StaticVolume(; P = 0, V = 0.1)
     end
 
     # equations ---------------------------
-    eqs = [connect(fluid_a, source_a.H)
-           connect(source_a.H, pipe_a.HA)
-           connect(pipe_a.HB, volume_a.H)
-           connect(fluid_b, source_b.H)
-           connect(source_b.H, pipe_b.HA)
-           connect(pipe_b.HB, volume_b.H)]
+    eqs = [
+        connect(fluid_a, source_a.H)
+        connect(source_a.H, pipe_a.HA)
+        connect(pipe_a.HB, volume_a.H)
+        connect(fluid_b, source_b.H)
+        connect(source_b.H, pipe_b.HA)
+        connect(pipe_b.HB, volume_b.H)
+    ]
 
-    System(eqs, t, vars, pars; name, systems)
+    return System(eqs, t, vars, pars; name, systems)
 end
 
 @named two_fluid_system = TwoFluidSystem()
@@ -480,23 +534,25 @@ function OneFluidSystem(; name)
     systems = @named begin
         fluid = Fluid(; R = 876, B = 1.2e9, V = 0.034)
 
-        source_a = StepSource(; P = 10e5)
-        pipe_a = Pipe(; P = 0, R = 1e6)
+        source_a = StepSource(; P = 10.0e5)
+        pipe_a = Pipe(; P = 0, R = 1.0e6)
         volume_a = StaticVolume(; P = 0, V = 0.1)
 
-        source_b = StepSource(; P = 20e5)
-        pipe_b = Pipe(; P = 0, R = 1e6)
+        source_b = StepSource(; P = 20.0e5)
+        pipe_b = Pipe(; P = 0, R = 1.0e6)
         volume_b = StaticVolume(; P = 0, V = 0.1)
     end
 
     # equations ---------------------------
-    eqs = [connect(fluid, source_a.H, source_b.H)
-           connect(source_a.H, pipe_a.HA)
-           connect(pipe_a.HB, volume_a.H)
-           connect(source_b.H, pipe_b.HA)
-           connect(pipe_b.HB, volume_b.H)]
+    eqs = [
+        connect(fluid, source_a.H, source_b.H)
+        connect(source_a.H, pipe_a.HA)
+        connect(pipe_a.HB, volume_a.H)
+        connect(source_b.H, pipe_b.HA)
+        connect(pipe_b.HB, volume_b.H)
+    ]
 
-    System(eqs, t, vars, pars; name, systems)
+    return System(eqs, t, vars, pars; name, systems)
 end
 
 @named one_fluid_system = OneFluidSystem()

--- a/lib/ModelingToolkitBase/test/symbolic_events.jl
+++ b/lib/ModelingToolkitBase/test/symbolic_events.jl
@@ -1,10 +1,10 @@
-using ModelingToolkitBase , OrdinaryDiffEq, StochasticDiffEq, JumpProcesses, Test
+using ModelingToolkitBase, OrdinaryDiffEq, StochasticDiffEq, JumpProcesses, Test
 using SciMLStructures: canonicalize, Discrete
 using ModelingToolkitBase: SymbolicContinuousCallback,
-                       SymbolicDiscreteCallback,
-                       t_nounits as t,
-                       D_nounits as D,
-                       affects, affect_negs, system, observed, AffectSystem
+    SymbolicDiscreteCallback,
+    t_nounits as t,
+    D_nounits as D,
+    affects, affect_negs, system, observed, AffectSystem
 import DiffEqNoiseProcess
 
 using StableRNGs
@@ -14,7 +14,7 @@ using Setfield
 rng = StableRNG(12345)
 
 function get_callback(prob)
-    prob.kwargs[:callback]
+    return prob.kwargs[:callback]
 end
 
 @variables x(t) = 0
@@ -87,7 +87,8 @@ affect_neg = [x ~ 1]
 
     # with different root finding ops
     e = SymbolicContinuousCallback(
-        eqs[], affect, affect_neg = affect_neg, rootfind = SciMLBase.LeftRootFind)
+        eqs[], affect, affect_neg = affect_neg, rootfind = SciMLBase.LeftRootFind
+    )
     @test e isa SymbolicContinuousCallback
     @test isequal(equations(e), eqs)
     @test e.rootfind == SciMLBase.LeftRootFind
@@ -177,7 +178,8 @@ end
     @test m.ctx === nothing
 
     m = ModelingToolkitBase.ImperativeAffect(
-        fmfa; modified = (; y = x), observed = (; y = x))
+        fmfa; modified = (; y = x), observed = (; y = x)
+    )
     @test m isa ModelingToolkitBase.ImperativeAffect
     @test m.f == fmfa
     @test isequal(m.obs, [x])
@@ -187,7 +189,8 @@ end
     @test m.ctx === nothing
 
     m = ModelingToolkitBase.ImperativeAffect(
-        fmfa; modified = (; y = x), observed = (; y = x), ctx = 3)
+        fmfa; modified = (; y = x), observed = (; y = x), ctx = 3
+    )
     @test m isa ModelingToolkitBase.ImperativeAffect
     @test m.f == fmfa
     @test isequal(m.obs, [x])
@@ -210,7 +213,7 @@ end
     @named sys = System(eqs, t, continuous_events = [x ~ 1])
     cevt1 = getfield(sys, :continuous_events)[]
     @test getfield(sys, :continuous_events)[] ==
-          SymbolicContinuousCallback(Equation[x ~ 1], nothing; zero_crossing_id = cevt1.zero_crossing_id)
+        SymbolicContinuousCallback(Equation[x ~ 1], nothing; zero_crossing_id = cevt1.zero_crossing_id)
     @test isequal(equations(getfield(sys, :continuous_events))[], x ~ 1)
     fsys = flatten(sys)
     @test isequal(equations(getfield(fsys, :continuous_events))[], x ~ 1)
@@ -218,11 +221,13 @@ end
     @named sys2 = System([D(x) ~ 1], t, continuous_events = [x ~ 2], systems = [sys])
     cevt2 = getfield(sys2, :continuous_events)[]
     @test getfield(sys2, :continuous_events)[] ==
-          SymbolicContinuousCallback(Equation[x ~ 2], nothing; zero_crossing_id = cevt2.zero_crossing_id)
-    @test all(ModelingToolkitBase.continuous_events(sys2) .== [
-        SymbolicContinuousCallback(Equation[x ~ 2], nothing; zero_crossing_id = cevt2.zero_crossing_id),
-        SymbolicContinuousCallback(Equation[sys.x ~ 1], nothing; zero_crossing_id = cevt1.zero_crossing_id)
-    ])
+        SymbolicContinuousCallback(Equation[x ~ 2], nothing; zero_crossing_id = cevt2.zero_crossing_id)
+    @test all(
+        ModelingToolkitBase.continuous_events(sys2) .== [
+            SymbolicContinuousCallback(Equation[x ~ 2], nothing; zero_crossing_id = cevt2.zero_crossing_id),
+            SymbolicContinuousCallback(Equation[sys.x ~ 1], nothing; zero_crossing_id = cevt1.zero_crossing_id),
+        ]
+    )
 
     @test isequal(equations(getfield(sys2, :continuous_events))[1], x ~ 2)
     @test length(ModelingToolkitBase.continuous_events(sys2)) == 2
@@ -252,8 +257,8 @@ end
     prob_nosplit = ODEProblem(sys_nosplit, Pair[], (0.0, 2.0))
     sol = solve(prob, Tsit5())
     sol_nosplit = solve(prob_nosplit, Tsit5())
-    @test minimum(t -> abs(t - 1), sol.t) < 1e-10 # test that the solver stepped at the root
-    @test minimum(t -> abs(t - 1), sol_nosplit.t) < 1e-10 # test that the solver stepped at the root
+    @test minimum(t -> abs(t - 1), sol.t) < 1.0e-10 # test that the solver stepped at the root
+    @test minimum(t -> abs(t - 1), sol_nosplit.t) < 1.0e-10 # test that the solver stepped at the root
 
     # Test user-provided callback is respected
     test_callback = DiscreteCallback(x -> x, x -> x)
@@ -290,28 +295,31 @@ end
     @test out[2] ≈ 1  # signature is u,p,t
 
     sol = solve(prob, Tsit5())
-    @test minimum(t -> abs(t - 1), sol.t) < 1e-9 # test that the solver stepped at the first root
-    @test minimum(t -> abs(t - 2), sol.t) < 1e-9 # test that the solver stepped at the second root
+    @test minimum(t -> abs(t - 1), sol.t) < 1.0e-9 # test that the solver stepped at the first root
+    @test minimum(t -> abs(t - 2), sol.t) < 1.0e-9 # test that the solver stepped at the second root
 
     @named sys = System(eqs, t, continuous_events = [x ~ 1, x ~ 2]) # two root eqs using the same unknown
     sys = complete(sys)
     prob = ODEProblem(sys, Pair[], (0.0, 3.0))
     @test get_callback(prob) isa ModelingToolkitBase.DiffEqCallbacks.VectorContinuousCallback
     sol = solve(prob, Tsit5())
-    @test minimum(t -> abs(t - 1), sol.t) < 1e-9 # test that the solver stepped at the first root
-    @test minimum(t -> abs(t - 2), sol.t) < 1e-9 # test that the solver stepped at the second root
+    @test minimum(t -> abs(t - 1), sol.t) < 1.0e-9 # test that the solver stepped at the first root
+    @test minimum(t -> abs(t - 2), sol.t) < 1.0e-9 # test that the solver stepped at the second root
 end
 
 @testset "Bouncing Ball" begin
     ###### 1D Bounce
-    @variables x(t)=1 v(t)=0
+    @variables x(t) = 1 v(t) = 0
 
     root_eqs = [x ~ 0]
     affect = [v ~ -Pre(v)]
 
     @named ball = System(
-        [D(x) ~ v
-         D(v) ~ -9.8], t, continuous_events = root_eqs => affect)
+        [
+            D(x) ~ v
+            D(v) ~ -9.8
+        ], t, continuous_events = root_eqs => affect
+    )
 
     cev = only(continuous_events(ball))
     @test isequal(only(equations(cev)), x ~ 0)
@@ -326,19 +334,24 @@ end
     tspan = (0.0, 5.0)
     prob = ODEProblem(ball, Pair[], tspan)
     sol = solve(prob, Tsit5())
-    @test 0 <= minimum(sol[x]) <= 1e-10 # the ball never went through the floor but got very close
+    @test 0 <= minimum(sol[x]) <= 1.0e-10 # the ball never went through the floor but got very close
 
     ###### 2D bouncing ball
-    @variables x(t)=1 y(t)=0 vx(t)=0 vy(t)=1
+    @variables x(t) = 1 y(t) = 0 vx(t) = 0 vy(t) = 1
 
-    events = [[x ~ 0] => [vx ~ -Pre(vx)]
-              [y ~ -1.5, y ~ 1.5] => [vy ~ -Pre(vy)]]
+    events = [
+        [x ~ 0] => [vx ~ -Pre(vx)]
+        [y ~ -1.5, y ~ 1.5] => [vy ~ -Pre(vy)]
+    ]
 
     @named ball = System(
-        [D(x) ~ vx
-         D(y) ~ vy
-         D(vx) ~ -9.8
-         D(vy) ~ -0.01vy], t; continuous_events = events)
+        [
+            D(x) ~ vx
+            D(y) ~ vy
+            D(vx) ~ -9.8
+            D(vy) ~ -0.01vy
+        ], t; continuous_events = events
+    )
 
     _ball = ball
     ball = mtkcompile(_ball)
@@ -364,10 +377,10 @@ end
 
     sol = solve(prob, Tsit5())
     sol_nosplit = solve(prob_nosplit, Tsit5())
-    @test 0 <= minimum(sol[x]) <= 1e-10 # the ball never went through the floor but got very close
+    @test 0 <= minimum(sol[x]) <= 1.0e-10 # the ball never went through the floor but got very close
     @test minimum(sol[y]) ≈ -1.5 # check wall conditions
     @test maximum(sol[y]) ≈ 1.5  # check wall conditions
-    @test 0 <= minimum(sol_nosplit[x]) <= 1e-10 # the ball never went through the floor but got very close
+    @test 0 <= minimum(sol_nosplit[x]) <= 1.0e-10 # the ball never went through the floor but got very close
     @test minimum(sol_nosplit[y]) ≈ -1.5 # check wall conditions
     @test maximum(sol_nosplit[y]) ≈ 1.5  # check wall conditions
 
@@ -376,10 +389,13 @@ end
     events = [[x ~ 0] => [vx ~ -Pre(vx), vy ~ -Pre(vy)]]
 
     @named ball = System(
-        [D(x) ~ vx
-         D(y) ~ vy
-         D(vx) ~ -1
-         D(vy) ~ 0], t; continuous_events = events)
+        [
+            D(x) ~ vx
+            D(y) ~ vy
+            D(vx) ~ -1
+            D(vy) ~ 0
+        ], t; continuous_events = events
+    )
 
     ball_nosplit = mtkcompile(ball)
     ball = mtkcompile(ball)
@@ -389,9 +405,9 @@ end
     prob_nosplit = ODEProblem(ball_nosplit, Pair[], tspan)
     sol = solve(prob, Tsit5())
     sol_nosplit = solve(prob_nosplit, Tsit5())
-    @test 0 <= minimum(sol[x]) <= 1e-10 # the ball never went through the floor but got very close
+    @test 0 <= minimum(sol[x]) <= 1.0e-10 # the ball never went through the floor but got very close
     @test -minimum(sol[y]) ≈ maximum(sol[y]) ≈ sqrt(2)  # the ball will never go further than √2 in either direction (gravity was changed to 1 to get this particular number)
-    @test 0 <= minimum(sol_nosplit[x]) <= 1e-10 # the ball never went through the floor but got very close
+    @test 0 <= minimum(sol_nosplit[x]) <= 1.0e-10 # the ball never went through the floor but got very close
     @test -minimum(sol_nosplit[y]) ≈ maximum(sol_nosplit[y]) ≈ sqrt(2)  # the ball will never go further than √2 in either direction (gravity was changed to 1 to get this particular number)
 end
 
@@ -399,9 +415,11 @@ end
 # tests that it works for ODAESystem
 @testset "ODAESystem" begin
     @variables vs(t) v(t) vmeasured(t)
-    eq = [vs ~ sin(2pi * t)
-          D(v) ~ vs - v
-          D(vmeasured) ~ 0.0]
+    eq = [
+        vs ~ sin(2pi * t)
+        D(v) ~ vs - v
+        D(vmeasured) ~ 0.0
+    ]
     ev = [sin(20pi * t) ~ 0.0] => [vmeasured ~ Pre(v)]
     @named sys = System(eq, t, continuous_events = ev)
     sys = mtkcompile(sys)
@@ -420,11 +438,11 @@ end
 
     function Mass(; name, m = 1.0, p = 0, v = 0)
         ps = @parameters m = m
-        sts = @variables pos(t)=p vel(t)=v
+        sts = @variables pos(t) = p vel(t) = v
         eqs = Dₜ(pos) ~ vel
         System(eqs, t, [pos, vel], ps; name)
     end
-    function Spring(; name, k = 1e4)
+    function Spring(; name, k = 1.0e4)
         ps = @parameters k = k
         @variables x(t) = 0 # Spring deflection
         System(Equation[], t, [x], ps; name)
@@ -437,20 +455,26 @@ end
     function SpringDamper(; name, k = false, c = false)
         spring = Spring(; name = :spring, k)
         damper = Damper(; name = :damper, c)
-        compose(System(Equation[], t; name),
-            spring, damper)
+        compose(
+            System(Equation[], t; name),
+            spring, damper
+        )
     end
     connect_sd(
-        sd, m1, m2) = [
-        sd.spring.x ~ m1.pos - m2.pos, sd.damper.vel ~ m1.vel - m2.vel]
+        sd, m1, m2
+    ) = [
+        sd.spring.x ~ m1.pos - m2.pos, sd.damper.vel ~ m1.vel - m2.vel,
+    ]
     sd_force(sd) = -sd.spring.k * sd.spring.x - sd.damper.c * sd.damper.vel
     @named mass1 = Mass(; m = 1)
     @named mass2 = Mass(; m = 1)
     @named sd = SpringDamper(; k = 1000, c = 10)
     function Model(u, d = 0)
-        eqs = [connect_sd(sd, mass1, mass2)
-               Dₜ(mass1.vel) ~ (sd_force(sd) + u) / mass1.m
-               Dₜ(mass2.vel) ~ (-sd_force(sd) + d) / mass2.m]
+        eqs = [
+            connect_sd(sd, mass1, mass2)
+            Dₜ(mass1.vel) ~ (sd_force(sd) + u) / mass1.m
+            Dₜ(mass2.vel) ~ (-sd_force(sd) + d) / mass2.m
+        ]
         @named _model = System(eqs, t; observed = [y ~ mass2.pos])
         @named model = compose(_model, mass1, mass2, sd)
     end
@@ -462,12 +486,13 @@ end
 @testset "SDE/ODESystem Discrete Callbacks" begin
     function testsol(
             sys, probtype, solver, u0, p, tspan; tstops = Float64[], paramtotest = nothing,
-            kwargs...)
+            kwargs...
+        )
         prob = probtype(complete(sys), [u0; p], tspan; kwargs...)
-        sol = solve(prob, solver(); tstops = tstops, abstol = 1e-10, reltol = 1e-10)
-        @test isapprox(sol(1.0000000001)[1] - sol(0.999999999)[1], 1.0; rtol = 1e-6)
+        sol = solve(prob, solver(); tstops = tstops, abstol = 1.0e-10, reltol = 1.0e-10)
+        @test isapprox(sol(1.0000000001)[1] - sol(0.999999999)[1], 1.0; rtol = 1.0e-6)
         paramtotest === nothing || (@test sol.ps[paramtotest] == [0.0, 1.0])
-        @test isapprox(sol(4.0)[1], 2 * exp(-2.0); rtol = 1e-6)
+        @test isapprox(sol(4.0)[1], 2 * exp(-2.0); rtol = 1.0e-6)
         sol
     end
 
@@ -497,15 +522,21 @@ end
     affect1a = [A ~ Pre(A) + 1, B ~ A]
     cb1a = cond1a => affect1a
     @named osys1 = System(eqs, t, [A, B], [k, t1, t2], discrete_events = [cb1a, cb2])
-    @named ssys1 = SDESystem(eqs, [0.0], t, [A, B], [k, t1, t2],
-        discrete_events = [cb1a, cb2])
+    @named ssys1 = SDESystem(
+        eqs, [0.0], t, [A, B], [k, t1, t2],
+        discrete_events = [cb1a, cb2]
+    )
     u0′ = [A => 1.0, B => 0.0]
-    sol = testsol(osys1, ODEProblem, Tsit5, u0′, p, tspan;
-        tstops = [1.0, 2.0], check_length = false, paramtotest = k)
+    sol = testsol(
+        osys1, ODEProblem, Tsit5, u0′, p, tspan;
+        tstops = [1.0, 2.0], check_length = false, paramtotest = k
+    )
     @test sol(1.0000001, idxs = B) == 2.0
 
-    sol = testsol(ssys1, SDEProblem, RI5, u0′, p, tspan; tstops = [1.0, 2.0],
-        check_length = false, paramtotest = k)
+    sol = testsol(
+        ssys1, SDEProblem, RI5, u0′, p, tspan; tstops = [1.0, 2.0],
+        check_length = false, paramtotest = k
+    )
     @test sol(1.0000001, idxs = B) == 2.0
 
     # same as above - but with set-time event syntax
@@ -518,8 +549,10 @@ end
 
     # mixing discrete affects
     @named osys3 = System(eqs, t, [A], [k, t1, t2], discrete_events = [cb1, cb2‵])
-    @named ssys3 = SDESystem(eqs, [0.0], t, [A], [k, t1, t2],
-        discrete_events = [cb1, cb2‵])
+    @named ssys3 = SDESystem(
+        eqs, [0.0], t, [A], [k, t1, t2],
+        discrete_events = [cb1, cb2‵]
+    )
     testsol(osys3, ODEProblem, Tsit5, u0, p, tspan; tstops = [1.0], paramtotest = k)
     testsol(ssys3, SDEProblem, RI5, u0, p, tspan; tstops = [1.0], paramtotest = k)
 
@@ -529,8 +562,10 @@ end
     end
     cb2‵‵ = [2.0] => (f = affect!, modified = (; k))
     @named osys4 = System(eqs, t, [A], [k, t1, t2], discrete_events = [cb1, cb2‵‵])
-    @named ssys4 = SDESystem(eqs, [0.0], t, [A], [k, t1, t2],
-        discrete_events = [cb1, cb2‵‵])
+    @named ssys4 = SDESystem(
+        eqs, [0.0], t, [A], [k, t1, t2],
+        discrete_events = [cb1, cb2‵‵]
+    )
     oprob4 = ODEProblem(complete(osys4), [u0; p], tspan)
     testsol(osys4, ODEProblem, Tsit5, u0, p, tspan; tstops = [1.0], paramtotest = k)
     testsol(ssys4, SDEProblem, RI5, u0, p, tspan; tstops = [1.0], paramtotest = k)
@@ -538,13 +573,17 @@ end
     # mixing with symbolic condition in the func affect
     cb2‵‵‵ = (t == t2) => (f = affect!, modified = (; k))
     @named osys5 = System(eqs, t, [A], [k, t1, t2], discrete_events = [cb1, cb2‵‵‵])
-    @named ssys5 = SDESystem(eqs, [0.0], t, [A], [k, t1, t2],
-        discrete_events = [cb1, cb2‵‵‵])
+    @named ssys5 = SDESystem(
+        eqs, [0.0], t, [A], [k, t1, t2],
+        discrete_events = [cb1, cb2‵‵‵]
+    )
     testsol(osys5, ODEProblem, Tsit5, u0, p, tspan; tstops = [1.0, 2.0])
     testsol(ssys5, SDEProblem, RI5, u0, p, tspan; tstops = [1.0, 2.0])
     @named osys6 = System(eqs, t, [A], [k, t1, t2], discrete_events = [cb2‵‵‵, cb1])
-    @named ssys6 = SDESystem(eqs, [0.0], t, [A], [k, t1, t2],
-        discrete_events = [cb2‵‵‵, cb1])
+    @named ssys6 = SDESystem(
+        eqs, [0.0], t, [A], [k, t1, t2],
+        discrete_events = [cb2‵‵‵, cb1]
+    )
     testsol(osys6, ODEProblem, Tsit5, u0, p, tspan; tstops = [1.0, 2.0], paramtotest = k)
     testsol(ssys6, SDEProblem, RI5, u0, p, tspan; tstops = [1.0, 2.0], paramtotest = k)
 
@@ -552,21 +591,27 @@ end
     cond3 = A ~ 0.1
     affect3 = [k ~ 0.0]
     cb3 = SymbolicContinuousCallback(cond3 => affect3, discrete_parameters = [k], iv = t)
-    @named osys7 = System(eqs, t, [A], [k, t1, t2], discrete_events = [cb1, cb2‵‵‵],
-        continuous_events = [cb3])
-    @named ssys7 = SDESystem(eqs, [0.0], t, [A], [k, t1, t2],
+    @named osys7 = System(
+        eqs, t, [A], [k, t1, t2], discrete_events = [cb1, cb2‵‵‵],
+        continuous_events = [cb3]
+    )
+    @named ssys7 = SDESystem(
+        eqs, [0.0], t, [A], [k, t1, t2],
         discrete_events = [cb1, cb2‵‵‵],
-        continuous_events = [cb3])
+        continuous_events = [cb3]
+    )
 
     sol = testsol(osys7, ODEProblem, Tsit5, u0, p, (0.0, 10.0); tstops = [1.0, 2.0])
-    @test isapprox(sol(10.0)[1], 0.1; atol = 1e-10, rtol = 1e-10)
+    @test isapprox(sol(10.0)[1], 0.1; atol = 1.0e-10, rtol = 1.0e-10)
     sol = testsol(ssys7, SDEProblem, RI5, u0, p, (0.0, 10.0); tstops = [1.0, 2.0])
-    @test isapprox(sol(10.0)[1], 0.1; atol = 1e-10, rtol = 1e-10)
+    @test isapprox(sol(10.0)[1], 0.1; atol = 1.0e-10, rtol = 1.0e-10)
 end
 
 @testset "JumpSystem Discrete Callbacks" begin
-    function testsol(jsys, u0, p, tspan; tstops = Float64[], paramtotest = nothing,
-            N = 40000, kwargs...)
+    function testsol(
+            jsys, u0, p, tspan; tstops = Float64[], paramtotest = nothing,
+            N = 40000, kwargs...
+        )
         jsys = complete(jsys)
         jprob = JumpProblem(jsys, [u0; p], tspan; aggregator = Direct(), kwargs...)
         sol = solve(jprob, SSAStepper(); tstops = tstops)
@@ -600,8 +645,10 @@ end
     cb1a = cond1a => affect1a
     @named jsys1 = JumpSystem(eqs, t, [A, B], [k, t1, t2], discrete_events = [cb1a, cb2])
     u0′ = [A => 1, B => 0]
-    sol = testsol(jsys1, u0′, p, tspan; tstops = [1.0, 2.0],
-        check_length = false, rng, paramtotest = k)
+    sol = testsol(
+        jsys1, u0′, p, tspan; tstops = [1.0, 2.0],
+        check_length = false, rng, paramtotest = k
+    )
     @test sol(1.000000001, idxs = B) == 2
 
     # same as above - but with set-time event syntax
@@ -632,8 +679,8 @@ end
 
 @testset "Namespacing" begin
     function oscillator_ce(k = 1.0; name)
-        sts = @variables x(t)=1.0 v(t)=0.0 F(t)
-        ps = @parameters k=k Θ=0.5
+        sts = @variables x(t) = 1.0 v(t) = 0.0 F(t)
+        ps = @parameters k = k Θ = 0.5
         eqs = [D(x) ~ v, D(v) ~ -k * x + F]
         ev = [x ~ Θ] => [x ~ 1.0, v ~ 0.0]
         System(eqs, t, sts, ps; continuous_events = [ev], name)
@@ -655,7 +702,7 @@ end
 
 @testset "Additional SymbolicContinuousCallback options" begin
     # baseline affect (pos + neg + left root find)
-    @variables c1(t)=1.0 c2(t)=1.0 # c1 = cos(t), c2 = cos(3t)
+    @variables c1(t) = 1.0 c2(t) = 1.0 # c1 = cos(t), c2 = cos(3t)
     eqs = [D(c1) ~ -sin(t); D(c2) ~ -3 * sin(3 * t)]
     function record_crossings(mod, obs, ctx, integ)
         push!(ctx, integ.t => obs.v)
@@ -664,19 +711,21 @@ end
     cr1 = []
     cr2 = []
     evt1 = ModelingToolkitBase.SymbolicContinuousCallback(
-        [c1 ~ 0], (f = record_crossings, observed = (; v = c1), ctx = cr1))
+        [c1 ~ 0], (f = record_crossings, observed = (; v = c1), ctx = cr1)
+    )
     evt2 = ModelingToolkitBase.SymbolicContinuousCallback(
-        [c2 ~ 0], (f = record_crossings, observed = (; v = c2), ctx = cr2))
+        [c2 ~ 0], (f = record_crossings, observed = (; v = c2), ctx = cr2)
+    )
     @named trigsys = System(eqs, t; continuous_events = [evt1, evt2])
     trigsys_ss = mtkcompile(trigsys)
     prob = ODEProblem(trigsys_ss, [], (0.0, 2π))
     sol = solve(prob, Tsit5())
     required_crossings_c1 = [π / 2, 3 * π / 2]
     required_crossings_c2 = [π / 6, π / 2, 5 * π / 6, 7 * π / 6, 3 * π / 2, 11 * π / 6]
-    @test maximum(abs.(first.(cr1) .- required_crossings_c1)) < 1e-4
-    @test maximum(abs.(first.(cr2) .- required_crossings_c2)) < 1e-4
-    @test sign.(cos.(required_crossings_c1 .- 1e-6)) == sign.(last.(cr1))
-    @test sign.(cos.(3 * (required_crossings_c2 .- 1e-6))) == sign.(last.(cr2))
+    @test maximum(abs.(first.(cr1) .- required_crossings_c1)) < 1.0e-4
+    @test maximum(abs.(first.(cr2) .- required_crossings_c2)) < 1.0e-4
+    @test sign.(cos.(required_crossings_c1 .- 1.0e-6)) == sign.(last.(cr1))
+    @test sign.(cos.(3 * (required_crossings_c2 .- 1.0e-6))) == sign.(last.(cr2))
 
     # with neg affect (pos * neg + left root find)
     cr1p = []
@@ -685,10 +734,12 @@ end
     cr2n = []
     evt1 = ModelingToolkitBase.SymbolicContinuousCallback(
         [c1 ~ 0], (f = record_crossings, observed = (; v = c1), ctx = cr1p);
-        affect_neg = (f = record_crossings, observed = (; v = c1), ctx = cr1n))
+        affect_neg = (f = record_crossings, observed = (; v = c1), ctx = cr1n)
+    )
     evt2 = ModelingToolkitBase.SymbolicContinuousCallback(
         [c2 ~ 0], (f = record_crossings, observed = (; v = c2), ctx = cr2p);
-        affect_neg = (f = record_crossings, observed = (; v = c2), ctx = cr2n))
+        affect_neg = (f = record_crossings, observed = (; v = c2), ctx = cr2n)
+    )
     @named trigsys = System(eqs, t; continuous_events = [evt1, evt2])
     trigsys_ss = mtkcompile(trigsys)
     prob = ODEProblem(trigsys_ss, [], (0.0, 2π))
@@ -697,30 +748,32 @@ end
     c1_nc = filter((>=)(0) ∘ sin, required_crossings_c1)
     c2_pc = filter(c -> -sin(3c) > 0, required_crossings_c2)
     c2_nc = filter(c -> -sin(3c) < 0, required_crossings_c2)
-    @test maximum(abs.(c1_pc .- first.(cr1p))) < 1e-5
-    @test maximum(abs.(c1_nc .- first.(cr1n))) < 1e-5
-    @test maximum(abs.(c2_pc .- first.(cr2p))) < 1e-5
-    @test maximum(abs.(c2_nc .- first.(cr2n))) < 1e-5
-    @test sign.(cos.(c1_pc .- 1e-6)) == sign.(last.(cr1p))
-    @test sign.(cos.(c1_nc .- 1e-6)) == sign.(last.(cr1n))
-    @test sign.(cos.(3 * (c2_pc .- 1e-6))) == sign.(last.(cr2p))
-    @test sign.(cos.(3 * (c2_nc .- 1e-6))) == sign.(last.(cr2n))
+    @test maximum(abs.(c1_pc .- first.(cr1p))) < 1.0e-5
+    @test maximum(abs.(c1_nc .- first.(cr1n))) < 1.0e-5
+    @test maximum(abs.(c2_pc .- first.(cr2p))) < 1.0e-5
+    @test maximum(abs.(c2_nc .- first.(cr2n))) < 1.0e-5
+    @test sign.(cos.(c1_pc .- 1.0e-6)) == sign.(last.(cr1p))
+    @test sign.(cos.(c1_nc .- 1.0e-6)) == sign.(last.(cr1n))
+    @test sign.(cos.(3 * (c2_pc .- 1.0e-6))) == sign.(last.(cr2p))
+    @test sign.(cos.(3 * (c2_nc .- 1.0e-6))) == sign.(last.(cr2n))
 
     # with nothing neg affect (pos * neg + left root find)
     cr1p = []
     cr2p = []
     evt1 = ModelingToolkitBase.SymbolicContinuousCallback(
-        [c1 ~ 0], (f = record_crossings, observed = (; v = c1), ctx = cr1p); affect_neg = nothing)
+        [c1 ~ 0], (f = record_crossings, observed = (; v = c1), ctx = cr1p); affect_neg = nothing
+    )
     evt2 = ModelingToolkitBase.SymbolicContinuousCallback(
-        [c2 ~ 0], (f = record_crossings, observed = (; v = c2), ctx = cr2p); affect_neg = nothing)
+        [c2 ~ 0], (f = record_crossings, observed = (; v = c2), ctx = cr2p); affect_neg = nothing
+    )
     @named trigsys = System(eqs, t; continuous_events = [evt1, evt2])
     trigsys_ss = mtkcompile(trigsys)
     prob = ODEProblem(trigsys_ss, [], (0.0, 2π))
     sol = solve(prob, Tsit5(); dtmax = 0.01)
-    @test maximum(abs.(c1_pc .- first.(cr1p))) < 1e-5
-    @test maximum(abs.(c2_pc .- first.(cr2p))) < 1e-5
-    @test sign.(cos.(c1_pc .- 1e-6)) == sign.(last.(cr1p))
-    @test sign.(cos.(3 * (c2_pc .- 1e-6))) == sign.(last.(cr2p))
+    @test maximum(abs.(c1_pc .- first.(cr1p))) < 1.0e-5
+    @test maximum(abs.(c2_pc .- first.(cr2p))) < 1.0e-5
+    @test sign.(cos.(c1_pc .- 1.0e-6)) == sign.(last.(cr1p))
+    @test sign.(cos.(3 * (c2_pc .- 1.0e-6))) == sign.(last.(cr2p))
 
     #mixed
     cr1p = []
@@ -728,10 +781,12 @@ end
     cr1n = []
     cr2n = []
     evt1 = ModelingToolkitBase.SymbolicContinuousCallback(
-        [c1 ~ 0], (f = record_crossings, observed = (; v = c1), ctx = cr1p); affect_neg = nothing)
+        [c1 ~ 0], (f = record_crossings, observed = (; v = c1), ctx = cr1p); affect_neg = nothing
+    )
     evt2 = ModelingToolkitBase.SymbolicContinuousCallback(
         [c2 ~ 0], (f = record_crossings, observed = (; v = c2), ctx = cr2p);
-        affect_neg = (f = record_crossings, observed = (; v = c2), ctx = cr2n))
+        affect_neg = (f = record_crossings, observed = (; v = c2), ctx = cr2n)
+    )
     @named trigsys = System(eqs, t; continuous_events = [evt1, evt2])
     trigsys_ss = mtkcompile(trigsys)
     prob = ODEProblem(trigsys_ss, [], (0.0, 2π))
@@ -739,81 +794,91 @@ end
     c1_pc = filter((<=)(0) ∘ sin, required_crossings_c1)
     c2_pc = filter(c -> -sin(3c) > 0, required_crossings_c2)
     c2_nc = filter(c -> -sin(3c) < 0, required_crossings_c2)
-    @test maximum(abs.(c1_pc .- first.(cr1p))) < 1e-5
-    @test maximum(abs.(c2_pc .- first.(cr2p))) < 1e-5
-    @test maximum(abs.(c2_nc .- first.(cr2n))) < 1e-5
-    @test sign.(cos.(c1_pc .- 1e-6)) == sign.(last.(cr1p))
-    @test sign.(cos.(3 * (c2_pc .- 1e-6))) == sign.(last.(cr2p))
-    @test sign.(cos.(3 * (c2_nc .- 1e-6))) == sign.(last.(cr2n))
+    @test maximum(abs.(c1_pc .- first.(cr1p))) < 1.0e-5
+    @test maximum(abs.(c2_pc .- first.(cr2p))) < 1.0e-5
+    @test maximum(abs.(c2_nc .- first.(cr2n))) < 1.0e-5
+    @test sign.(cos.(c1_pc .- 1.0e-6)) == sign.(last.(cr1p))
+    @test sign.(cos.(3 * (c2_pc .- 1.0e-6))) == sign.(last.(cr2p))
+    @test sign.(cos.(3 * (c2_nc .- 1.0e-6))) == sign.(last.(cr2n))
 
     # baseline affect w/ right rootfind (pos + neg + right root find)
-    @variables c1(t)=1.0 c2(t)=1.0 # c1 = cos(t), c2 = cos(3t)
+    @variables c1(t) = 1.0 c2(t) = 1.0 # c1 = cos(t), c2 = cos(3t)
     cr1 = []
     cr2 = []
     evt1 = ModelingToolkitBase.SymbolicContinuousCallback(
         [c1 ~ 0], (f = record_crossings, observed = (; v = c1), ctx = cr1);
-        rootfind = SciMLBase.RightRootFind)
+        rootfind = SciMLBase.RightRootFind
+    )
     evt2 = ModelingToolkitBase.SymbolicContinuousCallback(
         [c2 ~ 0], (f = record_crossings, observed = (; v = c2), ctx = cr2);
-        rootfind = SciMLBase.RightRootFind)
+        rootfind = SciMLBase.RightRootFind
+    )
     @named trigsys = System(eqs, t; continuous_events = [evt1, evt2])
     trigsys_ss = mtkcompile(trigsys)
     prob = ODEProblem(trigsys_ss, [], (0.0, 2π))
     sol = solve(prob, Tsit5(); dtmax = 0.01)
     required_crossings_c1 = [π / 2, 3 * π / 2]
     required_crossings_c2 = [π / 6, π / 2, 5 * π / 6, 7 * π / 6, 3 * π / 2, 11 * π / 6]
-    @test maximum(abs.(first.(cr1) .- required_crossings_c1)) < 1e-4
-    @test maximum(abs.(first.(cr2) .- required_crossings_c2)) < 1e-4
-    @test sign.(cos.(required_crossings_c1 .+ 1e-6)) == sign.(last.(cr1))
-    @test sign.(cos.(3 * (required_crossings_c2 .+ 1e-6))) == sign.(last.(cr2))
+    @test maximum(abs.(first.(cr1) .- required_crossings_c1)) < 1.0e-4
+    @test maximum(abs.(first.(cr2) .- required_crossings_c2)) < 1.0e-4
+    @test sign.(cos.(required_crossings_c1 .+ 1.0e-6)) == sign.(last.(cr1))
+    @test sign.(cos.(3 * (required_crossings_c2 .+ 1.0e-6))) == sign.(last.(cr2))
 
     # baseline affect w/ mixed rootfind (pos + neg + right root find)
     cr1 = []
     cr2 = []
     evt1 = ModelingToolkitBase.SymbolicContinuousCallback(
         [c1 ~ 0], (f = record_crossings, observed = (; v = c1), ctx = cr1);
-        rootfind = SciMLBase.LeftRootFind)
+        rootfind = SciMLBase.LeftRootFind
+    )
     evt2 = ModelingToolkitBase.SymbolicContinuousCallback(
         [c2 ~ 0], (f = record_crossings, observed = (; v = c2), ctx = cr2);
-        rootfind = SciMLBase.RightRootFind)
+        rootfind = SciMLBase.RightRootFind
+    )
     @named trigsys = System(eqs, t; continuous_events = [evt1, evt2])
     trigsys_ss = mtkcompile(trigsys)
     prob = ODEProblem(trigsys_ss, [], (0.0, 2π))
     sol = solve(prob, Tsit5())
-    @test maximum(abs.(first.(cr1) .- required_crossings_c1)) < 1e-4
-    @test maximum(abs.(first.(cr2) .- required_crossings_c2)) < 1e-4
-    @test sign.(cos.(required_crossings_c1 .- 1e-6)) == sign.(last.(cr1))
-    @test sign.(cos.(3 * (required_crossings_c2 .+ 1e-6))) == sign.(last.(cr2))
+    @test maximum(abs.(first.(cr1) .- required_crossings_c1)) < 1.0e-4
+    @test maximum(abs.(first.(cr2) .- required_crossings_c2)) < 1.0e-4
+    @test sign.(cos.(required_crossings_c1 .- 1.0e-6)) == sign.(last.(cr1))
+    @test sign.(cos.(3 * (required_crossings_c2 .+ 1.0e-6))) == sign.(last.(cr2))
 
     #flip order and ensure results are okay
     cr1 = []
     cr2 = []
     evt1 = ModelingToolkitBase.SymbolicContinuousCallback(
         [c1 ~ 0], (f = record_crossings, observed = (; v = c1), ctx = cr1);
-        rootfind = SciMLBase.LeftRootFind)
+        rootfind = SciMLBase.LeftRootFind
+    )
     evt2 = ModelingToolkitBase.SymbolicContinuousCallback(
         [c2 ~ 0], (f = record_crossings, observed = (; v = c2), ctx = cr2);
-        rootfind = SciMLBase.RightRootFind)
+        rootfind = SciMLBase.RightRootFind
+    )
     @named trigsys = System(eqs, t; continuous_events = [evt2, evt1])
     trigsys_ss = mtkcompile(trigsys)
     prob = ODEProblem(trigsys_ss, [], (0.0, 2π))
     sol = solve(prob, Tsit5())
-    @test maximum(abs.(first.(cr1) .- required_crossings_c1)) < 1e-4
-    @test maximum(abs.(first.(cr2) .- required_crossings_c2)) < 1e-4
-    @test sign.(cos.(required_crossings_c1 .- 1e-6)) == sign.(last.(cr1))
-    @test sign.(cos.(3 * (required_crossings_c2 .+ 1e-6))) == sign.(last.(cr2))
+    @test maximum(abs.(first.(cr1) .- required_crossings_c1)) < 1.0e-4
+    @test maximum(abs.(first.(cr2) .- required_crossings_c2)) < 1.0e-4
+    @test sign.(cos.(required_crossings_c1 .- 1.0e-6)) == sign.(last.(cr1))
+    @test sign.(cos.(3 * (required_crossings_c2 .+ 1.0e-6))) == sign.(last.(cr2))
 end
 
 if @isdefined(ModelingToolkit)
     @testset "Discrete event reinitialization (#3142)" begin
         @connector function LiquidPort(; name, p = nothing, Vdot = nothing)
             vars = @variables begin
-                p(t)::Float64, [description = "Set pressure in bar",
-                guess = 1.01325]
+                p(t)::Float64, [
+                        description = "Set pressure in bar",
+                        guess = 1.01325,
+                    ]
                 Vdot(t)::Float64,
-                [description = "Volume flow rate in L/min",
-                    guess = 0.0,
-                    connect = Flow]
+                    [
+                        description = "Volume flow rate in L/min",
+                        guess = 0.0,
+                        connect = Flow,
+                    ]
             end
             System(Equation[], t, vars, []; name)
         end
@@ -831,13 +896,13 @@ if @isdefined(ModelingToolkit)
             end
 
             equations = Equation[
-                port.p ~ p_set
+                port.p ~ p_set,
             ]
 
             return System(equations, t, vars, pars; name, systems)
         end
 
-        @component function BinaryValve(; name, p_ref = 1.0, ρ_ref = 1000.0, k_V = 1.0, k_leakage = 1e-08, ρ = 1000.0, S = nothing, Δp = nothing, Vdot = nothing)
+        @component function BinaryValve(; name, p_ref = 1.0, ρ_ref = 1000.0, k_V = 1.0, k_leakage = 1.0e-8, ρ = 1000.0, S = nothing, Δp = nothing, Vdot = nothing)
             pars = @parameters begin
                 k_V::Float64 = k_V, [description = "Valve coefficient in L/min/bar"]
                 k_leakage::Float64 = k_leakage, [description = "Leakage coefficient in L/min/bar"]
@@ -929,8 +994,10 @@ end
     cb2 = [x ~ 0.5] => (f = save_affect!, modified = (; b))
     cb3 = SymbolicDiscreteCallback(1.0 => [c ~ t], discrete_parameters = [c])
 
-    @mtkcompile sys = System(D(x) ~ cos(t), t, [x], [a, b, c];
-        continuous_events = [cb1, cb2], discrete_events = [cb3])
+    @mtkcompile sys = System(
+        D(x) ~ cos(t), t, [x], [a, b, c];
+        continuous_events = [cb1, cb2], discrete_events = [cb3]
+    )
     prob = ODEProblem(sys, [x => 1.0, a => 1.0, b => 2.0, c => 0.0], (0.0, 2pi))
     @test sort(canonicalize(Discrete(), prob.p)[1]) == [0.0, 1.0, 2.0]
     sol = solve(prob, Tsit5())
@@ -942,23 +1009,26 @@ end
 
 @testset "Heater" begin
     @variables temp(t)
-    params = @parameters furnace_on_threshold=0.5 furnace_off_threshold=0.7 furnace_power=1.0 leakage=0.1 furnace_on::Bool=false
+    params = @parameters furnace_on_threshold = 0.5 furnace_off_threshold = 0.7 furnace_power = 1.0 leakage = 0.1 furnace_on::Bool = false
     eqs = [
-        D(temp) ~ furnace_on * furnace_power - temp^2 * leakage
+        D(temp) ~ furnace_on * furnace_power - temp^2 * leakage,
     ]
 
     furnace_off = ModelingToolkitBase.SymbolicContinuousCallback(
         [temp ~ furnace_off_threshold],
         ModelingToolkitBase.ImperativeAffect(modified = (; furnace_on)) do x, o, i, c
             @set! x.furnace_on = false
-        end)
+        end
+    )
     furnace_enable = ModelingToolkitBase.SymbolicContinuousCallback(
         [temp ~ furnace_on_threshold],
         ModelingToolkitBase.ImperativeAffect(modified = (; furnace_on)) do x, o, i, c
             @set! x.furnace_on = true
-        end)
+        end
+    )
     @named sys = System(
-        eqs, t, [temp], params; continuous_events = [furnace_off, furnace_enable])
+        eqs, t, [temp], params; continuous_events = [furnace_off, furnace_enable]
+    )
     ss = mtkcompile(sys)
     prob = ODEProblem(ss, [temp => 0.0, furnace_on => true], (0.0, 100.0))
     sol = solve(prob, Tsit5(); dtmax = 0.01)
@@ -968,17 +1038,23 @@ end
         [temp ~ furnace_off_threshold],
         ModelingToolkitBase.ImperativeAffect(modified = (; furnace_on)) do x, o, c, i
             @set! x.furnace_on = false
-        end; initialize = ModelingToolkitBase.ImperativeAffect(modified = (;
-            temp)) do x, o, c, i
+        end; initialize = ModelingToolkitBase.ImperativeAffect(
+            modified = (;
+                temp,
+            )
+        ) do x, o, c, i
             @set! x.temp = 0.2
-        end)
+        end
+    )
     furnace_enable = ModelingToolkitBase.SymbolicContinuousCallback(
         [temp ~ furnace_on_threshold],
         ModelingToolkitBase.ImperativeAffect(modified = (; furnace_on)) do x, o, c, i
             @set! x.furnace_on = true
-        end)
+        end
+    )
     @named sys = System(
-        eqs, t, [temp], params; continuous_events = [furnace_off, furnace_enable])
+        eqs, t, [temp], params; continuous_events = [furnace_off, furnace_enable]
+    )
     ss = mtkcompile(sys)
     prob = ODEProblem(ss, [temp => 0.0, furnace_on => true], (0.0, 100.0))
     sol = solve(prob, Tsit5(); dtmax = 0.01)
@@ -988,65 +1064,86 @@ end
 
 @testset "ImperativeAffect errors and warnings" begin
     @variables temp(t)
-    params = @parameters furnace_on_threshold=0.5 furnace_off_threshold=0.7 furnace_power=1.0 leakage=0.1 furnace_on::Bool=false
+    params = @parameters furnace_on_threshold = 0.5 furnace_off_threshold = 0.7 furnace_power = 1.0 leakage = 0.1 furnace_on::Bool = false
     eqs = [
+        D(temp) ~ furnace_on * furnace_power - temp^2 * leakage,
+    ]
+
+    furnace_off = ModelingToolkitBase.SymbolicContinuousCallback(
+        [temp ~ furnace_off_threshold],
+        ModelingToolkitBase.ImperativeAffect(
+            modified = (; furnace_on), observed = (; furnace_on)
+        ) do x, o, c, i
+            @set! x.furnace_on = false
+        end
+    )
+    @named sys = System(eqs, t, [temp], params; continuous_events = [furnace_off])
+    ss = mtkcompile(sys)
+    @test_logs (
+        :warn,
+        "The symbols Any[:furnace_on] are declared as both observed and modified; this is a code smell because it becomes easy to confuse them and assign/not assign a value.",
+    ) prob = ODEProblem(
+        ss, [temp => 0.0, furnace_on => true], (0.0, 100.0)
+    )
+
+    @variables tempsq(t) # trivially eliminated
+    eqs = [
+        tempsq ~ temp^2
         D(temp) ~ furnace_on * furnace_power - temp^2 * leakage
     ]
 
     furnace_off = ModelingToolkitBase.SymbolicContinuousCallback(
         [temp ~ furnace_off_threshold],
         ModelingToolkitBase.ImperativeAffect(
-            modified = (; furnace_on), observed = (; furnace_on)) do x, o, c, i
+            modified = (; furnace_on, tempsq), observed = (; furnace_on)
+        ) do x, o, c, i
             @set! x.furnace_on = false
-        end)
-    @named sys = System(eqs, t, [temp], params; continuous_events = [furnace_off])
-    ss = mtkcompile(sys)
-    @test_logs (:warn,
-        "The symbols Any[:furnace_on] are declared as both observed and modified; this is a code smell because it becomes easy to confuse them and assign/not assign a value.") prob=ODEProblem(
-        ss, [temp => 0.0, furnace_on => true], (0.0, 100.0))
-
-    @variables tempsq(t) # trivially eliminated
-    eqs = [tempsq ~ temp^2
-           D(temp) ~ furnace_on * furnace_power - temp^2 * leakage]
-
-    furnace_off = ModelingToolkitBase.SymbolicContinuousCallback(
-        [temp ~ furnace_off_threshold],
-        ModelingToolkitBase.ImperativeAffect(
-            modified = (; furnace_on, tempsq), observed = (; furnace_on)) do x, o, c, i
-            @set! x.furnace_on = false
-        end)
+        end
+    )
     @named sys = System(
-        eqs, t, [temp, tempsq], params; continuous_events = [furnace_off])
+        eqs, t, [temp, tempsq], params; continuous_events = [furnace_off]
+    )
     ss = mtkcompile(sys)
     if @isdefined(ModelingToolkit)
-        @test_throws "refers to missing variable(s)" prob=ODEProblem(
-            ss, [temp => 0.0, furnace_on => true], (0.0, 100.0))
+        @test_throws "refers to missing variable(s)" prob = ODEProblem(
+            ss, [temp => 0.0, furnace_on => true], (0.0, 100.0)
+        )
     end
 
     @parameters not_actually_here
     furnace_off = ModelingToolkitBase.SymbolicContinuousCallback(
         [temp ~ furnace_off_threshold],
-        ModelingToolkitBase.ImperativeAffect(modified = (; furnace_on),
-            observed = (; furnace_on, not_actually_here)) do x, o, c, i
+        ModelingToolkitBase.ImperativeAffect(
+            modified = (; furnace_on),
+            observed = (; furnace_on, not_actually_here)
+        ) do x, o, c, i
             @set! x.furnace_on = false
-        end)
+        end
+    )
     @named sys = System(
-        eqs, t, [temp, tempsq], params; continuous_events = [furnace_off])
+        eqs, t, [temp, tempsq], params; continuous_events = [furnace_off]
+    )
     ss = mtkcompile(sys)
-    @test_throws "refers to missing variable(s)" prob=ODEProblem(
-        ss, [temp => 0.0, furnace_on => true], (0.0, 100.0))
+    @test_throws "refers to missing variable(s)" prob = ODEProblem(
+        ss, [temp => 0.0, furnace_on => true], (0.0, 100.0)
+    )
 
     furnace_off = ModelingToolkitBase.SymbolicContinuousCallback(
         [temp ~ furnace_off_threshold],
-        ModelingToolkitBase.ImperativeAffect(modified = (; furnace_on),
-            observed = (; furnace_on)) do x, o, c, i
+        ModelingToolkitBase.ImperativeAffect(
+            modified = (; furnace_on),
+            observed = (; furnace_on)
+        ) do x, o, c, i
             return (; fictional2 = false)
-        end)
+        end
+    )
     @named sys = System(
-        eqs, t, [temp, tempsq], params; continuous_events = [furnace_off])
+        eqs, t, [temp, tempsq], params; continuous_events = [furnace_off]
+    )
     ss = mtkcompile(sys)
     prob = ODEProblem(
-        ss, [temp => 0.0, furnace_on => true], (0.0, 100.0))
+        ss, [temp => 0.0, furnace_on => true], (0.0, 100.0)
+    )
     if @isdefined(ModelingToolkit)
         @test_throws "Tried to write back to" solve(prob, Tsit5())
     end
@@ -1054,25 +1151,28 @@ end
 
 @testset "Quadrature" begin
     @variables theta(t) omega(t)
-    params = @parameters qA=0 qB=0 hA=0 hB=0 cnt::Int=0
-    eqs = [D(theta) ~ omega
-           omega ~ 1.0]
+    params = @parameters qA = 0 qB = 0 hA = 0 hB = 0 cnt::Int = 0
+    eqs = [
+        D(theta) ~ omega
+        omega ~ 1.0
+    ]
     function decoder(oldA, oldB, newA, newB)
         state = (oldA, oldB, newA, newB)
         if state == (0, 0, 1, 0) || state == (1, 0, 1, 1) || state == (1, 1, 0, 1) ||
-           state == (0, 1, 0, 0)
+                state == (0, 1, 0, 0)
             return 1
         elseif state == (0, 0, 0, 1) || state == (0, 1, 1, 1) || state == (1, 1, 1, 0) ||
-               state == (1, 0, 0, 0)
+                state == (1, 0, 0, 0)
             return -1
         elseif state == (0, 0, 0, 0) || state == (0, 1, 0, 1) || state == (1, 0, 1, 0) ||
-               state == (1, 1, 1, 1)
+                state == (1, 1, 1, 1)
             return 0
         else
             return 0 # err is interpreted as no movement
         end
     end
-    qAevt = ModelingToolkitBase.SymbolicContinuousCallback([cos(100 * theta) ~ 0],
+    qAevt = ModelingToolkitBase.SymbolicContinuousCallback(
+        [cos(100 * theta) ~ 0],
         ModelingToolkitBase.ImperativeAffect((; qA, hA, hB, cnt), (; qB)) do x, o, c, i
             @set! x.hA = x.qA
             @set! x.hB = o.qB
@@ -1081,14 +1181,17 @@ end
             x
         end,
         affect_neg = ModelingToolkitBase.ImperativeAffect(
-            (; qA, hA, hB, cnt), (; qB)) do x, o, c, i
+            (; qA, hA, hB, cnt), (; qB)
+        ) do x, o, c, i
             @set! x.hA = x.qA
             @set! x.hB = o.qB
             @set! x.qA = 0
             @set! x.cnt += decoder(x.hA, x.hB, x.qA, o.qB)
             x
-        end; rootfind = SciMLBase.RightRootFind)
-    qBevt = ModelingToolkitBase.SymbolicContinuousCallback([cos(100 * theta - π / 2) ~ 0],
+        end; rootfind = SciMLBase.RightRootFind
+    )
+    qBevt = ModelingToolkitBase.SymbolicContinuousCallback(
+        [cos(100 * theta - π / 2) ~ 0],
         ModelingToolkitBase.ImperativeAffect((; qB, hA, hB, cnt), (; qA)) do x, o, c, i
             @set! x.hA = o.qA
             @set! x.hB = x.qB
@@ -1097,17 +1200,20 @@ end
             x
         end,
         affect_neg = ModelingToolkitBase.ImperativeAffect(
-            (; qB, hA, hB, cnt), (; qA)) do x, o, c, i
+            (; qB, hA, hB, cnt), (; qA)
+        ) do x, o, c, i
             @set! x.hA = o.qA
             @set! x.hB = x.qB
             @set! x.qB = 0
             @set! x.cnt += decoder(x.hA, x.hB, o.qA, x.qB)
             x
-        end; rootfind = SciMLBase.RightRootFind)
+        end; rootfind = SciMLBase.RightRootFind
+    )
     @named sys = System(
-        eqs, t, [theta, omega], params; continuous_events = [qAevt, qBevt])
+        eqs, t, [theta, omega], params; continuous_events = [qAevt, qBevt]
+    )
     ss = mtkcompile(sys)
-    prob = ODEProblem(ss, [theta => 1e-5], (0.0, pi))
+    prob = ODEProblem(ss, [theta => 1.0e-5], (0.0, pi))
     sol = solve(prob, @isdefined(ModelingToolkit) ? Tsit5() : Rodas5P(); dtmax = 0.01)
     @test getp(sol, cnt)(sol) == 198 # we get 2 pulses per phase cycle (cos 0 crossing) and we go to 100 cycles; we miss a few due to the initial state
 end
@@ -1117,7 +1223,8 @@ end
     seen = false
     f = ModelingToolkitBase.ImperativeAffect(f = (m, o, ctx, int) -> (seen = true; return (;)))
     cb1 = ModelingToolkitBase.SymbolicContinuousCallback(
-        [x ~ 0], nothing, initialize = [x ~ 1.5], finalize = f)
+        [x ~ 0], nothing, initialize = [x ~ 1.5], finalize = f
+    )
     @mtkcompile sys = System(D(x) ~ -1, t, [x], []; continuous_events = [cb1])
     prob = ODEProblem(sys, [x => 1.0], (0.0, 2))
     sol = solve(prob, Tsit5(); dtmax = 0.01)
@@ -1129,15 +1236,23 @@ end
     seen = false
     f = ModelingToolkitBase.ImperativeAffect(f = (m, o, ctx, int) -> (seen = true; return (;)))
     cb1 = ModelingToolkitBase.SymbolicContinuousCallback(
-        [x ~ 0], nothing, initialize = [x ~ 1.5], finalize = f)
+        [x ~ 0], nothing, initialize = [x ~ 1.5], finalize = f
+    )
     inited = false
     finaled = false
-    a = ModelingToolkitBase.ImperativeAffect(f = (
-        m, o, ctx, int) -> (inited = true; return (;)))
-    b = ModelingToolkitBase.ImperativeAffect(f = (
-        m, o, ctx, int) -> (finaled = true; return (;)))
+    a = ModelingToolkitBase.ImperativeAffect(
+        f = (
+            m, o, ctx, int,
+        ) -> (inited = true; return (;))
+    )
+    b = ModelingToolkitBase.ImperativeAffect(
+        f = (
+            m, o, ctx, int,
+        ) -> (finaled = true; return (;))
+    )
     cb2 = ModelingToolkitBase.SymbolicContinuousCallback(
-        [x ~ 0.1], nothing, initialize = a, finalize = b)
+        [x ~ 0.1], nothing, initialize = a, finalize = b
+    )
     @mtkcompile sys = System(D(x) ~ -1, t, [x], []; continuous_events = [cb1, cb2])
     prob = ODEProblem(sys, [x => 1.0], (0.0, 2))
     sol = solve(prob, Tsit5())
@@ -1151,13 +1266,14 @@ end
     inited = false
     finaled = false
     cb3 = ModelingToolkitBase.SymbolicDiscreteCallback(
-        1.0, [x ~ 2], initialize = a, finalize = b)
+        1.0, [x ~ 2], initialize = a, finalize = b
+    )
     @mtkcompile sys = System(D(x) ~ -1, t, [x], []; discrete_events = [cb3])
     prob = ODEProblem(sys, [x => 1.0], (0.0, 2))
     sol = solve(prob, Tsit5())
     @test inited == true
     @test finaled == true
-    @test isapprox(sol[x][3], 0.0, atol = 1e-9)
+    @test isapprox(sol[x][3], 0.0, atol = 1.0e-9)
     @test sol[x][4] ≈ 2.0
     @test sol[x][5] ≈ 1.0
 
@@ -1188,7 +1304,8 @@ end
     inited = false
     finaled = false
     cb3 = ModelingToolkitBase.SymbolicDiscreteCallback(
-        t == 1.0, f, initialize = a, finalize = b)
+        t == 1.0, f, initialize = a, finalize = b
+    )
     @mtkcompile sys = System(D(x) ~ -1, t, [x], []; discrete_events = [cb3])
     prob = ODEProblem(sys, [x => 1.0], (0.0, 2))
     sol = solve(prob, Tsit5(); tstops = 1.0)
@@ -1213,7 +1330,7 @@ end
     cb = [x ~ 0.0] => [x ~ 1, y ~ 1]
     @mtkcompile pend = System(eqs, t; continuous_events = [cb])
     prob = ODEProblem(pend, [x => 1], (0.0, 3.0), guesses = [y => x])
-    @test all(≈(0.0; atol = 1e-9), solve(prob, Rodas5())[[x, y]][end])
+    @test all(≈(0.0; atol = 1.0e-9), solve(prob, Rodas5())[[x, y]][end])
 end
 
 @testset "Issue#3154 Array variable in discrete condition" begin
@@ -1234,11 +1351,11 @@ end
         vars = [vars; discs]
 
         equations = Equation[
-            D(x) ~ -k * x
+            D(x) ~ -k * x,
         ]
 
         discrete_events = [
-            SymbolicDiscreteCallback((t == 1.0), [k ~ 1.0], discrete_parameters = [k])
+            SymbolicDiscreteCallback((t == 1.0), [k ~ 1.0], discrete_parameters = [k]),
         ]
 
         return System(equations, t, vars, pars; name, systems, discrete_events)
@@ -1256,17 +1373,24 @@ end
         vars = @variables begin
             x(t) = 0.0
         end
-        eqs = reduce(vcat, Symbolics.scalarize.([
-            D(x) ~ 1.0
-        ]))
+        eqs = reduce(
+            vcat, Symbolics.scalarize.(
+                [
+                    D(x) ~ 1.0,
+                ]
+            )
+        )
         reset = ModelingToolkitBase.ImperativeAffect(
-            modified = (; x, θ)) do m, o, _, i
+            modified = (; x, θ)
+        ) do m, o, _, i
             @set! m.θ = 0.0
             @set! m.x = 0.0
             return m
         end
-        return System(eqs, t, vars, params; name = name,
-            continuous_events = [[x ~ max_time] => reset])
+        return System(
+            eqs, t, vars, params; name = name,
+            continuous_events = [[x ~ max_time] => reset]
+        )
     end
 
     function weird2(max_time; name)
@@ -1276,27 +1400,45 @@ end
         vars = @variables begin
             x(t) = 0.0
         end
-        eqs = reduce(vcat, Symbolics.scalarize.([
-            D(x) ~ 1.0
-        ]))
+        eqs = reduce(
+            vcat, Symbolics.scalarize.(
+                [
+                    D(x) ~ 1.0,
+                ]
+            )
+        )
         return System(eqs, t, vars, params; name = name) # note no event
     end
 
     @named wd1 = weird1(0.021)
     @named wd2 = weird2(0.021)
 
-    sys1 = mtkcompile(System(Equation[], t; name = :parent,
-        discrete_events = [0.01 => ModelingToolkitBase.ImperativeAffect(
-            modified = (; θs = reduce(vcat, [[wd1.θ]])), ctx = [1]) do m, o, c, i
-            @set! m.θs[1] = c[] += 1
-        end],
-        systems = [wd1]))
-    sys2 = mtkcompile(System(Equation[], t; name = :parent,
-        discrete_events = [0.01 => ModelingToolkitBase.ImperativeAffect(
-            modified = (; θs = reduce(vcat, [[wd2.θ]])), ctx = [1]) do m, o, c, i
-            @set! m.θs[1] = c[] += 1
-        end],
-        systems = [wd2]))
+    sys1 = mtkcompile(
+        System(
+            Equation[], t; name = :parent,
+            discrete_events = [
+                0.01 => ModelingToolkitBase.ImperativeAffect(
+                    modified = (; θs = reduce(vcat, [[wd1.θ]])), ctx = [1]
+                ) do m, o, c, i
+                    @set! m.θs[1] = c[] += 1
+                end
+            ],
+            systems = [wd1]
+        )
+    )
+    sys2 = mtkcompile(
+        System(
+            Equation[], t; name = :parent,
+            discrete_events = [
+                0.01 => ModelingToolkitBase.ImperativeAffect(
+                    modified = (; θs = reduce(vcat, [[wd2.θ]])), ctx = [1]
+                ) do m, o, c, i
+                    @set! m.θs[1] = c[] += 1
+                end
+            ],
+            systems = [wd2]
+        )
+    )
 
     sol1 = solve(ODEProblem(sys1, [], (0.0, 1.0)), Tsit5())
     @test 100.0 ∈ sol1[sys1.wd1.θ]
@@ -1310,54 +1452,62 @@ if @isdefined(ModelingToolkit)
         using ModelingToolkitBase: UnsolvableCallbackError
         @parameters g
         @variables x(t) y(t) λ(t)
-        eqs = [D(D(x)) ~ λ * x
-               D(D(y)) ~ λ * y - g
-               x^2 + y^2 ~ 1]
+        eqs = [
+            D(D(x)) ~ λ * x
+            D(D(y)) ~ λ * y - g
+            x^2 + y^2 ~ 1
+        ]
         c_evt = [t ~ 5.0] => [x ~ Pre(x) + 0.1]
         @mtkcompile pend = System(eqs, t, continuous_events = c_evt)
         prob = ODEProblem(pend, [x => -1, D(x) => 0, g => 1], (0.0, 10.0), guesses = [λ => 1, y => 1])
         sol = solve(prob, FBDF())
-        @test ≈(sol(5.000001, idxs = x) - sol(4.999999, idxs = x), 0.1, rtol = 1e-4)
-        @test ≈(sol(5.000001, idxs = x)^2 + sol(5.000001, idxs = y)^2, 1, rtol = 1e-4)
+        @test ≈(sol(5.000001, idxs = x) - sol(4.999999, idxs = x), 0.1, rtol = 1.0e-4)
+        @test ≈(sol(5.000001, idxs = x)^2 + sol(5.000001, idxs = y)^2, 1, rtol = 1.0e-4)
 
         # Implicit affect with Pre
         c_evt = [t ~ 5.0] => [x ~ Pre(x) + y^2]
         @mtkcompile pend = System(eqs, t, continuous_events = c_evt)
-        prob = ODEProblem(pend, [x => 1, D(x) => 0, g => 1], (0.0, 10.0), guesses = [λ => 1,  y => 1])
+        prob = ODEProblem(pend, [x => 1, D(x) => 0, g => 1], (0.0, 10.0), guesses = [λ => 1, y => 1])
         sol = solve(prob, FBDF())
-        @test ≈(sol(5.000001, idxs = y)^2 + sol(4.999999, idxs = x),
-            sol(5.000001, idxs = x), rtol = 1e-4)
-        @test ≈(sol(5.000001, idxs = x)^2 + sol(5.000001, idxs = y)^2, 1, rtol = 1e-4)
+        @test ≈(
+            sol(5.000001, idxs = y)^2 + sol(4.999999, idxs = x),
+            sol(5.000001, idxs = x), rtol = 1.0e-4
+        )
+        @test ≈(sol(5.000001, idxs = x)^2 + sol(5.000001, idxs = y)^2, 1, rtol = 1.0e-4)
 
         # Impossible affect errors
         c_evt = [t ~ 5.0] => [x ~ Pre(x) + 2]
         @mtkcompile pend = System(eqs, t, continuous_events = c_evt)
         prob = ODEProblem(pend, [x => 1, y => 0, g => 1], (0.0, 10.0), guesses = [λ => 1])
-        @test_throws UnsolvableCallbackError sol=solve(prob, FBDF())
+        @test_throws UnsolvableCallbackError sol = solve(prob, FBDF())
 
         # Changing both variables and parameters in the same affect.
         @discretes g(t)
-        eqs = [D(D(x)) ~ λ * x
-               D(D(y)) ~ λ * y - g
-               x^2 + y^2 ~ 1]
+        eqs = [
+            D(D(x)) ~ λ * x
+            D(D(y)) ~ λ * y - g
+            x^2 + y^2 ~ 1
+        ]
         c_evt = SymbolicContinuousCallback(
-            [t ~ 5.0], [x ~ Pre(x) + 0.1, g ~ Pre(g) + 1], discrete_parameters = [g], iv = t)
+            [t ~ 5.0], [x ~ Pre(x) + 0.1, g ~ Pre(g) + 1], discrete_parameters = [g], iv = t
+        )
         @mtkcompile pend = System(eqs, t, continuous_events = c_evt)
         prob = ODEProblem(pend, [x => 1, y => 0, g => 1], (0.0, 10.0), guesses = [λ => 1])
         sol = solve(prob, FBDF())
         @test sol.ps[g] ≈ [1, 2]
-        @test ≈(sol(5.0000001, idxs = x) - sol(4.999999, idxs = x), 0.1, rtol = 1e-4)
+        @test ≈(sol(5.0000001, idxs = x) - sol(4.999999, idxs = x), 0.1, rtol = 1.0e-4)
 
         # Proper re-initialization after parameter change
         eqs = [y ~ g^2, D(x) ~ x]
         c_evt = SymbolicContinuousCallback(
-            [t ~ 5.0], [x ~ Pre(x) + 1, g ~ Pre(g) + 1], discrete_parameters = [g], iv = t)
+            [t ~ 5.0], [x ~ Pre(x) + 1, g ~ Pre(g) + 1], discrete_parameters = [g], iv = t
+        )
         @mtkcompile sys = System(eqs, t, continuous_events = c_evt)
         prob = ODEProblem(sys, [x => 1.0, g => 2], (0.0, 10.0))
         sol = solve(prob, FBDF())
         @test sol.ps[g] ≈ [2.0, 3.0]
-        @test ≈(sol(5.00000001, idxs = x) - sol(4.9999999, idxs = x), 1; rtol = 1e-4)
-        @test ≈(sol(5.00000001, idxs = y), 9, rtol = 1e-4)
+        @test ≈(sol(5.00000001, idxs = x) - sol(4.9999999, idxs = x), 1; rtol = 1.0e-4)
+        @test ≈(sol(5.00000001, idxs = y), 9, rtol = 1.0e-4)
 
         # Parameters that don't appear in affects should not be mutated.
         c_evt = [t ~ 5.0] => [x ~ Pre(x) + 1]
@@ -1373,24 +1523,33 @@ end
         vars = @variables begin
             x(t) = 0.0
         end
-        eqs = reduce(vcat, Symbolics.scalarize.([
-            D(x) ~ 1.0
-        ]))
+        eqs = reduce(
+            vcat, Symbolics.scalarize.(
+                [
+                    D(x) ~ 1.0,
+                ]
+            )
+        )
         reset = ModelingToolkitBase.ImperativeAffect(
-            modified = (; vals = Symbolics.scalarize(ParentScope.(vals)), x)) do m, o, _, i
+            modified = (; vals = Symbolics.scalarize(ParentScope.(vals)), x)
+        ) do m, o, _, i
             @set! m.vals = m.vals .+ 1
             @set! m.x = 0.0
             return m
         end
-        return System(eqs, t, vars, []; name = name,
-            continuous_events = [[x ~ max_time] => reset])
+        return System(
+            eqs, t, vars, []; name = name,
+            continuous_events = [[x ~ max_time] => reset]
+        )
     end
     shared_pars = @discretes begin
         vals(t)[1:2] = zeros(2)
     end
 
-    @named sys = System(Equation[], t, [], Symbolics.scalarize(vals);
-        systems = [child(vals; name = :child)])
+    @named sys = System(
+        Equation[], t, [], Symbolics.scalarize(vals);
+        systems = [child(vals; name = :child)]
+    )
     sys = mtkcompile(sys)
     sol = solve(ODEProblem(sys, [], (0.0, 1.0)), Tsit5())
 end
@@ -1400,7 +1559,8 @@ end
         @discretes p(t)::Int
         @variables x(t)
         cevs = ModelingToolkitBase.SymbolicContinuousCallback(
-            [x ~ 1.0], [p ~ Pre(p) + 1]; iv = t, discrete_parameters = [p])
+            [x ~ 1.0], [p ~ Pre(p) + 1]; iv = t, discrete_parameters = [p]
+        )
         System([D(x) ~ 1], t, [x], [p]; continuous_events = [cevs], name)
     end
     @named inner = Inner()
@@ -1428,7 +1588,7 @@ end
 
     eq = [
         D(x) ~ p2,
-        x2 ~ p_1(x)
+        x2 ~ p_1(x),
     ]
     @mtkcompile sys = System(eq, t, [x, x2], [p_1, p2], discrete_events = [event])
 
@@ -1436,7 +1596,7 @@ end
     sol = solve(prob)
     @test SciMLBase.successful_retcode(sol)
     @test sol[p2] ≈ [1.0, 0.5]
-    @test sol[x][end]≈0.75 atol=1e-6
+    @test sol[x][end] ≈ 0.75 atol = 1.0e-6
 end
 
 if @isdefined(ModelingToolkit)
@@ -1444,9 +1604,11 @@ if @isdefined(ModelingToolkit)
         @parameters g
         @variables x(t) [state_priority = 10.0] y(t) [guess = 1.0]
         @variables λ(t) [guess = 1.0]
-        eqs = [D(D(x)) ~ λ * x
-               D(D(y)) ~ λ * y - g
-               x^2 + y^2 ~ 1]
+        eqs = [
+            D(D(x)) ~ λ * x
+            D(D(y)) ~ λ * y - g
+            x^2 + y^2 ~ 1
+        ]
         cevts = [[x ~ 0.0] => [D(x) ~ Pre(D(x)) + 0.1sign(Pre(D(x)))]]
         @named pend = System(eqs, t; continuous_events = cevts)
 
@@ -1459,7 +1621,7 @@ if @isdefined(ModelingToolkit)
         @test scc.affect isa ModelingToolkitBase.AffectSystem
         @test length(ModelingToolkitBase.all_equations(scc.affect)) == 5 # 1 affect, 3 algebraic, 1 observed
 
-        u0 = [x => -1/2, D(x) => 1/2, g => 1]
+        u0 = [x => -1 / 2, D(x) => 1 / 2, g => 1]
         prob = ODEProblem(pend, u0, (0.0, 5.0))
         sol = solve(prob, FBDF())
         @test SciMLBase.successful_retcode(sol)
@@ -1493,11 +1655,11 @@ end
         append!(vars, discretes)
 
         equations = Equation[
-            D(x) ~ p * x
+            D(x) ~ p * x,
         ]
 
         discrete_events = [
-            SymbolicDiscreteCallback(1.0, [x ~ p * Pre(x) * sin(x)]; discrete_parameters = [p])
+            SymbolicDiscreteCallback(1.0, [x ~ p * Pre(x) * sin(x)]; discrete_parameters = [p]),
         ]
 
         return System(equations, t, vars, pars; name, systems, discrete_events)
@@ -1510,16 +1672,31 @@ end
     @discretes p(t)
     @parameters d
     @variables X(t)
-    @test_throws "Vectors of symbolic conditions are not allowed" SymbolicDiscreteCallback([X <
-                                                                                            5.0] => [X ~
-                                                                                                     Pre(X) +
-                                                                                                     10.0])
-    @test_throws "Vectors of symbolic conditions are not allowed" SymbolicDiscreteCallback([
-        X < 5.0, X > 10.0] => [X ~ Pre(X) + 10.0])
-    @test_throws "MethodError: no method" SymbolicContinuousCallback((X <
-                                                                      5.0) => [X ~
-                                                                               Pre(X) +
-                                                                               10.0])
+    @test_throws "Vectors of symbolic conditions are not allowed" SymbolicDiscreteCallback(
+        [
+            X <
+                5.0,
+        ] => [
+            X ~
+                Pre(X) +
+                10.0,
+        ]
+    )
+    @test_throws "Vectors of symbolic conditions are not allowed" SymbolicDiscreteCallback(
+        [
+            X < 5.0, X > 10.0,
+        ] => [X ~ Pre(X) + 10.0]
+    )
+    @test_throws "MethodError: no method" SymbolicContinuousCallback(
+        (
+            X <
+                5.0
+        ) => [
+            X ~
+                Pre(X) +
+                10.0,
+        ]
+    )
 end
 
 @testset "Issue#3990: Scalarized array passed to `discrete_parameters` of symbolic affect" begin
@@ -1599,7 +1776,7 @@ end
 end
 
 @testset "Check array parameter and variables event" begin
-    # Creates the model using the macro. 
+    # Creates the model using the macro.
     us = @variables begin
         X(t)[1:2] = [4.0, 4.0]
     end
@@ -1611,11 +1788,12 @@ end
     end
     ps = [ps; discs]
     eqs = [
-        D(X[1]) ~ -k[1]*X[1] + k[2]*X[2]
-        D(X[2]) ~ k[1]*X[1] - k[2]*X[2]
+        D(X[1]) ~ -k[1] * X[1] + k[2] * X[2]
+        D(X[2]) ~ k[1] * X[1] - k[2] * X[2]
     ]
     c_event = SymbolicContinuousCallback(
-        (k[2] ~ t) => [k[1] ~ Pre(k[1] + kup)]; discrete_parameters = [k[1]])
+        (k[2] ~ t) => [k[1] ~ Pre(k[1] + kup)]; discrete_parameters = [k[1]]
+    )
     @mtkcompile model = System(eqs, t, us, ps; continuous_events = [c_event])
 
     # Simulates the model. Checks that the correct values are achieved.
@@ -1624,6 +1802,6 @@ end
     @test sol.ps[model.kup] == 2.0
     @test sol.ps[model.k[1]][end] == 3.0
     @test sol.ps[model.k[2]][end] == 1.0
-    @test sol[model.X[1]][end]≈2.0 atol=1e-8 rtol=1e-8
-    @test sol[model.X[2]][end]≈6.0 atol=1e-8 rtol=1e-8
+    @test sol[model.X[1]][end] ≈ 2.0 atol = 1.0e-8 rtol = 1.0e-8
+    @test sol[model.X[2]][end] ≈ 6.0 atol = 1.0e-8 rtol = 1.0e-8
 end

--- a/lib/ModelingToolkitBase/test/symbolic_indexing_interface.jl
+++ b/lib/ModelingToolkitBase/test/symbolic_indexing_interface.jl
@@ -1,12 +1,12 @@
 using ModelingToolkitBase, SymbolicIndexingInterface, SciMLBase
 using ModelingToolkitBase: t_nounits as t, D_nounits as D, ParameterIndex,
-                       SymbolicContinuousCallback
+    SymbolicContinuousCallback
 using SciMLStructures: Tunable
 using Test
 
 @testset "System" begin
     @parameters a b
-    @variables x(t)=1.0 y(t)=2.0 xy(t)
+    @variables x(t) = 1.0 y(t) = 2.0 xy(t)
     eqs = [D(x) ~ a * y + t, D(y) ~ b * t]
     @named odesys = System(eqs, t, [x, y], [a, b]; observed = [xy ~ x + y])
     odesys = complete(odesys)
@@ -14,7 +14,7 @@ using Test
     @test all(is_variable.((odesys,), [x, y, 1, 2, :x, :y]))
     @test all(.!is_variable.((odesys,), [a, b, t, 3, 0, :a, :b]))
     @test variable_index.((odesys,), [x, y, a, b, t, 1, 2, :x, :y, :a, :b]) ==
-          [1, 2, nothing, nothing, nothing, 1, 2, 1, 2, nothing, nothing]
+        [1, 2, nothing, nothing, nothing, 1, 2, 1, 2, nothing, nothing]
     @test isequal(variable_symbols(odesys), [x, y])
     @test all(is_parameter.((odesys,), [a, b, ParameterIndex(Tunable(), 1), :a, :b]))
     @test all(.!is_parameter.((odesys,), [x, y, t, 3, 0, :x, :y]))
@@ -23,11 +23,17 @@ using Test
     @test parameter_index(odesys, b) == parameter_index(odesys, :b)
     @test parameter_index(odesys, b) isa ParameterIndex{Tunable, Int}
     @test parameter_index.(
-        (odesys,), [x, y, t, ParameterIndex(Tunable(), 1), :x, :y]) ==
-          [nothing, nothing, nothing, ParameterIndex(Tunable(), 1), nothing, nothing]
+        (odesys,), [x, y, t, ParameterIndex(Tunable(), 1), :x, :y]
+    ) ==
+        [nothing, nothing, nothing, ParameterIndex(Tunable(), 1), nothing, nothing]
     @test isequal(
-        Set(parameter_symbols(odesys)), Set([a, b, Initial(x), Initial(y), Initial(xy),
-            Initial(D(x)), Initial(D(y)), Initial(D(xy))]))
+        Set(parameter_symbols(odesys)), Set(
+            [
+                a, b, Initial(x), Initial(y), Initial(xy),
+                Initial(D(x)), Initial(D(y)), Initial(D(xy)),
+            ]
+        )
+    )
     @test all(is_independent_variable.((odesys,), [t, :t]))
     @test all(.!is_independent_variable.((odesys,), [x, y, a, :x, :y, :a]))
     @test isequal(independent_variable_symbols(odesys), [t])
@@ -47,17 +53,20 @@ using Test
     @test_nowarn @inferred getter(prob)
 
     @named odesys = System(
-        eqs, t, [x, y], [a, b]; initial_conditions = [xy => 3.0], observed = [xy ~ x + y])
+        eqs, t, [x, y], [a, b]; initial_conditions = [xy => 3.0], observed = [xy ~ x + y]
+    )
     odesys = complete(odesys)
     @test default_values(odesys)[xy] == 3.0
     pobs = parameter_observed(odesys, a + b)
     @test isempty(get_all_timeseries_indexes(odesys, a + b))
     @test pobs(
-        ModelingToolkitBase.MTKParameters(odesys, [a => 1.0, b => 2.0]), 0.0) ≈ 3.0
+        ModelingToolkitBase.MTKParameters(odesys, [a => 1.0, b => 2.0]), 0.0
+    ) ≈ 3.0
     pobs = parameter_observed(odesys, [a + b, a - b])
     @test isempty(get_all_timeseries_indexes(odesys, [a + b, a - b]))
     @test pobs(
-        ModelingToolkitBase.MTKParameters(odesys, [a => 1.0, b => 2.0]), 0.0) ≈ [3.0, -1.0]
+        ModelingToolkitBase.MTKParameters(odesys, [a => 1.0, b => 2.0]), 0.0
+    ) ≈ [3.0, -1.0]
 end
 
 # @testset "Clock system" begin
@@ -107,9 +116,11 @@ end
     @variables x y z
     @parameters σ ρ β
 
-    eqs = [0 ~ σ * (y - x),
+    eqs = [
+        0 ~ σ * (y - x),
         0 ~ x * (ρ - z) - y,
-        0 ~ x * y - β * z]
+        0 ~ x * y - β * z,
+    ]
     @named ns = System(eqs, [x, y, z], [σ, ρ, β])
     ns = complete(ns)
     @test SymbolicIndexingInterface.supports_tuple_observed(ns)
@@ -123,7 +134,8 @@ end
     @test pobs(ps) == [3.0, 5.0]
 
     prob = NonlinearProblem(
-        ns, [x => 1.0, y => 2.0, z => 3.0, σ => 1.0, ρ => 2.0, β => 3.0])
+        ns, [x => 1.0, y => 2.0, z => 3.0, σ => 1.0, ρ => 2.0, β => 3.0]
+    )
     getter = getu(ns, (x + 1, x + 2))
     @test getter(prob) isa Tuple
     @test_nowarn @inferred getter(prob)
@@ -144,14 +156,18 @@ end
     eq = Dtt(u(t, x)) ~ C^2 * Dxx(u(t, x))
 
     # Initial and boundary conditions
-    bcs = [u(t, 0) ~ 0.0,# for all t > 0
-        u(t, 1) ~ 0.0,# for all t > 0
+    bcs = [
+        u(t, 0) ~ 0.0, # for all t > 0
+        u(t, 1) ~ 0.0, # for all t > 0
         u(0, x) ~ x * (1.0 - x), #for all 0 < x < 1
-        Dt(u(0, x)) ~ 0.0] #for all  0 < x < 1]
+        Dt(u(0, x)) ~ 0.0,
+    ] #for all  0 < x < 1]
 
     # Space and time domains
-    domains = [t ∈ (0.0, 1.0),
-        x ∈ (0.0, 1.0)]
+    domains = [
+        t ∈ (0.0, 1.0),
+        x ∈ (0.0, 1.0),
+    ]
 
     @named pde_system = PDESystem(eq, bcs, domains, [t, x], [u])
 
@@ -164,11 +180,15 @@ end
     Dt = D
     Dxx = Differential(x)^2
     eq = Dt(u(t, x)) ~ h * Dxx(u(t, x))
-    bcs = [u(0, x) ~ -h * x * (x - 1) * sin(x),
-        u(t, 0) ~ 0, u(t, 1) ~ 0]
+    bcs = [
+        u(0, x) ~ -h * x * (x - 1) * sin(x),
+        u(t, 0) ~ 0, u(t, 1) ~ 0,
+    ]
 
-    domains = [t ∈ (0.0, 1.0),
-        x ∈ (0.0, 1.0)]
+    domains = [
+        t ∈ (0.0, 1.0),
+        x ∈ (0.0, 1.0),
+    ]
 
     analytic = [u(t, x) ~ -h * x * (x - 1) * sin(x) * exp(-2 * h * t)]
     analytic_function = (ps, t, x) -> -ps[1] * x * (x - 1) * sin(x) * exp(-2 * ps[1] * t)
@@ -181,12 +201,12 @@ end
 end
 
 @testset "Issue#2767" begin
-    @parameters p1[1:2]=[1.0, 2.0] p2[1:2]=[0.0, 0.0]
+    @parameters p1[1:2] = [1.0, 2.0] p2[1:2] = [0.0, 0.0]
     @variables x(t) = 0
 
     @named sys = System(
         [D(x) ~ sum(p1) * t + sum(p2)],
-        t;
+        t
     )
     prob = ODEProblem(complete(sys), [], (0.0, 1.0))
     get_dep = @test_nowarn getu(prob, 2p1)
@@ -198,7 +218,8 @@ end
     @parameters p1 p2[1:2, 1:2]
     @mtkcompile sys = System([D(x) ~ x * t + p1, y ~ 2x, D(z) ~ p2 * z], t)
     prob = ODEProblem(
-        sys, [x => 1.0, z => ones(2), p1 => 2.0, p2 => ones(2, 2)], (0.0, 1.0))
+        sys, [x => 1.0, z => ones(2), p1 => 2.0, p2 => ones(2, 2)], (0.0, 1.0)
+    )
     @test getu(prob, x)(prob) == getu(prob, :x)(prob)
     @test getu(prob, [x, y])(prob) == getu(prob, [:x, :y])(prob)
     @test getu(prob, z)(prob) == getu(prob, :z)(prob)
@@ -208,8 +229,8 @@ end
 
 @testset "Parameter dependencies as symbols" begin
     @variables x(t) = 1.0
-    @parameters a=1 b
-    @named model = System([D(x) ~ x + a - b], t; bindings = [b => a+1])
+    @parameters a = 1 b
+    @named model = System([D(x) ~ x + a - b], t; bindings = [b => a + 1])
     sys = complete(model)
     prob = ODEProblem(sys, [], (0.0, 1.0))
     @test prob.ps[b] == prob.ps[:b]
@@ -230,10 +251,11 @@ end
     @variables x(t)[1:2]
     @discretes p(t)[1:2, 1:2]
     ev = SymbolicContinuousCallback(
-        [x[1] ~ 2.0] => [p ~ -ones(2, 2)], discrete_parameters = [p])
+        [x[1] ~ 2.0] => [p ~ -ones(2, 2)], discrete_parameters = [p]
+    )
     @mtkcompile sys = System(D(x) ~ p * x, t; continuous_events = [ev])
     p = ModelingToolkitBase.unwrap(p)
     @test timeseries_parameter_index(sys, p) === ParameterTimeseriesIndex(1, (1, 1))
     @test timeseries_parameter_index(sys, p[1, 1]) ===
-          ParameterTimeseriesIndex(1, (1, 1, 1, 1))
+        ParameterTimeseriesIndex(1, (1, 1, 1, 1))
 end

--- a/lib/ModelingToolkitBase/test/test_variable_metadata.jl
+++ b/lib/ModelingToolkitBase/test/test_variable_metadata.jl
@@ -119,12 +119,14 @@ d = FakeNormal()
 ## System interface
 @independent_variables t
 Dₜ = Differential(t)
-@variables x(t)=0 [bounds=(-10, 10)] u(t)=0 [input=true] y(t)=0 [output=true]
+@variables x(t) = 0 [bounds = (-10, 10)] u(t) = 0 [input = true] y(t) = 0 [output = true]
 @parameters T [bounds = (0, Inf)]
 @parameters k [tunable = true, bounds = (0, Inf)]
 @parameters k2 [tunable = false]
-eqs = [Dₜ(x) ~ (-k2 * x + k * u) / T
-       y ~ x]
+eqs = [
+    Dₜ(x) ~ (-k2 * x + k * u) / T
+    y ~ x
+]
 sys = System(eqs, t, name = :tunable_first_order)
 unk_meta = ModelingToolkitBase.dump_unknowns(sys)
 @test length(unk_meta) == 3
@@ -176,11 +178,13 @@ sp = Set(p)
 @test_nowarn show(stdout, "text/plain", sys)
 
 # Defaults, guesses overridden by system, parameter dependencies
-@variables x(t)=1.0 y(t) [guess = 1.0]
-@parameters p=2.0 q
-@named sys = System(Equation[], t, [x, y], [p, q];
-                    bindings = [q => 2p], initial_conditions = Dict(x => 2.0, p => 3.0),
-                    guesses = Dict(y => 2.0))
+@variables x(t) = 1.0 y(t) [guess = 1.0]
+@parameters p = 2.0 q
+@named sys = System(
+    Equation[], t, [x, y], [p, q];
+    bindings = [q => 2p], initial_conditions = Dict(x => 2.0, p => 3.0),
+    guesses = Dict(y => 2.0)
+)
 sys = complete(sys)
 unks_meta = ModelingToolkitBase.dump_unknowns(sys)
 unks_meta = Dict([ModelingToolkitBase.getname(meta.var) => meta for meta in unks_meta])

--- a/lib/ModelingToolkitBase/test/variable_parsing.jl
+++ b/lib/ModelingToolkitBase/test/variable_parsing.jl
@@ -56,7 +56,7 @@ using ModelingToolkitBase: VariableConnectType, VariableUnit, rename
 using DynamicQuantities
 
 vals = [1, 2, 3, 4]
-@variables x=1 xs[1:4]=vals ys[1:5]=ones(5)
+@variables x = 1 xs[1:4] = vals ys[1:5] = ones(5)
 
 @test getmetadata(x, VariableDefaultValue) === 1
 @test getdefaultval(xs) == vals
@@ -73,7 +73,7 @@ end
 @test getmetadata(x, VariableUnit) == u
 @test getmetadata(y, VariableDefaultValue) === 2
 
-@variables x=[1, 2] [connect=Flow, unit=u] y=2
+@variables x = [1, 2] [connect = Flow, unit = u] y = 2
 
 @test getmetadata(x, VariableDefaultValue) == [1, 2]
 @test getmetadata(x, VariableConnectType) == Flow
@@ -99,7 +99,7 @@ a = rename(value(x), :a)
 @test getmetadata(a, VariableUnit) == u
 
 @independent_variables t
-@variables x(t)=1 [connect = Flow, unit = u]
+@variables x(t) = 1 [connect = Flow, unit = u]
 
 @test getmetadata(x, VariableDefaultValue) == 1
 @test getmetadata(x, VariableConnectType) == Flow
@@ -110,16 +110,15 @@ a = rename(value(x), :a)
 @test getmetadata(a, VariableConnectType) == Flow
 @test getmetadata(a, VariableUnit) == u
 
-@parameters p=2 [unit = u"m"]
+@parameters p = 2 [unit = u"m"]
 @test getmetadata(p, VariableDefaultValue) == 2
 @test !hasmetadata(p, VariableConnectType)
 @test getmetadata(p, VariableUnit) == u"m"
 @test ModelingToolkitBase.isparameter(p)
 
-@test_throws Any (@macroexpand @parameters p=2 [unit = u"m", abc = 2])
+@test_throws Any (@macroexpand @parameters p = 2 [unit = u"m", abc = 2])
 
 @testset "Parameters cannot be dependent" begin
     @test_throws ["cannot create time-dependent"] @parameters p(t)
     @test_throws ["cannot create time-independent"] @discretes p
 end
-

--- a/lib/ModelingToolkitBase/test/variable_scope.jl
+++ b/lib/ModelingToolkitBase/test/variable_scope.jl
@@ -18,10 +18,12 @@ GlobalScope(e.val)
 ie = ParentScope(1 / e)
 @test getmetadata(arguments(value(ie))[2], SymScope) === ParentScope(LocalScope())
 
-eqs = [0 ~ a
-       0 ~ b
-       0 ~ c
-       0 ~ d]
+eqs = [
+    0 ~ a
+    0 ~ b
+    0 ~ c
+    0 ~ d
+]
 @named sub4 = System(eqs, [a, b, c, d], [])
 @named sub3 = System(eqs, [a, b, c, d], [])
 @named sub2 = System(Equation[], [], [], systems = [sub3, sub4])
@@ -37,13 +39,18 @@ names = ModelingToolkitBase.getname.(unknowns(sys))
 
 @named foo = System(eqs, [a, b, c, d], [])
 @named bar = System(eqs, [a, b, c, d], [])
-@test ModelingToolkitBase.getname(ModelingToolkitBase.namespace_expr(
-    ModelingToolkitBase.namespace_expr(b,
-        foo),
-    bar)) == Symbol("bar₊b")
+@test ModelingToolkitBase.getname(
+    ModelingToolkitBase.namespace_expr(
+        ModelingToolkitBase.namespace_expr(
+            b,
+            foo
+        ),
+        bar
+    )
+) == Symbol("bar₊b")
 
 function renamed(nss, sym)
-    ModelingToolkitBase.getname(foldr(ModelingToolkitBase.renamespace, nss, init = sym))
+    return ModelingToolkitBase.getname(foldr(ModelingToolkitBase.renamespace, nss, init = sym))
 end
 
 @test renamed([:foo :bar :baz], a) == Symbol("foo₊bar₊baz₊a")
@@ -52,10 +59,12 @@ end
 @test renamed([:foo :bar :baz], d) == :d
 
 @parameters a b c d
-p = [a
-     ParentScope(b)
-     ParentScope(ParentScope(c))
-     GlobalScope(d)]
+p = [
+    a
+    ParentScope(b)
+    ParentScope(ParentScope(c))
+    GlobalScope(d)
+]
 
 level0 = System(Equation[], t, [], p; name = :level0)
 level1 = System(Equation[], t, [], []; name = :level1) ∘ level0

--- a/lib/ModelingToolkitBase/test/variable_utils.jl
+++ b/lib/ModelingToolkitBase/test/variable_utils.jl
@@ -19,7 +19,7 @@ new = (((1 / β - 1) + δ) / γ)^(1 / (γ - 1))
 
 # Continuous
 using ModelingToolkitBase: isdifferential, collect_differential_variables,
-                       collect_ivs
+    collect_ivs
 @independent_variables t
 @variables u(t) y(t)
 D = Differential(t)
@@ -50,9 +50,12 @@ ts = collect_ivs([eq])
             β
         end
         sys = System(
-            [D(D(x)) ~ σ * (y - x)
-             D(y) ~ x * (ρ - z) - y
-             D(z) ~ x * y - β * z], iv; name)
+            [
+                D(D(x)) ~ σ * (y - x)
+                D(y) ~ x * (ρ - z) - y
+                D(z) ~ x * y - β * z
+            ], iv; name
+        )
     end
     function ArrSys(; name)
         @variables begin
@@ -71,70 +74,70 @@ ts = collect_ivs([eq])
 
     @mtkcompile sys = Outer()
     for (str, var) in [
-        # unicode system, scalar variable
-        ("😄.x", sys.😄.x),
-        ("😄.x($iv)", sys.😄.x),
-        ("😄₊x", sys.😄.x),
-        ("😄₊x($iv)", sys.😄.x),
-        # derivative
-        ("D(😄.x)", D(sys.😄.x)),
-        ("D(😄.x($iv))", D(sys.😄.x)),
-        ("D(😄₊x)", D(sys.😄.x)),
-        ("D(😄₊x($iv))", D(sys.😄.x)),
-        ("Differential($iv)(😄.x)", D(sys.😄.x)),
-        ("Differential($iv)(😄.x($iv))", D(sys.😄.x)),
-        ("Differential($iv)(😄₊x)", D(sys.😄.x)),
-        ("Differential($iv)(😄₊x($iv))", D(sys.😄.x)),
-        # other derivative
-        ("😄.xˍ$iv", D(sys.😄.x)),
-        ("😄.x($iv)ˍ$iv", D(sys.😄.x)),
-        ("😄₊xˍ$iv", D(sys.😄.x)),
-        ("😄₊x($iv)ˍ$iv", D(sys.😄.x)),
-        # scalar parameter
-        ("😄.σ", sys.😄.σ),
-        ("😄₊σ", sys.😄.σ),
-        # array variable
-        ("arr.x", sys.arr.x),
-        ("arr₊x", sys.arr.x),
-        ("arr.x($iv)", sys.arr.x),
-        ("arr₊x($iv)", sys.arr.x),
-        # getindex
-        ("arr.x[1]", sys.arr.x[1]),
-        ("arr₊x[1]", sys.arr.x[1]),
-        ("arr.x($iv)[1]", sys.arr.x[1]),
-        ("arr₊x($iv)[1]", sys.arr.x[1]),
-        # derivative
-        ("D(arr.x($iv))", D(sys.arr.x)),
-        ("D(arr₊x($iv))", D(sys.arr.x)),
-        ("D(arr.x[1])", D(sys.arr.x[1])),
-        ("D(arr₊x[1])", D(sys.arr.x[1])),
-        ("D(arr.x($iv)[1])", D(sys.arr.x[1])),
-        ("D(arr₊x($iv)[1])", D(sys.arr.x[1])),
-        ("Differential($iv)(arr.x($iv))", D(sys.arr.x)),
-        ("Differential($iv)(arr₊x($iv))", D(sys.arr.x)),
-        ("Differential($iv)(arr.x[1])", D(sys.arr.x[1])),
-        ("Differential($iv)(arr₊x[1])", D(sys.arr.x[1])),
-        ("Differential($iv)(arr.x($iv)[1])", D(sys.arr.x[1])),
-        ("Differential($iv)(arr₊x($iv)[1])", D(sys.arr.x[1])),
-        # other derivative
-        ("arr.xˍ$iv", D(sys.arr.x)),
-        ("arr₊xˍ$iv", D(sys.arr.x)),
-        ("arr.xˍ$iv($iv)", D(sys.arr.x)),
-        ("arr₊xˍ$iv($iv)", D(sys.arr.x)),
-        ("arr.xˍ$iv[1]", D(sys.arr.x[1])),
-        ("arr₊xˍ$iv[1]", D(sys.arr.x[1])),
-        ("arr.xˍ$iv($iv)[1]", D(sys.arr.x[1])),
-        ("arr₊xˍ$iv($iv)[1]", D(sys.arr.x[1])),
-        ("arr.x($iv)ˍ$iv", D(sys.arr.x)),
-        ("arr₊x($iv)ˍ$iv", D(sys.arr.x)),
-        ("arr.x($iv)ˍ$iv[1]", D(sys.arr.x[1])),
-        ("arr₊x($iv)ˍ$iv[1]", D(sys.arr.x[1])),
-        # array parameter
-        ("arr.p", sys.arr.p),
-        ("arr₊p", sys.arr.p),
-        ("arr.p[1, 2]", sys.arr.p[1, 2]),
-        ("arr₊p[1, 2]", sys.arr.p[1, 2])
-    ]
+            # unicode system, scalar variable
+            ("😄.x", sys.😄.x),
+            ("😄.x($iv)", sys.😄.x),
+            ("😄₊x", sys.😄.x),
+            ("😄₊x($iv)", sys.😄.x),
+            # derivative
+            ("D(😄.x)", D(sys.😄.x)),
+            ("D(😄.x($iv))", D(sys.😄.x)),
+            ("D(😄₊x)", D(sys.😄.x)),
+            ("D(😄₊x($iv))", D(sys.😄.x)),
+            ("Differential($iv)(😄.x)", D(sys.😄.x)),
+            ("Differential($iv)(😄.x($iv))", D(sys.😄.x)),
+            ("Differential($iv)(😄₊x)", D(sys.😄.x)),
+            ("Differential($iv)(😄₊x($iv))", D(sys.😄.x)),
+            # other derivative
+            ("😄.xˍ$iv", D(sys.😄.x)),
+            ("😄.x($iv)ˍ$iv", D(sys.😄.x)),
+            ("😄₊xˍ$iv", D(sys.😄.x)),
+            ("😄₊x($iv)ˍ$iv", D(sys.😄.x)),
+            # scalar parameter
+            ("😄.σ", sys.😄.σ),
+            ("😄₊σ", sys.😄.σ),
+            # array variable
+            ("arr.x", sys.arr.x),
+            ("arr₊x", sys.arr.x),
+            ("arr.x($iv)", sys.arr.x),
+            ("arr₊x($iv)", sys.arr.x),
+            # getindex
+            ("arr.x[1]", sys.arr.x[1]),
+            ("arr₊x[1]", sys.arr.x[1]),
+            ("arr.x($iv)[1]", sys.arr.x[1]),
+            ("arr₊x($iv)[1]", sys.arr.x[1]),
+            # derivative
+            ("D(arr.x($iv))", D(sys.arr.x)),
+            ("D(arr₊x($iv))", D(sys.arr.x)),
+            ("D(arr.x[1])", D(sys.arr.x[1])),
+            ("D(arr₊x[1])", D(sys.arr.x[1])),
+            ("D(arr.x($iv)[1])", D(sys.arr.x[1])),
+            ("D(arr₊x($iv)[1])", D(sys.arr.x[1])),
+            ("Differential($iv)(arr.x($iv))", D(sys.arr.x)),
+            ("Differential($iv)(arr₊x($iv))", D(sys.arr.x)),
+            ("Differential($iv)(arr.x[1])", D(sys.arr.x[1])),
+            ("Differential($iv)(arr₊x[1])", D(sys.arr.x[1])),
+            ("Differential($iv)(arr.x($iv)[1])", D(sys.arr.x[1])),
+            ("Differential($iv)(arr₊x($iv)[1])", D(sys.arr.x[1])),
+            # other derivative
+            ("arr.xˍ$iv", D(sys.arr.x)),
+            ("arr₊xˍ$iv", D(sys.arr.x)),
+            ("arr.xˍ$iv($iv)", D(sys.arr.x)),
+            ("arr₊xˍ$iv($iv)", D(sys.arr.x)),
+            ("arr.xˍ$iv[1]", D(sys.arr.x[1])),
+            ("arr₊xˍ$iv[1]", D(sys.arr.x[1])),
+            ("arr.xˍ$iv($iv)[1]", D(sys.arr.x[1])),
+            ("arr₊xˍ$iv($iv)[1]", D(sys.arr.x[1])),
+            ("arr.x($iv)ˍ$iv", D(sys.arr.x)),
+            ("arr₊x($iv)ˍ$iv", D(sys.arr.x)),
+            ("arr.x($iv)ˍ$iv[1]", D(sys.arr.x[1])),
+            ("arr₊x($iv)ˍ$iv[1]", D(sys.arr.x[1])),
+            # array parameter
+            ("arr.p", sys.arr.p),
+            ("arr₊p", sys.arr.p),
+            ("arr.p[1, 2]", sys.arr.p[1, 2]),
+            ("arr₊p[1, 2]", sys.arr.p[1, 2]),
+        ]
         @test isequal(parse_variable(sys, str), var)
     end
 end

--- a/lib/SciCompDSL/ext/SciCompDSLDynamicQuantitiesExt.jl
+++ b/lib/SciCompDSL/ext/SciCompDSLDynamicQuantitiesExt.jl
@@ -11,16 +11,23 @@ using SciCompDSL: convert_units, NoValue, NO_VALUE
 import ModelingToolkitBase as MTK
 
 function SciCompDSL.convert_units(varunits::DynamicQuantities.Quantity, value)
-    DynamicQuantities.ustrip(DynamicQuantities.uconvert(
-        DynamicQuantities.SymbolicUnits.as_quantity(varunits), value))
+    return DynamicQuantities.ustrip(
+        DynamicQuantities.uconvert(
+            DynamicQuantities.SymbolicUnits.as_quantity(varunits), value
+        )
+    )
 end
 
 SciCompDSL.convert_units(::DynamicQuantities.Quantity, value::NoValue) = NO_VALUE
 
 function SciCompDSL.convert_units(
-        varunits::DynamicQuantities.Quantity, value::AbstractArray{T}) where {T}
-    DynamicQuantities.ustrip.(DynamicQuantities.uconvert.(
-        DynamicQuantities.SymbolicUnits.as_quantity(varunits), value))
+        varunits::DynamicQuantities.Quantity, value::AbstractArray{T}
+    ) where {T}
+    return DynamicQuantities.ustrip.(
+        DynamicQuantities.uconvert.(
+            DynamicQuantities.SymbolicUnits.as_quantity(varunits), value
+        )
+    )
 end
 
 SciCompDSL.convert_units(::DynamicQuantities.Quantity, value::AbstractArray{Num}) = value
@@ -39,8 +46,10 @@ function SciCompDSL.__generate_variable_with_unit(metadata_with_exprs, name, vv,
                 if isa(e, $(DynamicQuantities.DimensionError))
                     error("Unable to convert units for \'" * string(:($$vv)) * "\'")
                 elseif isa(e, MethodError)
-                    error("No or invalid units provided for \'" * string(:($$vv)) *
-                          "\'")
+                    error(
+                        "No or invalid units provided for \'" * string(:($$vv)) *
+                            "\'"
+                    )
                 else
                     rethrow(e)
                 end

--- a/lib/SciCompDSL/src/SciCompDSL.jl
+++ b/lib/SciCompDSL/src/SciCompDSL.jl
@@ -14,7 +14,7 @@ import ModelingToolkitBase: observed
 using Setfield
 
 let allnames = names(MTKBase; all = true),
-    banned_names = Set{Symbol}([:eval, :include, :Variable])
+        banned_names = Set{Symbol}([:eval, :include, :Variable])
 
     using_expr = Expr(:using, Expr(:(:), Expr(:., :ModelingToolkitBase)))
     inner_using_expr = using_expr.args[1]
@@ -28,7 +28,7 @@ let allnames = names(MTKBase; all = true),
 end
 
 using ModelingToolkitBase: COMMON_SENTINEL, COMMON_NOTHING, COMMON_MISSING,
-                           COMMON_TRUE, COMMON_FALSE, COMMON_INF
+    COMMON_TRUE, COMMON_FALSE, COMMON_INF
 
 @recompile_invalidations begin
     include("model_parsing.jl")

--- a/lib/SciCompDSL/test/model_parsing.jl
+++ b/lib/SciCompDSL/test/model_parsing.jl
@@ -1,8 +1,8 @@
 using ModelingToolkitBase, Symbolics, Test
 using ModelingToolkitBase: get_connector_type, get_initial_conditions, get_gui_metadata,
-                       get_systems, get_ps, getdefault, getname, readable_code,
-                       scalarize, symtype, VariableDescription, RegularConnector,
-                       get_unit, value
+    get_systems, get_ps, getdefault, getname, readable_code,
+    scalarize, symtype, VariableDescription, RegularConnector,
+    get_unit, value
 using SymbolicIndexingInterface
 using URIs: URI
 using Distributions
@@ -14,26 +14,26 @@ ENV["MTK_ICONS_DIR"] = "$(@__DIR__)/icons"
 
 # Mock module used to test if the `@mtkmodel` macro works with fully-qualified names as well.
 module MyMockModule
-using ModelingToolkitBase, DynamicQuantities, SciCompDSL
-using ModelingToolkitBase: t, D
+    using ModelingToolkitBase, DynamicQuantities, SciCompDSL
+    using ModelingToolkitBase: t, D
 
-export Pin
-@connector Pin begin
-    v(t), [unit = u"V"]                    # Potential at the pin [V]
-    i(t), [connect = Flow, unit = u"A"]    # Current flowing into the pin [A]
-    @icon "pin.png"
-end
+    export Pin
+    @connector Pin begin
+        v(t), [unit = u"V"]                    # Potential at the pin [V]
+        i(t), [connect = Flow, unit = u"A"]    # Current flowing into the pin [A]
+        @icon "pin.png"
+    end
 
-ground_logo = read(abspath(ENV["MTK_ICONS_DIR"], "ground.svg"), String)
-@mtkmodel Ground begin
-    @components begin
-        g = Pin()
+    ground_logo = read(abspath(ENV["MTK_ICONS_DIR"], "ground.svg"), String)
+    @mtkmodel Ground begin
+        @components begin
+            g = Pin()
+        end
+        @icon ground_logo
+        @equations begin
+            g.v ~ 0
+        end
     end
-    @icon ground_logo
-    @equations begin
-        g.v ~ 0
-    end
-end
 end
 
 using .MyMockModule
@@ -86,19 +86,19 @@ end
         R, [unit = u"Ω"]
     end
     @icon """<?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="80" height="30">
-<path d="M10 15
-l15 0
-l2.5 -5
-l5 10
-l5 -10
-l5 10
-l5 -10
-l5 10
-l2.5 -5
-l15 0" stroke="black" stroke-width="1" stroke-linejoin="bevel" fill="none"></path>
-</svg>
-"""
+    <svg xmlns="http://www.w3.org/2000/svg" width="80" height="30">
+    <path d="M10 15
+    l15 0
+    l2.5 -5
+    l5 10
+    l5 -10
+    l5 10
+    l5 -10
+    l5 10
+    l2.5 -5
+    l15 0" stroke="black" stroke-width="1" stroke-linejoin="bevel" fill="none"></path>
+    </svg>
+    """
     @equations begin
         v ~ i * R
     end
@@ -154,7 +154,7 @@ C_val = 20u"F"
 R_val = 20u"Ω"
 res__R = 100u"Ω"
 @mtkcompile rc = RC(; C_val, R_val, resistor.R = res__R)
-prob = ODEProblem(rc, [], (0, 1e9))
+prob = ODEProblem(rc, [], (0, 1.0e9))
 sol = solve(prob)
 defs = ModelingToolkitBase.initial_conditions(rc)
 @test sol[rc.capacitor.v][end] ≈ value(defs[rc.constant.k])
@@ -169,21 +169,21 @@ resistor = getproperty(rc, :resistor; namespace = false)
 @test getdefault(rc.capacitor.C) * get_unit(rc.capacitor.C) == C_val
 # Test that `k`'s default value is unchanged.
 @test getdefault(rc.constant.k) * get_unit(rc.constant.k) ==
-      eval(RC.structure[:kwargs][:k_val][:value])
+    eval(RC.structure[:kwargs][:k_val][:value])
 @test getdefault(rc.capacitor.v) == 0.0
 
 @test get_gui_metadata(rc.resistor).layout == Resistor.structure[:icon] ==
-      read(joinpath(ENV["MTK_ICONS_DIR"], "resistor.svg"), String)
+    read(joinpath(ENV["MTK_ICONS_DIR"], "resistor.svg"), String)
 @test get_gui_metadata(rc.ground).layout ==
-      read(abspath(ENV["MTK_ICONS_DIR"], "ground.svg"), String)
+    read(abspath(ENV["MTK_ICONS_DIR"], "ground.svg"), String)
 @test get_gui_metadata(rc.capacitor).layout ==
-      URI("https://upload.wikimedia.org/wikipedia/commons/7/78/Capacitor_symbol.svg")
+    URI("https://upload.wikimedia.org/wikipedia/commons/7/78/Capacitor_symbol.svg")
 @test OnePort.structure[:icon] ==
-      URI("file:///" * abspath(ENV["MTK_ICONS_DIR"], "oneport.png"))
+    URI("file:///" * abspath(ENV["MTK_ICONS_DIR"], "oneport.png"))
 @test ModelingToolkitBase.get_gui_metadata(rc.resistor.p).layout == Pin.structure[:icon] ==
-      URI("file:///" * abspath(ENV["MTK_ICONS_DIR"], "pin.png"))
+    URI("file:///" * abspath(ENV["MTK_ICONS_DIR"], "pin.png"))
 
-@test length(equations(rc)) == 1 broken=!@isdefined(ModelingToolkit)
+@test length(equations(rc)) == 1 broken = !@isdefined(ModelingToolkit)
 
 @testset "Constants" begin
     @mtkmodel PiModel begin
@@ -290,12 +290,12 @@ end
         @parameters begin
             (l(t)[1:2, 1:3] = ones(2, 3)), [description = "l is more than 1D"]
             (l2(t)[1:N, 1:M] = 2ones(N, M)),
-            [description = "l is more than 1D, with arbitrary length"]
+                [description = "l is more than 1D, with arbitrary length"]
             (l3(t)[1:3] = 3ones(3)), [description = "l2 is 1D"]
             (l4(t)[1:N] = 4ones(N)), [description = "l2 is 1D, with arbitrary length"]
             (l5(t)[1:3]::Int = 5ones(Int, 3)), [description = "l3 is 1D and has a type"]
             (l6(t)[1:N]::Int = 6ones(Int, N)),
-            [description = "l3 is 1D and has a type, with arbitrary length"]
+                [description = "l3 is 1D and has a type, with arbitrary length"]
         end
     end
 
@@ -322,7 +322,7 @@ end
             par0::Bool = true
             par1::Int = 1
             par2(t)::Int,
-            [description = "Enforced `par4` to be an Int by setting the type to the keyword-arg."]
+                [description = "Enforced `par4` to be an Int by setting the type to the keyword-arg."]
             par3(t)::BigFloat = 1.0
             par4(t)::Float64 = 1 # converts 1 to 1.0 of Float64 type
             par5[1:3]::BigFloat
@@ -411,15 +411,19 @@ end
 end
 
 @testset "Metadata in variables" begin
-    metadata = Dict(:description => "Variable to test metadata in the Model.structure",
+    metadata = Dict(
+        :description => "Variable to test metadata in the Model.structure",
         :input => true, :bounds => :((-1, 1)), :connection_type => :Flow,
-        :tunable => false, :disturbance => true, :dist => :(Normal(1, 1)))
+        :tunable => false, :disturbance => true, :dist => :(Normal(1, 1))
+    )
 
     @connector MockMeta begin
         m(t),
-        [description = "Variable to test metadata in the Model.structure",
-            input = true, bounds = (-1, 1), connect = Flow,
-            tunable = false, disturbance = true, dist = Normal(1, 1)]
+            [
+                description = "Variable to test metadata in the Model.structure",
+                input = true, bounds = (-1, 1), connect = Flow,
+                tunable = false, disturbance = true, dist = Normal(1, 1),
+            ]
     end
 
     for (k, v) in metadata
@@ -463,7 +467,8 @@ end
     @test A.structure[:equations] == ["e ~ 0"]
     @test A.structure[:kwargs] == Dict{Symbol, Dict}(
         :p => Dict{Symbol, Union{Nothing, DataType}}(:value => nothing, :type => Real),
-        :v => Dict{Symbol, Union{Nothing, DataType}}(:value => nothing, :type => Real))
+        :v => Dict{Symbol, Union{Nothing, DataType}}(:value => nothing, :type => Real)
+    )
     @test A.structure[:components] == [[:cc, :C]]
 end
 
@@ -501,24 +506,24 @@ end
 # Ensure that modules consisting MTKModels with component arrays and icons of
 # `Expr` type and `unit` metadata can be precompiled.
 module PrecompilationTest
-push!(LOAD_PATH, joinpath(@__DIR__, "precompile_test"))
-using DynamicQuantities, Test, ModelParsingPrecompile, ModelingToolkitBase
-using ModelingToolkitBase: getdefault, scalarize
-@testset "Precompile packages with MTKModels" begin
-    using ModelParsingPrecompile: ModelWithComponentArray
+    push!(LOAD_PATH, joinpath(@__DIR__, "precompile_test"))
+    using DynamicQuantities, Test, ModelParsingPrecompile, ModelingToolkitBase
+    using ModelingToolkitBase: getdefault, scalarize
+    @testset "Precompile packages with MTKModels" begin
+        using ModelParsingPrecompile: ModelWithComponentArray
 
-    @named model_with_component_array = ModelWithComponentArray()
+        @named model_with_component_array = ModelWithComponentArray()
 
-    @test eval(ModelWithComponentArray.structure[:parameters][:r][:unit]) ==
-          eval(u"Ω")
-    @test lastindex(parameters(model_with_component_array)) == 4
+        @test eval(ModelWithComponentArray.structure[:parameters][:r][:unit]) ==
+            eval(u"Ω")
+        @test lastindex(parameters(model_with_component_array)) == 4
 
-    # Test the constant `k`. Manually k's value should be kept in sync here
-    # and the ModelParsingPrecompile.
-    @test all(getdefault.(getdefault.(scalarize(model_with_component_array.r))) .== 1)
+        # Test the constant `k`. Manually k's value should be kept in sync here
+        # and the ModelParsingPrecompile.
+        @test all(getdefault.(getdefault.(scalarize(model_with_component_array.r))) .== 1)
 
-    pop!(LOAD_PATH)
-end
+        pop!(LOAD_PATH)
+    end
 end
 
 @testset "Conditional statements inside the blocks" begin
@@ -582,21 +587,27 @@ end
     @test nameof.(get_systems(elseif_in_sys)) == [:elseif_sys, :default_sys]
     @test nameof.(get_systems(else_in_sys)) == [:else_sys, :default_sys]
 
-    @test all([
-        if_in_sys.eq ~ 0,
-        if_in_sys.eq ~ 1,
-        if_in_sys.eq ~ 4
-    ] .∈ [equations(if_in_sys)])
-    @test all([
-        elseif_in_sys.eq ~ 0,
-        elseif_in_sys.eq ~ 2,
-        elseif_in_sys.eq ~ 5
-    ] .∈ [equations(elseif_in_sys)])
-    @test all([
-        else_in_sys.eq ~ 0,
-        else_in_sys.eq ~ 3,
-        else_in_sys.eq ~ 5
-    ] .∈ [equations(else_in_sys)])
+    @test all(
+        [
+            if_in_sys.eq ~ 0,
+            if_in_sys.eq ~ 1,
+            if_in_sys.eq ~ 4,
+        ] .∈ [equations(if_in_sys)]
+    )
+    @test all(
+        [
+            elseif_in_sys.eq ~ 0,
+            elseif_in_sys.eq ~ 2,
+            elseif_in_sys.eq ~ 5,
+        ] .∈ [equations(elseif_in_sys)]
+    )
+    @test all(
+        [
+            else_in_sys.eq ~ 0,
+            else_in_sys.eq ~ 3,
+            else_in_sys.eq ~ 5,
+        ] .∈ [equations(else_in_sys)]
+    )
 
     @test getdefault(if_in_sys.eq) == 1
     @test getdefault(elseif_in_sys.eq) == 0
@@ -675,38 +686,44 @@ end
     @test nameof.(get_systems(elseif_out_sys)) == [:elseif_sys, :default_sys]
     @test nameof.(get_systems(else_out_sys)) == [:else_sys, :default_sys]
 
-    @test Equation[if_out_sys.if_parameter ~ 0
-                   if_out_sys.default_parameter ~ 0] == equations(if_out_sys)
-    @test Equation[elseif_out_sys.elseif_parameter ~ 0
-                   elseif_out_sys.default_parameter ~ 0] == equations(elseif_out_sys)
-    @test Equation[else_out_sys.else_parameter ~ 0
-                   else_out_sys.default_parameter ~ 0] == equations(else_out_sys)
+    @test Equation[
+        if_out_sys.if_parameter ~ 0
+        if_out_sys.default_parameter ~ 0
+    ] == equations(if_out_sys)
+    @test Equation[
+        elseif_out_sys.elseif_parameter ~ 0
+        elseif_out_sys.default_parameter ~ 0
+    ] == equations(elseif_out_sys)
+    @test Equation[
+        else_out_sys.else_parameter ~ 0
+        else_out_sys.default_parameter ~ 0
+    ] == equations(else_out_sys)
 
     @mtkmodel TernaryBranchingOutsideTheBlock begin
         @structural_parameters begin
             condition = true
         end
         condition ? begin
-            @parameters begin
-                ternary_parameter_true
+                @parameters begin
+                    ternary_parameter_true
+                end
+                @equations begin
+                    ternary_parameter_true ~ 0
+                end
+                @components begin
+                    ternary_sys_true = C()
+                end
+            end : begin
+                @parameters begin
+                    ternary_parameter_false
+                end
+                @equations begin
+                    ternary_parameter_false ~ 0
+                end
+                @components begin
+                    ternary_sys_false = C()
+                end
             end
-            @equations begin
-                ternary_parameter_true ~ 0
-            end
-            @components begin
-                ternary_sys_true = C()
-            end
-        end : begin
-            @parameters begin
-                ternary_parameter_false
-            end
-            @equations begin
-                ternary_parameter_false ~ 0
-            end
-            @components begin
-                ternary_sys_false = C()
-            end
-        end
     end
 
     @named ternary_true = TernaryBranchingOutsideTheBlock()
@@ -767,7 +784,7 @@ end
         :comprehension_2,
         :written_out_for_1,
         :written_out_for_2,
-        :single_sub_component
+        :single_sub_component,
     ]
 
     @test getdefault(component.comprehension_1.sc) == 1
@@ -795,12 +812,14 @@ end
 
     @named elseif_component = ConditionalComponent(; N = 3)
     @test nameof.(get_systems(elseif_component)) ==
-          [:elseif_comprehension_1, :elseif_comprehension_2, :elseif_comprehension_3]
+        [:elseif_comprehension_1, :elseif_comprehension_2, :elseif_comprehension_3]
 
     @named else_component = ConditionalComponent(; N = 4)
     @test nameof.(get_systems(else_component)) ==
-          [:else_comprehension_1, :else_comprehension_2,
-        :else_comprehension_3, :else_comprehension_4]
+        [
+        :else_comprehension_1, :else_comprehension_2,
+        :else_comprehension_3, :else_comprehension_4,
+    ]
 end
 
 @testset "Parent module of Models" begin
@@ -893,24 +912,32 @@ end
 
 @testset "Duplicate names" begin
     mod = @__MODULE__
-    @test_throws ErrorException SciCompDSL._model_macro(mod, :ATest,
-        :(begin
-            @variables begin
-                a(t)
-                a(t)
+    @test_throws ErrorException SciCompDSL._model_macro(
+        mod, :ATest,
+        :(
+            begin
+                @variables begin
+                    a(t)
+                    a(t)
+                end
             end
-        end),
-        false)
-    @test_throws ErrorException SciCompDSL._model_macro(mod, :ATest,
-        :(begin
-            @variables begin
-                a(t)
+        ),
+        false
+    )
+    @test_throws ErrorException SciCompDSL._model_macro(
+        mod, :ATest,
+        :(
+            begin
+                @variables begin
+                    a(t)
+                end
+                @parameters begin
+                    a
+                end
             end
-            @parameters begin
-                a
-            end
-        end),
-        false)
+        ),
+        false
+    )
 end
 
 @mtkmodel BaseSys begin
@@ -1068,16 +1095,16 @@ end
             MyBool => false
             NewInt => 1
         end
-        
+
         @parameters begin
             k = 1.0
         end
-        
+
         @variables begin
             x(t)
             y(t)
         end
-        
+
         @equations begin
             D(x) ~ -k * x
             y ~ x
@@ -1094,7 +1121,7 @@ end
 end
 
 @testset "Pass parameters of higher level models as structural parameters" begin
-    let D=ModelingToolkitBase.D_nounits, t=ModelingToolkitBase.t_nounits
+    let D = ModelingToolkitBase.D_nounits, t = ModelingToolkitBase.t_nounits
         """
             ╭─────────╮
         in  │    K    │ out
@@ -1108,11 +1135,11 @@ end
                 T # Time constant
             end
             @variables begin
-                in(t), [description="Input signal", input=true]
-                out(t), [description="Output signal", output=true]
+                in(t), [description = "Input signal", input = true]
+                out(t), [description = "Output signal", output = true]
             end
             @equations begin
-                T * D(out) ~ K*in - out
+                T * D(out) ~ K * in - out
             end
         end
 
@@ -1128,18 +1155,18 @@ end
         """
         @mtkmodel DoubleLag begin
             @parameters begin
-                K1, [description="Proportional gain 1"]
-                T1, [description="Time constant 1"]
-                K2, [description="Proportional gain 2"]
-                T2, [description="Time constant 2"]
+                K1, [description = "Proportional gain 1"]
+                T1, [description = "Time constant 1"]
+                K2, [description = "Proportional gain 2"]
+                T2, [description = "Time constant 2"]
             end
             @components begin
                 lag1 = SimpleLag(K = K1, T = T1)
                 lag2 = SimpleLag(K = K2, T = T2)
             end
             @variables begin
-                in(t), [description="Input signal", input=true]
-                out(t), [description="Output signal", output=true]
+                in(t), [description = "Input signal", input = true]
+                out(t), [description = "Output signal", output = true]
             end
             @equations begin
                 in ~ lag1.in
@@ -1178,8 +1205,8 @@ end
 
             # check du values
             K1, K2, T1, T2 = 1, 2, 0.1, 0.2
-            @test du[lag1idx] ≈ (K1*1.0 - u[lag1idx]) / T1
-            @test du[lag2idx] ≈ (K2*u[lag1idx] - u[lag2idx]) / T2
+            @test du[lag1idx] ≈ (K1 * 1.0 - u[lag1idx]) / T1
+            @test du[lag2idx] ≈ (K2 * u[lag1idx] - u[lag2idx]) / T2
         end
     end
 end

--- a/src/ModelingToolkit.jl
+++ b/src/ModelingToolkit.jl
@@ -10,15 +10,15 @@ using PrecompileTools, Reexport
     import REPL
     using OffsetArrays: Origin
     import BlockArrays: BlockArray, BlockedArray, Block, blocksize, blocksizes, blockpush!,
-                        undef_blocks, blocks
+        undef_blocks, blocks
 end
 
 import SymbolicUtils
 import SymbolicUtils as SU
 import SymbolicUtils: iscall, arguments, operation, maketerm, promote_symtype,
-                      isadd, ismul, ispow, issym, FnType, isconst, BSImpl,
-                      @rule, Rewriters, substitute, metadata, BasicSymbolic,
-                      symtype
+    isadd, ismul, ispow, issym, FnType, isconst, BSImpl,
+    @rule, Rewriters, substitute, metadata, BasicSymbolic,
+    symtype
 using SymbolicUtils.Code
 import SymbolicUtils.Code: toexpr
 import SymbolicUtils.Rewriters: Chain, Postwalk, Prewalk, Fixpoint
@@ -46,8 +46,8 @@ using DocStringExtensions
 using Base: RefValue
 using Combinatorics
 using SciMLBase: StandardODEProblem, StandardNonlinearProblem, handle_varmap, TimeDomain,
-                 PeriodicClock, Clock, SolverStepClock, ContinuousClock, OverrideInit,
-                 NoInit
+    PeriodicClock, Clock, SolverStepClock, ContinuousClock, OverrideInit,
+    NoInit
 import Moshi
 using Moshi.Data: @data
 import SCCNonlinearSolve
@@ -60,19 +60,19 @@ using RuntimeGeneratedFunctions: drop_expr
 
 using Symbolics: degree, VartypeT, SymbolicT
 using Symbolics: parse_vars, value, @derivatives, get_variables,
-                 exprs_occur_in, symbolic_linear_solve, unwrap, wrap,
-                 VariableSource, getname, variable, COMMON_ZERO,
-                 NAMESPACE_SEPARATOR, setdefaultval, Arr,
-                 hasnode, fixpoint_sub, CallAndWrap, SArgsT, SSym, STerm
+    exprs_occur_in, symbolic_linear_solve, unwrap, wrap,
+    VariableSource, getname, variable, COMMON_ZERO,
+    NAMESPACE_SEPARATOR, setdefaultval, Arr,
+    hasnode, fixpoint_sub, CallAndWrap, SArgsT, SSym, STerm
 const NAMESPACE_SEPARATOR_SYMBOL = Symbol(NAMESPACE_SEPARATOR)
 import Symbolics: rename, get_variables!, _solve, hessian_sparsity,
-                  jacobian_sparsity, isaffine, islinear, _iszero, _isone,
-                  tosymbol, lower_varname, diff2term, var_from_nested_derivative,
-                  BuildTargets, JuliaTarget, StanTarget, CTarget, MATLABTarget,
-                  ParallelForm, SerialForm, MultithreadedForm, build_function,
-                  rhss, lhss, gradient,
-                  jacobian, hessian, derivative, sparsejacobian, sparsehessian,
-                  scalarize, hasderiv
+    jacobian_sparsity, isaffine, islinear, _iszero, _isone,
+    tosymbol, lower_varname, diff2term, var_from_nested_derivative,
+    BuildTargets, JuliaTarget, StanTarget, CTarget, MATLABTarget,
+    ParallelForm, SerialForm, MultithreadedForm, build_function,
+    rhss, lhss, gradient,
+    jacobian, hessian, derivative, sparsejacobian, sparsehessian,
+    scalarize, hasderiv
 import ModelingToolkitBase as MTKBase
 
 import DiffEqBase: @add_kwonly
@@ -120,7 +120,7 @@ macro import_mtkbase()
         end
     end
 
-    quote
+    return quote
         $using_expr
         $(esc(public_expr))
     end
@@ -129,7 +129,7 @@ end
 @import_mtkbase
 
 using ModelingToolkitBase: COMMON_SENTINEL, COMMON_NOTHING, COMMON_MISSING,
-                           COMMON_TRUE, COMMON_FALSE, COMMON_INF
+    COMMON_TRUE, COMMON_FALSE, COMMON_INF
 
 @recompile_invalidations begin
     include("linearization.jl")
@@ -158,7 +158,7 @@ end
 export SemilinearODEFunction, SemilinearODEProblem
 export alias_elimination
 export linearize, linearization_function,
-       LinearizationProblem, linearization_ap_transform
+    LinearizationProblem, linearization_ap_transform
 export solve
 export map_variables_to_equations, substitute_component
 
@@ -166,7 +166,7 @@ export TearingState
 
 export Clock, SolverStepClock, TimeDomain
 export get_sensitivity_function, get_comp_sensitivity_function,
-       get_looptransfer_function, get_sensitivity, get_comp_sensitivity, get_looptransfer
+    get_looptransfer_function, get_sensitivity, get_comp_sensitivity, get_looptransfer
 
 function FMIComponent end
 

--- a/src/discretedomain.jl
+++ b/src/discretedomain.jl
@@ -1,4 +1,3 @@
 using Symbolics: Operator, Num, Term, value, recursive_hasoperator
 
 MTKBase.ShiftIndex() = MTKBase.ShiftIndex(MTKTearing.Inferred())
-

--- a/src/initialization.jl
+++ b/src/initialization.jl
@@ -1,8 +1,10 @@
 MTKBase.singular_check(ts::TearingState) = StateSelection.singular_check(ts)
 
-function MTKBase.get_initialization_problem_type(sys::System, isys::System;
-                                                 warn_initialize_determined = true,
-                                                 use_scc = true, kwargs...)
+function MTKBase.get_initialization_problem_type(
+        sys::System, isys::System;
+        warn_initialize_determined = true,
+        use_scc = true, kwargs...
+    )
     neqs = length(equations(isys))
     nunknown = length(unknowns(isys))
     ts = get_tearing_state(isys)::TearingState
@@ -24,7 +26,7 @@ function MTKBase.get_initialization_problem_type(sys::System, isys::System;
     end
 
     unassigned_vars = MTKBase.singular_check(ts)
-    if neqs == nunknown && isempty(unassigned_vars)
+    return if neqs == nunknown && isempty(unassigned_vars)
         if use_scc && neqs > 0
             if is_split(isys)
                 SCCNonlinearProblem

--- a/src/problems/docs.jl
+++ b/src/problems/docs.jl
@@ -28,14 +28,18 @@ non-`nothing`. In other words, both of the functions in the split form must be n
 """
 
 for (mod, prob, func, istd, kws) in [
-    (SciMLBase, :SCCNonlinearProblem, NonlinearFunction, false, (; init = false)),
-    (ModelingToolkit,
-        :SemilinearODEProblem,
-        :SemilinearODEFunction,
-        true,
-        (; extra_body = SEMILINEAR_EXTRA_BODY, extra_kwargs = SEMILINEAR_A_B_C_KWARGS,
-            extra_kwargs_desc = SEMILINEAR_A_B_C_CONSTRAINT))
-]
+        (SciMLBase, :SCCNonlinearProblem, NonlinearFunction, false, (; init = false)),
+        (
+            ModelingToolkit,
+            :SemilinearODEProblem,
+            :SemilinearODEFunction,
+            true,
+            (;
+                extra_body = SEMILINEAR_EXTRA_BODY, extra_kwargs = SEMILINEAR_A_B_C_KWARGS,
+                extra_kwargs_desc = SEMILINEAR_A_B_C_CONSTRAINT,
+            ),
+        ),
+    ]
     kwexpr = Expr(:parameters)
     for (k, v) in pairs(kws)
         push!(kwexpr.args, Expr(:kw, k, v))
@@ -44,13 +48,17 @@ for (mod, prob, func, istd, kws) in [
 end
 
 for (mod, func, istd, optionals, kws) in [
-    (ModelingToolkit,
-        :SemilinearODEFunction,
-        true,
-        [:jac],
-        (; extra_body = SEMILINEAR_EXTRA_BODY, extra_kwargs = SEMILINEAR_A_B_C_KWARGS,
-            extra_kwargs_desc = SEMILINEAR_A_B_C_CONSTRAINT))
-]
+        (
+            ModelingToolkit,
+            :SemilinearODEFunction,
+            true,
+            [:jac],
+            (;
+                extra_body = SEMILINEAR_EXTRA_BODY, extra_kwargs = SEMILINEAR_A_B_C_KWARGS,
+                extra_kwargs_desc = SEMILINEAR_A_B_C_CONSTRAINT,
+            ),
+        ),
+    ]
     kwexpr = Expr(:parameters)
     for (k, v) in pairs(kws)
         push!(kwexpr.args, Expr(:kw, k, v))

--- a/src/problems/sccnonlinearproblem.jl
+++ b/src/problems/sccnonlinearproblem.jl
@@ -3,12 +3,14 @@ struct CacheWriter{F}
 end
 
 function (cw::CacheWriter)(p, sols)
-    cw.fn(p.caches, sols, p)
+    return cw.fn(p.caches, sols, p)
 end
 
-function CacheWriter(sys::AbstractSystem, buffer_types::Vector{TypeT},
+function CacheWriter(
+        sys::AbstractSystem, buffer_types::Vector{TypeT},
         exprs::Dict{TypeT, Vector{Any}}, solsyms, obseqs::Vector{Equation};
-        eval_expression = false, eval_module = @__MODULE__, cse = true, sparse = false)
+        eval_expression = false, eval_module = @__MODULE__, cse = true, sparse = false
+    )
     ps = parameters(sys; initial_parameters = true)
     rps = reorder_parameters(sys, ps)
     obs_assigns = [eq.lhs ← eq.rhs for eq in obseqs]
@@ -28,7 +30,8 @@ function CacheWriter(sys::AbstractSystem, buffer_types::Vector{TypeT},
         DestructuredArgs(DestructuredArgs.(solsyms), generated_argument_name(1)),
         rps...; p_start = 3, p_end = length(rps) + 2,
         expression = Val{true}, add_observed = false, cse,
-        extra_assignments = [array_assignments; obs_assigns; body])
+        extra_assignments = [array_assignments; obs_assigns; body]
+    )
     fn = eval_or_rgf(fn; eval_expression, eval_module)
     fn = GeneratedFunctionWrapper{(3, 3, is_split(sys))}(fn, nothing)
     return CacheWriter(fn)
@@ -38,30 +41,36 @@ struct SCCNonlinearFunction{iip} end
 
 function SCCNonlinearFunction{iip}(
         sys::System, _eqs, _dvs, _obs, cachesyms, op; eval_expression = false,
-        eval_module = @__MODULE__, cse = true, kwargs...) where {iip}
+        eval_module = @__MODULE__, cse = true, kwargs...
+    ) where {iip}
     ps = parameters(sys; initial_parameters = true)
     subsys = System(
-        _eqs, _dvs, ps; observed = _obs, name = nameof(sys), bindings = bindings(sys), initial_conditions = initial_conditions(sys))
+        _eqs, _dvs, ps; observed = _obs, name = nameof(sys), bindings = bindings(sys), initial_conditions = initial_conditions(sys)
+    )
     if get_index_cache(sys) !== nothing
         @set! subsys.index_cache = subset_unknowns_observed(
-            get_index_cache(sys), sys, _dvs, getproperty.(_obs, (:lhs,)))
+            get_index_cache(sys), sys, _dvs, getproperty.(_obs, (:lhs,))
+        )
         @set! subsys.parameter_bindings_graph = ParameterBindingsGraph(subsys)
         @set! subsys.complete = true
     end
     # generate linear problem instead
     if isaffine(subsys)
         return LinearFunction{iip}(
-            subsys; eval_expression, eval_module, cse, cachesyms, kwargs...)
+            subsys; eval_expression, eval_module, cse, cachesyms, kwargs...
+        )
     end
     rps = reorder_parameters(sys, ps)
 
     obs_assignments = [eq.lhs ← eq.rhs for eq in _obs]
 
     rhss = [eq.rhs - eq.lhs for eq in _eqs]
-    f_gen = build_function_wrapper(sys,
+    f_gen = build_function_wrapper(
+        sys,
         rhss, _dvs, rps..., cachesyms...; p_start = 2,
         p_end = length(rps) + length(cachesyms) + 1, add_observed = false,
-        extra_assignments = obs_assignments, expression = Val{true}, cse)
+        extra_assignments = obs_assignments, expression = Val{true}, cse
+    )
     f_oop, f_iip = eval_or_rgf.(f_gen; eval_expression, eval_module)
     f = GeneratedFunctionWrapper{(2, 2, is_split(sys))}(f_oop, f_iip)
 
@@ -69,11 +78,13 @@ function SCCNonlinearFunction{iip}(
 end
 
 function SciMLBase.SCCNonlinearProblem(sys::System, args...; kwargs...)
-    SCCNonlinearProblem{true}(sys, args...; kwargs...)
+    return SCCNonlinearProblem{true}(sys, args...; kwargs...)
 end
 
-function SciMLBase.SCCNonlinearProblem{iip}(sys::System, op; eval_expression = false,
-        eval_module = @__MODULE__, cse = true, u0_constructor = identity, kwargs...) where {iip}
+function SciMLBase.SCCNonlinearProblem{iip}(
+        sys::System, op; eval_expression = false,
+        eval_module = @__MODULE__, cse = true, u0_constructor = identity, kwargs...
+    ) where {iip}
     if !iscomplete(sys) || get_tearing_state(sys) === nothing
         error("A simplified `System` is required. Call `mtkcompile` on the system before creating an `SCCNonlinearProblem`.")
     end
@@ -88,9 +99,12 @@ function SciMLBase.SCCNonlinearProblem{iip}(sys::System, op; eval_expression = f
         @warn "System is simplified but does not have a schedule. This should not happen."
         var_eq_matching, var_sccs = StructuralTransformations.algebraic_variables_scc(ts)
         condensed_graph = MatchedCondensationGraph(
-            DiCMOBiGraph{true}(complete(ts.structure.graph),
-                complete(var_eq_matching)),
-            var_sccs)
+            DiCMOBiGraph{true}(
+                complete(ts.structure.graph),
+                complete(var_eq_matching)
+            ),
+            var_sccs
+        )
         toporder = topological_sort_by_dfs(condensed_graph)
         var_sccs = var_sccs[toporder]
         eq_sccs = map(Base.Fix1(getindex, var_eq_matching), var_sccs)
@@ -106,7 +120,8 @@ function SciMLBase.SCCNonlinearProblem{iip}(sys::System, op; eval_expression = f
 
     if length(var_sccs) == 1
         return NonlinearProblem{iip}(
-            sys, op; eval_expression, eval_module, kwargs...)
+            sys, op; eval_expression, eval_module, kwargs...
+        )
     end
 
     dvs = unknowns(sys)
@@ -115,8 +130,9 @@ function SciMLBase.SCCNonlinearProblem{iip}(sys::System, op; eval_expression = f
     obs = observed(sys)
 
     _, u0,
-    p = process_SciMLProblem(
-        EmptySciMLFunction{iip}, sys, op; eval_expression, eval_module, symbolic_u0 = true, kwargs...)
+        p = process_SciMLProblem(
+        EmptySciMLFunction{iip}, sys, op; eval_expression, eval_module, symbolic_u0 = true, kwargs...
+    )
 
     explicitfuns = []
     nlfuns = []
@@ -151,11 +167,13 @@ function SciMLBase.SCCNonlinearProblem{iip}(sys::System, op; eval_expression = f
         state = Dict()
         for i in eachindex(_obs)
             _obs[i] = _obs[i].lhs ~ subexpressions_not_involving_vars!(
-                _obs[i].rhs, banned_vars, state)
+                _obs[i].rhs, banned_vars, state
+            )
         end
         for i in eachindex(_eqs)
             _eqs[i] = _eqs[i].lhs ~ subexpressions_not_involving_vars!(
-                _eqs[i].rhs, banned_vars, state)
+                _eqs[i].rhs, banned_vars, state
+            )
         end
 
         # map from symtype to cached variables and their expressions
@@ -208,27 +226,40 @@ function SciMLBase.SCCNonlinearProblem{iip}(sys::System, op; eval_expression = f
         _obs = scc_obs[i]
         cachevars = scc_cachevars[i]
         cacheexprs = scc_cacheexprs[i]
-        available_vars = [dvs[reduce(vcat, var_sccs[1:(i - 1)]; init = Int[])];
-                          getproperty.(
-                              reduce(vcat, scc_obs[1:(i - 1)]; init = []), (:lhs,))]
-        _prevobsidxs = vcat(_prevobsidxs,
+        available_vars = [
+            dvs[reduce(vcat, var_sccs[1:(i - 1)]; init = Int[])];
+            getproperty.(
+                reduce(vcat, scc_obs[1:(i - 1)]; init = []), (:lhs,)
+            )
+        ]
+        _prevobsidxs = vcat(
+            _prevobsidxs,
             observed_equations_used_by(
-                sys, reduce(vcat, values(cacheexprs); init = []); available_vars))
+                sys, reduce(vcat, values(cacheexprs); init = []); available_vars
+            )
+        )
         if isempty(cachevars)
             push!(explicitfuns, Returns(nothing))
         else
             solsyms = getindex.((dvs,), view(var_sccs, 1:(i - 1)))
-            push!(explicitfuns,
-                CacheWriter(sys, cachetypes, cacheexprs, solsyms, obs[_prevobsidxs];
-                    eval_expression, eval_module, cse))
+            push!(
+                explicitfuns,
+                CacheWriter(
+                    sys, cachetypes, cacheexprs, solsyms, obs[_prevobsidxs];
+                    eval_expression, eval_module, cse
+                )
+            )
         end
 
-        cachebufsyms = Tuple(map(cachetypes) do T
-            get(cachevars, T, [])
-        end)
+        cachebufsyms = Tuple(
+            map(cachetypes) do T
+                get(cachevars, T, [])
+            end
+        )
         f = SCCNonlinearFunction{iip}(
             sys, _eqs, _dvs, _obs, cachebufsyms, op;
-            eval_expression, eval_module, cse, kwargs...)
+            eval_expression, eval_module, cse, kwargs...
+        )
         push!(nlfuns, f)
     end
 
@@ -262,15 +293,17 @@ function SciMLBase.SCCNonlinearProblem{iip}(sys::System, op; eval_expression = f
     subprobs = []
     for (i, (f, vscc)) in enumerate(zip(nlfuns, var_sccs))
         _u0 = SymbolicUtils.Code.create_array(
-            typeof(u0), eltype(u0), Val(1), Val(length(vscc)), u0[vscc]...)
+            typeof(u0), eltype(u0), Val(1), Val(length(vscc)), u0[vscc]...
+        )
         symbolic_idxs = findall(x -> x === nothing || symbolic_type(x) !== NotSymbolic(), _u0)
         if f isa LinearFunction
             _u0 = isempty(symbolic_idxs) ? _u0 : zeros(u0_eltype, length(_u0))
             _u0 = u0_eltype.(_u0)
             symbolic_interface = f.interface
             A,
-            b = get_A_b_from_LinearFunction(
-                sys, f, p; eval_expression, eval_module, u0_constructor, u0_eltype)
+                b = get_A_b_from_LinearFunction(
+                sys, f, p; eval_expression, eval_module, u0_constructor, u0_eltype
+            )
             prob = LinearProblem{iip}(A, b, p; f = symbolic_interface, u0 = _u0)
         else
             isempty(symbolic_idxs) || throw(MissingGuessError(dvs[vscc], _u0))
@@ -285,6 +318,7 @@ function SciMLBase.SCCNonlinearProblem{iip}(sys::System, op; eval_expression = f
     @set! sys.unknowns = new_dvs
     @set! sys.eqs = new_eqs
     @set! sys.index_cache = subset_unknowns_observed(
-        get_index_cache(sys), sys, new_dvs, getproperty.(obs, (:lhs,)))
+        get_index_cache(sys), sys, new_dvs, getproperty.(obs, (:lhs,))
+    )
     return SCCNonlinearProblem(Tuple(subprobs), Tuple(explicitfuns), p, true; sys)
 end

--- a/src/structural_transformation/StructuralTransformations.jl
+++ b/src/structural_transformation/StructuralTransformations.jl
@@ -15,23 +15,23 @@ import Moshi
 
 using ModelingToolkit
 using ModelingToolkitBase: System, AbstractSystem, var_from_nested_derivative, Differential,
-                       unknowns, equations, diff2term_with_unit,
-                       value,
-                       operation, arguments, simplify, symbolic_linear_solve,
-                       isdiffeq, isdifferential, isirreducible,
-                       empty_substitutions, get_substitutions,
-                       get_tearing_state, get_iv, independent_variables,
-                       has_tearing_state, InvalidSystemException,
-                       ExtraEquationsSystemException,
-                       ExtraVariablesSystemException,
-                       invalidate_cache!, Shift,
-                       topological_sort,
-                       filter_kwargs, lower_varname_with_unit,
-                       setio,
-                       has_equations, observed,
-                       Schedule, schedule, iscomplete, get_schedule, VariableUnshifted,
-                       VariableShift, DerivativeDict, shift2term, simplify_shifts,
-                       distribute_shift
+    unknowns, equations, diff2term_with_unit,
+    value,
+    operation, arguments, simplify, symbolic_linear_solve,
+    isdiffeq, isdifferential, isirreducible,
+    empty_substitutions, get_substitutions,
+    get_tearing_state, get_iv, independent_variables,
+    has_tearing_state, InvalidSystemException,
+    ExtraEquationsSystemException,
+    ExtraVariablesSystemException,
+    invalidate_cache!, Shift,
+    topological_sort,
+    filter_kwargs, lower_varname_with_unit,
+    setio,
+    has_equations, observed,
+    Schedule, schedule, iscomplete, get_schedule, VariableUnshifted,
+    VariableShift, DerivativeDict, shift2term, simplify_shifts,
+    distribute_shift
 
 using BipartiteGraphs
 import BipartiteGraphs: invview, complete, IncrementalCycleTracker, add_edge_checked!
@@ -55,7 +55,7 @@ import StateSelection
 import StateSelection: CLIL, SelectedState
 import ModelingToolkitTearing as MTKTearing
 using ModelingToolkitTearing: TearingState, SystemStructure, ReassembleAlgorithm,
-                              DefaultReassembleAlgorithm
+    DefaultReassembleAlgorithm
 
 export tearing, dae_index_lowering
 export dummy_derivative
@@ -70,7 +70,7 @@ function tearing_substitution(sys::AbstractSystem; kwargs...)
     neweqs = full_equations(sys::AbstractSystem; kwargs...)
     @set! sys.eqs = neweqs
     # @set! sys.substitutions = nothing
-    @set! sys.schedule = nothing
+    return @set! sys.schedule = nothing
 end
 
 include("symbolics_tearing.jl")

--- a/src/structural_transformation/pantelides.jl
+++ b/src/structural_transformation/pantelides.jl
@@ -24,7 +24,7 @@ function pantelides_reassemble(state::TearingState, var_eq_matching)
     for (varidx, diff) in edges(var_to_diff)
         # fullvars[diff] = D(fullvars[var])
         vi = out_vars[varidx]
-        @assert vi!==ModelingToolkit.COMMON_NOTHING "Something went wrong on reconstructing unknowns from variable association list"
+        @assert vi !== ModelingToolkit.COMMON_NOTHING "Something went wrong on reconstructing unknowns from variable association list"
         # `fullvars[i]` needs to be not a `D(...)`, because we want the DAE to be
         # first-order.
         if isdifferential(vi)
@@ -56,16 +56,22 @@ function pantelides_reassemble(state::TearingState, var_eq_matching)
         end
         rhs = ModelingToolkit.expand_derivatives(D(eq.rhs))
         rhs = substitute(rhs, state.param_derivative_map)
-        substitution_dict = Dict(x.lhs => x.rhs
-        for x in out_eqs if x !== NOTHING_EQ && !SU.isconst(x.lhs))
+        substitution_dict = Dict(
+            x.lhs => x.rhs
+                for x in out_eqs if x !== NOTHING_EQ && !SU.isconst(x.lhs)
+        )
         sub_rhs = substitute(rhs, substitution_dict)
         out_eqs[diff] = lhs ~ sub_rhs
     end
 
     final_vars = unique(filter(x -> !(operation(x) isa Differential), fullvars))
-    final_eqs = map(identity,
-        filter(x -> x.lhs !== ModelingToolkit.COMMON_NOTHING,
-            out_eqs[sort(filter(x -> x !== unassigned, var_eq_matching))]))
+    final_eqs = map(
+        identity,
+        filter(
+            x -> x.lhs !== ModelingToolkit.COMMON_NOTHING,
+            out_eqs[sort(filter(x -> x !== unassigned, var_eq_matching))]
+        )
+    )
 
     @set! sys.eqs = final_eqs
     @set! sys.unknowns = final_vars

--- a/src/structural_transformation/symbolics_tearing.jl
+++ b/src/structural_transformation/symbolics_tearing.jl
@@ -1,9 +1,11 @@
-function tearing(state::TearingState;
-                 tearing_alg::StateSelection.TearingAlgorithm = StateSelection.DummyDerivativeTearing(),
-                 kwargs...)
+function tearing(
+        state::TearingState;
+        tearing_alg::StateSelection.TearingAlgorithm = StateSelection.DummyDerivativeTearing(),
+        kwargs...
+    )
     state.structure.solvable_graph === nothing && StateSelection.find_solvables!(state; kwargs...)
     StateSelection.complete!(state.structure)
-    tearing_alg(state.structure)
+    return tearing_alg(state.structure)
 end
 
 """
@@ -13,11 +15,13 @@ Tear the nonlinear equations in system. When `simplify=true`, we simplify the
 new residual equations after tearing. End users are encouraged to call [`mtkcompile`](@ref)
 instead, which calls this function internally.
 """
-function tearing(sys::AbstractSystem, state = TearingState(sys); mm = nothing,
+function tearing(
+        sys::AbstractSystem, state = TearingState(sys); mm = nothing,
         reassemble_alg::ReassembleAlgorithm = DefaultReassembleAlgorithm(),
-        fully_determined = true, kwargs...)
+        fully_determined = true, kwargs...
+    )
     tearing_result, extras = tearing(state; kwargs...)
-    invalidate_cache!(reassemble_alg(state, tearing_result, mm; fully_determined))
+    return invalidate_cache!(reassemble_alg(state, tearing_result, mm; fully_determined))
 end
 
 function safe_isinteger(@nospecialize(x::Number))
@@ -50,9 +54,11 @@ end
 Perform index reduction and use the dummy derivative technique to ensure that
 the system is balanced.
 """
-function dummy_derivative(sys, state = TearingState(sys);
+function dummy_derivative(
+        sys, state = TearingState(sys);
         reassemble_alg::ReassembleAlgorithm = DefaultReassembleAlgorithm(),
-        mm = nothing, fully_determined = true, kwargs...)
+        mm = nothing, fully_determined = true, kwargs...
+    )
     jac = let state = state
         (eqs, vars) -> begin
             symeqs = equations(state)[eqs]
@@ -87,6 +93,7 @@ function dummy_derivative(sys, state = TearingState(sys);
         end
     end
     tearing_result, extras = StateSelection.dummy_derivative_graph!(
-        state, jac; state_priority, kwargs...)
-    reassemble_alg(state, tearing_result, mm; fully_determined)
+        state, jac; state_priority, kwargs...
+    )
+    return reassemble_alg(state, tearing_result, mm; fully_determined)
 end

--- a/src/structural_transformation/utils.jl
+++ b/src/structural_transformation/utils.jl
@@ -10,7 +10,7 @@ simplified and has a `schedule`.
 """
 function sorted_incidence_matrix(sys::AbstractSystem)
     if !iscomplete(sys) || get_tearing_state(sys) === nothing ||
-       get_schedule(sys) === nothing
+            get_schedule(sys) === nothing
         error("A simplified `System` is required. Call `mtkcompile` on the system before creating an `SCCNonlinearProblem`.")
     end
     sched = get_schedule(sys)
@@ -20,20 +20,20 @@ function sorted_incidence_matrix(sys::AbstractSystem)
     imat = Graphs.incidence_matrix(ts.structure.graph)
     buffer = similar(imat)
     permute!(buffer, imat, 1:size(imat, 2), reduce(vcat, var_sccs))
-    buffer
+    return buffer
 end
 
 ###
 ### Structural and symbolic utilities
 ###
 function highest_order_variable_mask(ts)
-    let v2d = ts.structure.var_to_diff
+    return let v2d = ts.structure.var_to_diff
         v -> isempty(outneighbors(v2d, v))
     end
 end
 
 function lowest_order_variable_mask(ts)
-    let v2d = ts.structure.var_to_diff
+    return let v2d = ts.structure.var_to_diff
         v -> isempty(inneighbors(v2d, v))
     end
 end
@@ -60,7 +60,7 @@ function but_ordered_incidence(ts::TearingState, varmask = highest_order_variabl
     end
     mm = incidence_matrix(graph)
     reverse!(vordering)
-    mm[[var_eq_matching[v] for v in vordering if var_eq_matching[v] isa Int], vordering], bb
+    return mm[[var_eq_matching[v] for v in vordering if var_eq_matching[v] isa Int], vordering], bb
 end
 
 """
@@ -99,8 +99,11 @@ function reordered_matrix(sys::System, torn_matching)
         end
 
         e_residual = setdiff(
-            [max_matching[v]
-             for v in vars if max_matching[v] !== unassigned], e_solved)
+            [
+                max_matching[v]
+                    for v in vars if max_matching[v] !== unassigned
+            ], e_solved
+        )
         for er in e_residual
             isdiffeq(eqs[er]) && continue
             ii += 1
@@ -110,7 +113,7 @@ function reordered_matrix(sys::System, torn_matching)
         end
     end
     # only plot algebraic variables and equations
-    sparse(I, J, true)
+    return sparse(I, J, true)
 end
 
 """

--- a/src/systems/alias_elimination.jl
+++ b/src/systems/alias_elimination.jl
@@ -116,7 +116,7 @@ struct ZeroVariablesIfFullyDetermined!
 end
 
 function (zvifd::ZeroVariablesIfFullyDetermined!)(structure::SystemStructure, ils::CLIL.SparseMatrixCLIL, v::Int)
-    zvifd.fully_determined ? StateSelection.force_var_to_zero!(structure, ils, v) : ils
+    return zvifd.fully_determined ? StateSelection.force_var_to_zero!(structure, ils, v) : ils
 end
 
 function exactdiv(a::Integer, b)

--- a/src/systems/analysis_points.jl
+++ b/src/systems/analysis_points.jl
@@ -44,7 +44,8 @@ $DOC_SYS_MODIFIER
 All other keyword arguments are forwarded to `linearization_function`.
 """
 function get_linear_analysis_function(
-        sys::AbstractSystem, transform, aps; system_modifier = identity, loop_openings = [], kwargs...)
+        sys::AbstractSystem, transform, aps; system_modifier = identity, loop_openings = [], kwargs...
+    )
     dus = []
     us = []
     sys = handle_loop_openings(sys, loop_openings)
@@ -54,7 +55,7 @@ function get_linear_analysis_function(
         push!(dus, du)
         push!(us, u)
     end
-    linearization_function(system_modifier(sys), dus, us; kwargs...)
+    return linearization_function(system_modifier(sys), dus, us; kwargs...)
 end
 """
     $(TYPEDSIGNATURES)
@@ -70,7 +71,7 @@ $DOC_SYS_MODIFIER
 All other keyword arguments are forwarded to `linearization_function`.
 """
 function get_sensitivity_function(sys::AbstractSystem, aps; kwargs...)
-    get_linear_analysis_function(sys, SensitivityTransform, aps; kwargs...)
+    return get_linear_analysis_function(sys, SensitivityTransform, aps; kwargs...)
 end
 
 """
@@ -87,7 +88,7 @@ $DOC_SYS_MODIFIER
 All other keyword arguments are forwarded to `linearization_function`.
 """
 function get_comp_sensitivity_function(sys::AbstractSystem, aps; kwargs...)
-    get_linear_analysis_function(sys, ComplementarySensitivityTransform, aps; kwargs...)
+    return get_linear_analysis_function(sys, ComplementarySensitivityTransform, aps; kwargs...)
 end
 
 """
@@ -104,19 +105,21 @@ $DOC_SYS_MODIFIER
 All other keyword arguments are forwarded to `linearization_function`.
 """
 function get_looptransfer_function(sys::AbstractSystem, aps; kwargs...)
-    get_linear_analysis_function(sys, LoopTransferTransform, aps; kwargs...)
+    return get_linear_analysis_function(sys, LoopTransferTransform, aps; kwargs...)
 end
 
 for f in [:get_sensitivity, :get_comp_sensitivity, :get_looptransfer]
     utility_fun = Symbol(f, :_function)
     @eval function $f(
             sys, ap, args...; loop_openings = [], system_modifier = identity,
-            allow_input_derivatives = true, kwargs...)
+            allow_input_derivatives = true, kwargs...
+        )
         lin_fun,
-        ssys = $(utility_fun)(
-            sys, ap, args...; loop_openings, system_modifier, kwargs...)
+            ssys = $(utility_fun)(
+            sys, ap, args...; loop_openings, system_modifier, kwargs...
+        )
         mats, extras = ModelingToolkit.linearize(ssys, lin_fun; allow_input_derivatives)
-        mats, ssys, extras
+        return mats, ssys, extras
     end
 end
 
@@ -130,9 +133,11 @@ Returns
 - `input_vars`: A vector of input variables corresponding to the input analysis points.
 - `output_vars`: A vector of output variables corresponding to the output analysis points.
 """
-function linearization_ap_transform(sys,
+function linearization_ap_transform(
+        sys,
         inputs::Union{Symbol, Vector{Symbol}, AnalysisPoint, Vector{AnalysisPoint}},
-        outputs, loop_openings)
+        outputs, loop_openings
+    )
     loop_openings = Set(map(nameof, canonicalize_ap(sys, loop_openings)))
     inputs = canonicalize_ap(sys, inputs)
     outputs = canonicalize_ap(sys, outputs)
@@ -161,12 +166,15 @@ function linearization_ap_transform(sys,
     return sys, input_vars, output_vars
 end
 
-function linearization_function(sys::AbstractSystem,
+function linearization_function(
+        sys::AbstractSystem,
         inputs::Union{Symbol, Vector{Symbol}, AnalysisPoint, Vector{AnalysisPoint}},
-        outputs; loop_openings = [], system_modifier = identity, kwargs...)
+        outputs; loop_openings = [], system_modifier = identity, kwargs...
+    )
     sys, input_vars,
-    output_vars = linearization_ap_transform(
-        sys, inputs, outputs, loop_openings)
+        output_vars = linearization_ap_transform(
+        sys, inputs, outputs, loop_openings
+    )
     return linearization_function(system_modifier(sys), input_vars, output_vars; kwargs...)
 end
 
@@ -212,4 +220,3 @@ Compute the (linearized) loop-transfer function in analysis point `ap`, from `ap
 
 See also [`get_sensitivity`](@ref), [`get_comp_sensitivity`](@ref), [`open_loop`](@ref).
 """ get_looptransfer
-

--- a/src/systems/clock_inference.jl
+++ b/src/systems/clock_inference.jl
@@ -1,8 +1,8 @@
 function MTKTearing.input_timedomain(::Sample, _::MTKTearing.IOTimeDomainArgsT = nothing)
-    MTKTearing.InputTimeDomainElT[ContinuousClock()]
+    return MTKTearing.InputTimeDomainElT[ContinuousClock()]
 end
 function MTKTearing.output_timedomain(s::Sample, _::MTKTearing.IOTimeDomainArgsT = nothing)
-    s.clock
+    return s.clock
 end
 
 function MTKTearing.input_timedomain(::Hold, args::MTKTearing.IOTimeDomainArgsT = nothing)
@@ -12,9 +12,9 @@ function MTKTearing.input_timedomain(::Hold, args::MTKTearing.IOTimeDomainArgsT 
             return MTKTearing.InputTimeDomainElT[MTKTearing.get_time_domain(arg)]
         end
     end
-    MTKTearing.InputTimeDomainElT[MTKTearing.InferredDiscrete()] # the Hold accepts any discrete
+    return MTKTearing.InputTimeDomainElT[MTKTearing.InferredDiscrete()] # the Hold accepts any discrete
 end
 
 function MTKTearing.output_timedomain(::Hold, _::MTKTearing.IOTimeDomainArgsT = nothing)
-    ContinuousClock()
+    return ContinuousClock()
 end

--- a/src/systems/if_lifting.jl
+++ b/src/systems/if_lifting.jl
@@ -47,7 +47,7 @@ function new_cond_sym(cw::CondRewriter, expr, dep)
     cvar = gensym("cond")
     st = symtype(expr)
     iv = cw.iv
-    cv = unwrap(first(@discretes $(cvar)(iv)::st = true)) # TODO: real init 
+    cv = unwrap(first(@discretes $(cvar)(iv)::st = true)) # TODO: real init
     cw.conditions[cv] = (dependency = dep, expression = expr)
     return cv
 end
@@ -77,7 +77,7 @@ and family.
 function (cw::CondRewriter)(expr, dep)
     # single variable, trivial case
     Moshi.Match.@match expr begin
-        BSImpl.Sym(;) => return (expr, expr, !expr)
+        BSImpl.Sym() => return (expr, expr, !expr)
         BSImpl.Term(; f) && if f isa SymbolicT && !SU.is_function_symbolic(f) end => begin
             return (expr, expr, !expr)
         end
@@ -112,9 +112,11 @@ function (cw::CondRewriter)(expr, dep)
         # expression is true if condition is true and THEN branch is true, or condition is false
         # and ELSE branch is true
         # similarly for expression being false
-        return (ifelse(rw_cond, rw_conda, rw_condb),
+        return (
+            ifelse(rw_cond, rw_conda, rw_condb),
             ctrue & truea | cfalse & trueb,
-            ctrue & falsea | cfalse & falseb)
+            ctrue & falsea | cfalse & falseb,
+        )
     elseif operation(expr) == Base.:(!) # NOT of expression
         (a,) = arguments(expr)
         (rw, ctrue, cfalse) = cw(a, dep)
@@ -145,12 +147,14 @@ function (cw::CondRewriter)(expr, dep)
     elseif !expression_is_time_dependent(expr, cw.iv)
         return (expr, expr, !expr)
     end
-    error("""
-    Unsupported expression form in decision variable computation $expr. If the expression
-    involves a registered function, declare the discontinuity using
-    `Symbolics.@register_discontinuity`. If this is not meant to be transformed via
-    `IfLifting`, wrap the parent expression in `ModelingToolkit.no_if_lift`.
-    """)
+    error(
+        """
+        Unsupported expression form in decision variable computation $expr. If the expression
+        involves a registered function, declare the discontinuity using
+        `Symbolics.@register_discontinuity`. If this is not meant to be transformed via
+        `IfLifting`, wrap the parent expression in `ModelingToolkit.no_if_lift`.
+        """
+    )
 end
 
 """
@@ -212,7 +216,7 @@ in the expression, `Differential(iv)` is in the expression, or a dependent varia
 as `@variables x(iv)` is in the expression.
 """
 function expression_is_time_dependent(expr, iv)
-    any(SU.search_variables(expr)) do sym
+    return any(SU.search_variables(expr)) do sym
         sym = unwrap(sym)
         isequal(sym, iv) && return true
         iscall(sym) || return false
@@ -252,7 +256,8 @@ function rewrite_ifs(cw::CondRewriter, expr, dep)
         rw_iftrue = rewrite_ifs(cw, iftrue, deptrue)
         rw_iffalse = rewrite_ifs(cw, iffalse, depfalse)
         return maketerm(
-            typeof(expr), ifelse, [unwrap(rw_cond), rw_iftrue, rw_iffalse], metadata(expr))
+            typeof(expr), ifelse, [unwrap(rw_cond), rw_iftrue, rw_iffalse], metadata(expr)
+        )
     end
 
     # recurse into the rest of the cases
@@ -307,7 +312,8 @@ function discontinuities_to_ifelse(expr, iv)
         leftexpr = leftfn(args...)
         rightexpr = rightfn(args...)
         return maketerm(
-            typeof(expr), ifelse, [rootexpr, leftexpr, rightexpr], metadata(expr))
+            typeof(expr), ifelse, [rootexpr, leftexpr, rightexpr], metadata(expr)
+        )
     end
 
     return maketerm(typeof(expr), op, args, metadata(expr))
@@ -351,95 +357,191 @@ function generate_affects(cw::CondRewriter, sym, new_cond_vars, new_cond_vars_gr
     # use reverse direction of edges because instead of finding the variables it depends
     # on, we want the variables that depend on it
     parents = bfs_parents(new_cond_vars_graph, sym_idx; dir = :in)
-    cond_vars_to_update = [new_cond_vars[i]
-                           for i in eachindex(parents) if !iszero(parents[i])]
+    cond_vars_to_update = [
+        new_cond_vars[i]
+            for i in eachindex(parents) if !iszero(parents[i])
+    ]
     update_syms = Symbol.(cond_vars_to_update)
     modified = NamedTuple{(update_syms...,)}(cond_vars_to_update)
 
-    upcrossing_update_exprs = [arguments(last(cw.conditions[sym]))[1] < 0
-                               for sym in cond_vars_to_update]
+    upcrossing_update_exprs = [
+        arguments(last(cw.conditions[sym]))[1] < 0
+            for sym in cond_vars_to_update
+    ]
     upcrossing = ImperativeAffect(
         modified, observed = NamedTuple{(update_syms...,)}(upcrossing_update_exprs),
-        skip_checks = true) do x, o, c, i
+        skip_checks = true
+    ) do x, o, c, i
         return o
     end
-    downcrossing_update_exprs = [arguments(last(cw.conditions[sym]))[1] <= 0
-                                 for sym in cond_vars_to_update]
+    downcrossing_update_exprs = [
+        arguments(last(cw.conditions[sym]))[1] <= 0
+            for sym in cond_vars_to_update
+    ]
     downcrossing = ImperativeAffect(
         modified, observed = NamedTuple{(update_syms...,)}(downcrossing_update_exprs),
-        skip_checks = true) do x, o, c, i
+        skip_checks = true
+    ) do x, o, c, i
         return o
     end
 
     return upcrossing, downcrossing
 end
 
-const CONDITION_SIMPLIFIER = Rewriters.Fixpoint(Rewriters.Postwalk(Rewriters.Chain([
-                                                                                    # simple boolean laws
-                                                                                    (@rule (!!(~x)) => (~x))
-                                                                                    (@rule ((~x) &
-                                                                                            true) => (~x))
-                                                                                    (@rule ((~x) &
-                                                                                            false) => false)
-                                                                                    (@rule ((~x) |
-                                                                                            true) => true)
-                                                                                    (@rule ((~x) |
-                                                                                            false) => (~x))
-                                                                                    (@rule ((~x) &
-                                                                                            !(~x)) => false)
-                                                                                    (@rule ((~x) |
-                                                                                            !(~x)) => true)
-                                                                                    # reversed order of the above, because it matters and `@acrule` refuses to do its job
-                                                                                    (@rule (true &
-                                                                                            (~x)) => (~x))
-                                                                                    (@rule (false &
-                                                                                            (~x)) => false)
-                                                                                    (@rule (true |
-                                                                                            (~x)) => true)
-                                                                                    (@rule (false |
-                                                                                            (~x)) => (~x))
-                                                                                    (@rule (!(~x) &
-                                                                                            (~x)) => false)
-                                                                                    (@rule (!(~x) |
-                                                                                            (~x)) => true)
-                                                                                    # idempotent
-                                                                                    (@rule ((~x) &
-                                                                                            (~x)) => (~x))
-                                                                                    (@rule ((~x) |
-                                                                                            (~x)) => (~x))
-                                                                                    # ifelse with determined branches
-                                                                                    (@rule ifelse(
-                                                                                        (~x),
-                                                                                        true,
-                                                                                        false) => (~x))
-                                                                                    (@rule ifelse(
-                                                                                        (~x),
-                                                                                        false,
-                                                                                        true) => !(~x))
-                                                                                    # ifelse with identical branches
-                                                                                    (@rule ifelse(
-                                                                                        (~x),
-                                                                                        (~y),
-                                                                                        (~y)) => (~y))
-                                                                                    (@rule ifelse(
-                                                                                        (~x),
-                                                                                        (~y),
-                                                                                        !(~y)) => ((~x) &
-                                                                                                   (~y)))
-                                                                                    (@rule ifelse(
-                                                                                        (~x),
-                                                                                        !(~y),
-                                                                                        (~y)) => ((~x) &
-                                                                                                  !(~y)))
-                                                                                    # ifelse with determined condition
-                                                                                    (@rule ifelse(
-                                                                                        true,
-                                                                                        (~x),
-                                                                                        (~y)) => (~x))
-                                                                                    (@rule ifelse(
-                                                                                        false,
-                                                                                        (~x),
-                                                                                        (~y)) => (~y))])))
+const CONDITION_SIMPLIFIER = Rewriters.Fixpoint(
+    Rewriters.Postwalk(
+        Rewriters.Chain(
+            [
+                # simple boolean laws
+                (@rule (!!(~x)) => (~x))
+                (
+                    @rule (
+                        (~x) &
+                            true
+                    ) => (~x)
+                )
+                (
+                    @rule (
+                        (~x) &
+                            false
+                    ) => false
+                )
+                (
+                    @rule (
+                        (~x) |
+                            true
+                    ) => true
+                )
+                (
+                    @rule (
+                        (~x) |
+                            false
+                    ) => (~x)
+                )
+                (
+                    @rule (
+                        (~x) &
+                            !(~x)
+                    ) => false
+                )
+                (
+                    @rule (
+                        (~x) |
+                            !(~x)
+                    ) => true
+                )
+                # reversed order of the above, because it matters and `@acrule` refuses to do its job
+                (
+                    @rule (
+                        true &
+                            (~x)
+                    ) => (~x)
+                )
+                (
+                    @rule (
+                        false &
+                            (~x)
+                    ) => false
+                )
+                (
+                    @rule (
+                        true |
+                            (~x)
+                    ) => true
+                )
+                (
+                    @rule (
+                        false |
+                            (~x)
+                    ) => (~x)
+                )
+                (
+                    @rule (
+                        !(~x) &
+                            (~x)
+                    ) => false
+                )
+                (
+                    @rule (
+                        !(~x) |
+                            (~x)
+                    ) => true
+                )
+                # idempotent
+                (
+                    @rule (
+                        (~x) &
+                            (~x)
+                    ) => (~x)
+                )
+                (
+                    @rule (
+                        (~x) |
+                            (~x)
+                    ) => (~x)
+                )
+                # ifelse with determined branches
+                (
+                    @rule ifelse(
+                        (~x),
+                        true,
+                        false
+                    ) => (~x)
+                )
+                (
+                    @rule ifelse(
+                        (~x),
+                        false,
+                        true
+                    ) => !(~x)
+                )
+                # ifelse with identical branches
+                (
+                    @rule ifelse(
+                        (~x),
+                        (~y),
+                        (~y)
+                    ) => (~y)
+                )
+                (
+                    @rule ifelse(
+                        (~x),
+                        (~y),
+                        !(~y)
+                    ) => (
+                        (~x) &
+                            (~y)
+                    )
+                )
+                (
+                    @rule ifelse(
+                        (~x),
+                        !(~y),
+                        (~y)
+                    ) => (
+                        (~x) &
+                            !(~y)
+                    )
+                )
+                # ifelse with determined condition
+                (
+                    @rule ifelse(
+                        true,
+                        (~x),
+                        (~y)
+                    ) => (~x)
+                )
+                (
+                    @rule ifelse(
+                        false,
+                        (~x),
+                        (~y)
+                    ) => (~y)
+                )
+            ]
+        )
+    )
+)
 
 """
 If lifting converts (nested) if statements into a series of continuous events + a logically equivalent if statement + parameters.
@@ -537,10 +639,13 @@ function IfLifting(sys::System)
     for var in new_cond_vars
         condition = generate_condition(cw, var)
         up_affect,
-        down_affect = generate_affects(
-            cw, var, new_cond_vars, new_cond_vars_graph)
-        cb = SymbolicContinuousCallback([condition], up_affect; affect_neg = down_affect,
-            initialize = up_affect, rootfind = SciMLBase.RightRootFind)
+            down_affect = generate_affects(
+            cw, var, new_cond_vars, new_cond_vars_graph
+        )
+        cb = SymbolicContinuousCallback(
+            [condition], up_affect; affect_neg = down_affect,
+            initialize = up_affect, rootfind = SciMLBase.RightRootFind
+        )
 
         push!(new_callbacks, cb)
         new_initial_conditions[var] = getdefault(var)

--- a/src/systems/solver_nlprob.jl
+++ b/src/systems/solver_nlprob.jl
@@ -1,5 +1,7 @@
-function MTKBase.generate_ODENLStepData(sys::System, u0, p, mm = calculate_massmatrix(sys),
-        nlstep_compile::Bool = true, nlstep_scc::Bool = false)
+function MTKBase.generate_ODENLStepData(
+        sys::System, u0, p, mm = calculate_massmatrix(sys),
+        nlstep_compile::Bool = true, nlstep_scc::Bool = false
+    )
     nlsys, outer_tmp, inner_tmp = inner_nlsystem(sys, mm, nlstep_compile)
     state = ProblemState(; u = u0, p)
     op = Dict()
@@ -26,18 +28,19 @@ function MTKBase.generate_ODENLStepData(sys::System, u0, p, mm = calculate_massm
     nlprobmap = generate_nlprobmap(sys, nlsys)
 
     return SciMLBase.ODENLStepData(
-        nlprob, subsetidxs, set_gamma_c, set_outer_tmp, set_inner_tmp, nlprobmap)
+        nlprob, subsetidxs, set_gamma_c, set_outer_tmp, set_inner_tmp, nlprobmap
+    )
 end
 
 const ODE_GAMMA = @parameters γ₁ₘₜₖ, γ₂ₘₜₖ, γ₃ₘₜₖ
 const ODE_C = only(@parameters cₘₜₖ)
 
 function get_outer_tmp(n::Int)
-    only(@parameters outer_tmpₘₜₖ[1:n])
+    return only(@parameters outer_tmpₘₜₖ[1:n])
 end
 
 function get_inner_tmp(n::Int)
-    only(@parameters inner_tmpₘₜₖ[1:n])
+    return only(@parameters inner_tmpₘₜₖ[1:n])
 end
 
 function inner_nlsystem(sys::System, mm, nlstep_compile::Bool)
@@ -53,7 +56,7 @@ function inner_nlsystem(sys::System, mm, nlstep_compile::Bool)
     outer_tmp = get_outer_tmp(N)
     inner_tmp = get_inner_tmp(N)
 
-    subrules = Dict([v => unwrap(gamma2*v + inner_tmp[i]) for (i, v) in enumerate(dvs)])
+    subrules = Dict([v => unwrap(gamma2 * v + inner_tmp[i]) for (i, v) in enumerate(dvs)])
     subrules[t] = unwrap(c)
     new_rhss = map(Base.Fix2(substitute, subrules), rhss)
     new_rhss = collect(outer_tmp) .+ gamma1 .* new_rhss .- gamma3 * mm * dvs
@@ -75,11 +78,11 @@ struct NLStep_probmap{F}
 end
 
 function (nlp::NLStep_probmap)(buffer, nlsol)
-    nlp.f(buffer, state_values(nlsol), parameter_values(nlsol))
+    return nlp.f(buffer, state_values(nlsol), parameter_values(nlsol))
 end
 
 function (nlp::NLStep_probmap)(nlsol)
-    nlp.f(state_values(nlsol), parameter_values(nlsol))
+    return nlp.f(state_values(nlsol), parameter_values(nlsol))
 end
 
 function generate_nlprobmap(sys::System, nlsys::System)

--- a/src/systems/substitute_component.jl
+++ b/src/systems/substitute_component.jl
@@ -4,7 +4,8 @@
 Validate the rules for replacement of subcomponents as defined in `substitute_component`.
 """
 function validate_replacement_rule(
-        rule::Pair{T, T}; namespace = []) where {T <: AbstractSystem}
+        rule::Pair{T, T}; namespace = []
+    ) where {T <: AbstractSystem}
     lhs, rhs = rule
 
     iscomplete(lhs) && throw(ArgumentError("LHS of replacement rule cannot be completed."))
@@ -32,8 +33,10 @@ function validate_replacement_rule(
             end
         end
         ru = getkey(rhs_u, u, nothing)
-        name = join([namespace; nameof(lhs); (hasname(u) ? getname(u) : Symbol(u))],
-            NAMESPACE_SEPARATOR)
+        name = join(
+            [namespace; nameof(lhs); (hasname(u) ? getname(u) : Symbol(u))],
+            NAMESPACE_SEPARATOR
+        )
         l_connect = something(getconnect(u), Equality)
         r_connect = something(getconnect(ru), Equality)
         if l_connect != r_connect
@@ -85,6 +88,7 @@ function validate_replacement_rule(
         name1 = join([namespace; nameof(lhs)], NAMESPACE_SEPARATOR)
         throw(ArgumentError("$name1 of replacement rule does not contain subsystem $(nameof(s))."))
     end
+    return
 end
 
 """
@@ -97,7 +101,8 @@ Chain `getproperty` calls on `root` in the order given in `hierarchy`.
 - `skip_namespace_first`: Whether to avoid namespacing in the first `getproperty` call.
 """
 function recursive_getproperty(
-        root::AbstractSystem, hierarchy::Vector{Symbol}; skip_namespace_first = true)
+        root::AbstractSystem, hierarchy::Vector{Symbol}; skip_namespace_first = true
+    )
     cur = root
     for (i, name) in enumerate(hierarchy)
         cur = getproperty(cur, name; namespace = i > 1 || !skip_namespace_first)
@@ -175,4 +180,3 @@ function substitute_component(sys::T, rule::Pair{T, T}) where {T <: AbstractSyst
     end
     return recreate_connections(newsys)
 end
-

--- a/test/downstream/inversemodel.jl
+++ b/test/downstream/inversemodel.jl
@@ -61,7 +61,7 @@ rc = 0.25 # Reference concentration
         D(xT) ~ -wa21 * xT + wa22 * gamma + wa23 + wb * xT_c,
         xc ~ c.u,
         xT ~ T.u,
-        xT_c ~ T_c.u
+        xT_c ~ T_c.u,
     ]
 
     return System(equations, t, vars, pars; name, systems)
@@ -69,7 +69,7 @@ end
 begin
     Ftf = tf(1, [(100), 1])^2
     Fss = ss(Ftf)
-    # Create an MTK-compatible constructor 
+    # Create an MTK-compatible constructor
     function RefFilter(; name)
         sys = System(Fss; name)
         "Compute initial state that yields y0 as output"
@@ -121,7 +121,7 @@ end
         connect(inverse_tank.T, feedback.input1),
         connect(tank.T, :y, noise_filter.input),
         connect(noise_filter.output, feedback.input2),
-        connect(feedback.output, :e, controller.err_input)
+        connect(feedback.output, :e, controller.err_input),
     ]
 
     return System(equations, t, vars, pars; name, systems)
@@ -144,7 +144,7 @@ sol = solve(prob, Rodas5P())
 # plot(sol, idxs=[model.tank.xc, model.tank.xT, model.controller.ctr_output.u], layout=3, sp=[1 2 3])
 # hline!([prob[cm.ref.k]], label="ref", sp=1)
 
-@test sol(tspan[2], idxs = cm.tank.xc)≈getp(prob, cm.ref.k)(prob) atol=1e-2 # Test that the inverse model led to the correct reference
+@test sol(tspan[2], idxs = cm.tank.xc) ≈ getp(prob, cm.ref.k)(prob) atol = 1.0e-2 # Test that the inverse model led to the correct reference
 
 # we need to provide `op` so the initialization system knows what to hold constant
 # the values don't matter

--- a/test/downstream/linearization_dd.jl
+++ b/test/downstream/linearization_dd.jl
@@ -21,36 +21,46 @@ D = Differential(t)
 @named fixed = Fixed()
 @named force = Force(use_support = false)
 
-eqs = [connect(link1.TX1, cart.flange)
-       connect(cart.flange, force.flange)
-       connect(link1.TY1, fixed.flange)]
+eqs = [
+    connect(link1.TX1, cart.flange)
+    connect(cart.flange, force.flange)
+    connect(link1.TY1, fixed.flange)
+]
 
 @named model = System(eqs, t, [], []; systems = [link1, cart, force, fixed])
 lin_outputs = [cart.s, cart.v, link1.A, link1.dA]
 lin_inputs = [force.f.u]
 
 # => nothing to remove extra defaults
-op = Dict(cart.s => 10, cart.v => 0, link1.A => -pi / 2, link1.dA => 0, force.f.u => 0,
-    link1.x1 => nothing, link1.y1 => nothing, link1.x2 => nothing, link1.x_cm => nothing)
+op = Dict(
+    cart.s => 10, cart.v => 0, link1.A => -pi / 2, link1.dA => 0, force.f.u => 0,
+    link1.x1 => nothing, link1.y1 => nothing, link1.x2 => nothing, link1.x_cm => nothing
+)
 guesses = [link1.fx1 => 0]
 @info "named_ss"
-G = named_ss(model, lin_inputs, lin_outputs; allow_symbolic = true, op,
-    allow_input_derivatives = true, zero_dummy_der = true, guesses)
+G = named_ss(
+    model, lin_inputs, lin_outputs; allow_symbolic = true, op,
+    allow_input_derivatives = true, zero_dummy_der = true, guesses
+)
 G = sminreal(G)
 @info "minreal"
 G = minreal(G)
 @info "poles"
 ps = poles(G)
 
-@test minimum(abs, ps) < 1e-6
-@test minimum(abs, complex(0, 1.3777260367206716) .- ps) < 1e-10
+@test minimum(abs, ps) < 1.0e-6
+@test minimum(abs, complex(0, 1.3777260367206716) .- ps) < 1.0e-10
 
 lsys,
-syss = linearize(model, lin_inputs, lin_outputs, allow_symbolic = true, op = op,
-    allow_input_derivatives = true, zero_dummy_der = true, guesses = guesses)
+    syss = linearize(
+    model, lin_inputs, lin_outputs, allow_symbolic = true, op = op,
+    allow_input_derivatives = true, zero_dummy_der = true, guesses = guesses
+)
 lsyss,
-sysss = ModelingToolkit.linearize_symbolic(model, lin_inputs, lin_outputs;
-    allow_input_derivatives = true)
+    sysss = ModelingToolkit.linearize_symbolic(
+    model, lin_inputs, lin_outputs;
+    allow_input_derivatives = true
+)
 
 dummyder = setdiff(unknowns(sysss), unknowns(model))
 # op2 = merge(ModelingToolkit.guesses(model), op, Dict(x => 0.0 for x in dummyder))

--- a/test/downstream/test_disturbance_model.jl
+++ b/test/downstream/test_disturbance_model.jl
@@ -37,7 +37,7 @@ indexof(sym, syms) = findfirst(isequal(sym), syms)
     equations = Equation[
         connect(torque.flange, inertia1.flange_a),
         connect(inertia1.flange_b, spring.flange_a, damper.flange_a),
-        connect(inertia2.flange_a, spring.flange_b, damper.flange_b)
+        connect(inertia2.flange_a, spring.flange_b, damper.flange_b),
     ]
 
     return System(equations, t, vars, pars; name, systems)
@@ -65,7 +65,7 @@ end
         connect(disturbance_signal1.output, :d1, disturbance_torque1.tau), # When we connect the input _signals_, we do so through an analysis point. This allows us to easily disconnect the input signals in situations when we do not need them.
         connect(disturbance_signal2.output, :d2, disturbance_torque2.tau),
         connect(disturbance_torque1.flange, system_model.inertia1.flange_b),
-        connect(disturbance_torque2.flange, system_model.inertia2.flange_b)
+        connect(disturbance_torque2.flange, system_model.inertia2.flange_b),
     ]
 
     return System(equations, t, vars, pars; name, systems)
@@ -82,7 +82,8 @@ using ControlSystemsBase, ControlSystemsMTK
 cmodel = complete(model)
 P = cmodel.system_model
 lsys = named_ss(
-    model, [:u, :d1], [P.inertia1.phi, P.inertia2.phi, P.inertia1.w, P.inertia2.w])
+    model, [:u, :d1], [P.inertia1.phi, P.inertia2.phi, P.inertia1.w, P.inertia2.w]
+)
 
 ##
 # If we now want to add a disturbance model, we cannot do that since we have already connected a constant to the disturbance input, we thus create a new wrapper model with inputs
@@ -113,7 +114,7 @@ dist(; name) = System(1 / s; name)
         connect(disturbance_model.output, disturbance_torque1.tau),
         connect(disturbance_signal2.output, :d2, disturbance_torque2.tau),
         connect(disturbance_torque1.flange, system_model.inertia1.flange_b),
-        connect(disturbance_torque2.flange, system_model.inertia2.flange_b)
+        connect(disturbance_torque2.flange, system_model.inertia2.flange_b),
     ]
 
     return System(equations, t, vars, pars; name, systems)
@@ -129,7 +130,7 @@ sol = solve(prob, Tsit5())
 @test SciMLBase.successful_retcode(sol)
 # plot(sol)
 
-## 
+##
 # Now we only have an integrating disturbance affecting inertia1, what if we want both integrating and direct Gaussian? We'd need a "PI controller" disturbancemodel. If we add the disturbance model (s+1)/s we get the integrating and non-integrating noises being correlated which is fine, it reduces the dimensions of the sigma point by 1.
 
 dist3(; name) = System(ss(1 + 10 / s, balance = false); name)
@@ -165,7 +166,7 @@ dist3(; name) = System(ss(1 + 10 / s, balance = false); name)
 
         connect(system_model.inertia1.flange_b, angle_sensor.flange),
         connect(angle_sensor.phi, y.input1),
-        connect(output_disturbance.output, :dy, y.input2)
+        connect(output_disturbance.output, :dy, y.input2),
     ]
 
     return System(equations, t, vars, pars; name, systems)
@@ -185,26 +186,31 @@ sol = solve(prob, Tsit5())
 # temp = open_loop(model_with_disturbance, :d)
 outputs = [P.inertia1.phi, P.inertia2.phi, P.inertia1.w, P.inertia2.w]
 f, x_sym,
-p_sym,
-io_sys = ModelingToolkit.generate_control_function(
-    model_with_disturbance, [:u], [:d1, :d2, :dy], split = false)
+    p_sym,
+    io_sys = ModelingToolkit.generate_control_function(
+    model_with_disturbance, [:u], [:d1, :d2, :dy], split = false
+)
 
 f, x_sym,
-p_sym,
-io_sys = ModelingToolkit.generate_control_function(
+    p_sym,
+    io_sys = ModelingToolkit.generate_control_function(
     model_with_disturbance, [:u], [:d1, :d2, :dy],
-    disturbance_argument = true, split = false)
+    disturbance_argument = true, split = false
+)
 
 measurement = ModelingToolkit.build_explicit_observed_function(
-    io_sys, outputs, inputs = ModelingToolkit.inputs(io_sys)[1:1])
+    io_sys, outputs, inputs = ModelingToolkit.inputs(io_sys)[1:1]
+)
 measurement2 = ModelingToolkit.build_explicit_observed_function(
     io_sys, [io_sys.y.output.u], inputs = ModelingToolkit.inputs(io_sys)[1:1],
     disturbance_inputs = ModelingToolkit.inputs(io_sys)[2:end],
-    disturbance_argument = true)
+    disturbance_argument = true
+)
 # Test new interface with known_disturbance_inputs (equivalent to above)
 measurement3 = ModelingToolkit.build_explicit_observed_function(
     io_sys, [io_sys.y.output.u], inputs = ModelingToolkit.inputs(io_sys)[1:1],
-    known_disturbance_inputs = ModelingToolkit.inputs(io_sys)[2:end])
+    known_disturbance_inputs = ModelingToolkit.inputs(io_sys)[2:end]
+)
 
 op = ModelingToolkit.inputs(io_sys) .=> 0
 x0 = ModelingToolkit.get_u0(io_sys, op)
@@ -236,7 +242,7 @@ d = [0, 0, 1]
 @test measurement3(x, u, p, 0.0, d) == [1]  # Test new interface
 
 ## Further downstream tests that the functions generated above actually have the properties required to use for state estimation
-# 
+#
 # using LowLevelParticleFilters, SeeToDee
 # Ts = 0.001
 # discrete_dynamics = SeeToDee.Rk4(f_oop2, Ts)

--- a/test/fmi/fmi.jl
+++ b/test/fmi/fmi.jl
@@ -7,7 +7,8 @@ const FMU_DIR = joinpath(@__DIR__, "fmus")
 @testset "Standalone pendulum model" begin
     fmu = loadFMU("SpringPendulum1D", "Dymola", "2022x"; type = :ME)
     truesol = FMI.simulate(
-        fmu, (0.0, 8.0); saveat = 0.0:0.1:8.0, recordValues = ["mass.s", "mass.v"])
+        fmu, (0.0, 8.0); saveat = 0.0:0.1:8.0, recordValues = ["mass.s", "mass.v"]
+    )
 
     function test_no_inputs_outputs(sys)
         for var in unknowns(sys)
@@ -20,64 +21,79 @@ const FMU_DIR = joinpath(@__DIR__, "fmus")
         @mtkcompile sys = MTK.FMIComponent(Val(2); fmu, type = :ME)
         test_no_inputs_outputs(sys)
         prob = ODEProblem{true, SciMLBase.FullSpecialize}(
-            sys, [sys.mass__s => 0.5, sys.mass__v => 0.0], (0.0, 8.0))
-        sol = solve(prob, Tsit5(); reltol = 1e-8, abstol = 1e-8)
+            sys, [sys.mass__s => 0.5, sys.mass__v => 0.0], (0.0, 8.0)
+        )
+        sol = solve(prob, Tsit5(); reltol = 1.0e-8, abstol = 1.0e-8)
         @test SciMLBase.successful_retcode(sol)
 
-        @test sol(0.0:0.1:8.0;
-            idxs = [sys.mass__s, sys.mass__v]).u≈collect.(truesol.values.saveval) atol=1e-4
+        @test sol(
+            0.0:0.1:8.0;
+            idxs = [sys.mass__s, sys.mass__v]
+        ).u ≈ collect.(truesol.values.saveval) atol = 1.0e-4
         # repeated solve works
         @test_nowarn solve(prob, Tsit5())
     end
     @testset "v2, CS" begin
         fmu = loadFMU("SpringPendulum1D", "Dymola", "2022x"; type = :CS)
         @named inner = MTK.FMIComponent(
-            Val(2); fmu, communication_step_size = 1e-5, type = :CS)
+            Val(2); fmu, communication_step_size = 1.0e-5, type = :CS
+        )
         @variables x(t) = 1.0
         @mtkcompile sys = System([D(x) ~ x], t; systems = [inner])
         test_no_inputs_outputs(sys)
 
         prob = ODEProblem{true, SciMLBase.FullSpecialize}(
-            sys, [sys.inner.mass__s => 0.5, sys.inner.mass__v => 0.0], (0.0, 8.0))
-        sol = solve(prob, Tsit5(); reltol = 1e-8, abstol = 1e-8)
+            sys, [sys.inner.mass__s => 0.5, sys.inner.mass__v => 0.0], (0.0, 8.0)
+        )
+        sol = solve(prob, Tsit5(); reltol = 1.0e-8, abstol = 1.0e-8)
         @test SciMLBase.successful_retcode(sol)
 
-        @test sol(0.0:0.1:8.0;
-            idxs = [sys.inner.mass__s, sys.inner.mass__v]).u≈collect.(truesol.values.saveval) rtol=1e-2
+        @test sol(
+            0.0:0.1:8.0;
+            idxs = [sys.inner.mass__s, sys.inner.mass__v]
+        ).u ≈ collect.(truesol.values.saveval) rtol = 1.0e-2
     end
 
     fmu = loadFMU("SpringPendulum1D", "Dymola", "2023x", "3.0"; type = :ME)
     truesol = FMI.simulate(
-        fmu, (0.0, 8.0); solver = Tsit5(), saveat = 0.0:0.1:8.0, recordValues = ["mass.s", "mass.v"], tstops = collect(0.0:0.1:8.0))
+        fmu, (0.0, 8.0); solver = Tsit5(), saveat = 0.0:0.1:8.0, recordValues = ["mass.s", "mass.v"], tstops = collect(0.0:0.1:8.0)
+    )
     @testset "v3, ME" begin
         fmu = loadFMU("SpringPendulum1D", "Dymola", "2023x", "3.0"; type = :ME)
         @mtkcompile sys = MTK.FMIComponent(Val(3); fmu, type = :ME)
         test_no_inputs_outputs(sys)
         prob = ODEProblem{true, SciMLBase.FullSpecialize}(
-            sys, [sys.mass__s => 0.5, sys.mass__v => 0.0], (0.0, 8.0))
-        sol = solve(prob, Tsit5(); reltol = 1e-8, abstol = 1e-8, tstops=collect(0.0:0.1:8.0))
+            sys, [sys.mass__s => 0.5, sys.mass__v => 0.0], (0.0, 8.0)
+        )
+        sol = solve(prob, Tsit5(); reltol = 1.0e-8, abstol = 1.0e-8, tstops = collect(0.0:0.1:8.0))
         @test SciMLBase.successful_retcode(sol)
 
-        @test sol(0.0:0.1:8.0;
-            idxs = [sys.mass__s, sys.mass__v]).u≈collect.(truesol.values.saveval) atol=1e-4
+        @test sol(
+            0.0:0.1:8.0;
+            idxs = [sys.mass__s, sys.mass__v]
+        ).u ≈ collect.(truesol.values.saveval) atol = 1.0e-4
         # repeated solve works
         @test_nowarn solve(prob, Tsit5())
     end
     @testset "v3, CS" begin
         fmu = loadFMU("SpringPendulum1D", "Dymola", "2023x", "3.0"; type = :CS)
         @named inner = MTK.FMIComponent(
-            Val(3); fmu, communication_step_size = 1e-5, type = :CS)
+            Val(3); fmu, communication_step_size = 1.0e-5, type = :CS
+        )
         @variables x(t) = 1.0
         @mtkcompile sys = System([D(x) ~ x], t; systems = [inner])
         test_no_inputs_outputs(sys)
 
         prob = ODEProblem{true, SciMLBase.FullSpecialize}(
-            sys, [sys.inner.mass__s => 0.5, sys.inner.mass__v => 0.0], (0.0, 8.0))
-        sol = solve(prob, Tsit5(); reltol = 1e-8, abstol = 1e-8)
+            sys, [sys.inner.mass__s => 0.5, sys.inner.mass__v => 0.0], (0.0, 8.0)
+        )
+        sol = solve(prob, Tsit5(); reltol = 1.0e-8, abstol = 1.0e-8)
         @test SciMLBase.successful_retcode(sol)
 
-        @test sol(0.0:0.1:8.0;
-            idxs = [sys.inner.mass__s, sys.inner.mass__v]).u≈collect.(truesol.values.saveval) rtol=1e-2
+        @test sol(
+            0.0:0.1:8.0;
+            idxs = [sys.inner.mass__s, sys.inner.mass__v]
+        ).u ≈ collect.(truesol.values.saveval) rtol = 1.0e-2
     end
 end
 
@@ -123,21 +139,25 @@ end
     function build_simple_adder(adder)
         @variables a(t) b(t) c(t) [guess = 1.0]
         @mtkcompile sys = System(
-            [adder.a ~ a, adder.b ~ b, D(a) ~ t,
-                D(b) ~ adder.out + adder.c, c^2 ~ adder.out + adder.value],
+            [
+                adder.a ~ a, adder.b ~ b, D(a) ~ t,
+                D(b) ~ adder.out + adder.c, c^2 ~ adder.out + adder.value,
+            ],
             t;
-            systems = [adder])
+            systems = [adder]
+        )
         # c will be solved for by initialization
         # this tests that initialization also works with FMUs
         prob = ODEProblem(
             sys, [sys.adder.c => 2.0, sys.a => 1.0, sys.b => 1.0, sys.adder.value => 2.0],
-            (0.0, 1.0))
+            (0.0, 1.0)
+        )
         return sys, prob
     end
 
     @named adder = SimpleAdder()
     truesys, trueprob = build_simple_adder(adder)
-    truesol = solve(trueprob, abstol = 1e-8, reltol = 1e-8)
+    truesol = solve(trueprob, abstol = 1.0e-8, reltol = 1.0e-8)
     @test SciMLBase.successful_retcode(truesol)
 
     @testset "v2, ME" begin
@@ -150,18 +170,24 @@ end
         @test !MTK.isinput(adder.c) && !MTK.isoutput(adder.c)
 
         sys, prob = build_simple_adder(adder)
-        sol = solve(prob, Rodas5P(autodiff = false), abstol = 1e-8, reltol = 1e-8)
+        sol = solve(prob, Rodas5P(autodiff = false), abstol = 1.0e-8, reltol = 1.0e-8)
         @test SciMLBase.successful_retcode(sol)
 
-        @test truesol(sol.t;
-            idxs = [truesys.a, truesys.b, truesys.c, truesys.adder.c]).u≈sol[[
-            sys.a, sys.b, sys.c, sys.adder.c]] rtol=1e-7
+        @test truesol(
+            sol.t;
+            idxs = [truesys.a, truesys.b, truesys.c, truesys.adder.c]
+        ).u ≈ sol[
+            [
+                sys.a, sys.b, sys.c, sys.adder.c,
+            ],
+        ] rtol = 1.0e-7
     end
     @testset "v2, CS" begin
         fmu = loadFMU(joinpath(FMU_DIR, "SimpleAdder.fmu"); type = :CS)
         @named adder = MTK.FMIComponent(
-            Val(2); fmu, type = :CS, communication_step_size = 1e-6,
-            reinitializealg = BrownFullBasicInit(abstol = 1e-7))
+            Val(2); fmu, type = :CS, communication_step_size = 1.0e-6,
+            reinitializealg = BrownFullBasicInit(abstol = 1.0e-7)
+        )
         @test MTK.isinput(adder.a)
         @test MTK.isinput(adder.b)
         @test MTK.isoutput(adder.out)
@@ -169,30 +195,33 @@ end
         @test !MTK.isinput(adder.c) && !MTK.isoutput(adder.c)
 
         sys, prob = build_simple_adder(adder)
-        sol = solve(prob, Rodas5P(autodiff = false), abstol = 1e-8, reltol = 1e-8)
+        sol = solve(prob, Rodas5P(autodiff = false), abstol = 1.0e-8, reltol = 1.0e-8)
         @test SciMLBase.successful_retcode(sol)
 
-        @test truesol(sol.t;
-            idxs = [truesys.a, truesys.b, truesys.c]).u≈sol[[sys.a, sys.b, sys.c]] rtol=4e-2
+        @test truesol(
+            sol.t;
+            idxs = [truesys.a, truesys.b, truesys.c]
+        ).u ≈ sol[[sys.a, sys.b, sys.c]] rtol = 4.0e-2
         # sys.adder.c is a discrete variable
-        @test truesol(sol.t; idxs = truesys.adder.c).u≈sol(sol.t; idxs = sys.adder.c).u rtol=4e-2
+        @test truesol(sol.t; idxs = truesys.adder.c).u ≈ sol(sol.t; idxs = sys.adder.c).u rtol = 4.0e-2
     end
 
     function build_sspace_model(sspace)
-        @variables u(t)=1.0 x(t)=1.0 y(t) [guess=1.0]
+        @variables u(t) = 1.0 x(t) = 1.0 y(t) [guess = 1.0]
         @mtkcompile sys = System(
             [sspace.u ~ u, D(u) ~ t, D(x) ~ sspace.x + sspace.y, y^2 ~ sspace.y + sspace.x], t;
             systems = [sspace]
         )
 
         prob = ODEProblem(
-            sys, [sys.sspace.x => 1.0, sys.sspace.A => 2.0], (0.0, 1.0); use_scc = false)
+            sys, [sys.sspace.x => 1.0, sys.sspace.A => 2.0], (0.0, 1.0); use_scc = false
+        )
         return sys, prob
     end
 
     @named sspace = StateSpace()
     truesys, trueprob = build_sspace_model(sspace)
-    truesol = solve(trueprob, abstol = 1e-8, reltol = 1e-8)
+    truesol = solve(trueprob, abstol = 1.0e-8, reltol = 1.0e-8)
     @test SciMLBase.successful_retcode(truesol)
 
     @testset "v3, ME" begin
@@ -203,30 +232,37 @@ end
         @test !MTK.isinput(sspace.x) && !MTK.isoutput(sspace.x)
 
         sys, prob = build_sspace_model(sspace)
-        sol = solve(prob, Rodas5P(autodiff = false); abstol = 1e-8, reltol = 1e-8)
+        sol = solve(prob, Rodas5P(autodiff = false); abstol = 1.0e-8, reltol = 1.0e-8)
         @test SciMLBase.successful_retcode(sol)
 
-        @test truesol(sol.t;
-            idxs = [truesys.u, truesys.x, truesys.y, truesys.sspace.x]).u≈sol[[
-            sys.u, sys.x, sys.y, sys.sspace.x]] rtol=1e-7
+        @test truesol(
+            sol.t;
+            idxs = [truesys.u, truesys.x, truesys.y, truesys.sspace.x]
+        ).u ≈ sol[
+            [
+                sys.u, sys.x, sys.y, sys.sspace.x,
+            ],
+        ] rtol = 1.0e-7
     end
 
     @testset "v3, CS" begin
         fmu = loadFMU(joinpath(FMU_DIR, "StateSpace.fmu"); type = :CS)
         @named sspace = MTK.FMIComponent(
-            Val(3); fmu, communication_step_size = 1e-6, type = :CS,
-            reinitializealg = BrownFullBasicInit(abstol = 1e-7))
+            Val(3); fmu, communication_step_size = 1.0e-6, type = :CS,
+            reinitializealg = BrownFullBasicInit(abstol = 1.0e-7)
+        )
         @test MTK.isinput(sspace.u)
         @test MTK.isoutput(sspace.y)
         @test !MTK.isinput(sspace.x) && !MTK.isoutput(sspace.x)
 
         sys, prob = build_sspace_model(sspace)
-        sol = solve(prob, Rodas5P(autodiff = false); abstol = 1e-8, reltol = 1e-8)
+        sol = solve(prob, Rodas5P(autodiff = false); abstol = 1.0e-8, reltol = 1.0e-8)
         @test SciMLBase.successful_retcode(sol)
 
         @test truesol(
-            sol.t; idxs = [truesys.u, truesys.x, truesys.y]).u≈sol[[sys.u, sys.x, sys.y]] rtol=1e-2
-        @test truesol(sol.t; idxs = truesys.sspace.x).u≈sol(sol.t; idxs = sys.sspace.x).u rtol=1e-2
+            sol.t; idxs = [truesys.u, truesys.x, truesys.y]
+        ).u ≈ sol[[sys.u, sys.x, sys.y]] rtol = 1.0e-2
+        @test truesol(sol.t; idxs = truesys.sspace.x).u ≈ sol(sol.t; idxs = sys.sspace.x).u rtol = 1.0e-2
     end
 end
 
@@ -234,19 +270,23 @@ end
     function build_looped_adders(adder1, adder2)
         @variables x(t) = 1
         @mtkcompile sys = System(
-            [D(x) ~ x, adder1.a ~ adder2.out2,
-                adder2.a ~ adder1.out2, adder1.b ~ 1.0, adder2.b ~ 2.0],
+            [
+                D(x) ~ x, adder1.a ~ adder2.out2,
+                adder2.a ~ adder1.out2, adder1.b ~ 1.0, adder2.b ~ 2.0,
+            ],
             t;
-            systems = [adder1, adder2])
+            systems = [adder1, adder2]
+        )
         prob = ODEProblem(
             sys, [adder1.c => 1.0, adder2.c => 1.0, adder1.a => 2.0],
-            (0.0, 1.0); guesses = [adder2.a => 0.0])
+            (0.0, 1.0); guesses = [adder2.a => 0.0]
+        )
         return sys, prob
     end
     @named adder1 = SimpleAdder()
     @named adder2 = SimpleAdder()
     truesys, trueprob = build_looped_adders(adder1, adder2)
-    truesol = solve(trueprob, Tsit5(), reltol = 1e-8)
+    truesol = solve(trueprob, Tsit5(), reltol = 1.0e-8)
     @test SciMLBase.successful_retcode(truesol)
 
     @testset "v2, ME" begin
@@ -254,39 +294,51 @@ end
         @named adder1 = MTK.FMIComponent(Val(2); fmu, type = :ME)
         @named adder2 = MTK.FMIComponent(Val(2); fmu, type = :ME)
         sys, prob = build_looped_adders(adder1, adder2)
-        sol = solve(prob, Rodas5P(autodiff = false); reltol = 1e-8)
+        sol = solve(prob, Rodas5P(autodiff = false); reltol = 1.0e-8)
         @test SciMLBase.successful_retcode(sol)
-        @test truesol(sol.t;
-            idxs = [truesys.adder1.c, truesys.adder2.c]).u≈sol(
-            sol.t; idxs = [sys.adder1.c, sys.adder2.c]).u rtol=1e-7
+        @test truesol(
+            sol.t;
+            idxs = [truesys.adder1.c, truesys.adder2.c]
+        ).u ≈ sol(
+            sol.t; idxs = [sys.adder1.c, sys.adder2.c]
+        ).u rtol = 1.0e-7
     end
     @testset "v2, CS" begin
         fmu = loadFMU(joinpath(FMU_DIR, "SimpleAdder.fmu"); type = :CS)
         @named adder1 = MTK.FMIComponent(
-            Val(2); fmu, type = :CS, communication_step_size = 1e-5)
+            Val(2); fmu, type = :CS, communication_step_size = 1.0e-5
+        )
         @named adder2 = MTK.FMIComponent(
-            Val(2); fmu, type = :CS, communication_step_size = 1e-5)
+            Val(2); fmu, type = :CS, communication_step_size = 1.0e-5
+        )
         sys, prob = build_looped_adders(adder1, adder2)
-        sol = solve(prob,
+        sol = solve(
+            prob,
             Tsit5();
-            reltol = 1e-8,
-            initializealg = SciMLBase.OverrideInit(nlsolve = FastShortcutNLLSPolyalg(autodiff = AutoFiniteDiff())))
-        @test truesol(sol.t;
-            idxs = [truesys.adder1.c, truesys.adder2.c]).u≈sol(
-            sol.t; idxs = [sys.adder1.c, sys.adder2.c]).u rtol=1e-3
+            reltol = 1.0e-8,
+            initializealg = SciMLBase.OverrideInit(nlsolve = FastShortcutNLLSPolyalg(autodiff = AutoFiniteDiff()))
+        )
+        @test truesol(
+            sol.t;
+            idxs = [truesys.adder1.c, truesys.adder2.c]
+        ).u ≈ sol(
+            sol.t; idxs = [sys.adder1.c, sys.adder2.c]
+        ).u rtol = 1.0e-3
     end
 
     function build_looped_sspace(sspace1, sspace2)
         @variables x(t) = 1
-        @mtkcompile sys = System([D(x) ~ x, sspace1.u ~ sspace2.x, sspace2.u ~ sspace1.y],
-            t; systems = [sspace1, sspace2])
+        @mtkcompile sys = System(
+            [D(x) ~ x, sspace1.u ~ sspace2.x, sspace2.u ~ sspace1.y],
+            t; systems = [sspace1, sspace2]
+        )
         prob = ODEProblem(sys, [sspace1.x => 1.0, sspace2.x => 1.0], (0.0, 1.0))
         return sys, prob
     end
     @named sspace1 = StateSpace()
     @named sspace2 = StateSpace()
     truesys, trueprob = build_looped_sspace(sspace1, sspace2)
-    truesol = solve(trueprob, Rodas5P(), reltol = 1e-8)
+    truesol = solve(trueprob, Rodas5P(), reltol = 1.0e-8)
     @test SciMLBase.successful_retcode(truesol)
 
     @testset "v3, ME" begin
@@ -294,24 +346,32 @@ end
         @named sspace1 = MTK.FMIComponent(Val(3); fmu, type = :ME)
         @named sspace2 = MTK.FMIComponent(Val(3); fmu, type = :ME)
         sys, prob = build_looped_sspace(sspace1, sspace2)
-        sol = solve(prob, Rodas5P(autodiff = false); reltol = 1e-8)
+        sol = solve(prob, Rodas5P(autodiff = false); reltol = 1.0e-8)
         @test SciMLBase.successful_retcode(sol)
-        @test truesol(sol.t;
-            idxs = [truesys.sspace1.x, truesys.sspace2.x]).u≈sol(
-            sol.t; idxs = [sys.sspace1.x, sys.sspace2.x]).u rtol=1e-7
+        @test truesol(
+            sol.t;
+            idxs = [truesys.sspace1.x, truesys.sspace2.x]
+        ).u ≈ sol(
+            sol.t; idxs = [sys.sspace1.x, sys.sspace2.x]
+        ).u rtol = 1.0e-7
     end
 
     @testset "v3, CS" begin
         fmu = loadFMU(joinpath(FMU_DIR, "StateSpace.fmu"); type = :CS)
         @named sspace1 = MTK.FMIComponent(
-            Val(3); fmu, type = :CS, communication_step_size = 1e-5)
+            Val(3); fmu, type = :CS, communication_step_size = 1.0e-5
+        )
         @named sspace2 = MTK.FMIComponent(
-            Val(3); fmu, type = :CS, communication_step_size = 1e-5)
+            Val(3); fmu, type = :CS, communication_step_size = 1.0e-5
+        )
         sys, prob = build_looped_sspace(sspace1, sspace2)
-        sol = solve(prob, Rodas5P(autodiff = false); reltol = 1e-8)
+        sol = solve(prob, Rodas5P(autodiff = false); reltol = 1.0e-8)
         @test SciMLBase.successful_retcode(sol)
-        @test truesol(sol.t;
-            idxs = [truesys.sspace1.x, truesys.sspace2.x]).u≈sol(
-            sol.t; idxs = [sys.sspace1.x, sys.sspace2.x]).u rtol=1e-2
+        @test truesol(
+            sol.t;
+            idxs = [truesys.sspace1.x, truesys.sspace2.x]
+        ).u ≈ sol(
+            sol.t; idxs = [sys.sspace1.x, sys.sspace2.x]
+        ).u rtol = 1.0e-2
     end
 end

--- a/test/fractional_to_ordinary.jl
+++ b/test/fractional_to_ordinary.jl
@@ -6,81 +6,81 @@ using Test
 @independent_variables t
 @variables x(t)
 D = Differential(t)
-tspan = (0., 1.)
-timepoint = [0., 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.]
+tspan = (0.0, 1.0)
+timepoint = [0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0]
 
 function expect(t, α)
-    return (3/2*t^(α/2) - t^4)^2
+    return (3 / 2 * t^(α / 2) - t^4)^2
 end
 
 α = 0.5
-eqs = (9*gamma(1 + α)/4) - (3*t^(4 - α/2)*gamma(5 + α/2)/gamma(5 - α/2))
-eqs += (gamma(9)*t^(8 - α)/gamma(9 - α)) + (3/2*t^(α/2)-t^4)^3 - x^(3/2)
+eqs = (9 * gamma(1 + α) / 4) - (3 * t^(4 - α / 2) * gamma(5 + α / 2) / gamma(5 - α / 2))
+eqs += (gamma(9) * t^(8 - α) / gamma(9 - α)) + (3 / 2 * t^(α / 2) - t^4)^3 - x^(3 / 2)
 sys = fractional_to_ordinary(eqs, x, α, 10^-7, 1)
 
 prob = ODEProblem(sys, [], tspan)
-sol = solve(prob, RadauIIA5(), saveat=timepoint, abstol = 1e-10, reltol = 1e-10)
+sol = solve(prob, RadauIIA5(), saveat = timepoint, abstol = 1.0e-10, reltol = 1.0e-10)
 
 for time in 0:0.1:1
-    @test isapprox(expect(time, α), sol(time, idxs=x), atol=1e-7)
+    @test isapprox(expect(time, α), sol(time, idxs = x), atol = 1.0e-7)
     time += 0.1
 end
 
 α = 0.3
-eqs = (9*gamma(1 + α)/4) - (3*t^(4 - α/2)*gamma(5 + α/2)/gamma(5 - α/2))
-eqs += (gamma(9)*t^(8 - α)/gamma(9 - α)) + (3/2*t^(α/2)-t^4)^3 - x^(3/2)
-sys = fractional_to_ordinary(eqs, x, α, 10^-7, 1; matrix=false)
+eqs = (9 * gamma(1 + α) / 4) - (3 * t^(4 - α / 2) * gamma(5 + α / 2) / gamma(5 - α / 2))
+eqs += (gamma(9) * t^(8 - α) / gamma(9 - α)) + (3 / 2 * t^(α / 2) - t^4)^3 - x^(3 / 2)
+sys = fractional_to_ordinary(eqs, x, α, 10^-7, 1; matrix = false)
 
 prob = ODEProblem(sys, [], tspan)
-sol = solve(prob, RadauIIA5(), saveat=timepoint, abstol = 1e-10, reltol = 1e-10)
+sol = solve(prob, RadauIIA5(), saveat = timepoint, abstol = 1.0e-10, reltol = 1.0e-10)
 
 for time in 0:0.1:1
-    @test isapprox(expect(time, α), sol(time, idxs=x), atol=1e-7)
+    @test isapprox(expect(time, α), sol(time, idxs = x), atol = 1.0e-7)
 end
 
 α = 0.9
-eqs = (9*gamma(1 + α)/4) - (3*t^(4 - α/2)*gamma(5 + α/2)/gamma(5 - α/2))
-eqs += (gamma(9)*t^(8 - α)/gamma(9 - α)) + (3/2*t^(α/2)-t^4)^3 - x^(3/2)
+eqs = (9 * gamma(1 + α) / 4) - (3 * t^(4 - α / 2) * gamma(5 + α / 2) / gamma(5 - α / 2))
+eqs += (gamma(9) * t^(8 - α) / gamma(9 - α)) + (3 / 2 * t^(α / 2) - t^4)^3 - x^(3 / 2)
 sys = fractional_to_ordinary(eqs, x, α, 10^-7, 1)
 
 prob = ODEProblem(sys, [], tspan)
-sol = solve(prob, RadauIIA5(), saveat=timepoint, abstol = 1e-10, reltol = 1e-10)
+sol = solve(prob, RadauIIA5(), saveat = timepoint, abstol = 1.0e-10, reltol = 1.0e-10)
 
 for time in 0:0.1:1
-    @test isapprox(expect(time, α), sol(time, idxs=x), atol=1e-7)
+    @test isapprox(expect(time, α), sol(time, idxs = x), atol = 1.0e-7)
 end
 
 # Testing for example 2 of Section 7
 @independent_variables t
 @variables x(t) y(t)
 D = Differential(t)
-tspan = (0., 220.)
+tspan = (0.0, 220.0)
 
-sys = fractional_to_ordinary([1 - 4*x + x^2 * y, 3*x - x^2 * y], [x, y], [1.3, 0.8], 10^-8, 220; initials=[[1.2, 1], 2.8], matrix=false)
+sys = fractional_to_ordinary([1 - 4 * x + x^2 * y, 3 * x - x^2 * y], [x, y], [1.3, 0.8], 10^-8, 220; initials = [[1.2, 1], 2.8], matrix = false)
 prob = ODEProblem(sys, [], tspan)
-sol = solve(prob, RadauIIA5(), abstol = 1e-8, reltol = 1e-8)
+sol = solve(prob, RadauIIA5(), abstol = 1.0e-8, reltol = 1.0e-8)
 
-@test isapprox(1.0097684171, sol(220, idxs=x), atol=1e-5)
-@test isapprox(2.1581264031, sol(220, idxs=y), atol=1e-5)
+@test isapprox(1.0097684171, sol(220, idxs = x), atol = 1.0e-5)
+@test isapprox(2.1581264031, sol(220, idxs = y), atol = 1.0e-5)
 
 #Testing for example 3 of Section 7
 @independent_variables t
 @variables x_0(t)
 D = Differential(t)
-tspan = (0., 5000.)
+tspan = (0.0, 5000.0)
 
 function expect(t)
-    return sqrt(2) * sin(t + pi/4)
+    return sqrt(2) * sin(t + pi / 4)
 end
 
-sys = linear_fractional_to_ordinary([3, 2.5, 2, 1, .5, 0], [1, 1, 1, 4, 1, 4], 6*cos(t), 10^-5, 5000; initials=[1, 1, -1])
+sys = linear_fractional_to_ordinary([3, 2.5, 2, 1, 0.5, 0], [1, 1, 1, 4, 1, 4], 6 * cos(t), 10^-5, 5000; initials = [1, 1, -1])
 prob = ODEProblem(sys, [], tspan)
-sol = solve(prob, RadauIIA5(), abstol = 1e-5, reltol = 1e-5)
+sol = solve(prob, RadauIIA5(), abstol = 1.0e-5, reltol = 1.0e-5)
 
-@test isapprox(expect(5000), sol(5000, idxs=x_0), atol=1e-5)
+@test isapprox(expect(5000), sol(5000, idxs = x_0), atol = 1.0e-5)
 
-msys = linear_fractional_to_ordinary([3, 2.5, 2, 1, .5, 0], [1, 1, 1, 4, 1, 4], 6*cos(t), 10^-5, 5000; initials=[1, 1, -1], matrix=false)
+msys = linear_fractional_to_ordinary([3, 2.5, 2, 1, 0.5, 0], [1, 1, 1, 4, 1, 4], 6 * cos(t), 10^-5, 5000; initials = [1, 1, -1], matrix = false)
 mprob = ODEProblem(sys, [], tspan)
-msol = solve(prob, RadauIIA5(), abstol = 1e-5, reltol = 1e-5)
+msol = solve(prob, RadauIIA5(), abstol = 1.0e-5, reltol = 1.0e-5)
 
-@test isapprox(expect(5000), msol(5000, idxs=x_0), atol=1e-5)
+@test isapprox(expect(5000), msol(5000, idxs = x_0), atol = 1.0e-5)

--- a/test/hierarchical_initialization_eqs.jl
+++ b/test/hierarchical_initialization_eqs.jl
@@ -20,11 +20,13 @@ A simple linear resistor model
     params = @parameters begin
         R = R, [description = "Resistance of this Resistor"]
     end
-    eqs = [v ~ p.v - n.v
-           i ~ p.i
-           p.i + n.i ~ 0
-           # Ohm's Law
-           v ~ i * R]
+    eqs = [
+        v ~ p.v - n.v
+        i ~ p.i
+        p.i + n.i ~ 0
+        # Ohm's Law
+        v ~ i * R
+    ]
     return System(eqs, t, vars, params; systems, name)
 end
 @connector function Pin(; name)
@@ -46,10 +48,12 @@ end
     params = @parameters begin
         V = 10
     end
-    eqs = [v ~ p.v - n.v
-           i ~ p.i
-           p.i + n.i ~ 0
-           v ~ V]
+    eqs = [
+        v ~ p.v - n.v
+        i ~ p.i
+        p.i + n.i ~ 0
+        v ~ V
+    ]
     return System(eqs, t, vars, params; systems, name)
 end
 
@@ -66,12 +70,14 @@ end
         C = C
     end
     initialization_eqs = [
-        v ~ 0
+        v ~ 0,
     ]
-    eqs = [v ~ p.v - n.v
-           i ~ p.i
-           p.i + n.i ~ 0
-           C * D(v) ~ i]
+    eqs = [
+        v ~ p.v - n.v
+        i ~ p.i
+        p.i + n.i ~ 0
+        C * D(v) ~ i
+    ]
     return System(eqs, t, vars, params; systems, name, initialization_eqs)
 end
 
@@ -80,7 +86,7 @@ end
         g = Pin()
     end
     eqs = [
-        g.v ~ 0
+        g.v ~ 0,
     ]
     return System(eqs, t, [], []; systems, name)
 end
@@ -97,10 +103,12 @@ end
     params = @parameters begin
         (L = L)
     end
-    eqs = [v ~ p.v - n.v
-           i ~ p.i
-           p.i + n.i ~ 0
-           L * D(i) ~ v]
+    eqs = [
+        v ~ p.v - n.v
+        i ~ p.i
+        p.i + n.i ~ 0
+        L * D(i) ~ v
+    ]
     return System(eqs, t, vars, params; systems, name)
 end
 
@@ -117,11 +125,13 @@ HTML as well.
         ground = Ground()
     end
     initialization_eqs = [
-        inductor.i ~ 0
+        inductor.i ~ 0,
     ]
-    eqs = [connect(source.p, inductor.n)
-           connect(inductor.p, resistor.p, capacitor.p)
-           connect(resistor.n, ground.g, capacitor.n, source.n)]
+    eqs = [
+        connect(source.p, inductor.n)
+        connect(inductor.p, resistor.p, capacitor.p)
+        connect(resistor.n, ground.g, capacitor.n, source.n)
+    ]
     return System(eqs, t, [], []; systems, name, initialization_eqs)
 end
 """Run model RLCModel from 0 to 10"""
@@ -129,7 +139,7 @@ function simple()
     @mtkcompile model = RLCModel()
     u0 = []
     prob = ODEProblem(model, u0, (0.0, 10.0))
-    sol = solve(prob)
+    return sol = solve(prob)
 end
 @test SciMLBase.successful_retcode(simple())
 

--- a/test/if_lifting.jl
+++ b/test/if_lifting.jl
@@ -18,7 +18,7 @@ using Test
 
         equations = Equation[
             D(x) ~ abs(y),
-            y ~ sin(t)
+            y ~ sin(t),
         ]
 
         return System(equations, t, vars, pars; name, systems)
@@ -45,8 +45,8 @@ using Test
     # x(t) = 1 - cos(t) in [0, pi)
     # x(t) = 3 + cos(t) in [pi, 2pi)
     _trueval = 3 + cos(_t)
-    @test !isapprox(sol1(_t)[1], _trueval; rtol = 1e-3)
-    @test isapprox(sol2(_t)[1], _trueval; rtol = 1e-3)
+    @test !isapprox(sol1(_t)[1], _trueval; rtol = 1.0e-3)
+    @test isapprox(sol2(_t)[1], _trueval; rtol = 1.0e-3)
 end
 
 @testset "Big test case" begin
@@ -82,7 +82,7 @@ end
             # all the boolean operators
             D(q) ~ ifelse((x < 1) & ((y < 0.5) | ifelse(y > 0.8, c, !c)), 1.0, 2.0),
             # don't touch time-independent condition, but modify time-dependent branches
-            D(r) ~ ifelse(p < 2, abs(x), max(y, 0.9))
+            D(r) ~ ifelse(p < 2, abs(x), max(y, 0.9)),
         ]
 
         return System(equations, t, vars, pars; name, systems)
@@ -144,12 +144,12 @@ end
 
         equations = Equation[
             D(x) ~ abs(y),
-            y ~ sin(t)
+            y ~ sin(t),
         ]
 
         return System(equations, t, vars, pars; name, systems)
     end
-    @test_nowarn @mtkcompile sys=SimpleAbs() additional_passes=[IfLifting]
+    @test_nowarn @mtkcompile sys = SimpleAbs() additional_passes = [IfLifting]
 end
 
 @testset "Nested conditions are handled properly" begin
@@ -169,17 +169,21 @@ end
         end
 
         equations = Equation[
-            y ~ ifelse(start_time < t,
-                ifelse(t < start_time + duration,
-                    (t - start_time) * height / duration, height),
-                0.0),
-            D(x) ~ y
+            y ~ ifelse(
+                start_time < t,
+                ifelse(
+                    t < start_time + duration,
+                    (t - start_time) * height / duration, height
+                ),
+                0.0
+            ),
+            D(x) ~ y,
         ]
 
         return System(equations, t, vars, pars; name, systems)
     end
     @mtkcompile sys = RampModel()
-    @mtkcompile sys2=RampModel() additional_passes=[IfLifting]
+    @mtkcompile sys2 = RampModel() additional_passes = [IfLifting]
     prob = ODEProblem(sys, [sys.x => 1.0], (0.0, 3.0))
     prob2 = ODEProblem(sys2, [sys.x => 1.0], (0.0, 3.0))
     sol = solve(prob)

--- a/test/inputoutput.jl
+++ b/test/inputoutput.jl
@@ -5,43 +5,58 @@ using ModelingToolkit, OrdinaryDiffEq, Symbolics, Test
 @variables x(t) y(t) z(t) F(t) u(t)
 D = Differential(t)
 
-eqs = [D(x) ~ σ * (y - x) + F,
+eqs = [
+    D(x) ~ σ * (y - x) + F,
     D(y) ~ x * (ρ - z) - y,
-    D(z) ~ x * y - β * z]
+    D(z) ~ x * y - β * z,
+]
 
 aliases = [u ~ x + y - z]
 lorenz1 = System(eqs, pins = [F], observed = aliases, name = :lorenz1)
 lorenz2 = System(eqs, pins = [F], observed = aliases, name = :lorenz2)
 
-connections = [lorenz1.F ~ lorenz2.u,
-    lorenz2.F ~ lorenz1.u]
-connected = System(Equation[], t, [], [], observed = connections,
-    systems = [lorenz1, lorenz2])
+connections = [
+    lorenz1.F ~ lorenz2.u,
+    lorenz2.F ~ lorenz1.u,
+]
+connected = System(
+    Equation[], t, [], [], observed = connections,
+    systems = [lorenz1, lorenz2]
+)
 
 sys = connected
 
 @variables lorenz1₊F lorenz2₊F
 @test pins(connected) == Variable[lorenz1₊F, lorenz2₊F]
-@test isequal(observed(connected),
-    [connections...,
+@test isequal(
+    observed(connected),
+    [
+        connections...,
         lorenz1.u ~ lorenz1.x + lorenz1.y - lorenz1.z,
-        lorenz2.u ~ lorenz2.x + lorenz2.y - lorenz2.z])
+        lorenz2.u ~ lorenz2.x + lorenz2.y - lorenz2.z,
+    ]
+)
 
 collapsed_eqs = [
-    D(lorenz1.x) ~ (lorenz1.σ * (lorenz1.y - lorenz1.x) +
-     (lorenz2.x + lorenz2.y - lorenz2.z)),
+    D(lorenz1.x) ~ (
+        lorenz1.σ * (lorenz1.y - lorenz1.x) +
+            (lorenz2.x + lorenz2.y - lorenz2.z)
+    ),
     D(lorenz1.y) ~ lorenz1.x * (lorenz1.ρ - lorenz1.z) - lorenz1.y,
     D(lorenz1.z) ~ lorenz1.x * lorenz1.y - (lorenz1.β * lorenz1.z),
-    D(lorenz2.x) ~ (lorenz2.σ * (lorenz2.y - lorenz2.x) +
-     (lorenz1.x + lorenz1.y - lorenz1.z)),
+    D(lorenz2.x) ~ (
+        lorenz2.σ * (lorenz2.y - lorenz2.x) +
+            (lorenz1.x + lorenz1.y - lorenz1.z)
+    ),
     D(lorenz2.y) ~ lorenz2.x * (lorenz2.ρ - lorenz2.z) - lorenz2.y,
-    D(lorenz2.z) ~ lorenz2.x * lorenz2.y - (lorenz2.β * lorenz2.z)]
+    D(lorenz2.z) ~ lorenz2.x * lorenz2.y - (lorenz2.β * lorenz2.z),
+]
 
 simplifyeqs(eqs) = Equation.((x -> x.lhs).(eqs), simplify.((x -> x.rhs).(eqs)))
 
 @test isequal(simplifyeqs(equations(connected)), simplifyeqs(collapsed_eqs))
 
-# Variables indicated to be input/output 
+# Variables indicated to be input/output
 @variables x [input = true]
 @test hasmetadata(x, Symbolics.option_to_metadata_type(Val(:input)))
 @test getmetadata(x, Symbolics.option_to_metadata_type(Val(:input))) == true

--- a/test/linearize.jl
+++ b/test/linearize.jl
@@ -6,10 +6,12 @@ using CommonSolve: solve
 # Test reorder_unknowns
 # sys = ssrand(1,1,4);
 mats = let
-    A = [-1.617708540405859 0.14199864151523162 1.8120551022076838 -1.246419696614408;
-         0.6704209450894298 -2.4251566699889575 0.6782529705706082 -1.3731519847672025;
-         -0.09336677360807291 -0.11211714788917712 -3.6877851408229523 -0.7073967284605489;
-         -1.1743200892334098 1.1808779444006103 1.5721685015907167 -0.10858833182921268]
+    A = [
+        -1.617708540405859 0.14199864151523162 1.8120551022076838 -1.246419696614408;
+        0.6704209450894298 -2.4251566699889575 0.6782529705706082 -1.3731519847672025;
+        -0.09336677360807291 -0.11211714788917712 -3.6877851408229523 -0.7073967284605489;
+        -1.1743200892334098 1.1808779444006103 1.5721685015907167 -0.10858833182921268
+    ]
     B = [-0.3286766047686936; -1.8473436385672866; -2.4092567234250954; -0.06371974677173559;;]
     C = [-0.7144567541084362 0.18898849455229796 0.023473101245754475 1.0369097263843963]
     D = [0.6397583934617636;;]
@@ -20,19 +22,21 @@ new = [x4, x1, x3, x2]
 old = [x1, x2, x3, x4]
 lsys = ModelingToolkit.reorder_unknowns(mats, old, new)
 P = [0 1 0 0; 0 0 0 1; 0 0 1 0; 1 0 0 0]
-@test isequal(P*new, old)
+@test isequal(P * new, old)
 @test lsys.A == ModelingToolkit.similarity_transform(mats, P).A
 
 # r is an input, and y is an output.
 @independent_variables t
-@variables x(t)=0 y(t)=0 u(t)=0 r(t)=0
-@variables x(t)=0 y(t)=0 u(t)=0 r(t)=0 [input=true]
+@variables x(t) = 0 y(t) = 0 u(t) = 0 r(t) = 0
+@variables x(t) = 0 y(t) = 0 u(t) = 0 r(t) = 0 [input = true]
 @parameters kp = 1
 D = Differential(t)
 
-eqs = [u ~ kp * (r - y)
-       D(x) ~ -x + u
-       y ~ x]
+eqs = [
+    u ~ kp * (r - y)
+    D(x) ~ -x + u
+    y ~ x
+]
 
 @named sys = System(eqs, t)
 
@@ -77,36 +81,42 @@ function plant(; name)
     @variables x(t)
     @variables u(t) y(t)
     D = Differential(t)
-    eqs = [D(x) ~ -x + u
-           y ~ x]
-    System(eqs, t; name = name)
+    eqs = [
+        D(x) ~ -x + u
+        y ~ x
+    ]
+    return System(eqs, t; name = name)
 end
 
 function filt_(; name)
     @variables x(t) y(t)
-    @variables u(t)=0 [input = true]
+    @variables u(t) = 0 [input = true]
     D = Differential(t)
-    eqs = [D(x) ~ -2 * x + u
-           y ~ x]
-    System(eqs, t, name = name)
+    eqs = [
+        D(x) ~ -2 * x + u
+        y ~ x
+    ]
+    return System(eqs, t, name = name)
 end
 
 function controller(kp; name)
-    @variables y(t)=0 r(t)=0 u(t)
+    @variables y(t) = 0 r(t) = 0 u(t)
     @parameters kp = kp
     eqs = [
-        u ~ kp * (r - y)
+        u ~ kp * (r - y),
     ]
-    System(eqs, t; name = name)
+    return System(eqs, t; name = name)
 end
 
 @named f = filt_()
 @named c = controller(1)
 @named p = plant()
 
-connections = [f.y ~ c.r # filtered reference to controller reference
-               c.u ~ p.u # controller output to plant input
-               p.y ~ c.y]
+connections = [
+    f.y ~ c.r # filtered reference to controller reference
+    c.u ~ p.u # controller output to plant input
+    p.y ~ c.y
+]
 
 @named cl = System(connections, t, systems = [f, c, p])
 
@@ -122,7 +132,7 @@ lsys2 = ModelingToolkit.reorder_unknowns(lsys1, unknowns(ssys), desired_order)
 @test lsys.D[] == lsys2.D[] == 0
 
 ## Symbolic linearization
-lsyss_ns, ssys_ns = ModelingToolkit.linearize_symbolic(cl, [f.u], [p.x], split=false)
+lsyss_ns, ssys_ns = ModelingToolkit.linearize_symbolic(cl, [f.u], [p.x], split = false)
 lsyss, ssys = ModelingToolkit.linearize_symbolic(cl, [f.u], [p.x])
 @test isequal(lsyss.A, lsyss_ns.A)
 
@@ -141,8 +151,10 @@ Nd = 10
 
 @unpack reference, measurement, ctr_output = pid
 lsys0,
-ssys = linearize(pid, [reference.u, measurement.u], [ctr_output.u];
-    op = Dict(reference.u => 0.0, measurement.u => 0.0))
+    ssys = linearize(
+    pid, [reference.u, measurement.u], [ctr_output.u];
+    op = Dict(reference.u => 0.0, measurement.u => 0.0)
+)
 @unpack int, der = pid
 desired_order = [int.x, der.x]
 lsys = ModelingToolkit.reorder_unknowns(lsys0, unknowns(ssys), desired_order)
@@ -153,18 +165,32 @@ lsys = ModelingToolkit.reorder_unknowns(lsys0, unknowns(ssys), desired_order)
 @test lsys.D == [4400 -4400]
 
 lsyss0,
-ssys2 = ModelingToolkit.linearize_symbolic(pid, [reference.u, measurement.u],
-    [ctr_output.u])
+    ssys2 = ModelingToolkit.linearize_symbolic(
+    pid, [reference.u, measurement.u],
+    [ctr_output.u]
+)
 lsyss = ModelingToolkit.reorder_unknowns(lsyss0, unknowns(ssys2), desired_order)
 
-@test value.(ModelingToolkit.fixpoint_sub(
-    lsyss.A, ModelingToolkit.initial_conditions_and_guesses(pid); fold = Val(true))) == lsys.A
-@test value.(ModelingToolkit.fixpoint_sub(
-    lsyss.B, ModelingToolkit.initial_conditions_and_guesses(pid); fold = Val(true))) == lsys.B
-@test value.(ModelingToolkit.fixpoint_sub(
-    lsyss.C, ModelingToolkit.initial_conditions_and_guesses(pid); fold = Val(true))) == lsys.C
-@test value.(ModelingToolkit.fixpoint_sub(
-    lsyss.D, ModelingToolkit.initial_conditions_and_guesses(pid); fold = Val(true))) == lsys.D
+@test value.(
+    ModelingToolkit.fixpoint_sub(
+        lsyss.A, ModelingToolkit.initial_conditions_and_guesses(pid); fold = Val(true)
+    )
+) == lsys.A
+@test value.(
+    ModelingToolkit.fixpoint_sub(
+        lsyss.B, ModelingToolkit.initial_conditions_and_guesses(pid); fold = Val(true)
+    )
+) == lsys.B
+@test value.(
+    ModelingToolkit.fixpoint_sub(
+        lsyss.C, ModelingToolkit.initial_conditions_and_guesses(pid); fold = Val(true)
+    )
+) == lsys.C
+@test value.(
+    ModelingToolkit.fixpoint_sub(
+        lsyss.D, ModelingToolkit.initial_conditions_and_guesses(pid); fold = Val(true)
+    )
+) == lsys.D
 
 # Test with the reverse desired unknown order as well to verify that similarity transform and reoreder_unknowns really works
 lsys = ModelingToolkit.reorder_unknowns(lsys, desired_order, reverse(desired_order))
@@ -175,30 +201,34 @@ lsys = ModelingToolkit.reorder_unknowns(lsys, desired_order, reverse(desired_ord
 @test lsys.D == [4400 -4400]
 
 ## Test that there is a warning when input is misspecified
-@test_throws ["inputs provided to `mtkcompile`", "not found"] linearize(pid,
+@test_throws ["inputs provided to `mtkcompile`", "not found"] linearize(
+    pid,
     [
         pid.reference.u,
-        pid.measurement.u
-    ], [ctr_output.u])
-@test_throws ["outputs provided to `mtkcompile`", "not found"] linearize(pid,
+        pid.measurement.u,
+    ], [ctr_output.u]
+)
+@test_throws ["outputs provided to `mtkcompile`", "not found"] linearize(
+    pid,
     [
         reference.u,
-        measurement.u
+        measurement.u,
     ],
-    [pid.ctr_output.u])
+    [pid.ctr_output.u]
+)
 
 ## Test operating points
 
 # The saturation has no dynamics
 function saturation(; y_max, y_min = y_max > 0 ? -y_max : -Inf, name)
-    @variables u(t)=0 y(t)=0
-    @parameters y_max=y_max y_min=y_min
+    @variables u(t) = 0 y(t) = 0
+    @parameters y_max = y_max y_min = y_min
     ie = ifelse
     eqs = [
-    # The equation below is equivalent to y ~ clamp(u, y_min, y_max)
-        y ~ ie(u > y_max, y_max, ie((y_min < u) & (u < y_max), u, y_min))
+        # The equation below is equivalent to y ~ clamp(u, y_min, y_max)
+        y ~ ie(u > y_max, y_max, ie((y_min < u) & (u < y_max), u, y_min)),
     ]
-    System(eqs, t, name = name)
+    return System(eqs, t, name = name)
 end
 @named sat = saturation(; y_max = 1)
 # inside the linear region, the function is identity
@@ -240,23 +270,27 @@ c = 10   # Damping coefficient
 @named torque = Torque()
 
 function SystemModel(u = nothing; name = :model)
-    eqs = [connect(torque.flange, inertia1.flange_a)
-           connect(inertia1.flange_b, spring.flange_a, damper.flange_a)
-           connect(inertia2.flange_a, spring.flange_b, damper.flange_b)]
+    eqs = [
+        connect(torque.flange, inertia1.flange_a)
+        connect(inertia1.flange_b, spring.flange_a, damper.flange_a)
+        connect(inertia2.flange_a, spring.flange_b, damper.flange_b)
+    ]
     if u !== nothing
         push!(eqs, connect(torque.tau, u.output))
-        return System(eqs, t;
+        return System(
+            eqs, t;
             systems = [
                 torque,
                 inertia1,
                 inertia2,
                 spring,
                 damper,
-                u
+                u,
             ],
-            name)
+            name
+        )
     end
-    System(eqs, t; systems = [torque, inertia1, inertia2, spring, damper], name)
+    return System(eqs, t; systems = [torque, inertia1, inertia2, spring, damper], name)
 end
 
 @named r = Step(start_time = 0)
@@ -266,22 +300,26 @@ model = SystemModel()
 @named sensor = AngleSensor()
 @named er = Add(k2 = -1)
 
-connections = [connect(r.output, :r, filt.input)
-               connect(filt.output, er.input1)
-               connect(pid.ctr_output, :u, model.torque.tau)
-               connect(model.inertia2.flange_b, sensor.flange)
-               connect(sensor.phi, :y, er.input2)
-               connect(er.output, :e, pid.err_input)]
+connections = [
+    connect(r.output, :r, filt.input)
+    connect(filt.output, er.input1)
+    connect(pid.ctr_output, :u, model.torque.tau)
+    connect(model.inertia2.flange_b, sensor.flange)
+    connect(sensor.phi, :y, er.input2)
+    connect(er.output, :e, pid.err_input)
+]
 
-closed_loop = System(connections, t, systems = [model, pid, filt, sensor, r, er],
+closed_loop = System(
+    connections, t, systems = [model, pid, filt, sensor, r, er],
     name = :closed_loop, initial_conditions = [
         model.inertia1.phi => 0.0,
         model.inertia2.phi => 0.0,
         model.inertia1.w => 0.0,
         model.inertia2.w => 0.0,
         filt.x => 0.0,
-        filt.xd => 0.0
-    ])
+        filt.xd => 0.0,
+    ]
+)
 
 @test_nowarn linearize(closed_loop, :r, :y; warn_empty_op = false)
 
@@ -312,7 +350,7 @@ closed_loop = System(connections, t, systems = [model, pid, filt, sensor, r, er]
         D(m) ~ md_i - md_e,
         m ~ ρ * V,
         V ~ A * h,
-        md_e ~ K * sqrt(h / h_ς)
+        md_e ~ K * sqrt(h / h_ς),
     ]
 
     return System(equations, t, vars, pars; name, systems)
@@ -324,7 +362,7 @@ m_ss = 2.4000000003229878
 @test_nowarn linearize(tank_noi, [md_i], [h]; op = Dict(m => m_ss, md_i => 2))
 
 # Test initialization
-@variables x(t) y(t) u(t)=1.0
+@variables x(t) y(t) u(t) = 1.0
 @parameters p = 1.0
 eqs = [D(x) ~ p * u, x ~ y]
 @named sys = System(eqs, t)
@@ -352,10 +390,12 @@ end
     @named sys = System(eqs, t; initial_conditions = [p => 1.0])
     sys = complete(sys)
     @test_throws ModelingToolkit.MissingGuessError linearize(
-        sys, [x], []; op = Dict(x => 1.0), allow_input_derivatives = true)
+        sys, [x], []; op = Dict(x => 1.0), allow_input_derivatives = true
+    )
     @test_nowarn linearize(
         sys, [x], []; op = Dict(x => 1.0), guesses = Dict(y => 1.0),
-        allow_input_derivatives = true)
+        allow_input_derivatives = true
+    )
 end
 
 @testset "Symbolic values for parameters in `linearize`" begin
@@ -363,7 +403,8 @@ end
     @unpack md_i, h, m, ρ, A, K = tank_noi
     m_ss = 2.4000000003229878
     @test_nowarn linearize(
-        tank_noi, [md_i], [h]; op = Dict(m => m_ss, md_i => 2, ρ => A / K, A => 5))
+        tank_noi, [md_i], [h]; op = Dict(m => m_ss, md_i => 2, ρ => A / K, A => 5)
+    )
 end
 
 @testset "Warn on empty operating point" begin
@@ -371,5 +412,6 @@ end
     @unpack md_i, h, m = tank_noi
     m_ss = 2.4000000003229878
     @test_warn ["empty operating point", "warn_empty_op"] linearize(
-        tank_noi, [md_i], [h]; p = [md_i => 1.0, m => m_ss])
+        tank_noi, [md_i], [h]; p = [md_i => 1.0, m => m_ss]
+    )
 end

--- a/test/problem_validation.jl
+++ b/test/problem_validation.jl
@@ -11,14 +11,14 @@ using ModelingToolkit: t_nounits as t, D_nounits as D
     p = "I accidentally renamed p"
     u0 = [X => 1.0]
     ps = [p => 1.0, d => 0.5]
-    @test_throws MissingParametersError oprob=ODEProblem(osys, u0, (0.0, 1.0), ps)
+    @test_throws MissingParametersError oprob = ODEProblem(osys, u0, (0.0, 1.0), ps)
 
     @parameters p d
     ps = [p => 1.0, d => 0.5, "Random stuff" => 3.0]
-    @test_throws InvalidKeyError oprob=ODEProblem(osys, u0, (0.0, 1.0), ps)
+    @test_throws InvalidKeyError oprob = ODEProblem(osys, u0, (0.0, 1.0), ps)
 
     u0 = [:X => 1.0, "random" => 3.0]
-    @test_throws InvalidKeyError oprob=ODEProblem(osys, u0, (0.0, 1.0), ps)
+    @test_throws InvalidKeyError oprob = ODEProblem(osys, u0, (0.0, 1.0), ps)
 
     @variables x(t) y(t) z(t)
     @parameters a b c d

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,23 +11,23 @@ const GROUP = get(ENV, "GROUP", "All")
 function activate_fmi_env()
     Pkg.activate("fmi")
     Pkg.develop([MTKBasePkgSpec, PackageSpec(path = dirname(@__DIR__))])
-    Pkg.instantiate()
+    return Pkg.instantiate()
 end
 
 function activate_extensions_env()
     Pkg.activate(joinpath(MTKBasePath, "test", "extensions"))
     Pkg.develop([MTKBasePkgSpec, PackageSpec(path = dirname(@__DIR__))])
-    Pkg.instantiate()
+    return Pkg.instantiate()
 end
 
 function activate_downstream_env()
     Pkg.activate("downstream")
     Pkg.develop([MTKBasePkgSpec, PackageSpec(path = dirname(@__DIR__))])
-    Pkg.instantiate()
+    return Pkg.instantiate()
 end
 
 macro mtktestset(name, file)
-    quote
+    return quote
         @safetestset $name begin
             using ModelingToolkit
             import ModelingToolkitBase
@@ -85,7 +85,7 @@ end
             @mtktestset("OptimizationSystem Test", "optimizationsystem.jl")
         end
     end
-    
+
     if GROUP == "All" || GROUP == "SymbolicIndexingInterface"
         @mtktestset("SciML Problem Input Test", "sciml_problem_inputs.jl")
         @mtktestset("MTKParameters Test", "mtkparameters.jl")

--- a/test/scc_nonlinear_problem.jl
+++ b/test/scc_nonlinear_problem.jl
@@ -53,18 +53,26 @@ end
     function f!(du, u, (p1, p2), t)
         x = (*)(p1[4], u[1])
         y = (*)(p1[4], (+)(0.1016, (*)(-1, u[1])))
-        z1 = ifelse((<)(p2[1], 0),
+        z1 = ifelse(
+            (<)(p2[1], 0),
             (*)((*)(457896.07999999996, p1[2]), sqrt((*)(1.1686468413521012e-5, p1[3]))),
-            0)
-        z2 = ifelse((>)(p2[1], 0),
+            0
+        )
+        z2 = ifelse(
+            (>)(p2[1], 0),
             (*)((*)((*)(0.58, p1[2]), sqrt((*)(1 // 86100, p1[3]))), u[4]),
-            0)
-        z3 = ifelse((>)(p2[1], 0),
+            0
+        )
+        z3 = ifelse(
+            (>)(p2[1], 0),
             (*)((*)(457896.07999999996, p1[2]), sqrt((*)(1.1686468413521012e-5, p1[3]))),
-            0)
-        z4 = ifelse((<)(p2[1], 0),
+            0
+        )
+        z4 = ifelse(
+            (<)(p2[1], 0),
             (*)((*)((*)(0.58, p1[2]), sqrt((*)(1 // 86100, p1[3]))), u[5]),
-            0)
+            0
+        )
         du[1] = p2[1]
         du[2] = (+)(z1, (*)(-1, z2))
         du[3] = (+)(z3, (*)(-1, z4))
@@ -72,14 +80,19 @@ end
         du[5] = (+)((*)(-1, u[3]), (*)((*)(1 // 86100, x), u[5]))
     end
     p = (
-        [0.04864391799335977, 7.853981633974484e-5, 1.4034843205574914,
-            0.018241469247509915, 300237.05, 9.226186337232914],
-        [0.0508])
+        [
+            0.04864391799335977, 7.853981633974484e-5, 1.4034843205574914,
+            0.018241469247509915, 300237.05, 9.226186337232914,
+        ],
+        [0.0508],
+    )
     u0 = [0.0, 0.0, 0.0, 789476.0, 101325.0]
     tspan = (0.0, 1.0)
-    mass_matrix = [1.0 0.0 0.0 0.0 0.0; 0.0 1.0 0.0 0.0 0.0; 0.0 0.0 1.0 0.0 0.0;
-                   0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0]
-    dt = 1e-3
+    mass_matrix = [
+        1.0 0.0 0.0 0.0 0.0; 0.0 1.0 0.0 0.0 0.0; 0.0 0.0 1.0 0.0 0.0;
+        0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0
+    ]
+    dt = 1.0e-3
     function nlf(u1, (u0, p))
         resid = Any[0 for _ in u0]
         f!(resid, u1, p, 0.0)
@@ -87,15 +100,15 @@ end
     end
 
     prob = NonlinearProblem(nlf, u0, (u0, p))
-    @test_throws Exception solve(prob, SimpleNewtonRaphson(), abstol = 1e-9)
-    sol = solve(prob, TrustRegion(); abstol = 1e-9)
+    @test_throws Exception solve(prob, SimpleNewtonRaphson(), abstol = 1.0e-9)
+    sol = solve(prob, TrustRegion(); abstol = 1.0e-9)
 
     @variables u[1:5] [irreducible = true]
     @parameters p1[1:6] p2
     eqs = 0 .~ collect(nlf(u, (u0, (p1, p2))))
     @mtkcompile sys = System(eqs, [u], [p1, p2])
     sccprob = SCCNonlinearProblem(sys, [u => u0, p1 => p[1], p2 => p[2][]])
-    sccsol = solve(sccprob, SimpleNewtonRaphson(); abstol = 1e-9)
+    sccsol = solve(sccprob, SimpleNewtonRaphson(); abstol = 1.0e-9)
     sccresid = prob.f(sccsol[u], (u0, p))
     @test SciMLBase.successful_retcode(sccsol)
     @test norm(sccresid) < norm(sol.resid)
@@ -105,17 +118,17 @@ end
 end
 
 @testset "Transistor amplifier" begin
-    C = [k * 1e-6 for k in 1:5]
+    C = [k * 1.0e-6 for k in 1:5]
     Ub = 6
     UF = 0.026
     α = 0.99
-    β = 1e-6
+    β = 1.0e-6
     R0 = 1000
     R = 9000
     Ue(t) = 0.1 * sin(200 * π * t)
 
     function transamp(out, du, u, p, t)
-        g(x) = 1e-6 * (exp(x / 0.026) - 1)
+        g(x) = 1.0e-6 * (exp(x / 0.026) - 1)
         y1, y2, y3, y4, y5, y6, y7, y8 = u
         out[1] = -Ue(t) / R0 + y1 / R0 + C[1] * du[1] - C[1] * du[2]
         out[2] = -Ub / R + y2 * 2 / R - (α - 1) * g(y2 - y3) - C[1] * du[1] + C[1] * du[2]
@@ -136,7 +149,7 @@ end
         -24.9757667,
         -Ub / (2 * (C[4] * R)),
         -10.00564453,
-        -10.00564453
+        -10.00564453,
     ]
     daeprob = DAEProblem(transamp, du0, u0, (0.0, 0.1))
     daesol = solve(daeprob, DImplicitEuler())
@@ -155,12 +168,12 @@ end
     eqs = substitute.(eqs, (subrules,))
     @mtkcompile sys = System(eqs)
     prob = NonlinearProblem(sys, [y => u0, t => t0])
-    sol = solve(prob, NewtonRaphson(); abstol = 1e-12)
+    sol = solve(prob, NewtonRaphson(); abstol = 1.0e-12)
 
     sccprob = SCCNonlinearProblem(sys, [y => u0, t => t0])
-    sccsol = solve(sccprob, NewtonRaphson(); abstol = 1e-12)
+    sccsol = solve(sccprob, NewtonRaphson(); abstol = 1.0e-12)
 
-    @test sol.u≈sccsol.u atol=1e-10
+    @test sol.u ≈ sccsol.u atol = 1.0e-10
 
     # Test BLT sorted
     @test istril(StructuralTransformations.sorted_incidence_matrix(sys), 1)
@@ -174,10 +187,14 @@ end
         x + y
     end
     @register_symbolic func(x, y)
-    @mtkcompile sys = System([0 ~ x[1]^3 + x[2]^3 - 5
-                              0 ~ sin(x[1] - x[2]) - 0.5
-                              0 ~ func(x[1], x[2]) * exp(x[3]) - x[4]^3 - 5
-                              0 ~ func(x[1], x[2]) * exp(x[4]) - x[3]^3 - 4])
+    @mtkcompile sys = System(
+        [
+            0 ~ x[1]^3 + x[2]^3 - 5
+            0 ~ sin(x[1] - x[2]) - 0.5
+            0 ~ func(x[1], x[2]) * exp(x[3]) - x[4]^3 - 5
+            0 ~ func(x[1], x[2]) * exp(x[4]) - x[3]^3 - 4
+        ]
+    )
     sccprob = SCCNonlinearProblem(sys, [])
     @test val[] == 0
     sccsol = solve(sccprob, NewtonRaphson())
@@ -192,25 +209,29 @@ import ModelingToolkitStandardLibrary.Hydraulic.IsothermalCompressible as IC
 @testset "Caching of subexpressions of different types" begin
     liquid_pressure(rho, rho_0, bulk) = (rho / rho_0 - 1) * bulk
     gas_pressure(rho, rho_0, p_gas, rho_gas) = rho * ((0 - p_gas) / (rho_0 - rho_gas))
-    full_pressure(rho,
+    full_pressure(
+        rho,
         rho_0,
         bulk,
         p_gas,
-        rho_gas) = ifelse(
+        rho_gas
+    ) = ifelse(
         rho >= rho_0, liquid_pressure(rho, rho_0, bulk),
-        gas_pressure(rho, rho_0, p_gas, rho_gas))
+        gas_pressure(rho, rho_0, p_gas, rho_gas)
+    )
 
     @component function Volume(;
             #parameters
             area,
             direction = +1,
             x_int,
-            name)
+            name
+        )
         pars = @parameters begin
             area = area
             x_int = x_int
             rho_0 = 1000
-            bulk = 1e9
+            bulk = 1.0e9
             p_gas = -1000
             rho_gas = 1
         end
@@ -231,49 +252,54 @@ import ModelingToolkitStandardLibrary.Hydraulic.IsothermalCompressible as IC
         end
 
         eqs = [
-               # connectors
-               port.p ~ p
-               port.dm ~ dm
-               flange.v * direction ~ dx
-               flange.f * direction ~ -f
+            # connectors
+            port.p ~ p
+            port.dm ~ dm
+            flange.v * direction ~ dx
+            flange.f * direction ~ -f
 
-               # differentials
-               D(x) ~ dx
-               D(m) ~ dm
+            # differentials
+            D(x) ~ dx
+            D(m) ~ dm
 
-               # physics
-               p ~ full_pressure(rho, rho_0, bulk, p_gas, rho_gas)
-               f ~ p * area
-               m ~ rho * x * area]
+            # physics
+            p ~ full_pressure(rho, rho_0, bulk, p_gas, rho_gas)
+            f ~ p * area
+            m ~ rho * x * area
+        ]
 
         return System(eqs, t, vars, pars; name, systems)
     end
 
     systems = @named begin
-        fluid = IC.HydraulicFluid(; bulk_modulus = 1e9)
+        fluid = IC.HydraulicFluid(; bulk_modulus = 1.0e9)
 
-        src1 = IC.Pressure(;)
-        src2 = IC.Pressure(;)
+        src1 = IC.Pressure()
+        src2 = IC.Pressure()
 
         vol1 = Volume(; area = 0.01, direction = +1, x_int = 0.1)
         vol2 = Volume(; area = 0.01, direction = +1, x_int = 0.1)
 
         mass = T.Mass(; m = 10)
 
-        sin1 = B.Sine(; frequency = 0.5, amplitude = +0.5e5, offset = 10e5)
-        sin2 = B.Sine(; frequency = 0.5, amplitude = -0.5e5, offset = 10e5)
+        sin1 = B.Sine(; frequency = 0.5, amplitude = +0.5e5, offset = 10.0e5)
+        sin2 = B.Sine(; frequency = 0.5, amplitude = -0.5e5, offset = 10.0e5)
     end
 
-    eqs = [connect(fluid, src1.port)
-           connect(fluid, src2.port)
-           connect(src1.port, vol1.port)
-           connect(src2.port, vol2.port)
-           connect(vol1.flange, mass.flange, vol2.flange)
-           connect(src1.p, sin1.output)
-           connect(src2.p, sin2.output)]
+    eqs = [
+        connect(fluid, src1.port)
+        connect(fluid, src2.port)
+        connect(src1.port, vol1.port)
+        connect(src2.port, vol2.port)
+        connect(vol1.flange, mass.flange, vol2.flange)
+        connect(src1.p, sin1.output)
+        connect(src2.p, sin2.output)
+    ]
 
-    initialization_eqs = [mass.s ~ 0.0
-                          mass.v ~ 0.0]
+    initialization_eqs = [
+        mass.s ~ 0.0
+        mass.v ~ 0.0
+    ]
 
     @mtkcompile sys = System(eqs, t, [], []; systems, initialization_eqs)
     prob = ODEProblem(sys, [], (0, 5))
@@ -284,8 +310,11 @@ end
 @testset "Array variables split across SCCs" begin
     @variables x[1:3]
     @parameters (f::Function)(..)
-    @mtkcompile sys = System([
-        0 ~ x[1]^2 - 9, x[2] ~ 2x[1], 0 ~ x[3]^2 - x[1]^2 + f(x)])
+    @mtkcompile sys = System(
+        [
+            0 ~ x[1]^2 - 9, x[2] ~ 2x[1], 0 ~ x[3]^2 - x[1]^2 + f(x),
+        ]
+    )
     prob = SCCNonlinearProblem(sys, [x => ones(3), f => sum])
     sol = solve(prob, NewtonRaphson())
     @test SciMLBase.successful_retcode(sol)
@@ -296,15 +325,20 @@ end
     @parameters σ β ρ
     @mtkcompile fullsys = System(
         [0 ~ x^3 * β + y^3 * ρ - σ, 0 ~ x^2 + 2x * y + y^2, 0 ~ z^2 - 4z + 4],
-        [x, y, z], [σ, β, ρ])
+        [x, y, z], [σ, β, ρ]
+    )
 
-    u0 = [x => 1.0,
+    u0 = [
+        x => 1.0,
         y => 0.0,
-        z => 0.0]
+        z => 0.0,
+    ]
 
-    p = [σ => 28.0,
+    p = [
+        σ => 28.0,
         ρ => 10.0,
-        β => 8 / 3]
+        β => 8 / 3,
+    ]
 
     sccprob = SCCNonlinearProblem(fullsys, [u0; p])
     @test isequal(parameters(fullsys), parameters(sccprob.f.sys))

--- a/test/semilinearodeproblem.jl
+++ b/test/semilinearodeproblem.jl
@@ -11,117 +11,120 @@ using ModelingToolkit: t_nounits as t, D_nounits as D
 
         # 1: H2
         du[1] = -1.2e-17 * u[1] +
-                n_H * (1.9e-6 * u[2] * u[3]) / (T^0.54) -
-                n_H * 4e-16 * u[1] * u[12] -
-                n_H * 7e-15 * u[1] * u[5] +
-                n_H * 1.7e-9 * u[10] * u[2] +
-                n_H * 2e-9 * u[2] * u[6] +
-                n_H * 2e-9 * u[2] * u[14] +
-                n_H * 8e-10 * u[2] * u[8] + sin(u[1]) / 1e20 # artificial nonlinear term for testing
+            n_H * (1.9e-6 * u[2] * u[3]) / (T^0.54) -
+            n_H * 4.0e-16 * u[1] * u[12] -
+            n_H * 7.0e-15 * u[1] * u[5] +
+            n_H * 1.7e-9 * u[10] * u[2] +
+            n_H * 2.0e-9 * u[2] * u[6] +
+            n_H * 2.0e-9 * u[2] * u[14] +
+            n_H * 8.0e-10 * u[2] * u[8] + sin(u[1]) / 1.0e20 # artificial nonlinear term for testing
 
         # 2: H3+
         du[2] = 1.2e-17 * u[1] +
-                n_H * (-1.9e-6 * u[3] * u[2]) / (T^0.54) -
-                n_H * 1.7e-9 * u[10] * u[2] -
-                n_H * 2e-9 * u[2] * u[6] -
-                n_H * 2e-9 * u[2] * u[14] -
-                n_H * 8e-10 * u[2] * u[8]
+            n_H * (-1.9e-6 * u[3] * u[2]) / (T^0.54) -
+            n_H * 1.7e-9 * u[10] * u[2] -
+            n_H * 2.0e-9 * u[2] * u[6] -
+            n_H * 2.0e-9 * u[2] * u[14] -
+            n_H * 8.0e-10 * u[2] * u[8]
 
         # 3: e
         du[3] = n_H * (-1.4e-10 * u[3] * u[12]) / (T^0.61) -
-                n_H * (3.8e-10 * u[13] * u[3]) / (T^0.65) -
-                n_H * (3.3e-5 * u[11] * u[3]) / T +
-                1.2e-17 * u[1] -
-                n_H * (1.9e-6 * u[3] * u[2]) / (T^0.54) +
-                6.8e-18 * u[4] -
-                n_H * (9e-11 * u[3] * u[5]) / (T^0.64) +
-                3e-10 * Go * exp(-3 * Av) * u[6] +
-                n_H * 2e-9 * u[2] * u[13]
+            n_H * (3.8e-10 * u[13] * u[3]) / (T^0.65) -
+            n_H * (3.3e-5 * u[11] * u[3]) / T +
+            1.2e-17 * u[1] -
+            n_H * (1.9e-6 * u[3] * u[2]) / (T^0.54) +
+            6.8e-18 * u[4] -
+            n_H * (9.0e-11 * u[3] * u[5]) / (T^0.64) +
+            3.0e-10 * Go * exp(-3 * Av) * u[6] +
+            n_H * 2.0e-9 * u[2] * u[13]
         +2.0e-10 * Go * exp(-1.9 * Av) * u[14]
 
         # 4: He
-        du[4] = n_H * (9e-11 * u[3] * u[5]) / (T^0.64) -
-                6.8e-18 * u[4] +
-                n_H * 7e-15 * u[1] * u[5] +
-                n_H * 1.6e-9 * u[10] * u[5]
+        du[4] = n_H * (9.0e-11 * u[3] * u[5]) / (T^0.64) -
+            6.8e-18 * u[4] +
+            n_H * 7.0e-15 * u[1] * u[5] +
+            n_H * 1.6e-9 * u[10] * u[5]
 
         # 5: He+
         du[5] = 6.8e-18 * u[4] -
-                n_H * (9e-11 * u[3] * u[5]) / (T^0.64) -
-                n_H * 7e-15 * u[1] * u[5] -
-                n_H * 1.6e-9 * u[10] * u[5]
+            n_H * (9.0e-11 * u[3] * u[5]) / (T^0.64) -
+            n_H * 7.0e-15 * u[1] * u[5] -
+            n_H * 1.6e-9 * u[10] * u[5]
 
         # 6: C
         du[6] = n_H * (1.4e-10 * u[3] * u[12]) / (T^0.61) -
-                n_H * 2e-9 * u[2] * u[6] -
-                n_H * 5.8e-12 * (T^0.5) * u[9] * u[6] +
-                1e-9 * Go * exp(-1.5 * Av) * u[7] -
-                3e-10 * Go * exp(-3 * Av) * u[6] +
-                1e-10 * Go * exp(-3 * Av) * u[10] * shield
+            n_H * 2.0e-9 * u[2] * u[6] -
+            n_H * 5.8e-12 * (T^0.5) * u[9] * u[6] +
+            1.0e-9 * Go * exp(-1.5 * Av) * u[7] -
+            3.0e-10 * Go * exp(-3 * Av) * u[6] +
+            1.0e-10 * Go * exp(-3 * Av) * u[10] * shield
 
         # 7: CHx
-        du[7] = n_H * (-2e-10) * u[7] * u[8] +
-                n_H * 4e-16 * u[1] * u[12] +
-                n_H * 2e-9 * u[2] * u[6] -
-                1e-9 * Go * u[7] * exp(-1.5 * Av)
+        du[7] = n_H * (-2.0e-10) * u[7] * u[8] +
+            n_H * 4.0e-16 * u[1] * u[12] +
+            n_H * 2.0e-9 * u[2] * u[6] -
+            1.0e-9 * Go * u[7] * exp(-1.5 * Av)
 
         # 8: O
-        du[8] = n_H * (-2e-10) * u[7] * u[8] +
-                n_H * 1.6e-9 * u[10] * u[5] -
-                n_H * 8e-10 * u[2] * u[8] +
-                5e-10 * Go * exp(-1.7 * Av) * u[9] +
-                1e-10 * Go * exp(-3 * Av) * u[10] * shield
+        du[8] = n_H * (-2.0e-10) * u[7] * u[8] +
+            n_H * 1.6e-9 * u[10] * u[5] -
+            n_H * 8.0e-10 * u[2] * u[8] +
+            5.0e-10 * Go * exp(-1.7 * Av) * u[9] +
+            1.0e-10 * Go * exp(-3 * Av) * u[10] * shield
 
         # 9: OHx
-        du[9] = n_H * (-1e-9) * u[9] * u[12] +
-                n_H * 8e-10 * u[2] * u[8] -
-                n_H * 5.8e-12 * (T^0.5) * u[9] * u[6] -
-                5e-10 * Go * exp(-1.7 * Av) * u[9]
+        du[9] = n_H * (-1.0e-9) * u[9] * u[12] +
+            n_H * 8.0e-10 * u[2] * u[8] -
+            n_H * 5.8e-12 * (T^0.5) * u[9] * u[6] -
+            5.0e-10 * Go * exp(-1.7 * Av) * u[9]
 
         # 10: CO
         du[10] = n_H * (3.3e-5 * u[11] * u[3]) / T +
-                 n_H * 2e-10 * u[7] * u[8] -
-                 n_H * 1.7e-9 * u[10] * u[2] -
-                 n_H * 1.6e-9 * u[10] * u[5] +
-                 n_H * 5.8e-12 * (T^0.5) * u[9] * u[6] -
-                 1e-10 * Go * exp(-3 * Av) * u[10] +
-                 1.5e-10 * Go * exp(-2.5 * Av) * u[11] * shield
+            n_H * 2.0e-10 * u[7] * u[8] -
+            n_H * 1.7e-9 * u[10] * u[2] -
+            n_H * 1.6e-9 * u[10] * u[5] +
+            n_H * 5.8e-12 * (T^0.5) * u[9] * u[6] -
+            1.0e-10 * Go * exp(-3 * Av) * u[10] +
+            1.5e-10 * Go * exp(-2.5 * Av) * u[11] * shield
 
         # 11: HCO+
         du[11] = n_H * (-3.3e-5 * u[11] * u[3]) / T +
-                 n_H * 1e-9 * u[9] * u[12] +
-                 n_H * 1.7e-9 * u[10] * u[2] -
-                 1.5e-10 * Go * exp(-2.5 * Av) * u[11]
+            n_H * 1.0e-9 * u[9] * u[12] +
+            n_H * 1.7e-9 * u[10] * u[2] -
+            1.5e-10 * Go * exp(-2.5 * Av) * u[11]
 
         # 12: C+
         du[12] = n_H * (-1.4e-10 * u[3] * u[12]) / (T^0.61) -
-                 n_H * 4e-16 * u[1] * u[12] -
-                 n_H * 1e-9 * u[9] * u[12] +
-                 n_H * 1.6e-9 * u[10] * u[5] +
-                 3e-10 * Go * exp(-3 * Av) * u[6]
+            n_H * 4.0e-16 * u[1] * u[12] -
+            n_H * 1.0e-9 * u[9] * u[12] +
+            n_H * 1.6e-9 * u[10] * u[5] +
+            3.0e-10 * Go * exp(-3 * Av) * u[6]
 
         # 13: M+
         du[13] = n_H * (-3.8e-10 * u[13] * u[3]) / (T^0.65) +
-                 n_H * 2e-9 * u[2] * u[14] +
-                 2.0e-10 * Go * exp(-1.9 * Av) * u[14]
+            n_H * 2.0e-9 * u[2] * u[14] +
+            2.0e-10 * Go * exp(-1.9 * Av) * u[14]
 
         # 14: M
         du[14] = n_H * (3.8e-10 * u[13] * u[3]) / (T^0.65) -
-                 n_H * 2e-9 * u[2] * u[14] -
-                 2.0e-10 * Go * exp(-1.9 * Av) * u[14]
+            n_H * 2.0e-9 * u[2] * u[14] -
+            2.0e-10 * Go * exp(-1.9 * Av) * u[14]
     end
 
     # Set the Timespan, Parameters, and Initial Conditions
     seconds_per_year = 3600 * 24 * 365
     tspan = (0.0, 30000 * seconds_per_year) # ~30 thousand yrs
 
-    params = (10,  # T
+    params = (
+        10,  # T
         2,   # Av
         1.7, # Go
         611, # n_H
-        1)   # shield
+        1,
+    )   # shield
 
-    u0 = [0.5,      # 1:  H2
+    u0 = [
+        0.5,      # 1:  H2
         9.059e-9, # 2:  H3+
         2.0e-4,   # 3:  e
         0.1,      # 4:  He
@@ -134,7 +137,8 @@ using ModelingToolkit: t_nounits as t, D_nounits as D
         0.0,      # 11: HCO+
         0.0002,   # 12: C+
         2.0e-7,   # 13: M+
-        2.0e-7]   # 14: M
+        2.0e-7,
+    ]   # 14: M
 
     prob = ODEProblem(Nelson!, u0, tspan, params)
     sys = mtkcompile(modelingtoolkitize(prob))
@@ -153,23 +157,29 @@ using ModelingToolkit: t_nounits as t, D_nounits as D
     linear_val = linear_fun(prob.u0, prob.p, 0.0)
     quadratic_val = quadratic_fun(prob.u0, prob.p, 0.0)
     nonlinear_val = nonlinear_fun(prob.u0, prob.p, 0.0)
-    refsol = solve(prob, Vern9(); abstol = 1e-14, reltol = 1e-14)
+    refsol = solve(prob, Vern9(); abstol = 1.0e-14, reltol = 1.0e-14)
 
     @testset "stiff_linear: $stiff_linear, stiff_quadratic: $stiff_quadratic, stiff_nonlinear: $stiff_nonlinear" for (
-        stiff_linear, stiff_quadratic, stiff_nonlinear) in Iterators.product(
-        [false, true], [false, true], [false, true])
+            stiff_linear, stiff_quadratic, stiff_nonlinear,
+        ) in Iterators.product(
+            [false, true], [false, true], [false, true]
+        )
         kwargs = (; stiff_linear, stiff_quadratic, stiff_nonlinear)
         if stiff_linear == stiff_quadratic == stiff_nonlinear
             if stiff_linear
                 @test_throws ["All of", "cannot be stiff"] SemilinearODEProblem(
-                    sys, nothing, tspan; kwargs...)
+                    sys, nothing, tspan; kwargs...
+                )
                 @test_throws ["All of", "cannot be stiff"] SemilinearODEFunction(
-                    sys; kwargs...)
+                    sys; kwargs...
+                )
             else
                 @test_throws ["All of", "cannot be non-stiff"] SemilinearODEProblem(
-                    sys, nothing, tspan; kwargs...)
+                    sys, nothing, tspan; kwargs...
+                )
                 @test_throws ["All of", "cannot be non-stiff"] SemilinearODEFunction(
-                    sys; kwargs...)
+                    sys; kwargs...
+                )
             end
             continue
         end
@@ -182,11 +192,11 @@ using ModelingToolkit: t_nounits as t, D_nounits as D
 
         @testset "Standard" begin
             prob = SemilinearODEProblem(sys, nothing, tspan; kwargs...)
-            @test prob.f.f1(prob.u0, prob.p, 0.0)≈reference_f1 atol=1e-10
-            @test prob.f.f2(prob.u0, prob.p, 0.0)≈reference_f2 atol=1e-10
+            @test prob.f.f1(prob.u0, prob.p, 0.0) ≈ reference_f1 atol = 1.0e-10
+            @test prob.f.f2(prob.u0, prob.p, 0.0) ≈ reference_f2 atol = 1.0e-10
             sol = solve(prob, KenCarp47())
             @test SciMLBase.successful_retcode(sol)
-            @test refsol(sol.t).u≈sol.u atol=1e-8 rtol=1e-8
+            @test refsol(sol.t).u ≈ sol.u atol = 1.0e-8 rtol = 1.0e-8
         end
 
         @testset "Symbolic jacobian" begin
@@ -194,22 +204,24 @@ using ModelingToolkit: t_nounits as t, D_nounits as D
             @test prob.f.f1.jac !== nothing
             sol = solve(prob, KenCarp47())
             @test SciMLBase.successful_retcode(sol)
-            @test refsol(sol.t).u≈sol.u atol=1e-8 rtol=1e-8
+            @test refsol(sol.t).u ≈ sol.u atol = 1.0e-8 rtol = 1.0e-8
         end
 
         @testset "Sparse" begin
             @test_throws ["sparse form", "unavailable"] SemilinearODEProblem(
-                sys, nothing, tspan; sparse = true, kwargs...)
+                sys, nothing, tspan; sparse = true, kwargs...
+            )
             @test_skip begin
                 sol = solve(prob, KenCarp47())
                 @test SciMLBase.successful_retcode(sol)
-                @test refsol(sol.t).u≈sol.u atol=1e-8 rtol=1e-8
+                @test refsol(sol.t).u ≈ sol.u atol = 1.0e-8 rtol = 1.0e-8
             end
         end
 
         @testset "Sparsejac" begin
             @test_throws ["sparse form", "unavailable"] SemilinearODEProblem(
-                sys, nothing, tspan; jac = true, sparse = true, kwargs...)
+                sys, nothing, tspan; jac = true, sparse = true, kwargs...
+            )
         end
     end
 end

--- a/test/structural_transformation/index_reduction.jl
+++ b/test/structural_transformation/index_reduction.jl
@@ -12,30 +12,40 @@ using ModelingToolkit: t_nounits as t, D_nounits as D
 @variables x(t) y(t) z(t) w(t) T(t)
 
 # Simple pendulum in cartesian coordinates
-eqs = [D(x) ~ w,
+eqs = [
+    D(x) ~ w,
     D(y) ~ z,
     D(w) ~ T * x,
     D(z) ~ T * y - g,
-    0 ~ x^2 + y^2 - L^2]
+    0 ~ x^2 + y^2 - L^2,
+]
 pendulum = System(eqs, t, [x, y, w, z, T], [L, g], name = :pendulum)
 
 state = TearingState(pendulum)
 @unpack graph, var_to_diff = state.structure
-@test StructuralTransformations.maximal_matching(graph, eq -> true,
-    v -> var_to_diff[v] === nothing) ==
-      map(x -> x == 0 ? StructuralTransformations.unassigned : x,
-    [3, 4, 2, 5, 0, 0, 0, 0, 0])
+@test StructuralTransformations.maximal_matching(
+    graph, eq -> true,
+    v -> var_to_diff[v] === nothing
+) ==
+    map(
+    x -> x == 0 ? StructuralTransformations.unassigned : x,
+    [3, 4, 2, 5, 0, 0, 0, 0, 0]
+)
 
-eqs2 = [D(D(x)) ~ T * x,
+eqs2 = [
+    D(D(x)) ~ T * x,
     D(D(y)) ~ T * y - g,
-    0 ~ x^2 + y^2 - L^2]
+    0 ~ x^2 + y^2 - L^2,
+]
 pendulum2 = System(eqs2, t, [x, y, T], [L, g], name = :pendulum)
 
-eqs = [D(x) ~ w,
+eqs = [
+    D(x) ~ w,
     D(y) ~ z,
     D(w) ~ T * x,
     D(z) ~ T * y - g,
-    0 ~ x^2 + y^2 - L^2]
+    0 ~ x^2 + y^2 - L^2,
+]
 pendulum = System(eqs, t, [x, y, w, z, T], [L, g], name = :pendulum)
 
 let sys = mtkcompile(pendulum2)
@@ -46,27 +56,30 @@ let sys = mtkcompile(pendulum2)
         x => sqrt(2) / 2,
         y => sqrt(2) / 2,
         L => 1.0,
-        g => 9.8
+        g => 9.8,
     ]
 
     prob_auto = ODEProblem(sys, ivs, (0.0, 0.5), guesses = [T => 0.0])
     sol = solve(prob_auto, FBDF())
     @test sol.retcode == ReturnCode.Success
-    @test norm(sol[x] .^ 2 + sol[y] .^ 2 .- 1) < 1e-2
+    @test norm(sol[x] .^ 2 + sol[y] .^ 2 .- 1) < 1.0e-2
 end
 
 let
     @parameters g
     @variables x(t) [state_priority = 10] y(t) λ(t)
 
-    eqs = [D(D(x)) ~ λ * x
-           D(D(y)) ~ λ * y - g
-           x^2 + y^2 ~ 1]
+    eqs = [
+        D(D(x)) ~ λ * x
+        D(D(y)) ~ λ * y - g
+        x^2 + y^2 ~ 1
+    ]
     @named pend = System(eqs, t)
     sys = complete(mtkcompile(pend; dummy_derivative = false))
     prob = ODEProblem(
-        sys, [x => 1, y => 0, D(x) => 0.0, g => 1], (0.0, 10.0), guesses = [λ => 0.0])
+        sys, [x => 1, y => 0, D(x) => 0.0, g => 1], (0.0, 10.0), guesses = [λ => 0.0]
+    )
     sol = solve(prob, Rodas5P())
     @test SciMLBase.successful_retcode(sol)
-    @test sol[x ^ 2 + y ^ 2][end] < 1.1
+    @test sol[x^2 + y^2][end] < 1.1
 end

--- a/test/structural_transformation/utils.jl
+++ b/test/structural_transformation/utils.jl
@@ -18,11 +18,13 @@ const ST = StructuralTransformations
 @variables x(t) y(t) w(t) z(t) T(t)
 
 # Simple pendulum in cartesian coordinates
-eqs = [D(x) ~ w,
+eqs = [
+    D(x) ~ w,
     D(y) ~ z,
     D(w) ~ T * x,
     D(z) ~ T * y - g,
-    0 ~ x^2 + y^2 - L^2]
+    0 ~ x^2 + y^2 - L^2,
+]
 pendulum = System(eqs, t, [x, y, w, z, T], [L, g], name = :pendulum)
 state = TearingState(pendulum)
 StateSelection.find_solvables!(state)
@@ -54,7 +56,8 @@ end
     @parameters foo(::AbstractVector)[1:2]
     _tmp_fn(x) = 2x
     @mtkcompile sys = System(
-        [D(x) ~ z[1] + z[2] + foo(z)[1], y[1] ~ 2t, y[2] ~ 3t, z ~ foo(y)], t)
+        [D(x) ~ z[1] + z[2] + foo(z)[1], y[1] ~ 2t, y[2] ~ 3t, z ~ foo(y)], t
+    )
     @test length(equations(sys)) == 1
     @test length(observed(sys)) == 6
     @test any(obs -> isequal(obs, y), observables(sys))
@@ -77,7 +80,8 @@ end
         @parameters foo(::AbstractVector)[1:2]
         _tmp_fn(x) = 2x
         @named sys = System(
-            [D(x) ~ z[1] + z[2] + foo(z)[1], y[1] ~ 2t, y[2] ~ 3t, z ~ foo(y)], t)
+            [D(x) ~ z[1] + z[2] + foo(z)[1], y[1] ~ 2t, y[2] ~ 3t, z ~ foo(y)], t
+        )
 
         sys2 = mtkcompile(sys; reassemble_alg)
         @test length(observed(sys2)) == 4
@@ -91,7 +95,8 @@ end
         @parameters foo(::AbstractVector)[1:2]
         _tmp_fn(x) = 2x
         @named sys = System(
-            [D(x) ~ z[1] + z[2] + foo(z)[1] + w, y[1] ~ 2t, y[2] ~ 3t, z ~ foo(y)], t)
+            [D(x) ~ z[1] + z[2] + foo(z)[1] + w, y[1] ~ 2t, y[2] ~ 3t, z ~ foo(y)], t
+        )
 
         sys2 = mtkcompile(sys; reassemble_alg, fully_determined = false)
         @test length(observed(sys2)) == 4
@@ -117,17 +122,22 @@ end
 
     # Expand shifts
     @test isequal(
-        ST.distribute_shift(Shift(t, -1)(x + y)), Shift(t, -1)(x) + Shift(t, -1)(y))
+        ST.distribute_shift(Shift(t, -1)(x + y)), Shift(t, -1)(x) + Shift(t, -1)(y)
+    )
 
     expr = a * Shift(t, -2)(x) + Shift(t, 2)(y) + b
-    @test isequal(ST.simplify_shifts(ST.distribute_shift(Shift(t, 2)(expr))),
-        a * x + Shift(t, 4)(y) + b)
+    @test isequal(
+        ST.simplify_shifts(ST.distribute_shift(Shift(t, 2)(expr))),
+        a * x + Shift(t, 4)(y) + b
+    )
     @test isequal(ST.distribute_shift(Shift(t, 2)(exp(z))), exp(Shift(t, 2)(z)))
     @test isequal(ST.distribute_shift(Shift(t, 2)(exp(a) + b)), exp(a) + b)
 
     expr = a^x - log(b * y) + z * x
-    @test isequal(ST.distribute_shift(Shift(t, -3)(expr)),
-        a^(Shift(t, -3)(x)) - log(b * Shift(t, -3)(y)) + Shift(t, -3)(z) * Shift(t, -3)(x))
+    @test isequal(
+        ST.distribute_shift(Shift(t, -3)(expr)),
+        a^(Shift(t, -3)(x)) - log(b * Shift(t, -3)(y)) + Shift(t, -3)(z) * Shift(t, -3)(x)
+    )
 
     expr = x(k + 1) ~ x + x(k - 1)
     @test isequal(ST.distribute_shift(Shift(t, -1)(expr)), x ~ x(k - 1) + x(k - 2))
@@ -152,9 +162,11 @@ end
         @testset "With dummy derivatives" begin
             @parameters g
             @variables x(t) y(t) [state_priority = 10] λ(t)
-            eqs = [D(D(x)) ~ λ * x
-                   D(D(y)) ~ λ * y - g
-                   x^2 + y^2 ~ 1]
+            eqs = [
+                D(D(x)) ~ λ * x
+                D(D(y)) ~ λ * y - g
+                x^2 + y^2 ~ 1
+            ]
             @mtkcompile sys = System(eqs, t)
             mapping = map_variables_to_equations(sys)
 
@@ -181,11 +193,13 @@ end
         end
         @testset "DDEs" begin
             function oscillator(; name, k = 1.0, τ = 0.01)
-                @parameters k=k τ=τ
-                @variables x(..)=0.1 y(t)=0.1 jcn(t)=0.0 delx(t)
-                eqs = [D(x(t)) ~ y,
+                @parameters k = k τ = τ
+                @variables x(..) = 0.1 y(t) = 0.1 jcn(t) = 0.0 delx(t)
+                eqs = [
+                    D(x(t)) ~ y,
                     D(y) ~ -k * x(t - τ) + jcn,
-                    delx ~ x(t - τ)]
+                    delx ~ x(t - τ),
+                ]
                 return System(eqs, t; name = name)
             end
 
@@ -193,8 +207,10 @@ end
                 osc1 = oscillator(k = 1.0, τ = 0.01)
                 osc2 = oscillator(k = 2.0, τ = 0.04)
             end
-            eqs = [osc1.jcn ~ osc2.delx,
-                osc2.jcn ~ osc1.delx]
+            eqs = [
+                osc1.jcn ~ osc2.delx,
+                osc2.jcn ~ osc1.delx,
+            ]
             @named coupledOsc = System(eqs, t)
             @mtkcompile sys = compose(coupledOsc, systems)
             mapping = map_variables_to_equations(sys)
@@ -236,9 +252,11 @@ end
             ddx(t)
         end
         systems = []
-        eqs = [D(x) ~ dx
-               D(dx) ~ ddx
-               dx ~ (k - x) / T]
+        eqs = [
+            D(x) ~ dx
+            D(dx) ~ ddx
+            dx ~ (k - x) / T
+        ]
         evt = SymbolicDiscreteCallback([1.0], [k ~ x]; discrete_parameters = [k])
         return System(eqs, t, [vars; discs], params; systems, name, discrete_events = [evt])
     end
@@ -256,10 +274,12 @@ end
             ddx(t)
         end
         systems = []
-        eqs = [D(x) ~ dx
-               D(dx) ~ ddx
-               D(k[1]) ~ 1.0
-               dx ~ (k[1] - x) / T]
+        eqs = [
+            D(x) ~ dx
+            D(dx) ~ ddx
+            D(k[1]) ~ 1.0
+            dx ~ (k[1] - x) / T
+        ]
         evt = SymbolicDiscreteCallback([1.0], [k[1] ~ x]; discrete_parameters = [k])
         return System(eqs, t, [vars; discs], params; systems, name, discrete_events = [evt])
     end
@@ -277,10 +297,12 @@ end
             ddx(t)
         end
         systems = []
-        eqs = [D(x) ~ dx
-               D(dx) ~ ddx
-               dx ~ (k - x) / T
-               D(k) ~ missing]
+        eqs = [
+            D(x) ~ dx
+            D(dx) ~ ddx
+            dx ~ (k - x) / T
+            D(k) ~ missing
+        ]
         evt = SymbolicDiscreteCallback([1.0], [k ~ x]; discrete_parameters = [k])
         return System(eqs, t, [vars; discs], params; systems, name, discrete_events = [evt])
     end
@@ -320,9 +342,11 @@ end
                 ddx(t)
             end
             systems = []
-            eqs = [D(x) ~ dx
-                   D(dx) ~ ddx
-                   dx ~ (k(t) - x) / T]
+            eqs = [
+                D(x) ~ dx
+                D(dx) ~ ddx
+                dx ~ (k(t) - x) / T
+            ]
             return System(eqs, t, vars, params; systems, name)
         end
 
@@ -344,23 +368,27 @@ end
         @variables x(t) p
         @parameters q
         @discretes y(t)
-        @mtkcompile sys = System([D(x) ~ x * q, x^2 + y^2 ~ p], t, [x, y],
+        @mtkcompile sys = System(
+            [D(x) ~ x * q, x^2 + y^2 ~ p], t, [x, y],
             [p, q]; initialization_eqs = [p + q ~ 3],
-            bindings = [p => missing], guesses = [p => 1.0, y => 1.0])
+            bindings = [p => missing], guesses = [p => 1.0, y => 1.0]
+        )
         @test length(equations(sys)) == 2
         @test length(parameters(sys)) == 2
         prob = ODEProblem(sys, [x => 1.0, q => 2.0], (0.0, 1.0))
-        integ = init(prob, Rodas5P(); abstol = 1e-10, reltol = 1e-8)
-        @test integ.ps[p]≈1.0 atol=1e-6
-        @test integ[y]≈0.0 atol=1e-5
+        integ = init(prob, Rodas5P(); abstol = 1.0e-10, reltol = 1.0e-8)
+        @test integ.ps[p] ≈ 1.0 atol = 1.0e-6
+        @test integ[y] ≈ 0.0 atol = 1.0e-5
     end
 
     @testset "NonlinearSystem" begin
         @variables x p
         @parameters y q
-        @mtkcompile sys = System([0 ~ p * x + y, x^3 + y^3 ~ q], [x, y],
+        @mtkcompile sys = System(
+            [0 ~ p * x + y, x^3 + y^3 ~ q], [x, y],
             [p, q]; initialization_eqs = [p ~ q + 1],
-            guesses = [p => 1.0], bindings = [p => missing])
+            guesses = [p => 1.0], bindings = [p => missing]
+        )
         @test length(equations(sys)) == length(unknowns(sys)) == 1
         @test length(observed(sys)) == 1
         @test observed(sys)[1].lhs in Set([x, y])
@@ -375,9 +403,11 @@ end
         @parameters q b
         @discretes y(t)
         @brownians c
-        @mtkcompile sys = System([D(x) ~ x + q * a, D(y) ~ y + p * b + c], t, [x, y],
+        @mtkcompile sys = System(
+            [D(x) ~ x + q * a, D(y) ~ y + p * b + c], t, [x, y],
             [p, q], [a, b, c]; initialization_eqs = [p + q ~ 4],
-            guesses = [p => 1.0], bindings = [p => missing])
+            guesses = [p => 1.0], bindings = [p => missing]
+        )
         @test length(equations(sys)) == 2
         @test issetequal(unknowns(sys), [x, y])
         @test issetequal(parameters(sys), [p, q])

--- a/test/substitute_component.jl
+++ b/test/substitute_component.jl
@@ -3,7 +3,7 @@ using ModelingToolkitStandardLibrary.Blocks
 using ModelingToolkitStandardLibrary.Electrical
 using OrdinaryDiffEq
 using ModelingToolkit: t_nounits as t, D_nounits as D, renamespace,
-                       NAMESPACE_SEPARATOR as NS
+    NAMESPACE_SEPARATOR as NS
 
 @component function SignalInterface(; name)
     pars = @parameters begin
@@ -40,7 +40,7 @@ end
         connect(signal.output.u, source.V.u),
         connect(source.p, component1.p),
         connect(component1.n, component2.p),
-        connect(component2.n, source.n, ground.g)
+        connect(component2.n, source.n, ground.g),
     ]
 
     return System(equations, t, vars, pars; name, systems)
@@ -68,7 +68,7 @@ end
         connect(constant.output, source.V),
         connect(source.p, component1.p),
         connect(component1.n, component2.p),
-        connect(component2.n, source.n, ground.g)
+        connect(component2.n, source.n, ground.g),
     ]
 
     return System(equations, t, vars, pars; name, systems)
@@ -95,7 +95,7 @@ end
 
     sol1 = solve(prob1, Tsit5())
     sol2 = solve(prob2, Tsit5(); saveat = sol1.t)
-    @test sol1.u≈sol2.u atol=1e-8
+    @test sol1.u ≈ sol2.u atol = 1.0e-8
 end
 
 @component function BadOnePort1(; name)
@@ -113,7 +113,7 @@ end
 
     equations = Equation[
         0 ~ p.i + n.i,
-        i ~ p.i
+        i ~ p.i,
     ]
 
     return System(equations, t, vars, pars; name, systems)
@@ -142,7 +142,7 @@ end
 
     equations = Equation[
         0 ~ p.v + n.v,
-        v ~ p.v
+        v ~ p.v,
     ]
 
     return System(equations, t, vars, pars; name, systems)
@@ -172,7 +172,7 @@ end
 
     equations = Equation[
         0 ~ p.v + n.v,
-        v ~ p.v
+        v ~ p.v,
     ]
 
     return System(equations, t, vars, pars; name, systems)
@@ -202,7 +202,7 @@ end
 
     equations = Equation[
         0 ~ p.v + n.v,
-        v ~ p.v
+        v ~ p.v,
     ]
 
     return System(equations, t, vars, pars; name, systems)
@@ -232,7 +232,7 @@ end
 
     equations = Equation[
         0 ~ p.v + n.v,
-        v ~ p.v
+        v ~ p.v,
     ]
 
     return System(equations, t, vars, pars; name, systems)
@@ -271,7 +271,7 @@ end
 
     equations = Equation[
         0 ~ p.v + n.v,
-        v ~ p.v
+        v ~ p.v,
     ]
 
     return System(equations, t, vars, pars; name, systems)
@@ -300,7 +300,7 @@ end
 
     equations = Equation[
         0 ~ p.i + n.i,
-        i ~ p.i
+        i ~ p.i,
     ]
 
     return System(equations, t, vars, pars; name, systems)
@@ -329,14 +329,18 @@ end
     @named component1 = Resistor(R = 1.0)
     @named component2 = Capacitor(C = 1.0, v = 0.0)
     @test_throws ["LHS", "cannot be completed"] substitute_component(
-        templated, complete(templated.component1) => component1)
+        templated, complete(templated.component1) => component1
+    )
     @test_throws ["RHS", "cannot be completed"] substitute_component(
-        templated, templated.component1 => complete(component1))
+        templated, templated.component1 => complete(component1)
+    )
     @test_throws ["RHS", "not be namespaced"] substitute_component(
-        templated, templated.component1 => renamespace(templated, component1))
+        templated, templated.component1 => renamespace(templated, component1)
+    )
     @named resistor = Resistor(R = 1.0)
     @test_throws ["RHS", "same name"] substitute_component(
-        templated, templated.component1 => resistor)
+        templated, templated.component1 => resistor
+    )
 
     @testset "Different indepvar" begin
         @independent_variables tt
@@ -344,38 +348,47 @@ end
         @named outer = System(Equation[], t; systems = [empty])
         @named empty = System(Equation[], tt)
         @test_throws ["independent variable"] substitute_component(
-            outer, outer.empty => empty)
+            outer, outer.empty => empty
+        )
     end
 
     @named component1 = BadOnePort1()
     @test_throws ["RHS", "unknown", "v(t)"] substitute_component(
-        templated, templated.component1 => component1)
+        templated, templated.component1 => component1
+    )
 
     @named component1 = BadOnePort2()
     @test_throws ["component1$(NS)p", "i(t)"] substitute_component(
-        templated, templated.component1 => component1)
+        templated, templated.component1 => component1
+    )
 
     @named component1 = BadOnePort3()
     @test_throws ["component1$(NS)p$(NS)i", "Flow"] substitute_component(
-        templated, templated.component1 => component1)
+        templated, templated.component1 => component1
+    )
 
     @named component1 = BadOnePort4()
     @test_throws ["component1$(NS)p$(NS)v", "differing causality", "input"] substitute_component(
-        templated, templated.component1 => component1)
+        templated, templated.component1 => component1
+    )
 
     @named component1 = BadOnePort5()
     @test_throws ["component1$(NS)p$(NS)v", "differing causality", "output"] substitute_component(
-        templated, templated.component1 => component1)
+        templated, templated.component1 => component1
+    )
 
     @named component1 = BadOnePort6()
     @test_throws ["templated$(NS)component1$(NS)p", "not a connector"] substitute_component(
-        templated, templated.component1 => component1)
+        templated, templated.component1 => component1
+    )
 
     @named component1 = BadOnePort7()
     @test_throws ["templated$(NS)component1$(NS)p", "DomainConnector", "RegularConnector"] substitute_component(
-        templated, templated.component1 => component1)
+        templated, templated.component1 => component1
+    )
 
     @named component1 = BadOnePort8()
     @test_throws ["templated$(NS)component1", "subsystem p"] substitute_component(
-        templated, templated.component1 => component1)
+        templated, templated.component1 => component1
+    )
 end


### PR DESCRIPTION
## Summary
- Updated CI workflow to use `fredrikekre/runic-action@v1` instead of JuliaFormatter
- Removed `.JuliaFormatter.toml` configuration file
- Reformatted all source files with Runic.jl

## Changes
This PR migrates the code formatting from JuliaFormatter with SciMLStyle to Runic.jl. Runic.jl is an opinionated formatter (similar to Go's gofmt) that requires no configuration.

Key differences from JuliaFormatter:
- Explicit `return` statements are added where implicit
- Different indentation and alignment for continuation lines
- Consistent multiline formatting for function arguments

## Test plan
- [ ] CI format check passes with Runic.jl
- [ ] All existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)