### PR TITLE
Declare AbstractSystem as Enzyme inactive_type

### DIFF
--- a/lib/ModelingToolkitBase/src/ModelingToolkitBase.jl
+++ b/lib/ModelingToolkitBase/src/ModelingToolkitBase.jl
@@ -369,6 +369,13 @@ function EnzymeCore.EnzymeRules.inactive_noinl(
     )
     return true
 end
+# Declare the type itself inactive so Enzyme's runtime-activity dispatch
+# (e.g. `MixedDuplicated`-wrapping) never tries to track a `System` as a
+# differentiable value. Without this, `Enzyme.gradient(set_runtime_activity(Reverse),
+# Const(loss), p)` over a closure capturing an MTK-generated problem
+# (which transitively carries the symbolic `System`) trips a
+# `MethodError MixedDuplicated(::System, ::System)` in `create_activity_wrapper`.
+EnzymeCore.EnzymeRules.inactive_type(::Type{<:AbstractSystem}) = true
 
 function __init__()
     SU.hashcons(unwrap(t_nounits), true)


### PR DESCRIPTION
**Please ignore until reviewed by @ChrisRackauckas.**

## Summary

`AbstractSystem` is symbolic metadata — never carries numerical derivative data. The existing `inactive_noinl` rule on `getproperty(::AbstractSystem, ::Symbol)` keeps Enzyme from trying to differentiate `sys.x` property accesses, but does not keep Enzyme's *runtime-activity dispatch* from trying to track the `System` itself.

When a user follows the documented Enzyme idioms — `Const(loss)` for a closure capturing a `Const`-correct mutable problem, plus `set_runtime_activity(Reverse)` for activity inference — and the closure transitively carries a `System` (which is the case for every MTK-generated `NonlinearFunction` / `ODEFunction` via the `ObservedFunctionCache{System,...}` field), Enzyme's runtime-activity wrapping trips:

```
MethodError: no method matching MixedDuplicated(::System, ::System)
  Closest candidates: MixedDuplicated(::T1, ::Base.RefValue{T1}) ...
```

`MixedDuplicated` only accepts a `RefValue`-boxed shadow, so Enzyme's machinery is asking for a shadow it can't produce. The right answer is to tell Enzyme to never wrap `System` in the first place — that's what `inactive_type(::Type{<:AbstractSystem}) = true` does.

## Effect

This is **necessary but not sufficient** to flip the three `@test_broken Enzyme.gradient` blocks in SciML/SciMLSensitivity.jl's `test/mtk.jl`, `test/parameter_initialization.jl`, `test/desauty_dae_mwe.jl`. With this PR applied locally on Julia 1.12.6 (Enzyme 0.13.148), `Enzyme.gradient(set_runtime_activity(Reverse), Const(loss), tunables)` advances past the `MixedDuplicated(::System, ::System)` error and onto the next upstream layer (`TypeError: in new, expected DataType, got Type{Core.SimpleVector}`). The remaining chain is tracked in SciML/SciMLSensitivity.jl#1359.

## Refs

- SciML/SciMLSensitivity.jl#1359 (parent issue)
- SciML/ModelingToolkit.jl#4551 (companion: `supports_initialization` → `get_jumps`)

## Test plan
- [x] Locally on Julia 1.12.6: `Enzyme.gradient(set_runtime_activity(Reverse), Const(loss), tunables)` on parameter_initialization's "Adjoint through Prob (Enzyme)" closure advances past the `MixedDuplicated(::System, ::System)` error after this declaration is added
- [ ] CI green