### PR TITLE
add new HashedRandom guess option and make it the default

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -50,11 +50,9 @@ OrdinaryDiffEqBDF = "6ad6398a-0878-4a85-9266-38940aa047c8"
 OrdinaryDiffEqDefault = "50262376-6c5a-4cf5-baba-aaf4f84d72d7"
 OrdinaryDiffEqRosenbrock = "43230ef6-c299-4910-a778-202eb28ce4ce"
 
-[sources.ModelingToolkitBase]
-subdir = "lib/ModelingToolkitBase"
-
-[sources.SciCompDSL]
-subdir = "lib/SciCompDSL"
+[sources]
+ModelingToolkitBase = {path = "lib/ModelingToolkitBase"}
+SciCompDSL = {path = "lib/SciCompDSL"}
 
 [extensions]
 MTKFMIExt = "FMIImport"

--- a/lib/ModelingToolkitBase/src/systems/problem_utils.jl
+++ b/lib/ModelingToolkitBase/src/systems/problem_utils.jl
@@ -293,17 +293,20 @@ numerical problem from a `System`.
 - `MissingGuessValue.Constant(val::Number)`: Missing guesses are set to the given value
   `val`.
 - `MissingGuessValue.Random(rng::AbstractRNG)`: Missing guesses are set to `rand(rng)`.
+- `MissingGuessValue.HashedRandom`: Missing guesses are set to a
+  deterministically determined random-like value based on the hash of the variable name
 - `MissingGuessValue.Error()`: Missing guess values cause an error.
 """
 Moshi.Data.@data MissingGuessValue begin
     Constant(Number)
     Random(AbstractRNG)
+    HashedRandom
     Error
 end
 
 # To be overloaded downstream by MTK
 default_missing_guess_value() = default_missing_guess_value(nothing)
-default_missing_guess_value(_) = MissingGuessValue.Error()
+default_missing_guess_value(_) = MissingGuessValue.HashedRandom()
 
 """
     $(TYPEDSIGNATURES)
