### PR TITLE
feat: add utility for moving variable bindings to initial conditions

### DIFF
--- a/lib/ModelingToolkitBase/src/ModelingToolkitBase.jl
+++ b/lib/ModelingToolkitBase/src/ModelingToolkitBase.jl
@@ -345,6 +345,7 @@ const set_scalar_metadata = setmetadata
 @public getdefault, setdefault, iscomplete, isparameter, modified_unknowns!
 @public renamespace, namespace_equations
 @public check_mutable_cache, store_to_mutable_cache!, should_invalidate_mutable_cache_entry
+@public convert_bindings_for_time_independent_system
 
 for prop in [SYS_PROPS; [:continuous_events, :discrete_events]]
     getter = Symbol(:get_, prop)

--- a/lib/ModelingToolkitBase/src/systems/system.jl
+++ b/lib/ModelingToolkitBase/src/systems/system.jl
@@ -578,17 +578,7 @@ function System(
     filter!(!(Base.Fix1(===, COMMON_NOTHING) ∘ last), guesses)
 
     if iv === nothing
-        filterer = let initial_conditions = initial_conditions, all_dvs = all_dvs
-            function _filterer(kvp)
-                k = kvp[1]
-                if k in all_dvs
-                    initial_conditions[k] = kvp[2]
-                    return false
-                end
-                return true
-            end
-        end
-        filter!(filterer, bindings)
+        move_variable_bindings_to_ics!(all_dvs, initial_conditions, bindings)
     end
 
     check_bindings(ps, bindings)

--- a/lib/ModelingToolkitBase/src/utils.jl
+++ b/lib/ModelingToolkitBase/src/utils.jl
@@ -1591,3 +1591,42 @@ function left_merge!(a::AtomicArrayDict{SymbolicT}, b::AtomicArrayDict{SymbolicT
     end
     return mergewith!(first ∘ tuple, a, b)
 end
+
+"""
+    $TYPEDSIGNATURES
+
+Move bindings of variables in `all_dvs` to the list of initial conditions `ics`.
+"""
+function move_variable_bindings_to_ics!(
+        all_dvs::AtomicArraySet, ics::AbstractDict{SymbolicT, SymbolicT},
+        binds::AbstractDict{SymbolicT, SymbolicT}
+    )
+    filterer = let initial_conditions = ics, all_dvs = all_dvs
+        function _filterer(kvp)
+            k = kvp[1]
+            if k in all_dvs
+                initial_conditions[k] = kvp[2]
+                return false
+            end
+            return true
+        end
+    end
+    filter!(filterer, binds)
+end
+
+"""
+    $TYPEDSIGNATURES
+
+Given a time-dependent `AbstractSystem`, move bindings of variables to initial
+conditions as required to convert `sys` to a time-independent system. Does not
+modify `sys`, and returns the new initial conditions and bindings respectively.
+"""
+function convert_bindings_for_time_independent_system(sys::AbstractSystem)
+    all_dvs = as_atomic_array_set(unknowns(sys))
+    union!(all_dvs, as_atomic_array_set(observables(sys)))
+    ics = copy(initial_conditions(sys))
+    binds = copy(parent(bindings(sys)))
+    move_variable_bindings_to_ics!(all_dvs, ics, binds)
+
+    return ics, binds
+end


### PR DESCRIPTION
Required by Catalyst, since `ReactionSystem` can codegen to both dynamical problems and nonlinear (steady state) problems. This allows moving the required bindings to initial conditions since nonlinear systems do not allow variable bindings.