### PR TITLE
fix: enable unscalarized array observed without individual observed elements

### DIFF
--- a/lib/ModelingToolkitBase/src/utils.jl
+++ b/lib/ModelingToolkitBase/src/utils.jl
@@ -1243,9 +1243,10 @@ function observed_equations_used_by(
     obsidxs = BitSet()
     for sym in involved_vars
         sym in available_vars && continue
-        arrsym = iscall(sym) && operation(sym) === getindex ? arguments(sym)[1] : nothing
+        arrsym = split_indexed_var(sym)[1]
         idx = @something(
             get(obsvar_to_idx, sym, nothing),
+            get(obsvar_to_idx, arrsym, nothing),
             Some(nothing)
         )
         idx === nothing && continue

--- a/lib/ModelingToolkitBase/test/code_generation.jl
+++ b/lib/ModelingToolkitBase/test/code_generation.jl
@@ -152,3 +152,9 @@ end
     ps = MTKParameters(sys, nothing)
     @test fn([1.0], ps, 1.5) ≈ 4.0
 end
+
+@testset "Non-scalarized array observed without individual elements being unknowns/observables" begin
+    @variables x(t)[1:3] y(t)
+    @mtkcomplete sys = System([D(y) ~ 2y + sum(x)], t, [y], []; observed = [x ~ [y, y + 1, y + 2]])
+    @test ModelingToolkitBase.observed_equations_used_by(sys, [x[1]]) == [1]
+end


### PR DESCRIPTION
This allows user-defined observed equations that define entire arrays, without the individual elements of the array being other observed equations. This is in contrast to the array hack, which adds `x ~ change_origin(...)` when `x` is an array for which some elements are observed variables.