@@ -367,6 +370,15 @@ function varmap_to_vars(
                         varmap[var] = rand(rng, size(var))
                     else
                         write_possibly_indexed_array!(varmap, var, Symbolics.SConst(rand(rng)), COMMON_NOTHING)
+                    end
+                end
+            end
+            MissingGuessValue.HashedRandom() => begin
+                for var in missing_vars
+                    if Symbolics.isarraysymbolic(var)
+                        varmap[var] = [hash(var,i) for i in eachindex(var)]./0x1p64
+                    else
+                        write_possibly_indexed_array!(varmap, var, Symbolics.SConst(hash(var)/0x1p64), COMMON_NOTHING)
                     end
                 end
             end

--- a/lib/ModelingToolkitBase/src/systems/problem_utils.jl
+++ b/lib/ModelingToolkitBase/src/systems/problem_utils.jl
@@ -376,7 +376,7 @@ function varmap_to_vars(
             MissingGuessValue.HashedRandom() => begin
                 for var in missing_vars
                     if Symbolics.isarraysymbolic(var)
-                        varmap[var] = [hash(var,i) for i in eachindex(var)]./0x1p64
+                        varmap[var] = [hash(var,hash(i)) for i in SU.stable_eachindex(var)]./0x1p64
                     else
                         write_possibly_indexed_array!(varmap, var, Symbolics.SConst(hash(var)/0x1p64), COMMON_NOTHING)
                     end

--- a/lib/ModelingToolkitBase/test/implicit_discrete_system.jl
+++ b/lib/ModelingToolkitBase/test/implicit_discrete_system.jl
@@ -30,7 +30,8 @@ rng = StableRNG(22525)
     @mtkcompile sys = System([x(k) ~ x(k) * x(k - 1) - 3], t)
     if @isdefined(ModelingToolkit)
         @test_throws ModelingToolkitBase.MissingGuessError prob = ImplicitDiscreteProblem(
-            sys, [], tspan
+            sys, [], tspan,
+            missing_guess_values = MissingGuessValue.Error()
         )
     end
 end

--- a/lib/ModelingToolkitBase/test/implicit_discrete_system.jl
+++ b/lib/ModelingToolkitBase/test/implicit_discrete_system.jl
@@ -31,7 +31,7 @@ rng = StableRNG(22525)
     if @isdefined(ModelingToolkit)
         @test_throws ModelingToolkitBase.MissingGuessError prob = ImplicitDiscreteProblem(
             sys, [], tspan,
-            missing_guess_values = MissingGuessValue.Error()
+            missing_guess_value = MissingGuessValue.Error()
         )
     end
 end

--- a/lib/ModelingToolkitBase/test/initial_values.jl
+++ b/lib/ModelingToolkitBase/test/initial_values.jl
@@ -203,7 +203,8 @@ end
     pend = complete(pend)
 
     @test_throws ModelingToolkitBase.MissingGuessError ODEProblem(
-        pend, [x => 1, g => 1], (0, 1); guesses = [y => λ, λ => y + 1]
+        pend, [x => 1, g => 1], (0, 1); guesses = [y => λ, λ => y + 1],
+        missing_guess_value==MissingGuessValue.Error()
     )
     ODEProblem(
         pend, [x => 1, D(y) => 0, g => 1], (0, 1);
@@ -215,7 +216,8 @@ end
     eqs = [D(a) ~ b, D(b) ~ c, D(c) ~ d, D(d) ~ e, D(e) ~ 1]
     @mtkcompile sys = System(eqs, t)
     @test_throws ["Cyclic guesses detected"] ODEProblem(
-        sys, [e => 2, a => b, b => a^2 + 1, c => d, d => c^2 + 1], (0, 1); use_scc=false
+        sys, [e => 2, a => b, b => a^2 + 1, c => d, d => c^2 + 1], (0, 1); use_scc=false,
+        missing_guess_value=MissingGuessValue.Error()
     )
 end
 

--- a/lib/ModelingToolkitBase/test/initial_values.jl
+++ b/lib/ModelingToolkitBase/test/initial_values.jl
@@ -204,7 +204,7 @@ end
 
     @test_throws ModelingToolkitBase.MissingGuessError ODEProblem(
         pend, [x => 1, g => 1], (0, 1); guesses = [y => λ, λ => y + 1],
-        missing_guess_value==MissingGuessValue.Error()
+        missing_guess_value = MissingGuessValue.Error()
     )
     ODEProblem(
         pend, [x => 1, D(y) => 0, g => 1], (0, 1);

--- a/lib/ModelingToolkitBase/test/initializationsystem.jl
+++ b/lib/ModelingToolkitBase/test/initializationsystem.jl
@@ -626,7 +626,7 @@ if @isdefined(ModelingToolkit)
         ssys = mtkcompile(sys)
         @test_throws ModelingToolkitBase.MissingGuessError ODEProblem(
             ssys, [x => 3], (0, 1),
-            missing_values = MissingGuessValue.Error()
+            missing_guess_values = MissingGuessValue.Error()
         ) # y should have a guess
     end
 end

--- a/lib/ModelingToolkitBase/test/initializationsystem.jl
+++ b/lib/ModelingToolkitBase/test/initializationsystem.jl
@@ -626,7 +626,7 @@ if @isdefined(ModelingToolkit)
         ssys = mtkcompile(sys)
         @test_throws ModelingToolkitBase.MissingGuessError ODEProblem(
             ssys, [x => 3], (0, 1),
-            missing_guess_values = MissingGuessValue.Error()
+            missing_guess_value = MissingGuessValue.Error()
         ) # y should have a guess
     end
 end

--- a/lib/ModelingToolkitBase/test/initializationsystem.jl
+++ b/lib/ModelingToolkitBase/test/initializationsystem.jl
@@ -625,7 +625,8 @@ if @isdefined(ModelingToolkit)
         @named sys = System([x^2 + y^2 ~ 25, D(x) ~ 1], t)
         ssys = mtkcompile(sys)
         @test_throws ModelingToolkitBase.MissingGuessError ODEProblem(
-            ssys, [x => 3], (0, 1)
+            ssys, [x => 3], (0, 1),
+            missing_values = MissingGuessValue.Error()
         ) # y should have a guess
     end
 end

--- a/src/linearization.jl
+++ b/src/linearization.jl
@@ -46,6 +46,7 @@ function linearization_function(
         warn_initialize_determined = true,
         guesses = Dict{SymbolicT, SymbolicT}(),
         warn_empty_op = true,
+        missing_guess_value = MTKBase.default_missing_guess_value(),
         t = 0.0,
         kwargs...
     )
@@ -91,7 +92,7 @@ function linearization_function(
 
     prob = ODEProblem{true, SciMLBase.FullSpecialize}(
         sys, merge(op, anydict(p)), (t, t); allow_incomplete = true,
-        algebraic_only = true, guesses
+        algebraic_only = true, guesses, missing_guess_value
     )
     u0 = state_values(prob)
 

--- a/src/problems/sccnonlinearproblem.jl
+++ b/src/problems/sccnonlinearproblem.jl
@@ -609,7 +609,7 @@ function SciMLBase.SCCNonlinearProblem{iip}(
                         end
                     end
                     MissingGuessValue.HashedRandom() => begin
-                        newval = [hash(var,i) for i in eachindex(symbolic_idxs)]./0x1p64
+                        newval = [hash(var,hash(i)) for i in SU.stable_eachindex(symbolic_idxs)]./0x1p64
                         _u0[symbolic_idxs] .= newval
                         for (idx, j) in enumerate(symbolic_idxs)
                             write_possibly_indexed_array!(

--- a/src/problems/sccnonlinearproblem.jl
+++ b/src/problems/sccnonlinearproblem.jl
@@ -608,6 +608,15 @@ function SciMLBase.SCCNonlinearProblem{iip}(
                             )
                         end
                     end
+                    MissingGuessValue.HashedRandom() => begin
+                        newval = [hash(var,i) for i in eachindex(symbolic_idxs)]./0x1p64
+                        _u0[symbolic_idxs] .= newval
+                        for (idx, j) in enumerate(symbolic_idxs)
+                            write_possibly_indexed_array!(
+                                op, dvs[vscc[j]], Symbolics.SConst(newval[idx]), COMMON_NOTHING
+                            )
+                        end
+                    end
                     MissingGuessValue.Error() => throw(MissingGuessError(dvs[vscc], _u0))
                 end
             end

--- a/test/linearize.jl
+++ b/test/linearize.jl
@@ -373,7 +373,8 @@ end
     @named sys = System(eqs, t; initial_conditions = [p => 1.0])
     sys = complete(sys)
     @test_throws ModelingToolkit.MissingGuessError linearize(
-        sys, [x], []; op = Dict(x => 1.0), allow_input_derivatives = true
+        sys, [x], []; op = Dict(x => 1.0), allow_input_derivatives = true,
+        missing_guess_values = MissingGuessValue.Error()
     )
     @test_nowarn linearize(
         sys, [x], []; op = Dict(x => 1.0), guesses = Dict(y => 1.0),

--- a/test/linearize.jl
+++ b/test/linearize.jl
@@ -374,7 +374,7 @@ end
     sys = complete(sys)
     @test_throws ModelingToolkit.MissingGuessError linearize(
         sys, [x], []; op = Dict(x => 1.0), allow_input_derivatives = true,
-        missing_guess_values = MissingGuessValue.Error()
+        missing_guess_value = MissingGuessValue.Error()
     )
     @test_nowarn linearize(
         sys, [x], []; op = Dict(x => 1.0), guesses = Dict(y => 1.0),


### PR DESCRIPTION
`HashedRandom` uses `hash(var)/2^64` as an initial value which has the significant advantage over regular random of being deterministic. As such, I think this is a generally reasonable initialization (although it might make sense to also add a multiplication by `getnominal` for both `Random` and `HashedRandom` now that https://github.com/SciML/ModelingToolkit.jl/pull/4425 is merged.