### PR TITLE
Forward eval_expression and eval_module in nonlinear SCC path

### DIFF
--- a/src/problems/sccnonlinearproblem.jl
+++ b/src/problems/sccnonlinearproblem.jl
@@ -447,6 +447,7 @@ function SCCNonlinearFunction{iip}(
     rps = reorder_parameters(subsys)
     f = generate_rhs(
         subsys; expression = Val{false}, wrap_gfw = Val{true}, cachesyms,
+        eval_expression, eval_module,
         obsidxs_to_use = eachindex(observed(subsys))
     )
 


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
