### PR TITLE
ci: add centralized sublibrary downgrade CI

### DIFF
--- a/.github/workflows/DowngradeSublibraries.yml
+++ b/.github/workflows/DowngradeSublibraries.yml
@@ -1,0 +1,23 @@
+name: Downgrade Sublibraries
+on:
+  pull_request:
+    branches:
+      - master
+    paths-ignore:
+      - 'docs/**'
+  push:
+    branches:
+      - master
+    paths-ignore:
+      - 'docs/**'
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+jobs:
+  downgrade-sublibraries:
+    uses: "SciML/.github/.github/workflows/sublibrary-downgrade.yml@v1"
+    secrets: "inherit"
+    with:
+      julia-version: "lts"
+      skip: "Pkg,TOML,Statistics,LinearAlgebra,SparseArrays,InteractiveUtils,Random,Test,ModelingToolkit,ModelingToolkitBase,SciCompDSL"
+      allow-reresolve: true


### PR DESCRIPTION
Please ignore until reviewed by @ChrisRackauckas.

Adds a `DowngradeSublibraries.yml` workflow that downgrade-tests all `lib/*` sublibraries via the centralized reusable workflow `SciML/.github/.github/workflows/sublibrary-downgrade.yml@v1` (matching OrdinaryDiffEq.jl's form). The reusable workflow auto-discovers each `lib/<sub>` with a `Project.toml` and runs julia-downgrade-compat + julia-buildpkg + julia-runtest per sublibrary.

Sublibraries covered (auto-discovered, no `projects`/`exclude` set):
- `lib/ModelingToolkitBase`
- `lib/SciCompDSL`

### Skip set and rationale
```
skip: Pkg,TOML,Statistics,LinearAlgebra,SparseArrays,InteractiveUtils,Random,Test,ModelingToolkit,ModelingToolkitBase,SciCompDSL
```
- Standard library entries (`Pkg`, `TOML`, `Statistics`, `LinearAlgebra`, `SparseArrays`, `InteractiveUtils`, `Random`, `Test`) — stdlibs have no meaningful "old" registered version to downgrade to.
- In-repo packages (`ModelingToolkit`, `ModelingToolkitBase`, `SciCompDSL`) — these are the repo's own packages. `SciCompDSL` depends on `ModelingToolkitBase` (via `[sources]` subdir) and its test `develop`s both `ModelingToolkitBase` and the root `ModelingToolkit`; the root `ModelingToolkit` also dev-depends on `ModelingToolkitBase` and `SciCompDSL` via `[sources]`. They must be skipped so downgrade-compat does not pin the in-repo packages to old registered versions — the point is to test the sublibraries against the **current** in-repo code.

No `group-env-*` is set: `ModelingToolkitBase/test/runtests.jl` reads `GROUP` (default `"All"`), and the default `"All"` already runs the full suite, so no env override is needed. `SciCompDSL/test/runtests.jl` reads no group env var.

### Notes
- This adds **new** required-looking status checks. Branch-protection settings may need updating once these checks start reporting; until then, new checks could appear on PRs.
- No existing `DowngradeSublibraries.yml` was present — this is a new file (not a conversion).
- The root-GROUP `sublibrary-tests.yml` model from OrdinaryDiffEq is intentionally NOT added: this repo's sublibs are standalone packages with their own `test/runtests.jl`, not root-GROUP-driven.

🤖 Generated with [Claude Code](https://claude.com/claude-code)