### PR TITLE
Allow `System` to contain only discrete parts

### DIFF
--- a/src/systems/systemstructure.jl
+++ b/src/systems/systemstructure.jl
@@ -157,7 +157,11 @@ function mtkcompile!(
             discrete_pass_idx = findfirst(discrete_compile_pass, additional_passes)
             discrete_compile = additional_passes[discrete_pass_idx]
             deleteat!(additional_passes, discrete_pass_idx)
-            return discrete_compile(tss, clocked_inputs, ci)
+            sys = System(
+                Equation[], get_iv(state.sys)::SymbolicT, SymbolicT[], get_ps(state.sys);
+                name = nameof(state.sys)
+            )
+            return discrete_compile(sys, tss, clocked_inputs, ci, id_to_clock)
         end
         throw(
             HybridSystemNotSupportedException(


### PR DESCRIPTION
So as to not require a dummy continuous part.

## Checklist

- [ ] Appropriate tests were added
- [X] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [X] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

