### PR TITLE
fix: remove initial conditions/bindings of unused variables in `mtkcompile`

### DIFF
--- a/lib/ModelingToolkitBase/src/systems/systems.jl
+++ b/lib/ModelingToolkitBase/src/systems/systems.jl
@@ -147,6 +147,16 @@ function __mtkcompile(sys::AbstractSystem;
     filter!(all_dvs) do v
         v in original_vars || split_indexed_var(v)[1] in original_vars
     end
+
+    new_binds = copy(parent(bindings(sys)))
+    new_ics = copy(initial_conditions(sys))
+    for unused in setdiff(original_vars, all_dvs)
+        arr, isarr = split_indexed_var(unused)
+        arr in all_dvs && continue
+        delete!(new_binds, arr)
+        delete!(new_ics, arr)
+    end
+
     setdiff!(all_dvs, inputs, disturbance_inputs)
     if fully_determined === nothing
         fully_determined = false
@@ -342,6 +352,8 @@ function __mtkcompile(sys::AbstractSystem;
     @set! sys.outputs = outputs
     @set! sys.schedule = schedule
     @set! sys.isscheduled = true
+    @set! sys.bindings = new_binds
+    @set! sys.initial_conditions = new_ics
     return sys
 end
 

--- a/lib/ModelingToolkitBase/test/initial_values.jl
+++ b/lib/ModelingToolkitBase/test/initial_values.jl
@@ -344,3 +344,23 @@ end
     sol = solve(prob2)
     @test SciMLBase.successful_retcode(sol)
 end
+
+@testset "metadata defaults for variables removed by `mtkcompile` are removed" begin
+    @parameters p d
+    @variables X(t) Y(t) = 1.0
+    eq = [
+        D(X) ~ p - d*X
+    ]
+    @named sys = System(eq, t, [X, Y], [p, d])
+    @test haskey(initial_conditions(sys), Y)
+    sys = mtkcompile(sys)
+    @test !haskey(initial_conditions(sys), Y)
+    @test_nowarn ODEProblem(sys, [X => 0.0, p => 2.0, d => 0.1], (0.0, 1.0))
+    
+    @variables X(t) Y(t) = X
+    @named sys = System(eq, t, [X, Y], [p, d])
+    @test haskey(bindings(sys), Y)
+    sys = mtkcompile(sys)
+    @test !haskey(bindings(sys), Y)
+    @test_nowarn ODEProblem(sys, [X => 0.0, p => 2.0, d => 0.1], (0.0, 1.0))
+end


### PR DESCRIPTION
Close #4102 

## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
