### PR TITLE
build: require ModelingToolkitBase 1.42 (fixes #4573 precompile MethodError)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ModelingToolkit"
 uuid = "961ee093-0014-501f-94e3-6117800e7a78"
-version = "11.26.6"
+version = "11.26.7"
 authors = ["Yingbo Ma <mayingbo5@gmail.com>", "Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
 
 [deps]
@@ -86,7 +86,7 @@ Libdl = "1"
 LinearAlgebra = "1"
 LinearSolve = "3.66"
 Logging = "1"
-ModelingToolkitBase = "1.41"
+ModelingToolkitBase = "1.42"
 ModelingToolkitStandardLibrary = "2.20"
 ModelingToolkitTearing = "1.12.1"
 Moshi = "0.3.6"


### PR DESCRIPTION
## Summary

Fixes #4573 — precompilation of `ModelingToolkit` fails on a fresh install with:

```
MethodError: no method matching topsort_equations(::Vector{Equation}, ::Vector{BasicSymbolic...})
  @ ModelingToolkit .../systemstructure.jl:229
```

## Root cause

This is a monorepo cross-package release-sync break.

Commit `da202cb` ("refactor: use `IRStructureSearchBuffer` in `observed2graph`") added a leading `sys::AbstractSystem` argument to two functions that are **defined in `ModelingToolkitBase` but called from `ModelingToolkit`'s `src/`**, *replacing* the old methods rather than overloading them:

| Function | ≤ 1.41 | 1.42 (`da202cb`) | Caller in MTK |
|---|---|---|---|
| `topsort_equations` | `(eqs, unknowns)` | `(sys, eqs, unknowns)` | `src/systems/systemstructure.jl:229` |
| `observed_dependency_graph` | `(eqs)` | `(sys, eqs)` | `src/systems/if_lifting.jl:633` |

`da202cb` updated both call sites **on master**, so master is internally consistent. But the change bumped neither package's version, and the **already-registered `ModelingToolkit ≤ 11.26.6`** still calls the old 2-arg / 1-arg forms. Every registered `11.26.x` declares `ModelingToolkitBase` compat with caret semantics that admits `1.42` (e.g. `"1.41"` ⇒ `[1.41, 2.0)`), so once `ModelingToolkitBase 1.42.0` was registered the resolver began pairing old MTK with the new MTKBase, and precompilation breaks for **everyone** (`topsort_equations` runs in MTKBase's precompile workload). `observed_dependency_graph` is a second, latent landmine on the `IfLifting` path.

## Fix

Raise MTK's lower bound to `ModelingToolkitBase = "1.42"` and bump MTK to `11.26.7`. No code change is required — master's `src/` already uses the 3-arg/2-arg call sites; this just ensures the released MTK requires the MTKBase that defines them.

**Note: a forward release does not rescue users pinned to MTK ≤ 11.26.6** (e.g. held back by another dependency). To fully close this, a retroactive General-registry compat patch capping `ModelingToolkit [11.26.0, 11.26.6]` to `ModelingToolkitBase < 1.42` should also be submitted. That is a JuliaRegistries/General change and is not part of this PR.

## Verification

Reproduced the exact issue error with `ModelingToolkit v11.26.6` + `ModelingToolkitBase v1.42.0` on Julia 1.10, then confirmed master `src/` (this branch) precompiles and loads cleanly against `ModelingToolkitBase 1.42.0`.

---

This PR was prepared by an automated agent — **please ignore until reviewed by @ChrisRackauckas.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
