### PR TITLE
Enable sys.x variable accessor pattern for PDESystem

### DIFF
--- a/lib/ModelingToolkitBase/test/pdesystem.jl
+++ b/lib/ModelingToolkitBase/test/pdesystem.jl
@@ -1,5 +1,6 @@
 using ModelingToolkitBase, DiffEqBase, LinearAlgebra, Test
 using ModelingToolkitBase: t_nounits as t, D_nounits as Dt
+using Symbolics: getname
 
 # Define some variables
 @parameters x
@@ -33,3 +34,101 @@ dt = 0:0.1:1
     pdesys.analytic_func[u(t, x)]([2], disct, discx) ≈
         analytic_function([2], disct, discx) for disct in dt, discx in dx
 )
+
+# Test sys.x accessor pattern for PDESystem
+using ModelingToolkitBase: renamespace, does_namespacing
+
+@testset "PDESystem property accessor (sys.x)" begin
+    @parameters y α β
+    @variables v(..) w(..)
+    Dy = Differential(y)
+    eq2 = [
+        Dt(v(t, y)) ~ α * Dy(Dy(v(t, y))),
+        Dt(w(t, y)) ~ β * Dy(Dy(w(t, y))),
+    ]
+    bcs2 = [
+        v(0, y) ~ sin(y), w(0, y) ~ cos(y),
+        v(t, 0) ~ 0, v(t, 1) ~ 0,
+        w(t, 0) ~ 1, w(t, 1) ~ 1,
+    ]
+    domains2 = [t ∈ (0.0, 1.0), y ∈ (0.0, 1.0)]
+
+    @named pdesys2 = PDESystem(eq2, bcs2, domains2, [t, y], [v, w], [α, β])
+
+    # PDESystem does namespacing by default (not complete), matching System behavior
+    @test does_namespacing(pdesys2)
+
+    # Access dependent variables (namespaced, matching System behavior)
+    @test !isequal(v, pdesys2.v)
+    @test isequal(renamespace(pdesys2, v), pdesys2.v)
+    @test !isequal(w, pdesys2.w)
+    @test isequal(renamespace(pdesys2, w), pdesys2.w)
+
+    # Access parameters (namespaced)
+    @test !isequal(α, pdesys2.α)
+    @test isequal(renamespace(pdesys2, α), pdesys2.α)
+    @test !isequal(β, pdesys2.β)
+    @test isequal(renamespace(pdesys2, β), pdesys2.β)
+
+    # Access independent variables — IVs are not namespaced
+    @test isequal(t, pdesys2.t)
+    @test isequal(y, pdesys2.y)
+
+    # Nonexistent variable throws
+    @test_throws ArgumentError pdesys2.nonexistent
+
+    # propertynames lists all accessible names
+    pnames = propertynames(pdesys2)
+    @test :v ∈ pnames
+    @test :w ∈ pnames
+    @test :α ∈ pnames
+    @test :β ∈ pnames
+    @test :t ∈ pnames
+    @test :y ∈ pnames
+
+    # Struct field access still works
+    @test pdesys2.eqs isa Vector
+    @test length(pdesys2.eqs) == 2
+    @test pdesys2.bcs isa Vector
+end
+
+@testset "PDESystem property accessor without parameters" begin
+    @parameters z
+    @variables f(..)
+    Dz = Differential(z)
+    eq3 = Dt(f(t, z)) ~ Dz(Dz(f(t, z)))
+    bcs3 = [f(0, z) ~ sin(z), f(t, 0) ~ 0, f(t, 1) ~ 0]
+    domains3 = [t ∈ (0.0, 1.0), z ∈ (0.0, 1.0)]
+
+    @named pdesys3 = PDESystem(eq3, bcs3, domains3, [t, z], [f])
+
+    # Access dependent variable (namespaced)
+    @test isequal(renamespace(pdesys3, f), pdesys3.f)
+
+    # Access independent variables (not namespaced)
+    @test isequal(t, pdesys3.t)
+    @test isequal(z, pdesys3.z)
+end
+
+@testset "PDESystem property accessor with subsystems" begin
+    @parameters s2 γ
+    @variables p(..) q(..)
+    Ds2 = Differential(s2)
+
+    eq_inner = [Dt(p(t, s2)) ~ γ * Ds2(p(t, s2))]
+    bcs_inner = [p(0, s2) ~ sin(s2), p(t, 0) ~ 0, p(t, 1) ~ 0]
+    domains_inner = [t ∈ (0.0, 1.0), s2 ∈ (0.0, 1.0)]
+    @named inner = PDESystem(eq_inner, bcs_inner, domains_inner, [t, s2], [p], [γ])
+
+    eq_outer = [Dt(q(t, s2)) ~ Ds2(q(t, s2))]
+    bcs_outer = [q(0, s2) ~ cos(s2), q(t, 0) ~ 1, q(t, 1) ~ 1]
+    domains_outer = [t ∈ (0.0, 1.0), s2 ∈ (0.0, 1.0)]
+    @named outer = PDESystem(eq_outer, bcs_outer, domains_outer, [t, s2], [q], [γ];
+        systems = [inner])
+
+    # Subsystem should be listed in propertynames
+    @test :inner ∈ propertynames(outer)
+
+    # Access own variables (namespaced)
+    @test isequal(renamespace(outer, q), outer.q)
+end


### PR DESCRIPTION
## Summary

- Adds `var_to_name` field to `PDESystem` and builds it from dependent variables and parameters in the constructor, enabling `getvar`'s fast O(1) variable lookup
- Rewrites `Base.getproperty` for `PDESystem` to fall through to `AbstractSystem`'s `getvar` for symbolic variable lookup (`sys.x` pattern) while preserving struct field access and deprecated name aliases
- Adds accessor bridges (`get_unknowns`, `has_unknowns`) mapping PDESystem's `dvs` field to the `unknowns` API expected by `getvar`
- Adds `Base.propertynames` override listing dependent variables, parameters, independent variables, and subsystems
- Handles independent variables without namespacing, matching `System` behavior
- Fixes a bug where `depwarn` calls in the original `getproperty` were dead code (placed after `return` statements)

## Test plan

- [x] All existing PDE tests pass (analytic_func access, independent_variables check)
- [x] New tests verify `sys.x` accessor for dependent variables, parameters, and independent variables
- [x] New tests verify `sys.x` accessor works without parameters (NullParameters)
- [x] New tests verify subsystem listing via `propertynames`
- [x] New tests verify namespacing behavior matches `System` (IVs not namespaced, DVs/params namespaced)
- [x] New tests verify struct field access still works (`sys.eqs`, `sys.bcs`)
- [x] New tests verify `ArgumentError` on nonexistent variables

🤖 Generated with [Claude Code](https://claude.com/claude-code)