### PR TITLE
fix: make @poissonians return a Vector like @variables and @brownians

### DIFF
--- a/lib/ModelingToolkitBase/src/variables.jl
+++ b/lib/ModelingToolkitBase/src/variables.jl
@@ -737,12 +737,8 @@ function _poissonians(exprs...)
         end)
     end
 
-    # Return the variables as a tuple (or single if only one)
-    if length(names) == 1
-        return Expr(:block, assignments..., names[1])
-    else
-        return Expr(:block, assignments..., Expr(:tuple, names...))
-    end
+    # Return the variables as a Vector, consistent with @variables and @brownians
+    return Expr(:block, assignments..., Expr(:vect, names...))
 end
 
 ## Guess ======================================================================

--- a/lib/ModelingToolkitBase/test/poissonians.jl
+++ b/lib/ModelingToolkitBase/test/poissonians.jl
@@ -84,6 +84,51 @@ using OrdinaryDiffEq, StochasticDiffEq
         @test !ispoissonian(x)
     end
 
+    @testset "Return type consistency with @variables" begin
+        @parameters λ₁ λ₂ λ₃
+
+        # Single inline: should return a 1-element Vector
+        result_single = @poissonians dN_a(λ₁)
+        @test result_single isa Vector
+        @test length(result_single) == 1
+        @test ispoissonian(result_single[1])
+        @test isequal(result_single[1], dN_a)
+
+        # Multiple inline: should return a Vector
+        result_multi = @poissonians dN_b(λ₁) dN_c(λ₂)
+        @test result_multi isa Vector
+        @test length(result_multi) == 2
+        @test all(ispoissonian, result_multi)
+        @test isequal(result_multi[1], dN_b)
+        @test isequal(result_multi[2], dN_c)
+
+        # Single in block: should return a 1-element Vector
+        result_block_single = @poissonians begin
+            dN_d(λ₁)
+        end
+        @test result_block_single isa Vector
+        @test length(result_block_single) == 1
+        @test ispoissonian(result_block_single[1])
+        @test isequal(result_block_single[1], dN_d)
+
+        # Multiple in block: should return a Vector
+        result_block_multi = @poissonians begin
+            dN_e(λ₂)
+            dN_f(λ₃)
+        end
+        @test result_block_multi isa Vector
+        @test length(result_block_multi) == 2
+        @test all(ispoissonian, result_block_multi)
+        @test isequal(result_block_multi[1], dN_e)
+        @test isequal(result_block_multi[2], dN_f)
+
+        # Three inline: should return a Vector of length 3
+        result_three = @poissonians dN_g(λ₁) dN_h(λ₂) dN_i(λ₃)
+        @test result_three isa Vector
+        @test length(result_three) == 3
+        @test all(ispoissonian, result_three)
+    end
+
     @testset "Error on missing rate" begin
         # This should error - rate is required
         @test_throws Exception @macroexpand @poissonians dN


### PR DESCRIPTION
## Summary

`@poissonians` returned inconsistent types compared to `@variables` and `@brownians`:

| Case | `@variables` / `@brownians` | `@poissonians` (before) |
|---|---|---|
| Single, inline | `[x]` (1-element `Vector`) | bare `Num` |
| Multiple, inline | `[x, y]` (`Vector`) | `(x, y)` (`Tuple`) |
| Block syntax | `[x, y]` (`Vector`) | bare `Num` or `Tuple` |

This happened because `@variables` and `@brownians` delegate to `Symbolics.parse_vars` (which always returns a `Vector` via `Expr(:vect, ...)`), while `@poissonians` used custom codegen that returned a bare name for single declarations and an `Expr(:tuple, ...)` for multiple.

## Fix

One-line change in `_poissonians`: replace the conditional bare/tuple return with `Expr(:vect, names...)` so it always returns a `Vector`.

No existing tests break since all current usages rely on the side effect of binding variables into scope, not on the return value. New tests verify the return type across all permutations (single/multiple, inline/block).
