### PR TITLE
refactor: re-run `eliminate_perfect_aliases!` after `alias_elimination!` 

### DIFF
--- a/src/systems/alias_elimination.jl
+++ b/src/systems/alias_elimination.jl
@@ -82,7 +82,6 @@ function find_perfect_aliases!(
     (; sys, fullvars, structure) = state
     (; graph, solvable_graph, var_to_diff, state_priorities) = structure
 
-    @assert solvable_graph === nothing
     diff_to_var = invview(var_to_diff)
     aliases = Dict{Int, Int}()
     subs = Dict{SymbolicT, SymbolicT}()

--- a/src/systems/alias_elimination.jl
+++ b/src/systems/alias_elimination.jl
@@ -37,7 +37,7 @@ function eliminate_perfect_aliases!(state::TearingState)
     old_to_new_eq, old_to_new_var = StateSelection.rm_eqs_vars!(
         state, eqs_to_rm, vars_to_rm; eqs_sorted_and_uniqued = true
     )
-    return nothing
+    return aliases, old_to_new_eq, old_to_new_var
 end
 
 """

--- a/src/systems/systemstructure.jl
+++ b/src/systems/systemstructure.jl
@@ -213,6 +213,9 @@ function _mtkcompile!(
     eliminate_perfect_aliases!(state)
     StateSelection.trivial_tearing!(state)
     sys, mm = ModelingToolkit.alias_elimination!(state; fully_determined, kwargs...)
+    aliases, old_to_new_eq, old_to_new_var = eliminate_perfect_aliases!(state)
+    sys = state.sys
+    mm = StateSelection.get_new_mm(aliases, old_to_new_eq, old_to_new_var, mm)
     if check_consistency
         fully_determined = StateSelection.check_consistency(
             state, orig_inputs; nothrow = fully_determined === nothing


### PR DESCRIPTION
We run `eliminate_perfect_aliases!` before `alias_elimination!` to (significantly) reduce the number of equations the latter pass has to process. However, `alias_elimination!` identifies additional `x ~ y` equations which can easily be removed by `eliminate_perfect_aliases!`. This has resulted in better simplification on some models.