### PR TITLE
test: use `inline_linear_sccs = false` for tests that pass `jac = true`

### DIFF
--- a/lib/ModelingToolkitBase/test/initial_values.jl
+++ b/lib/ModelingToolkitBase/test/initial_values.jl
@@ -292,7 +292,11 @@ end
         0 ~ x^2 + y^2 - w2^2,
     ]
 
-    @mtkcompile sys = System(eqs, t)
+    if @isdefined(ModelingToolkit)
+        @mtkcompile sys = System(eqs, t) reassemble_alg = StructuralTransformations.DefaultReassembleAlgorithm(; inline_linear_sccs = false)
+    else
+        @mtkcompile sys = System(eqs, t)
+    end
 
     u0 = [
         D(x) => 2.0,

--- a/lib/ModelingToolkitBase/test/jacobiansparsity.jl
+++ b/lib/ModelingToolkitBase/test/jacobiansparsity.jl
@@ -124,7 +124,7 @@ if @isdefined(ModelingToolkit)
             D(D(y)) ~ λ * y - g
             x^2 + y^2 ~ 1
         ]
-        @mtkcompile pend = System(eqs, t)
+        @mtkcompile pend = System(eqs, t) reassemble_alg = StructuralTransformations.DefaultReassembleAlgorithm(; inline_linear_sccs = false)
 
         u0 = [x => 1, y => 0]
         prob = ODEProblem(
@@ -161,7 +161,7 @@ if @isdefined(ModelingToolkit)
             D(D(y)) ~ λ * y - g
             x^2 + y^2 ~ 1
         ]
-        @mtkcompile pend = System(eqs, t)
+        @mtkcompile pend = System(eqs, t) reassemble_alg = StructuralTransformations.DefaultReassembleAlgorithm(; inline_linear_sccs = false)
         prob = ODEProblem(
             pend, [x => 0.0, D(x) => 1.0, g => 1.0], (0.0, 1.0);
             guesses = [y => 1.0, λ => 1.0], jac = true, sparse = true

--- a/test/semilinearodeproblem.jl
+++ b/test/semilinearodeproblem.jl
@@ -143,7 +143,10 @@ using ModelingToolkit: t_nounits as t, D_nounits as D
     ]   # 14: M
 
     prob = ODEProblem(Nelson!, u0, tspan, params)
-    sys = mtkcompile(modelingtoolkitize(prob))
+    sys = mtkcompile(
+        modelingtoolkitize(prob);
+        reassemble_alg = StructuralTransformations.DefaultReassembleAlgorithm(; inline_linear_sccs = false)
+    )
     A, B, C = ModelingToolkit.calculate_semiquadratic_form(sys)
     @test A !== nothing
     @test B !== nothing

--- a/test/state_selection.jl
+++ b/test/state_selection.jl
@@ -280,7 +280,10 @@ let
 
     # solution -------------------------------------------------------------------
     @named catapult = System(eqs, t, vars, params, initial_conditions = defs)
-    sys = mtkcompile(catapult)
+    sys = mtkcompile(
+        catapult;
+        reassemble_alg = StructuralTransformations.DefaultReassembleAlgorithm(; inline_linear_sccs = false)
+    )
     prob = ODEProblem(sys, [l_2f => 0.55, damp => 1.0e7], (0.0, 0.1); jac = true)
     @test solve(prob, Rodas4()).retcode == ReturnCode.Success
 end


### PR DESCRIPTION
This is in preparation for enabling `inline_linear_sccs` by default