### PR TITLE
fix: handle `adjoint` in equations

### DIFF
--- a/lib/ModelingToolkitBase/src/utils.jl
+++ b/lib/ModelingToolkitBase/src/utils.jl
@@ -1417,8 +1417,8 @@ function flatten_equation(eq::Equation)::Vector{Equation}
     if !SU.is_array_shape(SU.shape(eq.lhs))
         return [eq]
     end
-    lhs = vec(collect(eq.lhs)::Array{SymbolicT})::Vector{SymbolicT}
-    rhs = vec(collect(eq.rhs)::Array{SymbolicT})::Vector{SymbolicT}
+    lhs = vec(collect(collect(eq.lhs)::AbstractArray{SymbolicT}))::Vector{SymbolicT}
+    rhs = vec(collect(collect(eq.rhs)::AbstractArray{SymbolicT}))::Vector{SymbolicT}
     result = Equation[]
     for (l, r) in zip(lhs, rhs)
         push!(result, l ~ r)

--- a/lib/ModelingToolkitBase/test/system_building.jl
+++ b/lib/ModelingToolkitBase/test/system_building.jl
@@ -47,3 +47,9 @@ end
     @test y ∈ Set(unknowns(sys))
     @test q ∈ Set(parameters(sys))
 end
+
+@testset "`Adjoint` in equations" begin
+    @variables x(t)[1:3, 1:3]
+    @named sys = System([D(x) ~ x'], t)
+    @test_nowarn mtkcompile(sys)
+end


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
