### PR TITLE
refactor: improve error message for faulty causal connections

### DIFF
--- a/lib/ModelingToolkitBase/src/systems/connectors.jl
+++ b/lib/ModelingToolkitBase/src/systems/connectors.jl
@@ -853,6 +853,26 @@ function _flow_equations_from_idxs!(sys::AbstractSystem, eqs::Vector{Equation}, 
     return
 end
 
+struct CausalConnectionSetNoSourceError <: Exception
+    cset::Vector{ConnectionVertex}
+end
+
+function Base.showerror(io::IO, err::CausalConnectionSetNoSourceError)
+    println(
+        io, """
+        Found a causal connection set with no source. For a causal connection set to be valid \
+        it must have one outer input or one inner output. Typically, this happens when a \
+        component incorrectly has two input ports or two output ports instead of one input \
+        and one output port.
+
+        Problematic connection set:
+        """
+    )
+    for cvar in err.cset
+        println(io, "  ", cvar, " ", cvar.type === InputVar ? "(Input)" : "(Output)")
+    end
+end
+
 """
     $(TYPEDSIGNATURES)
 
@@ -895,6 +915,13 @@ function generate_connection_equations_and_stream_connections(
                     end
                     inner_output = cvert
                 end
+            end
+            if inner_output !== nothing
+                root_vert = inner_output
+            elseif outer_input !== nothing
+                root_vert = outer_input
+            else
+                throw(CausalConnectionSetNoSourceError(cset))
             end
             root_vert = something(inner_output, outer_input)
             root_var = variable_from_vertex(sys, root_vert)::SymbolicT

--- a/lib/ModelingToolkitBase/test/components.jl
+++ b/lib/ModelingToolkitBase/test/components.jl
@@ -510,3 +510,34 @@ end
     @test (ss.P1.input.u ~ ss.R.output.u[1]) in equations(sys)
     @test (ss.P2.input.u ~ ss.R.output.u[2]) in equations(sys)
 end
+
+if !@isdefined(ModelingToolkit)
+    @connector function Input(; name)
+        @variables u(t) [input = true]
+        return System(Equation[], t, [u], []; name)
+    end
+    @connector function Output(; name)
+        @variables u(t) [output = true]
+        return System(Equation[], t, [u], []; name)
+    end
+
+    @component function Bad(; name)
+        @named begin
+            in = Input()
+            out = Input()
+        end
+        return System([connect(in.u, out.u)], t, [], []; name, systems = [in, out])
+    end
+    @component function MWE(; name)
+        @named begin
+            bad = Bad()
+            src = Output()
+            dst = Input()
+        end
+        return System([connect(src.u, bad.in.u), connect(bad.out.u, dst.u)], t; name, systems = [bad, src, dst])
+    end
+    @testset "Bad causal connection set throws appropriate error" begin
+        @named sys = MWE()
+        @test_throws ModelingToolkitBase.CausalConnectionSetNoSourceError expand_connections(sys)
+    end
+end


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
