### PR TITLE
ModelingToolkitBase: allow DomainSets 0.8

### DIFF
--- a/lib/ModelingToolkitBase/Project.toml
+++ b/lib/ModelingToolkitBase/Project.toml
@@ -1,7 +1,7 @@
 name = "ModelingToolkitBase"
 uuid = "7771a370-6774-4173-bd38-47e70ca0b839"
 authors = ["Yingbo Ma <mayingbo5@gmail.com>", "Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
-version = "1.42.1"
+version = "1.42.2"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
@@ -117,7 +117,7 @@ DiffRules = "0.1, 1.0"
 DifferentiationInterface = "0.6.47, 0.7"
 Distributed = "1"
 DocStringExtensions = "0.8, 0.9"
-DomainSets = "0.6, 0.7"
+DomainSets = "0.6, 0.7, 0.8"
 DynamicQuantities = "^0.11.2, 0.12, 0.13, 1"
 EnumX = "1.0.4"
 EnzymeCore = "0.8"


### PR DESCRIPTION
**Please ignore until reviewed by @ChrisRackauckas.**

## What

Widen the `ModelingToolkitBase` `DomainSets` compat bound from `0.6, 0.7` to `0.6, 0.7, 0.8` (and bump the version `1.42.1 -> 1.42.2`).

## Why

This is required to unblock the DomainSets `0.7 -> 0.8` dependabot bump in MethodOfLines.jl ([SciML/MethodOfLines.jl#564](https://github.com/SciML/MethodOfLines.jl/pull/564)). While diagnosing that PR I found that PDEBase was not the only blocker: **ModelingToolkitBase** also pins `DomainSets = "0.6, 0.7"`, so any package that pulls ModelingToolkit (PDEBase, MethodOfLines, ...) cannot resolve DomainSets 0.8. Forcing DomainSets 0.8 in a MethodOfLines test environment produces:

```
ERROR: Unsatisfiable requirements detected for package ModelingToolkitBase [7771a370]:
 └─restricted by compatibility requirements with DomainSets [5b8099bc] to versions: uninstalled
   └─DomainSets [5b8099bc] restricted to versions 0.8 by an explicit requirement, leaving only versions: 0.8.0
```

Symbolics already supports DomainSets 0.8 (`DomainSets = "0.6 - 0.8"` from Symbolics 7.18.1), so ModelingToolkitBase is the last piece of the core MTK stack still capping it at 0.7.

## DomainSets 0.8 breaking changes and why they don't affect ModelingToolkitBase

DomainSets v0.8.0 ([JuliaApproximation/DomainSets.jl#178](https://github.com/JuliaApproximation/DomainSets.jl/issues/178)):
1. Removed an old type piracy so `DomainSets.×` and `LinearAlgebra.×` are now distinct functions.
2. Unexported some internal symbols that now live in FunctionMaps.jl.

ModelingToolkitBase's only DomainSets usage is in `lib/ModelingToolkitBase/src/utils.jl` (and `import DomainSets` in the module):

```julia
const AnyInterval{T} = DomainSets.Interval{A, B, T} where {A, B}
...
lo, hi = unwrap.(DomainSets.endpoints(domain))
lo, hi = DomainSets.endpoints(domain)
```

`DomainSets.Interval` and `DomainSets.endpoints` are fully qualified and remain exported/defined in DomainSets 0.8 (verified locally below). No bare `×` and no unexported internals are used, so **no source changes are required** — only the compat bound.

## Local verification

DomainSets 0.8.0 provides every name ModelingToolkitBase uses:

```
DomainSets version: 0.8.0
endpoints defined: true
endpoints(iv) = (0.0, 2.0)
Interval ctor works: 0.0 .. 2.0
AnyInterval alias ok; iv isa AnyInterval: true
```

With this ModelingToolkitBase branch + a DomainSets-0.8-compatible PDEBase developed into a MethodOfLines test environment, resolution succeeds and selects **DomainSets 0.8.0**, ModelingToolkitBase 1.42.2, and the full MTK/OrdinaryDiffEq/NonlinearSolve stack precompiles cleanly. ModelingToolkitBase precompiled successfully against DomainSets 0.8.0 (the pre-existing `@nospecialize annotation only supported on the first 32 arguments` warning is unrelated to this change). See the MethodOfLines PR for the full passing test output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
Part of the DomainSets 0.8 set: SciML/MethodOfLines.jl#565 (consumer), SciML/PDEBase.jl#81 (the other 0.7 pin).