### PR TITLE
feat: add experimental `CompilerOptions` feature

### DIFF
--- a/lib/ModelingToolkitBase/src/ModelingToolkitBase.jl
+++ b/lib/ModelingToolkitBase/src/ModelingToolkitBase.jl
@@ -236,6 +236,7 @@ const t_nounits = let
 end
 const D_nounits = Differential(t_nounits)
 
+export CompilerOptions
 export ODEFunction, convert_system_indepvar,
     System, OptimizationSystem, JumpSystem, SDESystem, NonlinearSystem, ODESystem
 export SDEFunction

--- a/lib/ModelingToolkitBase/src/systems/codegen.jl
+++ b/lib/ModelingToolkitBase/src/systems/codegen.jl
@@ -37,7 +37,7 @@ function generate_rhs(
         sys::System; implicit_dae = false,
         scalar = false, expression = Val{true}, wrap_gfw = Val{false},
         eval_expression = false, eval_module = @__MODULE__, override_discrete = false,
-        cachesyms = nothing,
+        cachesyms = nothing, optlevel::Int = -1,
         kwargs...
     )
     dvs = unknowns(sys)
@@ -120,7 +120,7 @@ function generate_rhs(
     end
     return maybe_compile_function(
         expression, wrap_gfw, (p_start, nargs, is_split(sys)),
-        res; eval_expression, eval_module
+        res; optlevel, eval_expression, eval_module
     )
 end
 

--- a/lib/ModelingToolkitBase/src/systems/codegen.jl
+++ b/lib/ModelingToolkitBase/src/systems/codegen.jl
@@ -245,7 +245,7 @@ function generate_jacobian(
         sys::System;
         simplify = false, sparse = false, eval_expression = false,
         eval_module = @__MODULE__, expression = Val{true}, wrap_gfw = Val{false},
-        checkbounds = false, kwargs...
+        checkbounds = false, optlevel::Int = -1, kwargs...
     )
     dvs = unknowns(sys)
     jac = calculate_jacobian(sys; simplify, sparse, dvs)
@@ -267,7 +267,8 @@ function generate_jacobian(
         expression_module = eval_module, checkbounds, kwargs...
     )
     return maybe_compile_function(
-        expression, wrap_gfw, (2, nargs, is_split(sys)), res; eval_expression, eval_module
+        expression, wrap_gfw, (2, nargs, is_split(sys)), res;
+        optlevel, eval_expression, eval_module
     )
 end
 
@@ -299,7 +300,7 @@ All other keyword arguments are forwarded to [`build_function_wrapper`](@ref).
 function generate_tgrad(
         sys::System;
         simplify = false, eval_expression = false, eval_module = @__MODULE__,
-        expression = Val{true}, wrap_gfw = Val{false}, kwargs...
+        expression = Val{true}, wrap_gfw = Val{false}, optlevel::Int = -1, kwargs...
     )
     dvs = unknowns(sys)
     ps = parameters(sys; initial_parameters = true)
@@ -317,7 +318,8 @@ function generate_tgrad(
     )
 
     return maybe_compile_function(
-        expression, wrap_gfw, (2, 3, is_split(sys)), res; eval_expression, eval_module
+        expression, wrap_gfw, (2, 3, is_split(sys)), res;
+        optlevel, eval_expression, eval_module
     )
 end
 
@@ -1498,7 +1500,8 @@ All other keyword arguments are forwarded to [`build_function_wrapper`](@ref).
 """
 function generate_update_A(
         sys::System, A::AbstractMatrix; expression = Val{true},
-        wrap_gfw = Val{false}, eval_expression = false, eval_module = @__MODULE__, cachesyms = (), kwargs...
+        wrap_gfw = Val{false}, eval_expression = false, eval_module = @__MODULE__,
+        cachesyms = (), optlevel::Int = -1, kwargs...
     )
     ps = reorder_parameters(sys)
 
@@ -1508,7 +1511,7 @@ function generate_update_A(
     )
     return maybe_compile_function(
         expression, wrap_gfw, (1, 1, is_split(sys)), res;
-        eval_expression, eval_module
+        optlevel, eval_expression, eval_module
     )
 end
 
@@ -1534,7 +1537,8 @@ end
 
 function generate_update_A(
         sys::System, A::Diagonal{SymbolicT, Vector{SymbolicT}}; expression = Val{true},
-        wrap_gfw = Val{false}, eval_expression = false, eval_module = @__MODULE__, cachesyms = (), kwargs...
+        wrap_gfw = Val{false}, eval_expression = false, eval_module = @__MODULE__,
+        cachesyms = (), optlevel::Int = -1, kwargs...
     )
     ps = reorder_parameters(sys)
 
@@ -1545,7 +1549,7 @@ function generate_update_A(
     return DiagonalAMatrixWrapper(
         maybe_compile_function(
             expression, wrap_gfw, (1, 1, is_split(sys)), res;
-            eval_expression, eval_module
+            optlevel, eval_expression, eval_module
         )
     )
 end
@@ -1574,7 +1578,8 @@ end
 
 function generate_update_A(
         sys::System, A::BandedMatrix{SymbolicT, Matrix{SymbolicT}}; expression = Val{true},
-        wrap_gfw = Val{false}, eval_expression = false, eval_module = @__MODULE__, cachesyms = (), kwargs...
+        wrap_gfw = Val{false}, eval_expression = false, eval_module = @__MODULE__,
+        cachesyms = (), optlevel::Int = -1, kwargs...
     )
     ps = reorder_parameters(sys)
 
@@ -1590,7 +1595,7 @@ function generate_update_A(
     return BandedAMatrixWrapper(
         maybe_compile_function(
             expression, wrap_gfw, (1, 1, is_split(sys)), res;
-            eval_expression, eval_module
+            optlevel, eval_expression, eval_module
         ), size(A, 1), BandedMatrices.bandwidths(A)
     )
 end
@@ -1609,7 +1614,8 @@ All other keyword arguments are forwarded to [`build_function_wrapper`](@ref).
 """
 function generate_update_b(
         sys::System, b::AbstractVector; expression = Val{true},
-        wrap_gfw = Val{false}, eval_expression = false, eval_module = @__MODULE__, cachesyms = (), kwargs...
+        wrap_gfw = Val{false}, eval_expression = false, eval_module = @__MODULE__,
+        cachesyms = (), optlevel::Int = -1, kwargs...
     )
     ps = reorder_parameters(sys)
 
@@ -1619,6 +1625,6 @@ function generate_update_b(
     )
     return maybe_compile_function(
         expression, wrap_gfw, (1, 1, is_split(sys)), res;
-        eval_expression, eval_module
+        optlevel, eval_expression, eval_module
     )
 end

--- a/lib/ModelingToolkitBase/src/systems/codegen.jl
+++ b/lib/ModelingToolkitBase/src/systems/codegen.jl
@@ -1381,8 +1381,9 @@ Base.@nospecializeinfer function build_explicit_observed_function(
         return (return_inplace isa Val{true} || return_inplace isa Bool && return_inplace) ? fns : fns[1]
     end
 
-    oop = eval_or_rgf(fns[1]; eval_expression, eval_module)
-    iip = eval_or_rgf(fns[2]; eval_expression, eval_module)
+    compiler_options = get(kwargs, :compiler_options, CompilerOptions())
+    oop = eval_or_rgf(fns[1]; eval_expression, eval_module, compiler_options)
+    iip = eval_or_rgf(fns[2]; eval_expression, eval_module, compiler_options)
     f = GeneratedFunctionWrapper{
         (
             p_start + wrap_delays, length(args) - length(rps) + 1 + wrap_delays, is_split(sys),

--- a/lib/ModelingToolkitBase/src/systems/codegen.jl
+++ b/lib/ModelingToolkitBase/src/systems/codegen.jl
@@ -37,7 +37,7 @@ function generate_rhs(
         sys::System; implicit_dae = false,
         scalar = false, expression = Val{true}, wrap_gfw = Val{false},
         eval_expression = false, eval_module = @__MODULE__, override_discrete = false,
-        cachesyms = nothing, optlevel::Int = -1,
+        cachesyms = nothing, compiler_options::CompilerOptions = CompilerOptions(),
         kwargs...
     )
     dvs = unknowns(sys)
@@ -120,7 +120,7 @@ function generate_rhs(
     end
     return maybe_compile_function(
         expression, wrap_gfw, (p_start, nargs, is_split(sys)),
-        res; optlevel, eval_expression, eval_module
+        res; compiler_options, eval_expression, eval_module
     )
 end
 
@@ -245,7 +245,7 @@ function generate_jacobian(
         sys::System;
         simplify = false, sparse = false, eval_expression = false,
         eval_module = @__MODULE__, expression = Val{true}, wrap_gfw = Val{false},
-        checkbounds = false, optlevel::Int = -1, kwargs...
+        checkbounds = false, compiler_options::CompilerOptions = CompilerOptions(), kwargs...
     )
     dvs = unknowns(sys)
     jac = calculate_jacobian(sys; simplify, sparse, dvs)
@@ -268,7 +268,7 @@ function generate_jacobian(
     )
     return maybe_compile_function(
         expression, wrap_gfw, (2, nargs, is_split(sys)), res;
-        optlevel, eval_expression, eval_module
+        compiler_options, eval_expression, eval_module
     )
 end
 
@@ -300,7 +300,8 @@ All other keyword arguments are forwarded to [`build_function_wrapper`](@ref).
 function generate_tgrad(
         sys::System;
         simplify = false, eval_expression = false, eval_module = @__MODULE__,
-        expression = Val{true}, wrap_gfw = Val{false}, optlevel::Int = -1, kwargs...
+        expression = Val{true}, wrap_gfw = Val{false},
+        compiler_options::CompilerOptions = CompilerOptions(), kwargs...
     )
     dvs = unknowns(sys)
     ps = parameters(sys; initial_parameters = true)
@@ -319,7 +320,7 @@ function generate_tgrad(
 
     return maybe_compile_function(
         expression, wrap_gfw, (2, 3, is_split(sys)), res;
-        optlevel, eval_expression, eval_module
+        compiler_options, eval_expression, eval_module
     )
 end
 
@@ -420,7 +421,8 @@ All other keyword arguments are forwarded to [`build_function_wrapper`](@ref).
 function generate_dae_jacobian(
         sys::System; simplify = false, sparse = false,
         expression = Val{true}, wrap_gfw = Val{false}, eval_expression = false,
-        eval_module = @__MODULE__, kwargs...
+        eval_module = @__MODULE__,
+        compiler_options::CompilerOptions = CompilerOptions(), kwargs...
     )
     dvs = unknowns(sys)
     ps = parameters(sys; initial_parameters = true)
@@ -439,7 +441,8 @@ function generate_dae_jacobian(
         u_arg = 2, p_start = 3, p_end = 2 + length(p), kwargs...
     )
     return maybe_compile_function(
-        expression, wrap_gfw, (3, 5, is_split(sys)), res; eval_expression, eval_module
+        expression, wrap_gfw, (3, 5, is_split(sys)), res;
+        compiler_options, eval_expression, eval_module
     )
 end
 
@@ -1501,7 +1504,7 @@ All other keyword arguments are forwarded to [`build_function_wrapper`](@ref).
 function generate_update_A(
         sys::System, A::AbstractMatrix; expression = Val{true},
         wrap_gfw = Val{false}, eval_expression = false, eval_module = @__MODULE__,
-        cachesyms = (), optlevel::Int = -1, kwargs...
+        cachesyms = (), compiler_options::CompilerOptions = CompilerOptions(), kwargs...
     )
     ps = reorder_parameters(sys)
 
@@ -1511,7 +1514,7 @@ function generate_update_A(
     )
     return maybe_compile_function(
         expression, wrap_gfw, (1, 1, is_split(sys)), res;
-        optlevel, eval_expression, eval_module
+        compiler_options, eval_expression, eval_module
     )
 end
 
@@ -1538,7 +1541,7 @@ end
 function generate_update_A(
         sys::System, A::Diagonal{SymbolicT, Vector{SymbolicT}}; expression = Val{true},
         wrap_gfw = Val{false}, eval_expression = false, eval_module = @__MODULE__,
-        cachesyms = (), optlevel::Int = -1, kwargs...
+        cachesyms = (), compiler_options::CompilerOptions = CompilerOptions(), kwargs...
     )
     ps = reorder_parameters(sys)
 
@@ -1549,7 +1552,7 @@ function generate_update_A(
     return DiagonalAMatrixWrapper(
         maybe_compile_function(
             expression, wrap_gfw, (1, 1, is_split(sys)), res;
-            optlevel, eval_expression, eval_module
+            compiler_options, eval_expression, eval_module
         )
     )
 end
@@ -1579,7 +1582,7 @@ end
 function generate_update_A(
         sys::System, A::BandedMatrix{SymbolicT, Matrix{SymbolicT}}; expression = Val{true},
         wrap_gfw = Val{false}, eval_expression = false, eval_module = @__MODULE__,
-        cachesyms = (), optlevel::Int = -1, kwargs...
+        cachesyms = (), compiler_options::CompilerOptions = CompilerOptions(), kwargs...
     )
     ps = reorder_parameters(sys)
 
@@ -1595,7 +1598,7 @@ function generate_update_A(
     return BandedAMatrixWrapper(
         maybe_compile_function(
             expression, wrap_gfw, (1, 1, is_split(sys)), res;
-            optlevel, eval_expression, eval_module
+            compiler_options, eval_expression, eval_module
         ), size(A, 1), BandedMatrices.bandwidths(A)
     )
 end
@@ -1615,7 +1618,7 @@ All other keyword arguments are forwarded to [`build_function_wrapper`](@ref).
 function generate_update_b(
         sys::System, b::AbstractVector; expression = Val{true},
         wrap_gfw = Val{false}, eval_expression = false, eval_module = @__MODULE__,
-        cachesyms = (), optlevel::Int = -1, kwargs...
+        cachesyms = (), compiler_options::CompilerOptions = CompilerOptions(), kwargs...
     )
     ps = reorder_parameters(sys)
 
@@ -1625,6 +1628,6 @@ function generate_update_b(
     )
     return maybe_compile_function(
         expression, wrap_gfw, (1, 1, is_split(sys)), res;
-        optlevel, eval_expression, eval_module
+        compiler_options, eval_expression, eval_module
     )
 end

--- a/lib/ModelingToolkitBase/src/systems/codegen_utils.jl
+++ b/lib/ModelingToolkitBase/src/systems/codegen_utils.jl
@@ -8,8 +8,13 @@ Given a function expression `expr`, return a callable version of it.
   RuntimeGeneratedFunctions.jl.
 - `eval_module`: The module to `eval` the expression `expr` in. If `!eval_expression`,
   this is the cache and context module for the `RuntimeGeneratedFunction`.
+- `optlevel`: LLVM optimization level (0-3) for the generated function, or -1 (default) to
+  inherit from the module. Injected as `:meta :optlevel` into the function body.
 """
-function eval_or_rgf(expr::Expr; eval_expression = false, eval_module = @__MODULE__)
+function eval_or_rgf(expr::Expr; eval_expression = false, eval_module = @__MODULE__, optlevel::Int = -1)
+    if optlevel != -1
+        expr = _inject_optlevel_meta(expr, optlevel)
+    end
     if eval_expression
         return eval_module.eval(expr)
     else
@@ -18,6 +23,20 @@ function eval_or_rgf(expr::Expr; eval_expression = false, eval_module = @__MODUL
 end
 
 eval_or_rgf(::Nothing; kws...) = nothing
+
+function _inject_optlevel_meta(expr::Expr, optlevel::Int)
+    if expr.head === :function || expr.head === :->
+        body = expr.args[2]
+        meta = Expr(:meta, Expr(:optlevel, optlevel))
+        if body isa Expr && body.head === :block
+            new_body = Expr(:block, meta, body.args...)
+        else
+            new_body = Expr(:block, meta, body)
+        end
+        return Expr(expr.head, expr.args[1], new_body)
+    end
+    return expr
+end
 
 """
     $(TYPEDSIGNATURES)
@@ -458,8 +477,8 @@ function GeneratedFunctionWrapper{P}(::Type{Val{true}}, foop, fiip; kwargs...) w
     return :($(GeneratedFunctionWrapper{P})($foop, $fiip))
 end
 
-function GeneratedFunctionWrapper{P}(::Type{Val{false}}, foop, fiip; kws...) where {P}
-    return GeneratedFunctionWrapper{P}(eval_or_rgf(foop; kws...), eval_or_rgf(fiip; kws...))
+function GeneratedFunctionWrapper{P}(::Type{Val{false}}, foop, fiip; optlevel::Int = -1, kws...) where {P}
+    return GeneratedFunctionWrapper{P}(eval_or_rgf(foop; optlevel, kws...), eval_or_rgf(fiip; optlevel, kws...))
 end
 
 function (gfw::GeneratedFunctionWrapper)(args...)
@@ -512,39 +531,46 @@ Optionally compile a method and optionally wrap it in a `GeneratedFunctionWrappe
 basis of `expression` `wrap_gfw`, both of type `Union{Type{Val{true}}, Type{Val{false}}}`.
 `gfw_args` is the first type parameter of `GeneratedFunctionWrapper`. `f` is a tuple of
 function expressions of the form `(oop, iip)` or a single out-of-place function expression.
-Keyword arguments are forwarded to `eval_or_rgf`.
+
+# Keyword Arguments
+
+- `optlevel`: LLVM optimization level (0-3) for the generated function, or -1 (default) to
+  inherit from the module. Injected as `:meta :optlevel` into the function body expression
+  so it ends up in the `generated_callfunc` CodeInfo.
+
+All other keyword arguments are forwarded to `eval_or_rgf`.
 """
 function maybe_compile_function(
         expression, wrap_gfw::Type{Val{true}},
-        gfw_args::Tuple{Int, Int, Bool}, f::NTuple{2, Expr}; kwargs...
+        gfw_args::Tuple{Int, Int, Bool}, f::NTuple{2, Expr}; optlevel::Int = -1, kwargs...
     )
-    return GeneratedFunctionWrapper{gfw_args}(expression, f...; kwargs...)
+    return GeneratedFunctionWrapper{gfw_args}(expression, f...; optlevel, kwargs...)
 end
 
 function maybe_compile_function(
         expression::Type{Val{false}}, wrap_gfw::Type{Val{false}},
-        gfw_args::Tuple{Int, Int, Bool}, f::NTuple{2, Expr}; kwargs...
+        gfw_args::Tuple{Int, Int, Bool}, f::NTuple{2, Expr}; optlevel::Int = -1, kwargs...
     )
-    return eval_or_rgf.(f; kwargs...)
+    return eval_or_rgf.(f; optlevel, kwargs...)
 end
 
 function maybe_compile_function(
         expression::Type{Val{true}}, wrap_gfw::Type{Val{false}},
-        gfw_args::Tuple{Int, Int, Bool}, f::Union{Expr, NTuple{2, Expr}}; kwargs...
+        gfw_args::Tuple{Int, Int, Bool}, f::Union{Expr, NTuple{2, Expr}}; optlevel::Int = -1, kwargs...
     )
     return f
 end
 
 function maybe_compile_function(
         expression, wrap_gfw::Type{Val{true}},
-        gfw_args::Tuple{Int, Int, Bool}, f::Expr; kwargs...
+        gfw_args::Tuple{Int, Int, Bool}, f::Expr; optlevel::Int = -1, kwargs...
     )
-    return GeneratedFunctionWrapper{gfw_args}(expression, f, nothing; kwargs...)
+    return GeneratedFunctionWrapper{gfw_args}(expression, f, nothing; optlevel, kwargs...)
 end
 
 function maybe_compile_function(
         expression::Type{Val{false}}, wrap_gfw::Type{Val{false}},
-        gfw_args::Tuple{Int, Int, Bool}, f::Expr; kwargs...
+        gfw_args::Tuple{Int, Int, Bool}, f::Expr; optlevel::Int = -1, kwargs...
     )
-    return eval_or_rgf(f; kwargs...)
+    return eval_or_rgf(f; optlevel, kwargs...)
 end

--- a/lib/ModelingToolkitBase/src/systems/codegen_utils.jl
+++ b/lib/ModelingToolkitBase/src/systems/codegen_utils.jl
@@ -47,6 +47,8 @@ end
 
 _has_options(co::CompilerOptions) = co.optlevel != -1 || co.compile != -1 || co.infer != -1
 
+const _COMPILER_OPTIONS_SUPPORTED = isdefined(Base.Experimental, :set_compile!)
+
 """
     $(TYPEDSIGNATURES)
 
@@ -63,7 +65,12 @@ Given a function expression `expr`, return a callable version of it.
 function eval_or_rgf(expr::Expr; eval_expression = false, eval_module = @__MODULE__,
                      compiler_options::CompilerOptions = CompilerOptions())
     if _has_options(compiler_options)
-        expr = _inject_compiler_options_meta(expr, compiler_options)
+        if _COMPILER_OPTIONS_SUPPORTED
+            expr = _inject_compiler_options_meta(expr, compiler_options)
+        else
+            @warn "Non-default CompilerOptions were provided but this Julia build does not \
+                   support per-method compiler options. The options will be ignored." maxlog=1
+        end
     end
     if eval_expression
         return eval_module.eval(expr)

--- a/lib/ModelingToolkitBase/src/systems/codegen_utils.jl
+++ b/lib/ModelingToolkitBase/src/systems/codegen_utils.jl
@@ -1,3 +1,52 @@
+const _COMPILE_OPTIONS = Dict{Symbol, Int}(
+    :off => 0,
+    :on => 1,
+    :all => 2,
+    :min => 3,
+)
+
+"""
+    CompilerOptions(; optlevel = -1, compile = :default, infer = :default)
+
+Options controlling the Julia compiler for generated functions.
+
+Note that this feature is considered experimental.
+
+# Fields
+- `optlevel::Int`: LLVM optimization level (0-3), or -1 (default) to inherit from the module.
+- `compile::Int`: Compilation mode as an integer (0=off, 1=on, 2=all, 3=min), or -1 (default)
+  to inherit. Can also be specified as a symbol: `:off`, `:on`, `:all`, `:min`, or `:default`.
+- `infer::Int`: Type inference (0=off, 1=on), or -1 (default) to inherit. Can also be specified
+  as a Bool or `:default`.
+"""
+struct CompilerOptions
+    optlevel::Int
+    compile::Int
+    infer::Int
+end
+
+function CompilerOptions(; optlevel::Int = -1, compile::Union{Int, Symbol} = :default,
+                           infer::Union{Int, Bool, Symbol} = :default)
+    _compile = if compile isa Symbol
+        compile === :default ? -1 : get(_COMPILE_OPTIONS, compile) do
+            throw(ArgumentError("Invalid compile option: $compile. Valid options: :default, :off, :on, :all, :min"))
+        end
+    else
+        compile
+    end
+    _infer = if infer isa Symbol
+        infer === :default ? -1 :
+            throw(ArgumentError("Invalid infer option: $infer. Valid options: :default, true, false"))
+    elseif infer isa Bool
+        Int(infer)
+    else
+        infer
+    end
+    return CompilerOptions(optlevel, _compile, _infer)
+end
+
+_has_options(co::CompilerOptions) = co.optlevel != -1 || co.compile != -1 || co.infer != -1
+
 """
     $(TYPEDSIGNATURES)
 
@@ -8,12 +57,13 @@ Given a function expression `expr`, return a callable version of it.
   RuntimeGeneratedFunctions.jl.
 - `eval_module`: The module to `eval` the expression `expr` in. If `!eval_expression`,
   this is the cache and context module for the `RuntimeGeneratedFunction`.
-- `optlevel`: LLVM optimization level (0-3) for the generated function, or -1 (default) to
-  inherit from the module. Injected as `:meta :optlevel` into the function body.
+- `compiler_options`: A [`CompilerOptions`](@ref) controlling LLVM optimization level,
+  compilation mode, and type inference for the generated function.
 """
-function eval_or_rgf(expr::Expr; eval_expression = false, eval_module = @__MODULE__, optlevel::Int = -1)
-    if optlevel != -1
-        expr = _inject_optlevel_meta(expr, optlevel)
+function eval_or_rgf(expr::Expr; eval_expression = false, eval_module = @__MODULE__,
+                     compiler_options::CompilerOptions = CompilerOptions())
+    if _has_options(compiler_options)
+        expr = _inject_compiler_options_meta(expr, compiler_options)
     end
     if eval_expression
         return eval_module.eval(expr)
@@ -24,14 +74,17 @@ end
 
 eval_or_rgf(::Nothing; kws...) = nothing
 
-function _inject_optlevel_meta(expr::Expr, optlevel::Int)
+function _inject_compiler_options_meta(expr::Expr, co::CompilerOptions)
     if expr.head === :function || expr.head === :->
         body = expr.args[2]
-        meta = Expr(:meta, Expr(:optlevel, optlevel))
+        metas = Expr[]
+        co.optlevel != -1 && push!(metas, Expr(:meta, Expr(:optlevel, co.optlevel)))
+        co.compile != -1 && push!(metas, Expr(:meta, Expr(:compile, co.compile)))
+        co.infer != -1 && push!(metas, Expr(:meta, Expr(:infer, co.infer)))
         if body isa Expr && body.head === :block
-            new_body = Expr(:block, meta, body.args...)
+            new_body = Expr(:block, metas..., body.args...)
         else
-            new_body = Expr(:block, meta, body)
+            new_body = Expr(:block, metas..., body)
         end
         return Expr(expr.head, expr.args[1], new_body)
     end
@@ -477,8 +530,10 @@ function GeneratedFunctionWrapper{P}(::Type{Val{true}}, foop, fiip; kwargs...) w
     return :($(GeneratedFunctionWrapper{P})($foop, $fiip))
 end
 
-function GeneratedFunctionWrapper{P}(::Type{Val{false}}, foop, fiip; optlevel::Int = -1, kws...) where {P}
-    return GeneratedFunctionWrapper{P}(eval_or_rgf(foop; optlevel, kws...), eval_or_rgf(fiip; optlevel, kws...))
+function GeneratedFunctionWrapper{P}(::Type{Val{false}}, foop, fiip;
+        compiler_options::CompilerOptions = CompilerOptions(), kws...) where {P}
+    return GeneratedFunctionWrapper{P}(eval_or_rgf(foop; compiler_options, kws...),
+                                       eval_or_rgf(fiip; compiler_options, kws...))
 end
 
 function (gfw::GeneratedFunctionWrapper)(args...)
@@ -534,43 +589,47 @@ function expressions of the form `(oop, iip)` or a single out-of-place function 
 
 # Keyword Arguments
 
-- `optlevel`: LLVM optimization level (0-3) for the generated function, or -1 (default) to
-  inherit from the module. Injected as `:meta :optlevel` into the function body expression
-  so it ends up in the `generated_callfunc` CodeInfo.
+- `compiler_options`: A [`CompilerOptions`](@ref) controlling LLVM optimization level,
+  compilation mode, and type inference for the generated function.
 
 All other keyword arguments are forwarded to `eval_or_rgf`.
 """
 function maybe_compile_function(
         expression, wrap_gfw::Type{Val{true}},
-        gfw_args::Tuple{Int, Int, Bool}, f::NTuple{2, Expr}; optlevel::Int = -1, kwargs...
+        gfw_args::Tuple{Int, Int, Bool}, f::NTuple{2, Expr};
+        compiler_options::CompilerOptions = CompilerOptions(), kwargs...
     )
-    return GeneratedFunctionWrapper{gfw_args}(expression, f...; optlevel, kwargs...)
+    return GeneratedFunctionWrapper{gfw_args}(expression, f...; compiler_options, kwargs...)
 end
 
 function maybe_compile_function(
         expression::Type{Val{false}}, wrap_gfw::Type{Val{false}},
-        gfw_args::Tuple{Int, Int, Bool}, f::NTuple{2, Expr}; optlevel::Int = -1, kwargs...
+        gfw_args::Tuple{Int, Int, Bool}, f::NTuple{2, Expr};
+        compiler_options::CompilerOptions = CompilerOptions(), kwargs...
     )
-    return eval_or_rgf.(f; optlevel, kwargs...)
+    return eval_or_rgf.(f; compiler_options, kwargs...)
 end
 
 function maybe_compile_function(
         expression::Type{Val{true}}, wrap_gfw::Type{Val{false}},
-        gfw_args::Tuple{Int, Int, Bool}, f::Union{Expr, NTuple{2, Expr}}; optlevel::Int = -1, kwargs...
+        gfw_args::Tuple{Int, Int, Bool}, f::Union{Expr, NTuple{2, Expr}};
+        compiler_options::CompilerOptions = CompilerOptions(), kwargs...
     )
     return f
 end
 
 function maybe_compile_function(
         expression, wrap_gfw::Type{Val{true}},
-        gfw_args::Tuple{Int, Int, Bool}, f::Expr; optlevel::Int = -1, kwargs...
+        gfw_args::Tuple{Int, Int, Bool}, f::Expr;
+        compiler_options::CompilerOptions = CompilerOptions(), kwargs...
     )
-    return GeneratedFunctionWrapper{gfw_args}(expression, f, nothing; optlevel, kwargs...)
+    return GeneratedFunctionWrapper{gfw_args}(expression, f, nothing; compiler_options, kwargs...)
 end
 
 function maybe_compile_function(
         expression::Type{Val{false}}, wrap_gfw::Type{Val{false}},
-        gfw_args::Tuple{Int, Int, Bool}, f::Expr; optlevel::Int = -1, kwargs...
+        gfw_args::Tuple{Int, Int, Bool}, f::Expr;
+        compiler_options::CompilerOptions = CompilerOptions(), kwargs...
     )
-    return eval_or_rgf(f; optlevel, kwargs...)
+    return eval_or_rgf(f; compiler_options, kwargs...)
 end

--- a/lib/ModelingToolkitBase/src/systems/codegen_utils.jl
+++ b/lib/ModelingToolkitBase/src/systems/codegen_utils.jl
@@ -49,6 +49,64 @@ _has_options(co::CompilerOptions) = co.optlevel != -1 || co.compile != -1 || co.
 
 const _COMPILER_OPTIONS_SUPPORTED = isdefined(Base.Experimental, :set_compile!)
 
+# Fallback modules with module-level compiler options for Julia versions
+# that don't support per-method compiler options (Base.Experimental.set_compile!).
+# We pre-create modules for the most common combinations:
+#   - optimize=0
+#   - optimize=1
+#   - optimize=0, infer=false
+# On Julia versions with per-method support, these modules are still defined
+# but without any special compiler options (they are never used in that case).
+module _EvalModuleOpt0
+    @static if !isdefined(Base.Experimental, :set_compile!)
+        Base.Experimental.@compiler_options optimize=0
+        using RuntimeGeneratedFunctions
+        RuntimeGeneratedFunctions.init(@__MODULE__)
+    end
+end
+module _EvalModuleOpt1
+    @static if !isdefined(Base.Experimental, :set_compile!)
+        Base.Experimental.@compiler_options optimize=1
+        using RuntimeGeneratedFunctions
+        RuntimeGeneratedFunctions.init(@__MODULE__)
+    end
+end
+module _EvalModuleOpt0NoInfer
+    @static if !isdefined(Base.Experimental, :set_compile!)
+        Base.Experimental.@compiler_options optimize=0 infer=false
+        using RuntimeGeneratedFunctions
+        RuntimeGeneratedFunctions.init(@__MODULE__)
+    end
+end
+
+"""
+    _resolve_fallback_eval_module(co::CompilerOptions)
+
+Return a pre-made module with the appropriate module-level compiler options for the
+given `CompilerOptions`. This is used as a fallback on Julia versions that do not support
+per-method compiler options. Only a limited set of option combinations is supported;
+unsupported combinations will throw an error.
+"""
+function _resolve_fallback_eval_module(co::CompilerOptions)
+    if co.compile != -1
+        throw(ArgumentError(
+            "Non-default `compile` compiler option is not supported on Julia $VERSION. " *
+            "Per-method compiler options require Julia with `Base.Experimental.set_compile!` support."))
+    end
+    if co.optlevel == 0 && co.infer == -1
+        return _EvalModuleOpt0
+    elseif co.optlevel == 1 && co.infer == -1
+        return _EvalModuleOpt1
+    elseif co.optlevel == 0 && co.infer == 0
+        return _EvalModuleOpt0NoInfer
+    else
+        throw(ArgumentError(
+            "The compiler option combination (optlevel=$(co.optlevel), infer=$(co.infer)) " *
+            "is not supported on Julia $VERSION without per-method compiler options. " *
+            "Supported fallback combinations: (optlevel=0), (optlevel=1), (optlevel=0, infer=false)."))
+    end
+end
+
 """
     $(TYPEDSIGNATURES)
 
@@ -68,8 +126,12 @@ function eval_or_rgf(expr::Expr; eval_expression = false, eval_module = @__MODUL
         if _COMPILER_OPTIONS_SUPPORTED
             expr = _inject_compiler_options_meta(expr, compiler_options)
         else
-            @warn "Non-default CompilerOptions were provided but this Julia build does not \
-                   support per-method compiler options. The options will be ignored." maxlog=1
+            if eval_module !== @__MODULE__
+                throw(ArgumentError(
+                    "Cannot use both a non-default `eval_module` and non-default `compiler_options` " *
+                    "on Julia $VERSION. Per-method compiler options require `Base.Experimental.set_compile!` support."))
+            end
+            eval_module = _resolve_fallback_eval_module(compiler_options)
         end
     end
     if eval_expression

--- a/lib/ModelingToolkitBase/src/systems/problem_utils.jl
+++ b/lib/ModelingToolkitBase/src/systems/problem_utils.jl
@@ -1795,7 +1795,10 @@ function __process_SciMLProblem(
         substitution_limit = 100, use_scc = true, time_dependent_init = is_time_dependent(sys),
         algebraic_only = false, missing_guess_value = default_missing_guess_value(),
         allow_incomplete = false, is_initializeprob = false, is_steadystateprob = false,
-        return_operating_point = false, kwargs...
+        return_operating_point = false,
+        compiler_options::CompilerOptions = CompilerOptions(),
+        init_compiler_options::CompilerOptions = CompilerOptions(),
+        kwargs...
     )
     dvs = unknowns(sys)
     ps = parameters(sys; initial_parameters = true)
@@ -1833,6 +1836,7 @@ function __process_SciMLProblem(
             circular_dependency_max_cycle_length, circular_dependency_max_cycles, use_scc,
             algebraic_only, allow_incomplete, u0_constructor, p_constructor, floatT,
             time_dependent_init, missing_guess_value, is_steadystateprob, implicit_dae,
+            compiler_options = init_compiler_options,
             kwargs...
         )
 
@@ -1939,6 +1943,7 @@ function __process_SciMLProblem(
         sys; u0 = u0, p = p, t = t,
         eval_expression = eval_expression,
         eval_module = eval_module,
+        compiler_options,
         kwargs...
     )
     if return_operating_point


### PR DESCRIPTION
This allows better control over how Julia compiles specific methods. Currently this does not work with custom `eval_module` without https://github.com/JuliaLang/julia/tree/kc/method_level_optlevel. 