### PR TITLE
Add nominal value metadata

### DIFF
--- a/docs/src/API/variables.md
+++ b/docs/src/API/variables.md
@@ -173,6 +173,33 @@ getbounds
 ModelingToolkit.VariableBounds
 ```
 
+## Nominal Value
+
+A nominal value represents the characteristic magnitude of a variable. This is useful
+for scaling constraints in optimal control problems, preventing ill-conditioning when
+variables have vastly different magnitudes. The default nominal value is `1.0`.
+
+```@repl metadata
+@variables x [nominal_value = 1000.0];
+hasnominalvalue(x)
+getnominalvalue(x)
+```
+
+Nominal values can also be specified for array variables:
+
+```@repl metadata
+@variables x[1:3] [nominal_value = [100.0, 200.0, 300.0]];
+getnominalvalue(x)
+getnominalvalue(x[1])
+```
+
+```@docs
+hasnominalvalue
+getnominalvalue
+setnominalvalue
+ModelingToolkit.VariableNominalValue
+```
+
 ## Guess
 
 Specify an initial guess for variables of a `System`. This is used when building the

--- a/docs/src/API/variables.md
+++ b/docs/src/API/variables.md
@@ -180,24 +180,24 @@ for scaling constraints in optimal control problems, preventing ill-conditioning
 variables have vastly different magnitudes. The default nominal value is `1.0`.
 
 ```@repl metadata
-@variables x [nominal_value = 1000.0];
-hasnominalvalue(x)
-getnominalvalue(x)
+@variables x [nominal = 1000.0];
+hasnominal(x)
+getnominal(x)
 ```
 
 Nominal values can also be specified for array variables:
 
 ```@repl metadata
-@variables x[1:3] [nominal_value = [100.0, 200.0, 300.0]];
-getnominalvalue(x)
-getnominalvalue(x[1])
+@variables x[1:3] [nominal = [100.0, 200.0, 300.0]];
+getnominal(x)
+getnominal(x[1])
 ```
 
 ```@docs
-hasnominalvalue
-getnominalvalue
-setnominalvalue
-ModelingToolkit.VariableNominalValue
+hasnominal
+getnominal
+setnominal
+ModelingToolkit.VariableNominal
 ```
 
 ## Guess

--- a/lib/ModelingToolkitBase/src/ModelingToolkitBase.jl
+++ b/lib/ModelingToolkitBase/src/ModelingToolkitBase.jl
@@ -257,7 +257,7 @@ export flatten
 export connect, domain_connect, @connector, Connection, AnalysisPoint, Flow, Stream,
     instream
 export @component, @mtkcompile, @mtkbuild, @mtkcomplete
-export isinput, isoutput, getbounds, hasbounds, getguess, hasguess, isdisturbance,
+export isinput, isoutput, getbounds, hasbounds, getnominalvalue, hasnominalvalue, setnominalvalue, getguess, hasguess, isdisturbance,
     istunable, getdist, hasdist,
     tunable_parameters, isirreducible, getdescription, hasdescription,
     hasunit, getunit, hasconnect, getconnect,

--- a/lib/ModelingToolkitBase/src/ModelingToolkitBase.jl
+++ b/lib/ModelingToolkitBase/src/ModelingToolkitBase.jl
@@ -257,7 +257,7 @@ export flatten
 export connect, domain_connect, @connector, Connection, AnalysisPoint, Flow, Stream,
     instream
 export @component, @mtkcompile, @mtkbuild, @mtkcomplete
-export isinput, isoutput, getbounds, hasbounds, getnominalvalue, hasnominalvalue, setnominalvalue, getguess, hasguess, isdisturbance,
+export isinput, isoutput, getbounds, hasbounds, getnominal, hasnominal, setnominal, getguess, hasguess, isdisturbance,
     istunable, getdist, hasdist,
     tunable_parameters, isirreducible, getdescription, hasdescription,
     hasunit, getunit, hasconnect, getconnect,

--- a/lib/ModelingToolkitBase/src/variables.jl
+++ b/lib/ModelingToolkitBase/src/variables.jl
@@ -465,38 +465,38 @@ function setbounds(x::Num, bounds)
     return setmetadata(x, VariableBounds, (lb, ub))
 end
 
-## NominalValue ================================================================
-struct VariableNominalValue end
-Symbolics.option_to_metadata_type(::Val{:nominal_value}) = VariableNominalValue
+## Nominal =====================================================================
+struct VariableNominal end
+Symbolics.option_to_metadata_type(::Val{:nominal}) = VariableNominal
 
 """
-    getnominalvalue(x)
+    getnominal(x)
 
 Get the nominal value associated with symbolic variable `x`. Returns `1.0` if no nominal value is set.
 Create variables with a nominal value like this
 
 ```
