### PR TITLE
fix: allow `Hold` variables to be observed

### DIFF
--- a/lib/ModelingToolkitBase/src/utils.jl
+++ b/lib/ModelingToolkitBase/src/utils.jl
@@ -1207,7 +1207,10 @@ function observed_equations_used_by(
     )
     if involved_vars === nothing
         involved_vars = Set{SymbolicT}()
-        SU.search_variables!(involved_vars, exprs; is_atomic = OperatorIsAtomic{Union{Shift, Differential, Initial}}())
+        SU.search_variables!(
+            involved_vars, exprs;
+            is_atomic = OperatorIsAtomic{Union{Shift, Differential, Initial, Hold}}()
+        )
     elseif !(involved_vars isa Set{SymbolicT})
         involved_vars = Set{SymbolicT}(involved_vars)
     end

--- a/test/clock.jl
+++ b/test/clock.jl
@@ -184,3 +184,11 @@ SciMLBase.is_discrete_time_domain(::ZeroArgOp) = true
     ci, clkmap = infer_clocks(sys)
     @test clkmap[ZeroArgOp()()] == clk
 end
+
+@testset "Allow `Hold` on the LHS of observed equations" begin
+    # Typically relevant for initialization systems
+    @variables x(t)
+    @mtkcompile sys = System(Hold(x) ~ 3)
+    prob = NonlinearProblem(sys, nothing)
+    @test prob.ps[Hold(x)] ≈ 3
+end


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
