### PR TITLE
Simplify license statement

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,34 +1,22 @@
-The ModelingToolkit.jl package is licensed under the MIT "Expat" License:
+MIT License
 
-> Copyright (c) 2018-22: Yingbo Ma, Christopher Rackauckas, Julia Computing, and
-> contributors
->
-> Permission is hereby granted, free of charge, to any person obtaining a copy
->
-> of this software and associated documentation files (the "Software"), to deal
->
-> in the Software without restriction, including without limitation the rights
->
-> to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
->
-> copies of the Software, and to permit persons to whom the Software is
->
-> furnished to do so, subject to the following conditions:
->
-> The above copyright notice and this permission notice shall be included in all
->
-> copies or substantial portions of the Software.
->
-> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
->
-> IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
->
-> FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
->
-> AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
->
-> LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
->
-> OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
->
-> SOFTWARE.
+Copyright (c) 2018-2026: Yingbo Ma, Christopher Rackauckas, Julia Computing, and 
+https://github.com/SciML/ModelingToolkit.jl contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
This makes it match https://github.com/JuliaSparse/SparseArrays.jl/blob/main/LICENSE.md exactly, which also has GPL dependencies, so since it's the standard set by the Julia standard library we can just follow that. If anyone has any qualms there, they can open an issue with the julialang/julia or SparseArrays.jl and if that template is changed we will change it downstream, but it's best to just follow the precedent of the whole community instead of acting like lawyers and making stuff up (given this was all already the proposed setup by the legal team for Julia itself).

Fixes https://github.com/SciML/ModelingToolkit.jl/issues/4217
