### PR TITLE
refactor: wrap `update_A!`, `update_b!` with FWW

### DIFF
--- a/lib/ModelingToolkitBase/src/ModelingToolkitBase.jl
+++ b/lib/ModelingToolkitBase/src/ModelingToolkitBase.jl
@@ -46,6 +46,7 @@ using DocStringExtensions
 using Base: RefValue
 using Combinatorics
 import FunctionWrappersWrappers
+import FunctionWrappersWrappers: FunctionWrappersWrapper
 import FunctionWrappers: FunctionWrapper
 using SciMLStructures
 using Compat

--- a/lib/ModelingToolkitBase/src/problems/linearproblem.jl
+++ b/lib/ModelingToolkitBase/src/problems/linearproblem.jl
@@ -1,5 +1,5 @@
-struct LinearFunction{iip, I} <: SciMLBase.AbstractSciMLFunction{iip}
-    interface::I
+struct LinearFunction{iip} <: SciMLBase.AbstractSciMLFunction{iip}
+    interface::Any
     A::Union{
         Matrix{SymbolicT}, SparseMatrixCSC{SymbolicT, Int},
         Diagonal{SymbolicT, Vector{SymbolicT}},
@@ -66,7 +66,7 @@ function LinearFunction{iip}(
         )
     end
 
-    return LinearFunction{iip, typeof(symbolic_interface)}(symbolic_interface, A, b)
+    return LinearFunction{iip}(symbolic_interface, A, b)
 end
 
 function SciMLBase.LinearProblem(sys::System, op; kwargs...)

--- a/lib/ModelingToolkitBase/src/problems/linearproblem.jl
+++ b/lib/ModelingToolkitBase/src/problems/linearproblem.jl
@@ -109,11 +109,39 @@ function SciMLBase.LinearProblem{iip}(
     A, b = get_A_b_from_LinearFunction(
         sys, f, op; eval_expression, eval_module, expression, u0_constructor
     )
+    if expression === Val{false}
+        symbolic_interface = wrap_symbolic_linear_interface(symbolic_interface, iip, A, b, p)
+    end
 
     kwargs = (; u0, process_kwargs(sys; kwargs...)..., f = symbolic_interface)
     args = (; A, b, p)
 
     return maybe_codegen_scimlproblem(expression, LinearProblem{iip}, args; kwargs...)
+end
+
+function __make_fww(@nospecialize(f), retT, argsT)
+    fwt = (
+        FunctionWrapper{retT, argsT}(f),
+    )
+    cs = FunctionWrappersWrappers.SingleCacheStorage()
+    return FunctionWrappersWrapper{typeof(fwt), FunctionWrappersWrappers.AllowNonIsBits, typeof(cs)}(fwt, cs)
+end
+
+Base.@nospecializeinfer function wrap_symbolic_linear_interface(
+        symbolic_interface::SciMLBase.SymbolicLinearInterface, iip::Bool, A, b, p
+    )
+    # We'll never infer the type of these, so no point specializing on them
+    @nospecialize symbolic_interface, A, b, p
+    if iip
+        update_A! = __make_fww(SciMLBase.Void{Any}(symbolic_interface.update_A!), Nothing, typeof((A, p)))
+        update_b! = __make_fww(SciMLBase.Void{Any}(symbolic_interface.update_b!), Nothing, typeof((b, p)))
+    else
+        update_A! = __make_fww(symbolic_interface.update_A!, typeof(A), typeof((p,)))
+        update_b! = __make_fww(symbolic_interface.update_b!, typeof(b), typeof((p,)))
+    end
+    return SciMLBase.SymbolicLinearInterface(
+        update_A!, update_b!, symbolic_interface.sys, symbolic_interface.observed, nothing
+    )
 end
 
 function get_A_b_from_LinearFunction(

--- a/lib/ModelingToolkitBase/test/initializationsystem.jl
+++ b/lib/ModelingToolkitBase/test/initializationsystem.jl
@@ -1734,7 +1734,6 @@ end
         @test_broken @inferred remake(prob; u0 = 2 .* prob.u0, p = prob.p)
         @test_broken @inferred solve(prob)
     end
-    @inferred solve(prob)
 end
 
 @testset "Issue#3570, #3552: `Initial`s/guesses are copied to `u0` during `solve`/`init`" begin

--- a/src/problems/sccnonlinearproblem.jl
+++ b/src/problems/sccnonlinearproblem.jl
@@ -583,6 +583,7 @@ function SciMLBase.SCCNonlinearProblem{iip}(
             A, b = get_A_b_from_LinearFunction(
                 sys, f, subber; eval_expression, eval_module, u0_constructor, u0_eltype
             )
+            symbolic_interface = MTKBase.wrap_symbolic_linear_interface(symbolic_interface, iip, A, b, p)
             for (j, val) in zip(vscc, _u0)
                 write_possibly_indexed_array!(op, dvs[j], Symbolics.SConst(val), COMMON_NOTHING)
             end

--- a/test/structural_transformation/tearing.jl
+++ b/test/structural_transformation/tearing.jl
@@ -295,7 +295,7 @@ end
 end
 
 @testset "AD through inline linear SCCs works" begin
-    reassemble_alg = StructuralTransformations.DefaultReassembleAlgorithm(; inline_linear_sccs = true)
+    reassemble_alg = StructuralTransformations.DefaultReassembleAlgorithm(; inline_linear_sccs = true, analytical_linear_scc_limit = 1)
     @mtkcompile sys = RCModel() reassemble_alg = reassemble_alg
     prob = ODEProblem(sys, [], (0.0, 10.0))
     @assert prob.p.nonnumeric[1] isa


### PR DESCRIPTION
This avoids excessive specialization during initialization and reduces TTFX.