### PR TITLE
Fix: Support empty Vector{Any} ([]) in system keyword arguments (fixes #4206)

### DIFF
--- a/lib/ModelingToolkitBase/src/systems/system.jl
+++ b/lib/ModelingToolkitBase/src/systems/system.jl
@@ -377,6 +377,7 @@ function unwrap_vars(vars::AbstractArray)
 end
 
 defsdict(x::SymmapT) = x
+defsdict(x::Vector{Any}) = isempty(x) ? SymmapT() : defsdict(Dict(x))
 function defsdict(x::Union{AbstractDict, AbstractArray{<:Pair}})
     result = SymmapT()
     for (k, v) in x


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

I added a one-line dispatch to defsdict in src/systems/system.jl to handle Vector{Any}:
defsdict(d::Vector{Any}) = isempty(d) ? Dict{Any, Any}() : defsdict(Dict(d))
