### PR TITLE
Fix `DiffCacheAllocatorAPIWrapper` conversion errors

### DIFF
--- a/lib/ModelingToolkitBase/src/systems/diffeqs/basic_transformations.jl
+++ b/lib/ModelingToolkitBase/src/systems/diffeqs/basic_transformations.jl
@@ -1166,6 +1166,10 @@ end
 
 DiffCacheAllocatorAPIWrapper{T}(dcapiw::DiffCacheAllocatorAPIWrapper{T}) where {T} = dcapiw
 
+function DiffCacheAllocatorAPIWrapper{T}(dcapiw::DiffCacheAllocatorAPIWrapper) where {T}
+    convert(DiffCacheAllocatorAPIWrapper{T}, dcapiw)
+end
+
 function (dcapiw::DiffCacheAllocatorAPIWrapper)(reference, sz::NTuple{N, Int}) where {N}
     return reshape(get_tmp(dcapiw.cache, reference), sz)
 end

--- a/lib/ModelingToolkitBase/test/index_cache.jl
+++ b/lib/ModelingToolkitBase/test/index_cache.jl
@@ -165,3 +165,24 @@ end
     idata = prob.f.initialization_data
     @test_nowarn @inferred idata.metadata.oop_reconstruct_u0_p.pgetter(prob, idata.initializeprob)
 end
+
+@testset "gradients with special `DiffCache` params" begin
+    @variables x(t)
+    @parameters p1=2.0 p2=3.0
+    @named sys = System([D(x) ~ -p1*x + p2*t], t)
+    sys, _ = ModelingToolkitBase.add_diffcache(sys, 4)
+    sys = complete(sys)
+
+    prob = ODEProblem(sys, [x => 1.0], (0.0, 1.0))
+    setter = setp_oop(prob, [p1, p2])
+
+    function costfn(theta)
+        p = setter(prob, theta)
+        newprob = SciMLBase.remake(prob; p)
+        sol = solve(newprob, Rodas5P(); saveat=0.1)
+        sum(abs2, sol[x])
+    end
+
+    @test costfn([2.0, 3.0]) ≠ zeros(2)
+    @test_nowarn @inferred ForwardDiff.gradient(costfn, [2.0, 3.0])
+end


### PR DESCRIPTION
Fixes
```
ERROR: MethodError: Cannot `convert` an object of type ModelingToolkitBase.DiffCacheAllocatorAPIWrapper{Float64} to an object of type PreallocationTools.DiffCache{Vector{ForwardDiff.Dual{ForwardDiff.Tag{typeof(costfn), Float64}, Float64, 2}}, Vector{ForwardDiff.Dual{ForwardDiff.Tag{typeof(costfn), Float64}, Float64, 2}}}
The function `convert` exists, but no method is defined for this combination of argument types.

Closest candidates are:
  (::Type{PreallocationTools.DiffCache{T, S}} where {T<:AbstractArray, S<:AbstractArray})(::Any, ::Any, ::Any, ::Any)
   @ PreallocationTools ~/.julia/packages/PreallocationTools/K2Foo/src/PreallocationTools.jl:82
  convert(::Type{T}, ::T) where T
   @ Base Base_compiler.jl:133

Stacktrace:
  [1] ModelingToolkitBase.DiffCacheAllocatorAPIWrapper{…}(cache::ModelingToolkitBase.DiffCacheAllocatorAPIWrapper{…})
    @ ModelingToolkitBase ~/.julia/packages/ModelingToolkitBase/jyweh/src/systems/diffeqs/basic_transformations.jl:1164
  [2] _broadcast_getindex_evalf
    @ ./broadcast.jl:699 [inlined]
  [3] _broadcast_getindex
    @ ./broadcast.jl:672 [inlined]
  [4] _getindex
    @ ./broadcast.jl:620 [inlined]
  [5] getindex
    @ ./broadcast.jl:616 [inlined]
  [6] copy
    @ ./broadcast.jl:933 [inlined]
  [7] materialize
    @ ./broadcast.jl:894 [inlined]
  [8] macro expansion
    @ ~/.julia/packages/Setfield/ZezIj/src/sugar.jl:198 [inlined]
  [9] (::ModelingToolkitBase.var"#_getter#742"{…})(valp::NonlinearProblem{…}, initprob::ODEProblem{…})
    @ ModelingToolkitBase ~/.julia/packages/ModelingToolkitBase/jyweh/src/systems/problem_utils.jl:851
 [10] (::ModelingToolkitBase.var"#initprobpmap_split#746"{…})(prob::ODEProblem{…}, initsol::NonlinearProblem{…})
    @ ModelingToolkitBase ~/.julia/packages/ModelingToolkitBase/jyweh/src/systems/problem_utils.jl:974
 [11] get_initial_values(prob::ODEProblem{…}, valp::ODEProblem{…}, f::ODEFunction{…}, alg::SciMLBase.OverrideInit{…}, iip::Val{…}; nlsolve_alg::Nothing, abstol::Nothing, reltol::Nothing, kwargs::@Kwargs{})
    @ SciMLBase ~/.julia/packages/SciMLBase/Ag5zT/src/initialization.jl:325
 [12] get_initial_values
    @ ~/.julia/packages/SciMLBase/Ag5zT/src/initialization.jl:267 [inlined]
 [13] maybe_eager_initialize_problem(prob::ODEProblem{…}, initialization_data::SciMLBase.OverrideInitData{…}, lazy_initialization::Nothing)
    @ SciMLBase ~/.julia/packages/SciMLBase/Ag5zT/src/remake.jl:1576
 [14] remake(prob::ODEProblem{…}; f::Missing, u0::Missing, tspan::Missing, p::MTKParameters{…}, kwargs::Missing, interpret_symbolicmap::Bool, build_initializeprob::Type, use_defaults::Bool, lazy_initialization::Nothing, _kwargs::@Kwargs{})
    @ SciMLBase ~/.julia/packages/SciMLBase/Ag5zT/src/remake.jl:392
 [15] costfn(theta::Vector{ForwardDiff.Dual{ForwardDiff.Tag{typeof(costfn), Float64}, Float64, 2}})
    @ Main ./REPL[19]:3
```

by adding an explicit constructor that does the conversion

## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
