### PR TITLE
fix: fix loop openings of causal variable analysis points

### DIFF
--- a/lib/ModelingToolkitBase/src/systems/analysis_points.jl
+++ b/lib/ModelingToolkitBase/src/systems/analysis_points.jl
@@ -556,12 +556,18 @@ function apply_transformation(tf::Break, sys::AbstractSystem)
             for out in outs
                 out_var = ap_var(out)
                 if tf.outputs_to_params
-                    new_dvs = copy(get_unknowns(breaksys))
-                    @set! breaksys.unknowns = new_dvs
-                    new_ps = copy(get_ps(breaksys))
-                    @set! breaksys.ps = new_ps
-                    deleteat!(new_dvs, findfirst(isequal(out_var), new_dvs)::Int)
-                    push!(new_ps, out_var)
+                    namespace = namespace_hierarchy(getname(out_var))
+                    insert!(namespace, 1, nameof(breaksys))
+                    breaksys, _ = modify_nested_subsystem(breaksys, @view(namespace[1:end-1])) do apsys
+                        new_dvs = copy(get_unknowns(apsys))
+                        var_in_apsys = getvar(apsys, namespace[end]; namespace = false)
+                        deleteat!(new_dvs, findfirst(isequal(var_in_apsys), new_dvs)::Int)
+                        @set! apsys.unknowns = new_dvs
+                        new_ps = copy(get_ps(apsys))
+                        push!(new_ps, var_in_apsys)
+                        @set! apsys.ps = new_ps
+                        return apsys, ()
+                    end
                 end
                 push!(out_vars, ap_var(out))
             end

--- a/lib/ModelingToolkitBase/test/analysis_points.jl
+++ b/lib/ModelingToolkitBase/test/analysis_points.jl
@@ -869,3 +869,22 @@ using DynamicQuantities
     @named sys2 = TestAPWithNoOutputs()
     @test sys2 isa System
 end
+
+@testset "Loop openings work with causal variable analysis points" begin
+    @named P = FirstOrder(k = 1, T = 1)
+    @named C = ModelingToolkitStandardLibrary.Blocks.Gain(; k = -1)
+
+    ap = AnalysisPoint(:plant_input)
+    eqs = [
+        connect(P.output, C.input)
+        connect(C.output.u, ap, P.input.u)
+    ]
+    @named sys = System(eqs, t; systems = [P, C])
+
+    newsys, (apvars,) = MTK.apply_transformation(MTK.Break(ap, true), sys)
+
+    @test isequal(only(apvars), P.input.u)
+    @test any(isequal(only(apvars)), parameters(newsys))
+    @test length(equations(expand_connections(sys))) == 9
+    @test length(equations(expand_connections(newsys))) == 8
+end


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
