### PR TITLE
fix: fix old `IndexCache` influencing subsequent `complete` calls

### DIFF
--- a/lib/ModelingToolkitBase/src/systems/abstractsystem.jl
+++ b/lib/ModelingToolkitBase/src/systems/abstractsystem.jl
@@ -717,6 +717,9 @@ function complete(
         @set! sys.parameter_bindings_graph = nothing
     end
     if split && has_index_cache(sys)
+        # The `IndexCache` constructor uses `is_parameter` and family. If the system already
+        # contains an index cache, it'll get wrong results.
+        @set! sys.index_cache = nothing
         @set! sys.index_cache = IndexCache(sys)
         # Ideally we'd do `get_ps` but if `flatten = false`
         # we don't get all of them. So we call `parameters`.

--- a/lib/ModelingToolkitBase/test/index_cache.jl
+++ b/lib/ModelingToolkitBase/test/index_cache.jl
@@ -1,5 +1,7 @@
 using ModelingToolkitBase, SymbolicIndexingInterface, SciMLStructures
-using ModelingToolkitBase: t_nounits as t
+using ModelingToolkitBase: t_nounits as t, D_nounits as D, SymbolicDiscreteCallback
+using Symbolics: unwrap
+using Setfield: @set!
 using Test
 
 # Ensure indexes of array symbolics are cached appropriately
@@ -122,4 +124,18 @@ end
     ss = @test_nowarn complete(sys)
     @test length(parameters(ss)) == 1
     @test !is_timeseries_parameter(ss, p_1)
+end
+
+@testset "Old index cache doesn't influence new index cache construction" begin
+    @variables x(t)
+    @discretes d(t)
+    @named sys = System([D(x) ~ t + 2], t)
+    sys = complete(sys)
+    @set! sys.discrete_events = [SymbolicDiscreteCallback(x > 1, [d ~ Pre(d) + 1]; discrete_parameters = [d])]
+    @set! sys.ps = [unwrap(d)]
+    # This used to throw, since `d` wasn't a parameter before and thus not present in
+    # the `IndexCache`. This failed the construction of the subsequent `IndexCache`, since
+    # it uses `is_parameter` to check if `discrete_parameters` are in the parameters of
+    # the system.
+    @test_nowarn complete(sys)
 end


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
