### PR TITLE
Add tspan field

### DIFF
--- a/lib/ModelingToolkitBase/src/systems/system.jl
+++ b/lib/ModelingToolkitBase/src/systems/system.jl
@@ -200,6 +200,10 @@ struct System <: IntermediateDeprecationSystem
     """
     tstops::Vector{Any}
     """
+    The time span of the problem.
+    """
+    tspan::Union{Nothing,Tuple{Any,Any}}
+    """
     $INTERNAL_FIELD_WARNING
     The list of input variables of the system.
     """
@@ -289,7 +293,7 @@ struct System <: IntermediateDeprecationSystem
             brownians, iv, observed, var_to_name, name, description, bindings,
             initial_conditions, guesses, systems, initialization_eqs, continuous_events,
             discrete_events, connector_type, assertions = Dict{SymbolicT, String}(),
-            metadata = MetadataT(), gui_metadata = nothing, is_dde = false, tstops = [],
+            metadata = MetadataT(), gui_metadata = nothing, is_dde = false, tstops = [], tspan = nothing,
             inputs = Set{SymbolicT}(), outputs = Set{SymbolicT}(),
             tearing_state = nothing, namespacing = true,
             complete = false, index_cache = nothing, parameter_bindings_graph = nothing,
@@ -347,7 +351,7 @@ struct System <: IntermediateDeprecationSystem
             observed, var_to_name, name, description, bindings, initial_conditions,
             guesses, systems, initialization_eqs, continuous_events, discrete_events,
             connector_type, assertions, metadata, gui_metadata, is_dde,
-            tstops, inputs, outputs, tearing_state, namespacing,
+            tstops, tspan, inputs, outputs, tearing_state, namespacing,
             complete, index_cache, parameter_bindings_graph, ignored_connections,
             preface, parent, initializesystem, is_initializesystem, is_discrete,
             state_priorities, irreducibles,
@@ -424,7 +428,7 @@ function System(
         constraints = Union{Equation, Inequality}[], noise_eqs = nothing, jumps = JumpType[],
         costs = SymbolicT[], consolidate = default_consolidate,
         # `@nospecialize` is only supported on the first 32 arguments. Keep this early.
-        @nospecialize(preface = nothing), @nospecialize(tstops = []),
+        @nospecialize(preface = nothing), @nospecialize(tstops = []), tspan = nothing,
         observed = Equation[], bindings = SymmapT(), initial_conditions = SymmapT(),
         guesses = SymmapT(), systems = System[], initialization_eqs = Equation[],
         continuous_events = SymbolicContinuousCallback[], discrete_events = SymbolicDiscreteCallback[],
@@ -601,7 +605,7 @@ function System(
         costs, consolidate, dvs, ps, brownians, iv, observed,
         var_to_name, name, description, bindings, initial_conditions, guesses, systems, initialization_eqs,
         continuous_events, discrete_events, connector_type, assertions, metadata, gui_metadata, is_dde,
-        tstops, inputs, outputs, tearing_state, true, false,
+        tstops, tspan, inputs, outputs, tearing_state, true, false,
         nothing, nothing, ignored_connections, preface, parent,
         initializesystem, is_initializesystem, is_discrete, state_priorities, irreducibles; checks
     )

--- a/test/tspan_field.jl
+++ b/test/tspan_field.jl
@@ -1,0 +1,17 @@
+using ModelingToolkit
+using ModelingToolkit: t_nounits as t, D_nounits as D
+using Test
+
+@testset "tspan field storage" begin
+    @parameters σ ρ β
+    @variables x(t) y(t) z(t)
+    eqs = [D(x) ~ σ*(y-x), D(y) ~ x*(ρ-z)-y, D(z) ~ x*y - β*z]
+
+    # Test 1: Check if tspan is stored correctly
+    @named sys = ODESystem(eqs, t, [x,y,z], [σ,ρ,β]; tspan=(0.0, 10.0))
+    @test getfield(sys, :tspan) == (0.0, 10.0)
+
+    # Test 2: Check if it works without tspan (backward compatibility)
+    @named sys_no_tspan = ODESystem(eqs, t, [x,y,z], [σ,ρ,β])
+    @test getfield(sys_no_tspan, :tspan) === nothing
+end


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

**Summary**
This PR adds a `tspan` field to the `System` struct and updates the `ODESystem` constructor to accept `tspan` as a keyword argument.

**Changes**
- Added `tspan` to the `System` definition in `system.jl`.
- Updated `ODESystem` to store `tspan` when provided.
- Added a test case in `test/tspan_field.jl` to verify storage.
- Ran JuliaFormatter on modified files.

**Example Usage**
```julia
sys = ODESystem(eqs, t, [x,y,z], [p]; tspan=(0.0, 10.0))
# tspan is now stored in the system!
