### PR TITLE
Fix MissingGuessValue.Random in SCCNonlinearProblem

### DIFF
--- a/src/problems/sccnonlinearproblem.jl
+++ b/src/problems/sccnonlinearproblem.jl
@@ -345,11 +345,11 @@ function SciMLBase.SCCNonlinearProblem{iip}(
                         end
                     end
                     MissingGuessValue.Random(rng) => begin
-                        newval = rand(rng, length(symbolic_ixs))
-                        _u0[dvs[vscc]] .= newval
-                        for j in symbolic_idxs
+                        newval = rand(rng, length(symbolic_idxs))
+                        _u0[symbolic_idxs] .= newval
+                        for (idx, j) in enumerate(symbolic_idxs)
                             write_possibly_indexed_array!(
-                                op, dvs[vscc[j]], Symbolics.SConst(newval[j]), COMMON_NOTHING
+                                op, dvs[vscc[j]], Symbolics.SConst(newval[idx]), COMMON_NOTHING
                             )
                         end
                     end


### PR DESCRIPTION
The `MissingGuessValue.Random` branch had three bugs:
- Typo: `symbolic_ixs` → `symbolic_idxs`
- indexing: `_u0[dvs[vscc]]` → `_u0[symbolic_idxs]`
- Index mismatch in loop: `newval[j]` → `newval[idx]` via `enumerate`

Fixes #4314 