### PR TITLE
Allow BifurcationKit 0.8 in ModelingToolkitBase

### DIFF
--- a/lib/ModelingToolkitBase/Project.toml
+++ b/lib/ModelingToolkitBase/Project.toml
@@ -1,7 +1,7 @@
 name = "ModelingToolkitBase"
 uuid = "7771a370-6774-4173-bd38-47e70ca0b839"
 authors = ["Yingbo Ma <mayingbo5@gmail.com>", "Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
-version = "1.42.2"
+version = "1.42.3"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
@@ -97,7 +97,7 @@ BoundaryValueDiffEqAscher = "1.6.0"
 BoundaryValueDiffEqMIRK = "1.7.0"
 BandedMatrices = "1.11.0"
 BenchmarkTools = "1"
-BifurcationKit = "0.4, 0.5"
+BifurcationKit = "0.4, 0.5, 0.8"
 BipartiteGraphs = "0.1.0"
 BlockArrays = "1.1"
 CasADi = "1.0.7"


### PR DESCRIPTION
> **Please ignore until reviewed by @ChrisRackauckas.** Opened as a draft.

Widens the `BifurcationKit` weakdep compat in `ModelingToolkitBase` to include **0.8** (`"0.4, 0.5"` → `"0.4, 0.5, 0.8"`), and bumps the patch version `1.42.2` → `1.42.3`.

### Why
`MTKBifurcationKitExt` currently caps BifurcationKit at 0.5, which blocks downstream packages from upgrading. In particular, SciML/Catalyst.jl#1476 (Dependabot) tries to allow BifurcationKit 0.8, but the resolver silently falls back to 0.5.8 because this weakcompat is the binding constraint. This change unblocks BifurcationKit 0.8 across the ecosystem.

### Is any extension code change needed? No.
The 0.8 API surface used by `MTKBifurcationKitExt` is unchanged from 0.5:
- `BifurcationKit.BifurcationProblem(F, u0, parms, lens; J, record_from_solution, inplace, ...)` — same keyword signature.
- `BifurcationKit.record_sol_default` and `BifurcationKit.@optic` — still present.
- The `record_from_solution(x, p; k...)` callback contract is unchanged.

### Verification (Julia 1.10, run locally)
- **MTKBase's own extension test** (`lib/ModelingToolkitBase/test/extensions/bifurcationkit.jl`, non-`ModelingToolkit`-gated blocks, exactly as MTK CI runs it) against a dev'd MTKBase 1.42.3 + BifurcationKit 0.8.0: **4/4 pass**.
- **Catalyst's full BifurcationKit extension suite** (which delegates straight into this extension and exercises observables, conservation-law/array `Γ` parameters, nested systems, DAE-coupled CRNs, defaults, and non-autonomous error paths) against the same dev'd MTKBase + BifurcationKit 0.8.0: **35/35 pass**.

This intentionally skips 0.6/0.7 (not tested here); it adds only the 0.8 range that downstream needs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
