### PR TITLE
Add type assertions for improved static analysis

### DIFF
--- a/src/systems/systems.jl
+++ b/src/systems/systems.jl
@@ -25,9 +25,9 @@ function MTKBase.__mtkcompile(
         inputs::OrderedSet{SymbolicT} = OrderedSet{SymbolicT}(),
         outputs::OrderedSet{SymbolicT} = OrderedSet{SymbolicT}(),
         disturbance_inputs::OrderedSet{SymbolicT} = OrderedSet{SymbolicT}(),
-        sort_eqs = true,
+        sort_eqs::Bool = true,
         kwargs...
-    )
+    )::System
     sys, statemachines = extract_top_level_statemachines(sys)
     sys, source_info = expand_connections(sys, Val(true))
     state = TearingState(sys, source_info; sort_eqs)
@@ -87,8 +87,8 @@ function MTKBase.__mtkcompile(
         ]
         ode_sys = mtkcompile(
             sys; inputs, outputs, disturbance_inputs, kwargs...
-        )
-        eqs = equations(ode_sys)
+        )::System
+        eqs = equations(ode_sys)::Vector{Equation}
         sorted_g_rows = fill(COMMON_ZERO, length(eqs), size(g, 2))
         for (i, eq) in enumerate(eqs)
             dvar = eq.lhs
@@ -133,7 +133,7 @@ function MTKBase.__mtkcompile(
     end
 end
 
-function MTKBase.simplify_sde_system(sys::System; kwargs...)
+function MTKBase.simplify_sde_system(sys::System; kwargs...)::System
     return __mtkcompile(sys; kwargs...)
 end
 

--- a/test/jet_tests.jl
+++ b/test/jet_tests.jl
@@ -1,0 +1,51 @@
+using ModelingToolkit
+using ModelingToolkit: SciMLBase
+using Test
+
+# Note: Full JET.jl analysis is too slow for regular CI testing.
+# This file contains basic type stability tests that verify critical
+# functions return expected types.
+
+@testset "Type stability checks" begin
+    # Basic system setup for testing
+    @independent_variables t
+    @variables x(t) y(t)
+    @parameters p q
+    D = Differential(t)
+
+    # Create a simple linear ODE system
+    eqs = [D(x) ~ p * x + q * y, D(y) ~ -q * x + p * y]
+
+    @testset "System construction types" begin
+        sys = ODESystem(eqs, t; name = :test_sys)
+        @test sys isa System
+    end
+
+    @testset "structural_simplify return type" begin
+        sys = ODESystem(eqs, t; name = :test_sys)
+        simp_sys = structural_simplify(sys)
+        @test simp_sys isa System
+    end
+
+    @testset "Accessor function types" begin
+        sys = ODESystem(eqs, t; name = :test_sys)
+        simp_sys = structural_simplify(sys)
+
+        # Core accessor functions should return proper types
+        @test equations(simp_sys) isa Vector{Equation}
+        @test unknowns(simp_sys) isa Vector
+        @test parameters(simp_sys) isa Vector
+        @test observed(simp_sys) isa Vector{Equation}
+    end
+
+    @testset "ODEProblem construction" begin
+        sys = ODESystem(eqs, t; name = :test_sys)
+        simp_sys = structural_simplify(sys)
+
+        # Test that problem construction returns correct type
+        # Use the non-deprecated API: merge u0 and p into a single Dict
+        op = merge(Dict(x => 1.0, y => 0.0), Dict(p => -0.1, q => 2.0))
+        prob = ODEProblem(simp_sys, op, (0.0, 1.0))
+        @test prob isa SciMLBase.ODEProblem
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -39,6 +39,7 @@ end
 @time begin
     if GROUP == "All" || GROUP == "InterfaceI"
         @testset "InterfaceI" begin
+            @safetestset "Type Stability Tests" include("jet_tests.jl")
             @mtktestset("Input Output Test", "input_output_handling.jl")
             @safetestset "Clock Test" include("clock.jl")
             @mtktestset("Variable binding semantics", "binding_semantics.jl")


### PR DESCRIPTION
## Summary
- Add return type annotation `::System` to `__mtkcompile` function for better type inference
- Add type annotation `::Bool` to `sort_eqs` parameter
- Add type assertions to recursive `mtkcompile` call and `equations` result in the SDE branch
- Add return type annotation to `simplify_sde_system`
- Create new `test/jet_tests.jl` with type stability tests

## Motivation
These changes improve type stability and reduce runtime dispatch in core system compilation functions. This is part of preparing the codebase for:
- Better JET.jl static analysis compatibility
- Julia 1.12 trim support (native compilation)
- Improved type inference throughout dependent code

## Analysis
JET.jl analysis identified runtime dispatch in `__mtkcompile` at lines 88-91 where the recursive `mtkcompile` call returned `Any` type due to the union return. Adding type assertions ensures the compiler knows the exact return type.

## Test plan
- [x] Added `test/jet_tests.jl` with type stability tests
- [x] Tests verify that `System`, `structural_simplify`, and `ODEProblem` construction return correct types
- [x] Standalone tests pass (7/7 tests in ~69 seconds)

cc @ChrisRackauckas

🤖 Generated with [Claude Code](https://claude.com/claude-code)