### PR TITLE
Add Mooncake tangent_type override for MissingGuessValue

### DIFF
--- a/lib/ModelingToolkitBase/ext/MTKMooncakeExt.jl
+++ b/lib/ModelingToolkitBase/ext/MTKMooncakeExt.jl
@@ -1,7 +1,7 @@
 module MTKMooncakeExt
 
 using ModelingToolkitBase: MTKParameters, ParameterIndex, NONNUMERIC_PORTION, AbstractSystem,
-    SetInitialUnknowns, GeneratedFunctionWrapper, ObservedFunctionCache
+    SetInitialUnknowns, GeneratedFunctionWrapper, ObservedFunctionCache, MissingGuessValue
 using ModelingToolkitBase: System
 import ModelingToolkitBase as MTK
 import Mooncake
@@ -23,6 +23,13 @@ Mooncake.tangent_type(::Type{<:GeneratedFunctionWrapper}) = NoTangent
 
 # ObservedFunctionCache contains System reference and Dict{Any,Any}.
 Mooncake.tangent_type(::Type{<:ObservedFunctionCache}) = NoTangent
+
+# MissingGuessValue is a Moshi @data tagged union with a
+# Union{Error, Constant, Random} storage field. Mooncake's FData/RData
+# decomposition cannot handle Union-typed tangent fields where the member
+# tangent types are distinct Tangent{NamedTuple{...}} structs.
+# This is not differentiable anyway — it's a configuration enum.
+Mooncake.tangent_type(::Type{<:MissingGuessValue.Type}) = NoTangent
 
 # Port ChainRules rrules to Mooncake using @from_rrule.
 # These mirror the rules in MTKChainRulesCoreExt.jl.


### PR DESCRIPTION
## Summary

- Adds `Mooncake.tangent_type(::Type{<:MissingGuessValue.Type}) = NoTangent` to `MTKMooncakeExt`
- Fixes `MethodError` in Mooncake when closures capture an `ODEFunction` with DAE `initialization_data`

## Root cause

`MissingGuessValue` is a Moshi `@data` tagged union with a `Union{Error, Constant, Random}` storage field. When Mooncake computes the tangent type for this field, it produces `Union{NoTangent, Tangent{A}, Tangent{B}}`. Then during FData/RData decomposition, Mooncake calls `tangent_type` with 2 arguments (the FData and RData union types), which triggers a `MethodError`:

```
MethodError: no method matching tangent_type(
  ::Type{Union{NoFData, FData{NamedTuple{field#754}}, FData{NamedTuple{field#755}}}},
  ::Type{Union{NoRData, RData{NamedTuple{field#754}}, RData{NamedTuple{field#755}}}})
```

The failure chain is:
```
ODEFunction
  → initialization_data (OverrideInitData)
    → metadata (InitializationMetadata)
      → missing_guess_value (MissingGuessValue — Moshi @data type)
        → data :: Union{Error, Constant, Random}
          → tangent_type = Union{NoTangent, Tangent{A}, Tangent{B}}
            → FData/RData decomposition fails with MethodError
```

`MissingGuessValue` is a configuration enum (Error/Constant/Random), not a differentiable quantity, so `NoTangent` is correct.

## Test plan

- [x] Verified `Mooncake.build_rrule` on closure capturing full `ODEFunction` (was failing, now works)
- [x] Verified Mooncake VJP of `f(du,u,p,t)` matches FiniteDiff baseline: grad=[0.5] vs [0.5]
- [x] Verified all other existing `tangent_type` overrides still work

Note: There is a separate downstream issue in SciMLSensitivity where `recursive_copyto!` doesn't handle `Mooncake.Tangent` types for `MTKParameters`, which prevents the full `InterpolatingAdjoint(autojacvec=MooncakeVJP())` path from working end-to-end. That is tracked in SciML/SciMLSensitivity.jl#1358.

Ref: SciML/SciMLSensitivity.jl#1358

🤖 Generated with [Claude Code](https://claude.com/claude-code)