### PR TITLE
CI: disable Downgrade workflow until ecosystem stabilizes

### DIFF
--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -14,6 +14,7 @@ on:
       - 'benchmark/**'
 jobs:
   test:
+    if: false
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
Downgrade CI on master is currently red because the lower-bound resolution can't satisfy the constraint set after the SciMLBase v3 / OrdinaryDiffEq v7 / RecursiveArrayTools v4 ecosystem rollout. Mirroring the pattern in `SciML/OrdinaryDiffEq.jl`'s `Downgrade.yml` (`if: false` at the job level), disable the workflow until the ecosystem floors are bumped. The workflow is preserved in tree so it can be re-enabled later.

Ignore until reviewed by @ChrisRackauckas.