### PR TITLE
nospecialize a few more things that gain many specializations without having significant runtime

### DIFF
--- a/lib/ModelingToolkitBase/src/problems/linearproblem.jl
+++ b/lib/ModelingToolkitBase/src/problems/linearproblem.jl
@@ -117,15 +117,17 @@ function SciMLBase.LinearProblem{iip}(
 end
 
 function get_A_b_from_LinearFunction(
-        sys::System, f::LinearFunction, op; kws...
+        sys::System, @nospecialize(f::LinearFunction), op; kws...
     )
     return get_A_b_from_LinearFunction(sys, f, Symbolics.FixpointSubstituter{true}(op); kws...)
 end
 
 function get_A_b_from_LinearFunction(
-        sys::System, f::LinearFunction, subber::Symbolics.FixpointSubstituter{true}; eval_expression = false,
-        eval_module = @__MODULE__, expression = Val{false}, u0_constructor = identity,
-        u0_eltype = float
+        sys::System, @nospecialize(f::LinearFunction), subber::Symbolics.FixpointSubstituter{true};
+        eval_expression = false, eval_module = @__MODULE__,
+        @nospecialize(expression = Val{false}),
+        @nospecialize(u0_constructor = identity),
+        @nospecialize(u0_eltype = float)
     )
     @unpack A, b, interface = f
     if A isa Matrix{SymbolicT}

--- a/lib/ModelingToolkitBase/src/systems/codegen.jl
+++ b/lib/ModelingToolkitBase/src/systems/codegen.jl
@@ -1213,8 +1213,8 @@ The signatures will be of the form `g(...)` with arguments:
 For example, a function `g(op, unknowns, p..., inputs, t, known_disturbances)` will be the in-place function generated if `return_inplace` is true, `ts` is a vector,
 an array of inputs `inputs` is given, `known_disturbance_inputs` is provided, and `param_only` is false for a time-dependent system.
 """
-function build_explicit_observed_function(
-        sys, ts;
+Base.@nospecializeinfer function build_explicit_observed_function(
+        sys, @nospecialize(ts);
         inputs = nothing,
         disturbance_inputs = nothing,
         known_disturbance_inputs = nothing,

--- a/lib/ModelingToolkitBase/src/systems/codegen_utils.jl
+++ b/lib/ModelingToolkitBase/src/systems/codegen_utils.jl
@@ -28,7 +28,11 @@ function generated_argument_name(i::Int)
     return Symbol(:__mtk_arg_, i)
 end
 
-@inline function compute_array_variable_buffer_idxs(args; ignore_vars = Set{SymbolicT}())
+function compute_array_variable_buffer_idxs(@nospecialize(args); ignore_vars = Set{SymbolicT}())
+    _compute_array_variable_buffer_idxs(args isa Vector ? args : collect(args), ignore_vars)
+end
+
+function _compute_array_variable_buffer_idxs(args::Vector, ignore_vars)
     # map array symbolic to an identically sized array where each element is (buffer_idx, idx_in_buffer)
     var_to_arridxs = Dict{SymbolicT, Vector{Tuple{Int, Int}}}()
     for (i, arg) in enumerate(args)
@@ -132,7 +136,7 @@ reconstruct array variables if they are present scalarized in `args`.
   generated function.
 """
 function array_variable_assignments(
-        args...; ignore_vars = Set{SymbolicT}(), filter_vars = nothing,
+        @nospecialize(args...); ignore_vars = Set{SymbolicT}(), filter_vars = nothing,
         argument_name = generated_argument_name, buffer_offset = 0
     )
     var_to_arridxs = compute_array_variable_buffer_idxs(args; ignore_vars)
@@ -332,7 +336,7 @@ Base.@nospecializeinfer function build_function_wrapper(
         p_start += 1
         p_end += 1
     end
-    
+
     ir_info = get_ir_info(sys)
     expr = ir_info.obs_subber(expr)
 

--- a/lib/ModelingToolkitBase/src/systems/problem_utils.jl
+++ b/lib/ModelingToolkitBase/src/systems/problem_utils.jl
@@ -1548,8 +1548,8 @@ $PROBLEM_INTERNAL_KWARGS
 
 All other keyword arguments are passed as-is to `constructor`.
 """
-function process_SciMLProblem(
-        constructor, sys::AbstractSystem, op;
+Base.@nospecializeinfer function process_SciMLProblem(
+        @nospecialize(constructor), sys::AbstractSystem, @nospecialize(op);
         build_initializeprob = supports_initialization(sys),
         implicit_dae = false, t = nothing, guesses = AnyDict(),
         warn_initialize_determined = true, initialization_eqs = [],


### PR DESCRIPTION
I used SnoopCompile (https://github.com/JuliaDebug/SnoopCompile.jl/pull/462 needed) to basically run https://juliadebug.github.io/SnoopCompile.jl/dev/tutorials/pgdsgui/ on creating an ODEProblem and looking at methods that had many specializations

```
  Top 30 methods by inclusive inference time
==================================================================================================================================
Rank  Method                                    Module                Inclusive(s)  Exclusive(s)  #Specs  Location
----------------------------------------------------------------------------------------------------------------------------------
   1  #get_A_b_from_LinearFunction#918          ModelingToolkitBase         1.8858        1.8352      89  /Users/kc/JuliaTests/SymbolicUtilPerf/ModelingToolkit.jl/lib/ModelingToolkitBase/src/problems/linearproblem.jl:125
   2  process_SciMLProblem                      ModelingToolkitBase         1.6369        0.0560      14  /Users/kc/JuliaTests/SymbolicUtilPerf/ModelingToolkit.jl/lib/ModelingToolkitBase/src/systems/problem_utils.jl:1511
   3  #_#795                                    ModelingToolkitBase         1.5327        0.0075       1  /Users/kc/JuliaTests/SymbolicUtilPerf/ModelingToolkit.jl/lib/ModelingToolkitBase/src/problems/odeproblem.jl:101
   4  ODEProblem                                ModelingToolkitBase         1.5317        0.0023       1  none:0
   5  #ODEProblem#793                           ModelingToolkitBase         1.5293        0.0008       2  none:0
   6  #_#794                                    ModelingToolkitBase         1.5276        0.0008       3  none:0
   7  ODEProblem                                ModelingToolkitBase         1.5273        0.0004       3  none:0
   8  ODEProblem                                ModelingToolkitBase         1.5264        0.0005       3  /Users/kc/JuliaTests/SymbolicUtilPerf/ModelingToolkit.jl/lib/ModelingToolkitBase/src/problems/odeproblem.jl:101
   9  #build_explicit_observed_function#699     ModelingToolkitBase         0.9100        0.5522      30  /Users/kc/JuliaTests/SymbolicUtilPerf/ModelingToolkit.jl/lib/ModelingToolkitBase/src/systems/codegen.jl:1219
```

This m method despecializes some of these and timing compile time and runtime for

```
using Multibody, ModelingToolkit

@named model = Multibody.Robot6DOF();
ssys = multibody(model)
prob = ODEProblem(ssys, [
                   ssys.mechanics.r1.phi => deg2rad(-60)
                   ssys.mechanics.r2.phi => deg2rad(20)
                   ssys.mechanics.r3.phi => deg2rad(90)
                   ssys.mechanics.r4.phi => deg2rad(0)
                   ssys.mechanics.r5.phi => deg2rad(-110)
                   ssys.mechanics.r6.phi => deg2rad(0)

                   ssys.axis1.motor.Jmotor.phi => deg2rad(-60) * (-105) # Multiply by gear ratio
                   ssys.axis2.motor.Jmotor.phi => deg2rad(20) * (210)
                   ssys.axis3.motor.Jmotor.phi => deg2rad(90) * (60)

                   ssys.axis1.motor.Jmotor.w => 0
                   ssys.axis2.motor.Jmotor.w => 0
                   ssys.axis3.motor.Jmotor.w => 0
               ], (0.0, 2.0));
```

I get for compile time and runtime respectively:

```

# PR:
# 20.132280 seconds (154.21 M allocations: 8.043 GiB, 7.63% gc time, 67.38% compilation time: 17% of which was recompilation)
# 5.196923 seconds (64.45 M allocations: 3.164 GiB, 14.40% gc time, 1.38% compilation time)

# Master:
#  23.805818 seconds (169.28 M allocations: 8.799 GiB, 8.30% gc time, 71.23% compilation time: 13% of which was recompilation)
#   5.201396 seconds (64.71 M allocations: 3.185 GiB, 15.22% gc time, 2.45% compilation time)
```

so no observed reduction in runtime but around 15% reduced compile time. 