### PR TITLE
fix: handle array parameters in BifurcationKitExt

### DIFF
--- a/lib/ModelingToolkitBase/ext/MTKBifurcationKitExt.jl
+++ b/lib/ModelingToolkitBase/ext/MTKBifurcationKitExt.jl
@@ -120,7 +120,9 @@ function BifurcationKit.BifurcationProblem(
         )
         nsys = complete(nsys)
     end
+    @set! nsys.ps = mapreduce(collect, vcat, ModelingToolkitBase.get_ps(nsys))
     @set! nsys.index_cache = nothing # force usage of a parameter vector instead of `MTKParameters`
+    nsys = complete(nsys; split = false)
     # Creates F and J functions.
     ofun = NonlinearFunction(nsys; jac = jac)
     F = let f = ofun.f

--- a/lib/ModelingToolkitBase/test/extensions/bifurcationkit.jl
+++ b/lib/ModelingToolkitBase/test/extensions/bifurcationkit.jl
@@ -207,3 +207,17 @@ if @isdefined(ModelingToolkit)
     bf = bifurcationdiagram(bp, PALC(), 2, opts_br)
     @test bf.γ.specialpoint[1].param ≈ 0.1 atol = 1.0e-4 rtol = 1.0e-4
 end
+
+@testset "With array parameters" begin
+    @variables X1(t) X2(t)
+    @parameters k1 k2 Γ[1:1]
+    eqs = [
+        0 ~ -k1*X1 + k2*(-X1 + Γ[1])
+        0 ~ X2 + X1 - Γ[1]
+    ]
+    @mtkcompile nsys2 = System(eqs)
+
+    @test_nowarn BifurcationKit.BifurcationProblem(
+        nsys2, [X1 => 5.0, X2 => 8.0], [k1 => 8.0, k2 => 1.0, Γ => [13.0]], k1; plot_var = X1
+    )
+end


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
