### PR TITLE
Fix typo in optimization tutorial documentation

### DIFF
--- a/docs/src/tutorials/optimization.md
+++ b/docs/src/tutorials/optimization.md
@@ -70,7 +70,7 @@ scatter!([u_opt[1]], [u_opt[2]], ms = 10, label = "minimum")
 
 ## Rosenbrock Function with Constraints
 
-ModelingToolkit is also capable of handing more complicated constraints than box constraints.
+ModelingToolkit is also capable of handling more complicated constraints than box constraints.
 Non-linear equality and inequality constraints can be added to the `OptimizationSystem`.
 Let's add an inequality constraint to the previous example:
 


### PR DESCRIPTION
I think that is what was originally meant.

## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
