### PR TITLE
fix: only examine RHS in equation_dependencies

### DIFF
--- a/lib/ModelingToolkitBase/src/systems/dependency_graphs.jl
+++ b/lib/ModelingToolkitBase/src/systems/dependency_graphs.jl
@@ -44,7 +44,10 @@ function equation_dependencies(
     depeqs_to_vars = Vector{Vector}(undef, length(eqs))
 
     for (i, eq) in enumerate(eqs)
-        get_variables!(deps, eq, variables)
+        # For Equations, only examine RHS (dependencies, not what's modified).
+        # For jumps, use the whole object (specialized search_variables! handles it).
+        target = eq isa Equation ? eq.rhs : eq
+        get_variables!(deps, target, variables)
         depeqs_to_vars[i] = [value(v) for v in deps]
         empty!(deps)
     end


### PR DESCRIPTION
Symbolics@5fe7a2d6 added a `search_variables!` method for `Equation` that searches both LHS and RHS. This broke `equation_dependencies` which relies on finding only RHS dependencies.

The original MTK behavior (from 2020, commit 3160770b56) explicitly only examined `eq.rhs`. This fix restores that behavior by passing `eq.rhs` directly instead of relying on the generic `Equation` method.

## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
