### PR TITLE
Fix @named macro to recognize parametric AbstractSystem subtypes

### DIFF
--- a/lib/ModelingToolkitBase/src/systems/abstractsystem.jl
+++ b/lib/ModelingToolkitBase/src/systems/abstractsystem.jl
@@ -2622,7 +2622,7 @@ function _named(name, call, runtime = false)
     end
     op = call.args[1]
     return quote
-        $is_sys_construction = ($op isa $DataType) && ($op <: $AbstractSystem)
+        $is_sys_construction = ($op isa $Type) && ($op <: $AbstractSystem)
         $call
     end
 end


### PR DESCRIPTION
## Fix `@named` macro to recognize parametric (UnionAll) `AbstractSystem` subtypes

### Problem

The `@named` macro incorrectly applies `default_to_parentscope` to kwargs of parametric `AbstractSystem` subtypes. This is because `_named` uses `op isa DataType` to check whether the constructor is a system type:

```julia
$is_sys_construction = ($op isa $DataType) && ($op <: $AbstractSystem)
```

This works for `System` (which is a `DataType`), but parametric subtypes like Catalyst.jl's `ReactionSystem{V <: NetworkProperties}` are `UnionAll`, not `DataType`. So the check fails and `default_to_parentscope` is applied to all their kwargs, wrapping symbolic variables with `ParentScope(LocalScope())` metadata.

### Impact

This causes two issues for downstream packages with parametric `AbstractSystem` subtypes:

1. **Variable auto-discovery fails**: `collect_vars!` skips variables with `ParentScope` metadata (by design — it assumes they belong to a parent system). So parameters that appear only in kwargs like `tstops`, `continuous_events`, etc. aren't auto-discovered.

2. **Stored values have unexpected scope metadata**: Symbolic values passed as kwargs get `ParentScope` metadata baked in, which can break equality comparisons and downstream processing.

Events (`discrete_events`, `continuous_events`) happen to be unaffected because `default_to_parentscope` uses `apply_to_variables`, which doesn't recurse into `Pair` structures (the `condition => affect` form). But kwargs that contain direct symbolic expressions (like `tstops`) are fully scoped.

### Fix

Change `isa DataType` to `isa Type`, which is the common supertype of both `DataType` and `UnionAll`:

```julia
$is_sys_construction = ($op isa $Type) && ($op <: $AbstractSystem)
```

This is a one-line change. `Type` is the abstract supertype in Julia's type hierarchy that covers both concrete types (`DataType`) and parametric types (`UnionAll`), so all `AbstractSystem` subtypes are now correctly recognized regardless of whether they're parametric.
