### PR TITLE
MTKBaseEnzymeExt: mirror Mooncake's tangent_type=NoTangent via EnzymeRules.inactive_type

### DIFF
--- a/lib/ModelingToolkitBase/Project.toml
+++ b/lib/ModelingToolkitBase/Project.toml
@@ -1,7 +1,7 @@
 name = "ModelingToolkitBase"
 uuid = "7771a370-6774-4173-bd38-47e70ca0b839"
 authors = ["Yingbo Ma <mayingbo5@gmail.com>", "Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
-version = "1.40.0"
+version = "1.40.1"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
@@ -67,6 +67,7 @@ CasADi = "c49709b8-5c63-11e9-2fb2-69db5844192f"
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
 DiffEqNoiseProcess = "77a26b50-5914-5dd7-bc55-306e6241c503"
 DynamicQuantities = "06fc5a27-2a28-4c7c-a15d-362465fb6821"
+Enzyme = "7da242da-08ed-463a-9acd-ee780be4f1d9"
 InfiniteOpt = "20393b10-9daf-11e9-18c9-8db751c92c57"
 JuliaFormatter = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
 LabelledArrays = "2ee39098-c373-598a-b85f-a56591580800"
@@ -76,6 +77,7 @@ Pyomo = "0e8e1daf-01b5-4eba-a626-3897743a3816"
 Tracker = "9f7883ad-71c0-57eb-9f7f-b5c9e6d3789c"
 
 [extensions]
+MTKBaseEnzymeExt = "Enzyme"
 MTKBifurcationKitExt = "BifurcationKit"
 MTKCasADiDynamicOptExt = "CasADi"
 MTKChainRulesCoreExt = "ChainRulesCore"
@@ -117,6 +119,7 @@ DocStringExtensions = "0.8, 0.9"
 DomainSets = "0.6, 0.7"
 DynamicQuantities = "^0.11.2, 0.12, 0.13, 1"
 EnumX = "1.0.4"
+Enzyme = "0.13"
 EnzymeCore = "0.8"
 ExprTools = "0.1.10"
 FillArrays = "1.13.0"

--- a/lib/ModelingToolkitBase/ext/MTKBaseEnzymeExt.jl
+++ b/lib/ModelingToolkitBase/ext/MTKBaseEnzymeExt.jl
@@ -1,0 +1,37 @@
+module MTKBaseEnzymeExt
+
+using ModelingToolkitBase: GeneratedFunctionWrapper, ObservedFunctionCache,
+    MissingGuessValue, System
+import Enzyme: EnzymeRules
+
+# Mirror of the declarations in `MTKMooncakeExt` that mark non-differentiable
+# structural / configuration types as inactive. Mooncake handles this through
+# `Mooncake.tangent_type(::Type{T}) = NoTangent`; Enzyme uses
+# `EnzymeRules.inactive_type`.
+#
+# Without these, Enzyme's runtime-activity dispatch and `make_zero` traversal
+# recurse into self-referential or otherwise-unhandleable fields when a
+# closure (or problem/solution struct) transitively captures one of these
+# values, producing activity-analysis errors or `MethodError`s in
+# `create_activity_wrapper`.
+
+# `AbstractSystem` is already declared `inactive_type` in
+# `ModelingToolkitBase.jl` itself (EnzymeCore is a hard dep there); this
+# subtype declaration is redundant but explicit, and keeps the extension in
+# direct one-to-one parity with `MTKMooncakeExt`.
+EnzymeRules.inactive_type(::Type{<:System}) = true
+
+# `GeneratedFunctionWrapper` wraps RuntimeGeneratedFunctions - the model RHS
+# closure, not differentiable data.
+EnzymeRules.inactive_type(::Type{<:GeneratedFunctionWrapper}) = true
+
+# `ObservedFunctionCache` contains a `System` reference and a `Dict{Any,Any}`
+# of cached observed-function closures. Not a derivative carrier.
+EnzymeRules.inactive_type(::Type{<:ObservedFunctionCache}) = true
+
+# `MissingGuessValue.Type` is a Moshi `@data` tagged union
+# (`Constant{<:Number} | Random{<:AbstractRNG} | Error`) used as a
+# configuration enum for initialization. Not differentiable.
+EnzymeRules.inactive_type(::Type{<:MissingGuessValue.Type}) = true
+
+end


### PR DESCRIPTION
## Summary

Adds a new package extension `MTKBaseEnzymeExt` (triggered on `Enzyme`) that registers `EnzymeRules.inactive_type` for the same MTKBase-owned types that `MTKMooncakeExt` already marks `Mooncake.tangent_type = NoTangent`. This is one of several follow-ups for full Enzyme support through MTK-generated problem / initialization-problem closures.

## Types declared inactive

| Type | Where it lives | Rationale |
|---|---|---|
| `System` | `lib/ModelingToolkitBase/src/systems/system.jl` | Self-referential fields `systems::Vector{System}`, `parent::Union{Nothing, System}`, `initializesystem::Union{Nothing, System}`. Already covered by the existing `<:AbstractSystem` declaration in `ModelingToolkitBase.jl`; restated here for one-to-one parity with `MTKMooncakeExt` and explicitness. |
| `GeneratedFunctionWrapper` | `lib/ModelingToolkitBase/src/systems/codegen_utils.jl` | Wraps `RuntimeGeneratedFunctions` — the model RHS closure, not a derivative carrier. |
| `ObservedFunctionCache` | `lib/ModelingToolkitBase/src/systems/abstractsystem.jl` | Contains a `System` reference and a `Dict{Any, Any}` of cached observed-function closures. |
| `MissingGuessValue.Type` | `lib/ModelingToolkitBase/src/systems/problem_utils.jl` | Moshi `@data` tagged union (`Constant{<:Number} \| Random{<:AbstractRNG} \| Error`) used as a configuration enum for the initialization solver. |

## Why this is needed

Without these declarations, Enzyme's runtime-activity dispatch and `make_zero` traversal recurse into self-referential or otherwise-unhandleable fields when a closure (or problem / solution struct) transitively captures one of these values, producing activity-analysis errors or `MethodError`s in `create_activity_wrapper`.

`MTKMooncakeExt` already handles the equivalent on the Mooncake side via `Mooncake.tangent_type(::Type{T}) = NoTangent`. This PR brings the Enzyme side to parity for the types MTKBase owns. Types that live in other packages (`SciMLBase`'s `OverrideInitData` / `ODENLStepData`, `FunctionWrappersWrappers`' `FunctionWrappersWrapper`, `Base`'s `ImmutableDict`) are intentionally **not** declared here — they belong in their own packages' Enzyme extensions; separate PRs to follow.

## Verification

Local smoke test confirmed the extension loads and the declarations apply:

```
System inactive: true
GFW{(3,3,true),Nothing,Nothing} inactive: true
ObservedFunctionCache inactive: true
MissingGuessValue.Type inactive: true
MissingGuessValue.Error type inactive: true
```

## Project.toml changes

- Adds `Enzyme = "7da242da-08ed-463a-9acd-ee780be4f1d9"` to `[weakdeps]`.
- Adds `MTKBaseEnzymeExt = "Enzyme"` to `[extensions]`.
- Adds `Enzyme = "0.13"` to `[compat]`.
- Bumps `ModelingToolkitBase` patch version to `1.40.1`.

## Notes

Please ignore until reviewed by @ChrisRackauckas.

This is the second follow-up in a series of small PRs targeting MTKBase's Enzyme story. The first was the `<:AbstractSystem` `inactive_type` declaration already on master. A separate PR will address the `MTKParameters.canonicalize(::Tunable, ...)` repack closure aliasing fresh `caches` buffers — that fix is independent and stacked on its own branch (`enzyme-fresh-caches-on-repack`).

## Test plan
- [ ] CI green on MTKBase tests (no regression from the inactive_type declarations).
- [ ] Downstream smoke: SCC init-problem gradient through Enzyme (see `test_caches_fix.jl` MWE referenced in the surrounding investigation).

Co-Authored-By: Chris Rackauckas <accounts@chrisrackauckas.com>