### PR TITLE
fix: discover array `GlobalScope` variables in unscalarized form

### DIFF
--- a/lib/ModelingToolkitBase/src/systems/abstractsystem.jl
+++ b/lib/ModelingToolkitBase/src/systems/abstractsystem.jl
@@ -637,6 +637,15 @@ function discover_globalscoped(sys::AbstractSystem)
     iv::Union{SymbolicT, Nothing} = has_iv(sys) ? get_iv(sys) : nothing
     collect_scoped_vars!(newunknowns, newparams, sys, iv; depth = -1)
     setdiff!(newunknowns, observables(sys))
+    # Find parameters that were discovered scalarized, and add the array instead.
+    # We can push to the set while iterating over it because it is an `OrderedSet`
+    for p in newparams
+        arrp, isarr = split_indexed_var(p)
+        isarr || continue
+        push!(newparams, arrp)
+    end
+    # Remove indexed parameters
+    filter!(!last ∘ split_indexed_var, newparams)
     @set! sys.ps = unique!(vcat(get_ps(sys), collect(newparams)))
     @set! sys.unknowns = unique!(vcat(get_unknowns(sys), collect(newunknowns)))
     return sys

--- a/lib/ModelingToolkitBase/test/variable_scope.jl
+++ b/lib/ModelingToolkitBase/test/variable_scope.jl
@@ -171,3 +171,11 @@ end
     @variables x(t)
     @named foo = Foo(; k = [k + 1, x + 2])
 end
+
+@testset "Array `GlobalScope` variables are discovered unscalarized" begin
+    @parameters p[1:2]
+    p = GlobalScope(p)
+    @variables x(t)
+    @named sys = System([D(x) ~ p[1] * x + p[2]], t)
+    @test_nowarn complete(sys)
+end


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
