### PR TITLE
build: re-add Ipopt_jll to test extras + target

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -138,6 +138,7 @@ Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 DynamicQuantities = "06fc5a27-2a28-4c7c-a15d-362465fb6821"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 Ipopt = "b6b21f68-93f8-5de0-b562-5493be1d77c9"
+Ipopt_jll = "9cc047cb-c261-5740-88fc-0cf96f7bdcc7"
 JumpProcesses = "ccbc3e58-028d-4f4c-8cd5-9ae44345cda5"
 Latexify = "23fbe1c1-3f47-55db-b15f-69d7ec21a316"
 LinearSolve = "7ed4a6bd-45f5-4d41-b270-4a48e9bafcae"
@@ -176,4 +177,4 @@ TestEnv = "1e6cf692-eddd-4d53-88a5-2d735e33781b"
 URIs = "5c2747f8-b7ea-4ff2-ba2e-563bfd36b1d4"
 
 [targets]
-test = ["AmplNLWriter", "BenchmarkTools", "BoundaryValueDiffEqMIRK", "BoundaryValueDiffEqAscher", "ControlSystemsBase", "DataInterpolations", "DelayDiffEq", "NonlinearSolve", "ForwardDiff", "Ipopt", "ModelingToolkitStandardLibrary", "Optimization", "OptimizationOptimJL", "OptimizationMOI", "OrdinaryDiffEq", "OrdinaryDiffEqCore", "OrdinaryDiffEqDefault", "REPL", "Random", "ReferenceTests", "SafeTestsets", "StableRNGs", "Statistics", "SteadyStateDiffEq", "Test", "StochasticDiffEq", "Sundials", "Pkg", "OrdinaryDiffEqNonlinearSolve", "Logging", "OptimizationBase", "LinearSolve", "Latexify", "Distributed", "DiffEqNoiseProcess", "DynamicQuantities", "DiffEqCallbacks", "URIs", "JumpProcesses", "RecursiveArrayTools", "SciMLStructures", "SpecialFunctions", "SciCompDSL", "OrdinaryDiffEqRosenbrock", "OrdinaryDiffEqSDIRK", "OrdinaryDiffEqBDF", "OrdinaryDiffEqFunctionMap", "OrdinaryDiffEqFIRK"]
+test = ["AmplNLWriter", "BenchmarkTools", "BoundaryValueDiffEqMIRK", "BoundaryValueDiffEqAscher", "ControlSystemsBase", "DataInterpolations", "DelayDiffEq", "NonlinearSolve", "ForwardDiff", "Ipopt", "Ipopt_jll", "ModelingToolkitStandardLibrary", "Optimization", "OptimizationOptimJL", "OptimizationMOI", "OrdinaryDiffEq", "OrdinaryDiffEqCore", "OrdinaryDiffEqDefault", "REPL", "Random", "ReferenceTests", "SafeTestsets", "StableRNGs", "Statistics", "SteadyStateDiffEq", "Test", "StochasticDiffEq", "Sundials", "Pkg", "OrdinaryDiffEqNonlinearSolve", "Logging", "OptimizationBase", "LinearSolve", "Latexify", "Distributed", "DiffEqNoiseProcess", "DynamicQuantities", "DiffEqCallbacks", "URIs", "JumpProcesses", "RecursiveArrayTools", "SciMLStructures", "SpecialFunctions", "SciCompDSL", "OrdinaryDiffEqRosenbrock", "OrdinaryDiffEqSDIRK", "OrdinaryDiffEqBDF", "OrdinaryDiffEqFunctionMap", "OrdinaryDiffEqFIRK"]


### PR DESCRIPTION
**Ignore until reviewed by @ChrisRackauckas.**

## Summary
- Commit 293de55b ("build: add missing compat entries") accidentally removed `Ipopt_jll` from both the `[extras]` section and the `test` target in the top-level `Project.toml`.
- That same commit changed the in-repo `lib/ModelingToolkitBase/test/optimizationsystem.jl` to use `using Ipopt: Ipopt_jll` instead of `using Ipopt_jll`, which is why MTK's own `ModelingToolkit/InterfaceII` CI stays green (it `Pkg.develop`s the in-repo `lib/ModelingToolkitBase`, so it gets the patched source).
- The registered `ModelingToolkitBase v1.40.0` / `v1.41.0`, however, still ships the original `using Ipopt_jll` form in `test/optimizationsystem.jl`.

## The downstream failure
When MTK's test suite is run as a downstream integration test from another package (e.g. NonlinearSolve.jl's `IntegrationTest` workflow), `Pkg.test` activates MTK's test target — which no longer lists `Ipopt_jll` — but then `runtests.jl`'s `@mtktestset("OptimizationSystem Test", "optimizationsystem.jl")` includes the file from `pkgdir(ModelingToolkitBase)`, where `ModelingToolkitBase` is the registered `v1.40.0` package. That file's first line is:

```julia
using ModelingToolkitBase, SparseArrays, Test, Optimization, OptimizationOptimJL,
    OptimizationMOI, Ipopt, AmplNLWriter, Ipopt_jll, SymbolicIndexingInterface,
    LinearAlgebra
```

and that errors with:
```
LoadError: ArgumentError: Package Ipopt_jll not found in current path.
- Run `import Pkg; Pkg.add("Ipopt_jll")` to install the Ipopt_jll package.
```

Example failure: https://github.com/SciML/NonlinearSolve.jl/actions/runs/26425154569 (job `ModelingToolkit.jl/InterfaceII/1`, `OptimizationSystem Test` errored, `854 passed, 0 failed, 1 errored, 7 broken`).

## The fix
Re-add `Ipopt_jll` to `[extras]` and to the `test` target list in `Project.toml`. This restores the dep so the resolver puts it into the activated test environment in both MTK's own CI and any downstream `Pkg.test` of MTK.

## Test plan
- [ ] Local: `Pkg.activate(".")` + `Pkg.Types.read_project("Project.toml")` confirms `Ipopt_jll` is present in extras and in the `test` target.
- [ ] CI: `ModelingToolkit/InterfaceII` job stays green (it already was, since the in-repo MTKBase patches the import).
- [ ] CI: rerun NonlinearSolve.jl's `IntegrationTest` once this is merged — the `OptimizationSystem Test` should resolve `Ipopt_jll` successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)