### PR TITLE
fix: add missing OrderedSet/unwrap imports in CasADi/Pyomo dynamic-opt exts

### DIFF
--- a/lib/ModelingToolkitBase/ext/MTKCasADiDynamicOptExt.jl
+++ b/lib/ModelingToolkitBase/ext/MTKCasADiDynamicOptExt.jl
@@ -4,7 +4,8 @@ using CasADi
 using DiffEqBase
 using UnPack
 using NaNMath
-using Symbolics: SymbolicT
+using OrderedCollections: OrderedSet
+using Symbolics: SymbolicT, unwrap
 const MTK = ModelingToolkitBase
 
 function __init__()

--- a/lib/ModelingToolkitBase/ext/MTKPyomoDynamicOptExt.jl
+++ b/lib/ModelingToolkitBase/ext/MTKPyomoDynamicOptExt.jl
@@ -5,6 +5,8 @@ using DiffEqBase
 using UnPack
 using NaNMath
 using Setfield
+using OrderedCollections: OrderedSet
+using Symbolics: SymbolicT, unwrap
 import SymbolicUtils as SU
 const MTK = ModelingToolkitBase
 


### PR DESCRIPTION
## Summary

The `__init__` workaround added in 4888437 to fix a Julia 1.10 method invalidation bug calls `OrderedSet{SymbolicT}()` and `unwrap(...)`, but neither name is imported in `MTKCasADiDynamicOptExt` or `MTKPyomoDynamicOptExt`. As a result, on Julia 1.10/LTS the extensions fail to load with:

```
InitError: UndefVarError: `OrderedSet` not defined
```

This breaks the LTS `Tests (lts, ModelingToolkit/Extensions)` job — visible failure is the `Rocket launch` test in `test/extensions/dynamic_optimization.jl:320`. The sibling `MTKInfiniteOptExt` already has the proper `using OrderedCollections: OrderedSet` and `using Symbolics: unwrap`, so it loads fine. Mirror those imports.

## Changes

- `lib/ModelingToolkitBase/ext/MTKCasADiDynamicOptExt.jl`: add `using OrderedCollections: OrderedSet` and `using Symbolics: SymbolicT, unwrap`.
- `lib/ModelingToolkitBase/ext/MTKPyomoDynamicOptExt.jl`: same.

## Verification

Reproduced locally on Julia 1.10.11 against this branch: `_force_collect_var_compilation()` now executes successfully. `OrderedCollections` is already a direct `[deps]` of `ModelingToolkitBase` (no `Project.toml` change required).

## Notes

> **Please ignore until reviewed by @ChrisRackauckas.**

This is one fix; master CI is also failing for several other reasons unrelated to this PR (BVP cost-function `DimensionMismatch` in `bvproblem.jl:334/357`, `index_cache.jl:171` `gradients with special DiffCache params` inference failure, Aqua piracy/stale-deps regressions in `ModelingToolkitBase/QA`, plus a missing `gcc` on the `deepsea3-19` self-hosted runner causing the `C Compilation Test` to fail in `Tests (1, ModelingToolkitBase/Extended)`). Each is a separate concern; I'll file an issue tracking them.

## Test plan

- [ ] CI passes the `Tests (lts, ModelingToolkit/Extensions)` job that previously failed loading `MTKCasADiDynamicOptExt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)