### PR TITLE
refactor: update to new SciMLBase `remake` API hooks with context structs

### DIFF
--- a/lib/ModelingToolkitBase/src/systems/nonlinear/initializesystem.jl
+++ b/lib/ModelingToolkitBase/src/systems/nonlinear/initializesystem.jl
@@ -691,7 +691,7 @@ end
 @static if isdefined(SciMLBase, :LateBindingUpdateU0PContext)
     function SciMLBase.late_binding_update_u0_p(
             prob, sys::AbstractSystem, u0, p, t0, newu0, newp,
-            ctx::SciMLBase.LateBindingUpdateU0PContext = SciMLBase.LateBindingUpdateU0PContext()
+            ctx::SciMLBase.LateBindingUpdateU0PContext
         )
         return _late_binding_update_u0_p_impl(prob, sys, u0, p, t0, newu0, newp)
     end

--- a/lib/ModelingToolkitBase/src/systems/nonlinear/initializesystem.jl
+++ b/lib/ModelingToolkitBase/src/systems/nonlinear/initializesystem.jl
@@ -688,7 +688,26 @@ function promote_u0_p(u0, p, t0)
     return u0, p
 end
 
-function SciMLBase.late_binding_update_u0_p(
+# SciMLBase v3.1.0 added a trailing `ctx::LateBindingUpdateU0PContext`
+# argument (with default) that the v3 public path forwards as an 8th
+# positional. We accept the new arg only when the type exists so that the
+# `SciMLBase = "2, 3"` compat range continues to work on the v2 line.
+@static if isdefined(SciMLBase, :LateBindingUpdateU0PContext)
+    function SciMLBase.late_binding_update_u0_p(
+            prob, sys::AbstractSystem, u0, p, t0, newu0, newp,
+            ctx::SciMLBase.LateBindingUpdateU0PContext = SciMLBase.LateBindingUpdateU0PContext()
+        )
+        return _late_binding_update_u0_p_impl(prob, sys, u0, p, t0, newu0, newp)
+    end
+else
+    function SciMLBase.late_binding_update_u0_p(
+            prob, sys::AbstractSystem, u0, p, t0, newu0, newp
+        )
+        return _late_binding_update_u0_p_impl(prob, sys, u0, p, t0, newu0, newp)
+    end
+end
+
+function _late_binding_update_u0_p_impl(
         prob, sys::AbstractSystem, u0, p, t0, newu0, newp
     )
     supports_initialization(sys) || return newu0, newp

--- a/lib/ModelingToolkitBase/src/systems/nonlinear/initializesystem.jl
+++ b/lib/ModelingToolkitBase/src/systems/nonlinear/initializesystem.jl
@@ -688,10 +688,6 @@ function promote_u0_p(u0, p, t0)
     return u0, p
 end
 
-# SciMLBase v3.1.0 added a trailing `ctx::LateBindingUpdateU0PContext`
-# argument (with default) that the v3 public path forwards as an 8th
-# positional. We accept the new arg only when the type exists so that the
-# `SciMLBase = "2, 3"` compat range continues to work on the v2 line.
 @static if isdefined(SciMLBase, :LateBindingUpdateU0PContext)
     function SciMLBase.late_binding_update_u0_p(
             prob, sys::AbstractSystem, u0, p, t0, newu0, newp,

--- a/lib/ModelingToolkitBase/src/systems/nonlinear/initializesystem.jl
+++ b/lib/ModelingToolkitBase/src/systems/nonlinear/initializesystem.jl
@@ -542,7 +542,22 @@ function _has_delays(sys::AbstractSystem, ex, banned)
     return any(x -> _has_delays(sys, x, banned), args)
 end
 
-function SciMLBase.remake_initialization_data(
+@static if isdefined(SciMLBase, :RemakeInitializationDataContext)
+    function SciMLBase.remake_initialization_data(
+            sys::AbstractSystem, odefn, u0, t0, p, newu0, newp,
+            ::SciMLBase.RemakeInitializationDataContext
+        )
+        _remake_initialization_data_impl(sys, odefn, u0, t0, p, newu0, newp)
+    end
+else
+    function SciMLBase.remake_initialization_data(
+            sys::AbstractSystem, odefn, u0, t0, p, newu0, newp
+        )
+        _remake_initialization_data_impl(sys, odefn, u0, t0, p, newu0, newp)
+    end
+end
+
+function _remake_initialization_data_impl(
         sys::AbstractSystem, odefn, u0, t0, p, newu0, newp
     )
     if u0 === missing && p === missing


### PR DESCRIPTION
Supersedes #4474 