### PR TITLE
BVP cleanup

### DIFF
--- a/lib/ModelingToolkitBase/test/bvproblem.jl
+++ b/lib/ModelingToolkitBase/test/bvproblem.jl
@@ -67,25 +67,21 @@ end
     tspan = (0.0, 6.0)
 
     op = ODEProblem(pend, [u0map; parammap], tspan)
-    osol = solve(op, Vern9())
+    osol = solve(op, Vern9(), abstol = 1.0e-10, reltol = 1.0e-10)
 
-    bvp = SciMLBase.BVProblem{true, SciMLBase.AutoSpecialize}(
-        pend, [u0map; parammap], tspan
-    )
+    bvp = BVProblem(pend, [u0map; parammap], tspan)
     for solver in solvers
-        sol = solve(bvp, solver(), dt = 0.01)
-        @test isapprox(sol.u[end], osol.u[end]; atol = 0.01)
+        sol = solve(bvp, solver(), dt = 1.0e-2)
+        @test isapprox(sol.u[end], osol.u[end])
         @test sol.u[1] == [π / 2, π / 2]
     end
 
     # Test out-of-place
-    bvp2 = SciMLBase.BVProblem{false, SciMLBase.FullSpecialize}(
-        pend, [u0map; parammap], tspan
-    )
+    bvp2 = BVProblem{false, SciMLBase.FullSpecialize}(pend, [u0map; parammap], tspan)
 
     for solver in solvers
         sol = solve(bvp2, solver(), dt = 0.01)
-        @test isapprox(sol.u[end], osol.u[end]; atol = 0.01)
+        @test isapprox(sol.u[end], osol.u[end])
         @test sol.u[1] == [π / 2, π / 2]
     end
 end

--- a/lib/ModelingToolkitBase/test/bvproblem.jl
+++ b/lib/ModelingToolkitBase/test/bvproblem.jl
@@ -149,24 +149,17 @@ end
 end
 
 function test_solvers(
-        solvers, prob, u0map, constraints, equations = []; dt = 0.005, atol = 1.0e-2
+        solvers, prob, u0map, constraints, equations = []; dt = 0.005, atol = 5.0e-6
     )
     for solver in solvers
         println("Solver: $solver")
-        sol = solve(prob, solver(), dt = dt, abstol = 1.0e-8, reltol = 1.0e-8)
+        sol = solve(prob, solver(), dt = dt)
         @test SciMLBase.successful_retcode(sol.retcode)
         p = prob.p
         t = sol.t
         bc = prob.f.bc
         ns = length(prob.u0)
 
-        cache = init(prob, solver(), dt = dt, abstol = 1.0e-8, reltol = 1.0e-8)
-        eval_sol = BoundaryValueDiffEqMIRK.EvalSol(
-            BoundaryValueDiffEqMIRK.__restructure_sol(
-                sol.u, cache.in_size
-            ), cache.mesh, cache
-        )
-        @test_broken bc(zeros(ns), eval_sol, p, t) ≈ zeros(ns)
         if isinplace(prob.f)
             resid = zeros(ns)
             bc(resid, sol, p, t)
@@ -211,7 +204,7 @@ end
     bvp = SciMLBase.BVProblem{true, SciMLBase.AutoSpecialize}(
         lksys, u0map, tspan; guesses = guess, cse = false
     )
-    test_solvers(solvers, bvp, u0map, constr; dt = 1.0e-4)
+    test_solvers(solvers, bvp, u0map, constr; dt = 1.0e-2)
 
     # Testing that more complicated constraints give correct solutions.
     constr = [EvalAt(0.2)(y) + EvalAt(0.8)(x) ~ 3.0, EvalAt(0.3)(y) ~ 2.0]
@@ -219,14 +212,14 @@ end
     bvp = SciMLBase.BVProblem{false, SciMLBase.FullSpecialize}(
         lksys, u0map, tspan; guesses = guess
     )
-    test_solvers(solvers, bvp, u0map, constr; dt = 1.0e-4)
+    test_solvers(solvers, bvp, u0map, constr; dt = 1.0e-2)
 
     constr = [α * β - EvalAt(0.6)(x) ~ 0.0, EvalAt(0.2)(y) ~ 3.0]
     @mtkcompile lksys = System(eqs, t; constraints = constr)
     bvp = SciMLBase.BVProblem{true, SciMLBase.AutoSpecialize}(
         lksys, u0map, tspan; guesses = guess
     )
-    test_solvers(solvers, bvp, u0map, constr; dt = 1.0e-4)
+    test_solvers(solvers, bvp, u0map, constr; dt = 1.0e-2)
 end
 
 # Cartesian pendulum from the docs.


### PR DESCRIPTION
There was a bug in the BVP interpolation and I added some tests
that were using the internals of BVP solvers. That is no longer needed.

## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

See also https://github.com/SciML/BoundaryValueDiffEq.jl/pull/452
The tests should pass once that merges (and it's released).
