### PR TITLE
GeneratedFunctionWrapper: define `SciMLBase.numargs` from type parameter

### DIFF
--- a/lib/ModelingToolkitBase/src/systems/codegen_utils.jl
+++ b/lib/ModelingToolkitBase/src/systems/codegen_utils.jl
@@ -466,6 +466,18 @@ function (gfw::GeneratedFunctionWrapper)(args...)
     return _generated_call(gfw, args...)
 end
 
+# Arity is encoded in the type parameter; avoid `methods(f)` (and the
+# `Tuple.parameters → Core.SimpleVector` runtime-getproperty chain it triggers
+# under Enzyme reverse-mode `remake`) by returning the known oop/iip widths
+# directly. Mirrors the existing `SciMLBase.numargs(::RuntimeGeneratedFunction)`
+# special-case for a downstream-defined function type, so callers in SciMLBase
+# (e.g. `SciMLBase.isinplace` during `remake`) dispatch here rather than the
+# generic `methods`-based fallback.
+function SciMLBase.numargs(::GeneratedFunctionWrapper{P}) where {P}
+    n_oop = P[2]
+    return (n_oop, n_oop + 1)
+end
+
 @generated function _generated_call(gfw::GeneratedFunctionWrapper{P}, args...) where {P}
     paramidx, nargs, issplit = P
     iip = false

--- a/lib/ModelingToolkitBase/src/systems/codegen_utils.jl
+++ b/lib/ModelingToolkitBase/src/systems/codegen_utils.jl
@@ -466,13 +466,6 @@ function (gfw::GeneratedFunctionWrapper)(args...)
     return _generated_call(gfw, args...)
 end
 
-# Arity is encoded in the type parameter; avoid `methods(f)` (and the
-# `Tuple.parameters → Core.SimpleVector` runtime-getproperty chain it triggers
-# under Enzyme reverse-mode `remake`) by returning the known oop/iip widths
-# directly. Mirrors the existing `SciMLBase.numargs(::RuntimeGeneratedFunction)`
-# special-case for a downstream-defined function type, so callers in SciMLBase
-# (e.g. `SciMLBase.isinplace` during `remake`) dispatch here rather than the
-# generic `methods`-based fallback.
 function SciMLBase.numargs(::GeneratedFunctionWrapper{P}) where {P}
     n_oop = P[2]
     return (n_oop, n_oop + 1)


### PR DESCRIPTION
**Please ignore until reviewed by @ChrisRackauckas.**

## Summary

`GeneratedFunctionWrapper{P, O, I}` encodes its arity in `P` (a 3-tuple `(paramidx, n_oop, issplit)`). Defining `SciMLBase.numargs` directly from `P` avoids `SciMLBase.numargs`'s default `methods(f)` fallback, which triggers Enzyme's `make_zero(::Core.SimpleVector)` failure on Julia 1.12 via the `getproperty(::Type{Tuple}, :parameters)` chain in `Base.signature_type` / `Base._methods`.

This mirrors the existing `SciMLBase.numargs(::RuntimeGeneratedFunction)` special-case at `SciMLBase/src/utils.jl:16`.

## How it surfaces

`Enzyme.gradient(set_runtime_activity(Reverse), Const(loss), p)` over a closure that does `remake(prob; p = repack(tunables))` on an MTK-generated problem reaches `SciMLBase.isinplace(::NonlinearFunction)` during the `remake` chain, which calls `numargs(prob.f.f)`. Without this special-case, that's a `methods(::GeneratedFunctionWrapper)` call, and Enzyme's runtime-activity wrapping of the resulting `Tuple.parameters` getproperty trips `make_zero(::Core.SimpleVector)` because EnzymeCore has no method for `SimpleVector`.

Replacing the `methods` call with a `(n_oop, n_oop+1)` tuple from the type parameter sidesteps the whole runtime-getproperty path.

## Effect

Verified locally on Julia 1.12.6 + Enzyme 0.13.149: with this patch, the bare `Enzyme.gradient(...)` over `remake(prob; p)` MWE now advances past the `Core.SimpleVector` error and lands on the next layer (DiffEqBase custom-rule `Duplicated{Any}` MethodError, tracked separately).

This unblocks the `@test_broken Enzyme.gradient` blocks in SciMLSensitivity's `test/parameter_initialization.jl` and `test/mtk.jl` at their current failure layer — they'll still hit downstream items, but Layer 6a is one of three concurrent blockers on the chain.

## Refs

- SciML/SciMLSensitivity.jl#1359 (umbrella tracker — "layer 6a" in the most recent status comments)

## Test plan
- [x] `SciMLBase.numargs(::GeneratedFunctionWrapper{(2,3,true), Any, Any})` returns `(3, 4)` as expected
- [x] Local reduction of the SciMLSens `parameter_initialization.jl` / `mtk.jl` Enzyme path advances past the `Core.SimpleVector` failure
- [ ] CI green