-@variables x [nominal_value = 4785.0]
+@variables x [nominal = 4785.0]
 ```
 """
-getnominalvalue(x::Union{Num, Symbolics.Arr}) = getnominalvalue(unwrap(x))
-function getnominalvalue(x::SymbolicT)
-    s = Symbolics.getmetadata_maybe_indexed(x, VariableNominalValue, nothing)
+getnominal(x::Union{Num, Symbolics.Arr}) = getnominal(unwrap(x))
+function getnominal(x::SymbolicT)
+    s = Symbolics.getmetadata_maybe_indexed(x, VariableNominal, nothing)
     s === nothing ? 1.0 : s
 end
 
 """
-    hasnominalvalue(x)
+    hasnominal(x)
 
 Determine whether symbolic variable `x` has a nominal value associated with it.
-See also [`getnominalvalue`](@ref).
+See also [`getnominal`](@ref).
 """
-function hasnominalvalue(x)
-    Symbolics.getmetadata_maybe_indexed(unwrap(x), VariableNominalValue, nothing) !== nothing
+function hasnominal(x)
+    Symbolics.getmetadata_maybe_indexed(unwrap(x), VariableNominal, nothing) !== nothing
 end
 
-function setnominalvalue(x::Num, val)
-    return setmetadata(x, VariableNominalValue, val)
+function setnominal(x::Num, val)
+    return setmetadata(x, VariableNominal, val)
 end
 
 ## Disturbance =================================================================
@@ -643,23 +643,23 @@ function getbounds(p::AbstractVector)
 end
 
 """
-    getnominalvalue(sys::ModelingToolkitBase.AbstractSystem, vars = parameters(sys))
+    getnominal(sys::ModelingToolkitBase.AbstractSystem, vars = parameters(sys))
 
-Returns a dict with pairs `var => nominal_value` mapping variables of `sys` to their nominal values.
+Returns a dict with pairs `var => nominal` mapping variables of `sys` to their nominal values.
 Create variables with a nominal value like this
 
 ```
