### PR TITLE
docs: resolve in-tree subpackages via [sources]

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -18,6 +18,7 @@ Ipopt = "b6b21f68-93f8-5de0-b562-5493be1d77c9"
 JumpProcesses = "ccbc3e58-028d-4f4c-8cd5-9ae44345cda5"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 ModelingToolkit = "961ee093-0014-501f-94e3-6117800e7a78"
+ModelingToolkitBase = "7771a370-6774-4173-bd38-47e70ca0b839"
 ModelingToolkitStandardLibrary = "16a59e39-deab-5bd0-87e4-056b12336739"
 NonlinearSolve = "8913a72c-1f9b-4ce2-8d82-65094dcecaec"
 Optim = "429524aa-4258-5aef-a3af-852621145aeb"
@@ -68,3 +69,8 @@ StochasticDiffEq = "6, 7"
 SymbolicIndexingInterface = "0.3.1"
 SymbolicUtils = "4"
 Symbolics = "7"
+
+[sources]
+ModelingToolkit = {path = ".."}
+ModelingToolkitBase = {path = "../lib/ModelingToolkitBase"}
+SciCompDSL = {path = "../lib/SciCompDSL"}


### PR DESCRIPTION
## Summary
Add a `[sources]` table to `docs/Project.toml` so that `Pkg.instantiate()` automatically dev-links the in-tree subpackages used by the docs build (`ModelingToolkit` itself, plus `ModelingToolkitBase` from `lib/ModelingToolkitBase/` and `SciCompDSL` from `lib/SciCompDSL/`). Also adds the missing `ModelingToolkitBase` entry to `[deps]` (it is `using`-imported from `docs/make.jl` but was not listed).

## Why
Without this, a fresh clone followed by `julia --project=docs -e 'using Pkg; Pkg.instantiate()' && julia --project=docs docs/make.jl` fails with `Package ModelingToolkitBase not found in current path`. CI currently side-channels this via an inline `Pkg.develop([...])` in `.github/workflows/Documentation.yml`; `[sources]` is the Pkg-native equivalent and lets the same `Pkg.instantiate()` call work for contributors, downstream doc tooling, and CI alike.

## Test plan
- [x] `rm docs/Manifest.toml && julia --project=docs -e 'using Pkg; Pkg.instantiate()'` completes clean
- [x] `julia --project=docs -e 'using ModelingToolkit; using ModelingToolkitBase'` succeeds
- [ ] CI docs build still passes (will exercise on this PR)

Note: the existing `Pkg.develop([...])` step in `.github/workflows/Documentation.yml` becomes redundant once `[sources]` is in place and could be simplified to just `Pkg.instantiate()` in a follow-up; this PR leaves it untouched to keep the change minimal.