### PR TITLE
docs: fix volume port density reference in tutorial

### DIFF
--- a/docs/src/tutorials/domain_connections.md
+++ b/docs/src/tutorials/domain_connections.md
@@ -119,7 +119,7 @@ To see how the domain works, we can examine the set parameter values for each of
 
 ```@repl domain
 sys = mtkcompile(odesys)
-ModelingToolkit.bindings(sys)[odesys.vol.port.ρ]
+ModelingToolkit.bindings(sys)[sys.vol.port.ρ]
 ```
 
 ## Multiple Domain Networks


### PR DESCRIPTION
Fixed the reference to sys.vol.port.p in example to fix the "Key not found" error

## Checklist

- [N/A] Appropriate tests were added
- [N/A] Any code changes were done in a way that does not break public API
- [N/A] All documentation related to code changes were updated
- [X] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [X] Any new documentation only uses public API
  
## Additional context