-@variables x [nominal_value = 40.0]
+@variables x [nominal = 40.0]
 ```
 
-To obtain unknown variable nominal values, call `getnominalvalue(sys, unknowns(sys))`
+To obtain unknown variable nominal values, call `getnominal(sys, unknowns(sys))`
 """
-function getnominalvalue(sys::ModelingToolkitBase.AbstractSystem, p = parameters(sys))
-    return Dict(p .=> getnominalvalue.(p))
+function getnominal(sys::ModelingToolkitBase.AbstractSystem, p = parameters(sys))
+    return Dict(p .=> getnominal.(p))
 end
 
-function getnominalvalue(p::AbstractVector)
-    return getnominalvalue.(p)
+function getnominal(p::AbstractVector)
+    return getnominal.(p)
 end
 
 ## Description =================================================================

--- a/lib/ModelingToolkitBase/src/variables.jl
+++ b/lib/ModelingToolkitBase/src/variables.jl
@@ -465,6 +465,40 @@ function setbounds(x::Num, bounds)
     return setmetadata(x, VariableBounds, (lb, ub))
 end
 
+## NominalValue ================================================================
+struct VariableNominalValue end
+Symbolics.option_to_metadata_type(::Val{:nominal_value}) = VariableNominalValue
+
+"""
+    getnominalvalue(x)
+
+Get the nominal value associated with symbolic variable `x`. Returns `1.0` if no nominal value is set.
+Create variables with a nominal value like this
+
+```
+@variables x [nominal_value = 4785.0]
+```
+"""
+getnominalvalue(x::Union{Num, Symbolics.Arr}) = getnominalvalue(unwrap(x))
+function getnominalvalue(x::SymbolicT)
+    s = Symbolics.getmetadata_maybe_indexed(x, VariableNominalValue, nothing)
+    s === nothing ? 1.0 : s
+end
+
+"""
+    hasnominalvalue(x)
+
+Determine whether symbolic variable `x` has a nominal value associated with it.
+See also [`getnominalvalue`](@ref).
+"""
+function hasnominalvalue(x)
+    Symbolics.getmetadata_maybe_indexed(unwrap(x), VariableNominalValue, nothing) !== nothing
+end
+
+function setnominalvalue(x::Num, val)
+    return setmetadata(x, VariableNominalValue, val)
+end
+
 ## Disturbance =================================================================
 struct VariableDisturbance end
 Symbolics.option_to_metadata_type(::Val{:disturbance}) = VariableDisturbance
@@ -606,6 +640,26 @@ function getbounds(p::AbstractVector)
     lb = first.(bounds)
     ub = last.(bounds)
     return (; lb, ub)
+end
+
+"""
+    getnominalvalue(sys::ModelingToolkitBase.AbstractSystem, vars = parameters(sys))
+
+Returns a dict with pairs `var => nominal_value` mapping variables of `sys` to their nominal values.
+Create variables with a nominal value like this
+
+```
+@variables x [nominal_value = 40.0]
+```
+
+To obtain unknown variable nominal values, call `getnominalvalue(sys, unknowns(sys))`
+"""
+function getnominalvalue(sys::ModelingToolkitBase.AbstractSystem, p = parameters(sys))
+    return Dict(p .=> getnominalvalue.(p))
+end
+
+function getnominalvalue(p::AbstractVector)
+    return getnominalvalue.(p)
 end
 
 ## Description =================================================================

--- a/lib/ModelingToolkitBase/test/test_variable_metadata.jl
+++ b/lib/ModelingToolkitBase/test/test_variable_metadata.jl
@@ -264,48 +264,48 @@ x = ModelingToolkitBase.toparam(x)
 @brownians z
 @test ModelingToolkitBase.getvariabletype(z) == ModelingToolkitBase.BROWNIAN
 
-# NominalValue
-@variables x [nominal_value = 100.0]
-@test getnominalvalue(x) == 100.0
-@test hasnominalvalue(x)
+# Nominal
+@variables x [nominal = 100.0]
+@test getnominal(x) == 100.0
+@test hasnominal(x)
 
 @variables y
-@test !hasnominalvalue(y)
-@test getnominalvalue(y) == 1.0
+@test !hasnominal(y)
+@test getnominal(y) == 1.0
 
-y2 = setnominalvalue(y, 50.0)
-@test getnominalvalue(y2) == 50.0
-@test hasnominalvalue(y2)
+y2 = setnominal(y, 50.0)
+@test getnominal(y2) == 50.0
+@test hasnominal(y2)
 
-@variables z [nominal_value = 0.001]
-@test getnominalvalue(z) == 0.001
+@variables z [nominal = 0.001]
+@test getnominal(z) == 0.001
 
 # Vector of variables
-vals = getnominalvalue([x, y, z])
+vals = getnominal([x, y, z])
 @test vals == [100.0, 1.0, 0.001]
 
 # Vector variables
-@variables yv[1:3] [nominal_value = [100.0, 200.0, 300.0]]
-@test hasnominalvalue(yv)
-@test getnominalvalue(yv) == [100.0, 200.0, 300.0]
+@variables yv[1:3] [nominal = [100.0, 200.0, 300.0]]
+@test hasnominal(yv)
+@test getnominal(yv) == [100.0, 200.0, 300.0]
 for i in 1:3
-    @test hasnominalvalue(yv[i])
+    @test hasnominal(yv[i])
 end
-@test getnominalvalue(yv[1]) == 100.0
-@test getnominalvalue(yv[2]) == 200.0
-@test getnominalvalue(yv[3]) == 300.0
+@test getnominal(yv[1]) == 100.0
+@test getnominal(yv[2]) == 200.0
+@test getnominal(yv[3]) == 300.0
 
 @variables wv[1:3]
-@test !hasnominalvalue(wv)
-@test getnominalvalue(wv[1]) == 1.0
+@test !hasnominal(wv)
+@test getnominal(wv[1]) == 1.0
 
 # System-level accessor
 @independent_variables t5
 Dₜ5 = Differential(t5)
-@variables x5(t5) [nominal_value = 100.0] y5(t5) z5(t5) [nominal_value = 0.001]
+@variables x5(t5) [nominal = 100.0] y5(t5) z5(t5) [nominal = 0.001]
 @parameters α5 = 1.5 β5 = 1.0
 eqs5 = [Dₜ5(x5) ~ α5 * x5, Dₜ5(y5) ~ -β5 * y5, Dₜ5(z5) ~ x5 - z5]
 sys5 = System(eqs5, t5, name = :nominal_test)
-nv = getnominalvalue(sys5, unknowns(sys5))
+nv = getnominal(sys5, unknowns(sys5))
 @test nv isa Dict
 @test length(nv) == length(unknowns(sys5))

--- a/lib/ModelingToolkitBase/test/test_variable_metadata.jl
+++ b/lib/ModelingToolkitBase/test/test_variable_metadata.jl
@@ -263,3 +263,49 @@ x = ModelingToolkitBase.toparam(x)
 
 @brownians z
 @test ModelingToolkitBase.getvariabletype(z) == ModelingToolkitBase.BROWNIAN
+
+# NominalValue
+@variables x [nominal_value = 100.0]
+@test getnominalvalue(x) == 100.0
+@test hasnominalvalue(x)
+
+@variables y
+@test !hasnominalvalue(y)
+@test getnominalvalue(y) == 1.0
+
+y2 = setnominalvalue(y, 50.0)
+@test getnominalvalue(y2) == 50.0
+@test hasnominalvalue(y2)
+
+@variables z [nominal_value = 0.001]
+@test getnominalvalue(z) == 0.001
+
+# Vector of variables
+vals = getnominalvalue([x, y, z])
+@test vals == [100.0, 1.0, 0.001]
+
+# Vector variables
+@variables yv[1:3] [nominal_value = [100.0, 200.0, 300.0]]
+@test hasnominalvalue(yv)
+@test getnominalvalue(yv) == [100.0, 200.0, 300.0]
+for i in 1:3
+    @test hasnominalvalue(yv[i])
+end
+@test getnominalvalue(yv[1]) == 100.0
+@test getnominalvalue(yv[2]) == 200.0
+@test getnominalvalue(yv[3]) == 300.0
+
+@variables wv[1:3]
+@test !hasnominalvalue(wv)
+@test getnominalvalue(wv[1]) == 1.0
+
+# System-level accessor
+@independent_variables t5
+Dₜ5 = Differential(t5)
+@variables x5(t5) [nominal_value = 100.0] y5(t5) z5(t5) [nominal_value = 0.001]
+@parameters α5 = 1.5 β5 = 1.0
+eqs5 = [Dₜ5(x5) ~ α5 * x5, Dₜ5(y5) ~ -β5 * y5, Dₜ5(z5) ~ x5 - z5]
+sys5 = System(eqs5, t5, name = :nominal_test)
+nv = getnominalvalue(sys5, unknowns(sys5))
+@test nv isa Dict
+@test length(nv) == length(unknowns(sys5))


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

Adds nominal value metadata that can be used to scale the dynamics in the context of dynamic optimization or for better tolerance selections for integrators (or several other applications where one benefits from knowing this).
