### PR TITLE
supports_initialization: use get_jumps to keep Enzyme readonly

### DIFF
--- a/lib/ModelingToolkitBase/src/systems/system.jl
+++ b/lib/ModelingToolkitBase/src/systems/system.jl
@@ -1503,7 +1503,15 @@ function Base.showerror(io::IO, err::EventsInTimeIndependentSystemError)
 end
 
 function supports_initialization(sys::System)
-    return isempty(get_systems(sys)) && isempty(jumps(sys)) &&
+    # Use `get_jumps` rather than the flattened `jumps`. The two are
+    # equivalent here because the `isempty(get_systems(sys))` short-circuit
+    # before this term guarantees the subsystem-flattening branch in
+    # `jumps(sys)` (which does `copy` + `append!`) is unreachable. The
+    # mutation in that unreachable branch nevertheless prevents Enzyme from
+    # proving `sys` is read-only, blocking `Enzyme.gradient` through any
+    # closure that ends up at `_late_binding_update_u0_p_impl` — including
+    # `remake(prob; p = repack(tunables))` on MTK-generated problems.
+    return isempty(get_systems(sys)) && isempty(get_jumps(sys)) &&
         isempty(get_costs(sys)) && isempty(get_constraints(sys))
 end
 

--- a/lib/ModelingToolkitBase/src/systems/system.jl
+++ b/lib/ModelingToolkitBase/src/systems/system.jl
@@ -1503,14 +1503,6 @@ function Base.showerror(io::IO, err::EventsInTimeIndependentSystemError)
 end
 
 function supports_initialization(sys::System)
-    # Use `get_jumps` rather than the flattened `jumps`. The two are
-    # equivalent here because the `isempty(get_systems(sys))` short-circuit
-    # before this term guarantees the subsystem-flattening branch in
-    # `jumps(sys)` (which does `copy` + `append!`) is unreachable. The
-    # mutation in that unreachable branch nevertheless prevents Enzyme from
-    # proving `sys` is read-only, blocking `Enzyme.gradient` through any
-    # closure that ends up at `_late_binding_update_u0_p_impl` — including
-    # `remake(prob; p = repack(tunables))` on MTK-generated problems.
     return isempty(get_systems(sys)) && isempty(get_jumps(sys)) &&
         isempty(get_costs(sys)) && isempty(get_constraints(sys))
 end


### PR DESCRIPTION
**Please ignore until reviewed by @ChrisRackauckas.**

## Summary

`supports_initialization(sys)` short-circuits on `isempty(get_systems(sys))`, so the call to `jumps(sys)` here only ever reaches the early-return branch where `jumps(sys) === get_jumps(sys)`. However the unreached `copy(js) + append!(js, namespace_jumps(subsys))` branch in `jumps` is enough to prevent Enzyme's static analysis from proving `sys` read-only at this call site — and that breaks `Enzyme.gradient` through any closure that reaches `_late_binding_update_u0_p_impl`, e.g. `remake(prob; p = repack(tunables))` on any MTK-generated problem.

Swap to `get_jumps(sys)`, which is a pure field accessor and identical in this short-circuited position.

## Verification

The MWE from #4550:

```julia
@parameters a b c
@variables x(t) y(t) z(t)
eqs = [D(x) ~ a*x + y + z, 0 ~ y^3 + y - b*x, 0 ~ z^3 + z - c*y]
@mtkbuild sys = ODESystem(eqs, t)
prob = ODEProblem(sys, [x => 1.0], (0.0, 0.1),
                  [a => -0.5, b => 2.0, c => 1.5];
                  guesses = [y => 1.0, z => 0.5], use_scc = false)
iprob = prob.f.initialization_data.initializeprob
itunables, irepack, _ = SS.canonicalize(SS.Tunable(), parameter_values(iprob))
remake_only = let iprob = iprob, irepack = irepack
    p -> sum(remake(iprob, p = irepack(p)).u0)
end
Enzyme.gradient(Enzyme.Reverse, remake_only, itunables)
```

Before this PR: `EnzymeMutabilityException` at `supports_initialization` → `jumps(sys)`.

After this PR: `Enzyme.gradient` completes (returns a vector). The returned gradient itself is currently `[0.0, …]` because MTK#4181 (Enzyme rule for `SetInitialUnknowns`) is still missing — that's a separate semantic-correctness issue that this PR doesn't touch; it just removes the compile-time blocker.

## What downstream this unblocks

This is **Layer 1** of a 4-layer Enzyme-through-MTK-remake stack documented during the SciMLSensitivity #1323 / #1359 investigation. Layers 2–4 (FunctionWrappersWrappers cache mutation, SciMLBase `Const(loss)` `EnzymeRuntimeActivityError`, Enzyme.jl `MixedDuplicated{NonlinearSolution}` MethodError) still bite once you go past `remake` to `remake + solve`. Those need separate upstream work. The `@test_broken Enzyme.gradient` blocks in SciMLSensitivity's `mtk.jl` / `parameter_initialization.jl` / `desauty_dae_mwe.jl` stay until all four are resolved.

## Refs

- Closes #4550
- Related: #4181 (Enzyme rule for `SetInitialUnknowns` — Layer 4, separate)
- SciML/SciMLSensitivity.jl#1359, #1323

## Test plan
- [x] Local: `Enzyme.gradient` on the MWE no longer errors
- [ ] CI green