### PR TITLE
ci: route CI through SciML/.github reusable workflows (@v1)

### DIFF
--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -14,24 +14,13 @@ on:
       - 'benchmark/**'
 jobs:
   test:
+    name: "Downgrade"
+    # Preserved from the previous bespoke workflow: this job is intentionally disabled.
     if: false
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        downgrade_mode: ['alldeps']
-        julia-version: ['1.10']
-        group: ['InterfaceI']
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v2
-        with:
-          version: ${{ matrix.julia-version }}
-      - uses: julia-actions/julia-downgrade-compat@v2
-        with:
-          skip: Pkg,TOML
-      - uses: julia-actions/julia-buildpkg@1
-      - uses: julia-actions/julia-runtest@1
-        with:
-          ALLOW_RERESOLVE: false
-        env:
-          GROUP: ${{ matrix.group }}
+    uses: "SciML/.github/.github/workflows/downgrade.yml@v1"
+    with:
+      julia-version: "1.10"
+      group: "InterfaceI"
+      skip: "Pkg,TOML"
+      allow-reresolve: false
+    secrets: "inherit"

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -11,12 +11,6 @@ on:
 
 jobs:
   runic:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v2
-        with:
-          version: '1'
-      - uses: fredrikekre/runic-action@v1
-        with:
-          version: '1'
+    name: "Runic"
+    uses: "SciML/.github/.github/workflows/runic.yml@v1"
+    secrets: "inherit"

--- a/.github/workflows/SpellCheck.yml
+++ b/.github/workflows/SpellCheck.yml
@@ -4,10 +4,6 @@ on: [pull_request]
 
 jobs:
   typos-check:
-    name: Spell Check with Typos
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Actions Repository
-        uses: actions/checkout@v6
-      - name: Check spelling
-        uses: crate-ci/typos@v1.18.0
+    name: "Spell Check with Typos"
+    uses: "SciML/.github/.github/workflows/spellcheck.yml@v1"
+    secrets: "inherit"

--- a/.github/workflows/SublibraryCI.yml
+++ b/.github/workflows/SublibraryCI.yml
@@ -1,0 +1,25 @@
+name: Sublibrary CI
+
+on:
+  pull_request:
+    branches:
+      - master
+      - 'release-'
+      - as/su-v4
+    paths-ignore:
+      - 'docs/**'
+  push:
+    branches:
+      - master
+    paths-ignore:
+      - 'docs/**'
+      - 'benchmark/**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+
+jobs:
+  sublibrary-ci:
+    uses: "SciML/.github/.github/workflows/sublibrary-tests.yml@v1"
+    secrets: "inherit"

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -31,74 +31,19 @@ jobs:
           - "1"
           - "lts"
           - "pre"
-        pkggroup:
-          - ModelingToolkit/InterfaceI
-          - ModelingToolkit/InterfaceII
-          - ModelingToolkit/Initialization
-          - ModelingToolkit/SymbolicIndexingInterface
-          - ModelingToolkit/Extensions
-          - ModelingToolkit/Optimization
-          - ModelingToolkit/Downstream
-          - ModelingToolkit/FMI
-          - ModelingToolkitBase/InterfaceI
-          - ModelingToolkitBase/InterfaceII
-          - ModelingToolkitBase/Initialization
-          - ModelingToolkitBase/SymbolicIndexingInterface
-          - ModelingToolkitBase/Extended
-          - ModelingToolkitBase/RegressionI
-          - ModelingToolkitBase/Extensions
-          - ModelingToolkitBase/Optimization
-          - ModelingToolkitBase/QA
-          - SciCompDSL/All
-        exclude:
-          - version: "pre"
-            pkggroup: ModelingToolkitBase/QA
-    runs-on: ${{ vars.USE_SELF_HOSTED == 'true' && 'self-hosted' || 'ubuntu-latest' }}
-    steps:
-      - uses: actions/checkout@v6
-      - name: "Setup Julia ${{ matrix.version }}"
-        uses: julia-actions/setup-julia@v2
-        with:
-          version: "${{ matrix.version }}"
-          arch: "${{ runner.arch }}"
-      - name: "Test ${{ matrix.pkggroup }}"
-        env:
-          PKGGROUP: ${{ matrix.pkggroup }}
-          JULIA_PKG_PRECOMPILE_AUTO: 0
-        shell: julia --color=yes --check-bounds=yes --depwarn=yes {0}
-        run: |
-          using Pkg
-          const PKGGROUP = ENV["PKGGROUP"]
-          const PKG = split(PKGGROUP, "/")[1]
-          const GROUP = split(PKGGROUP, "/")[2]
-          ENV["GROUP"] = GROUP
-
-          if PKG == "ModelingToolkitBase"
-            @info "Testing ModelingToolkitBase"
-            Pkg.activate("lib/ModelingToolkitBase")
-            @info "Running tests" GROUP
-            Pkg.test()
-          elseif PKG == "ModelingToolkit"
-            @info "Testing ModelingToolkit"
-            Pkg.activate(".")
-            @info "`dev`ing ModelingToolkitBase"
-            Pkg.develop(PackageSpec(; path = "lib/ModelingToolkitBase"))
-            @info "Running tests" GROUP
-            Pkg.test()
-          elseif PKG == "SciCompDSL"
-            @info "Testing SciCompDSL"
-            Pkg.activate("lib/SciCompDSL")
-            @info "Running tests" GROUP
-            Pkg.test()
-          else
-            error("Invalid package $PKG")
-          end
-      - uses: julia-actions/julia-processcoverage@v1
-        with:
-          directories: "src,ext,lib/ModelingToolkitBase/src,lib/ModelingToolkitBase/ext"
-      - name: "Report Coverage with Codecov"
-        uses: codecov/codecov-action@v6
-        with:
-          files: lcov.info
-          token: "${{ secrets.CODECOV_TOKEN }}"
-          fail_ci_if_error: true
+        group:
+          - InterfaceI
+          - InterfaceII
+          - Initialization
+          - SymbolicIndexingInterface
+          - Extensions
+          - Optimization
+          - Downstream
+          - FMI
+    uses: "SciML/.github/.github/workflows/tests.yml@v1"
+    with:
+      julia-version: "${{ matrix.version }}"
+      group: "${{ matrix.group }}"
+      self-hosted: ${{ vars.USE_SELF_HOSTED == 'true' }}
+      coverage-directories: "src,ext,lib/ModelingToolkitBase/src,lib/ModelingToolkitBase/ext"
+    secrets: "inherit"

--- a/lib/ModelingToolkitBase/test/test_groups.toml
+++ b/lib/ModelingToolkitBase/test/test_groups.toml
@@ -1,0 +1,30 @@
+# Test groups and Julia version matrix for the ModelingToolkitBase sublibrary.
+# Consumed by SciML/.github sublibrary-tests.yml (compute_affected_sublibraries.jl).
+# These mirror the per-group matrix that previously lived in .github/workflows/Tests.yml.
+
+[InterfaceI]
+versions = ["lts", "1", "pre"]
+
+[InterfaceII]
+versions = ["lts", "1", "pre"]
+
+[Initialization]
+versions = ["lts", "1", "pre"]
+
+[SymbolicIndexingInterface]
+versions = ["lts", "1", "pre"]
+
+[Extended]
+versions = ["lts", "1", "pre"]
+
+[RegressionI]
+versions = ["lts", "1", "pre"]
+
+[Extensions]
+versions = ["lts", "1", "pre"]
+
+[Optimization]
+versions = ["lts", "1", "pre"]
+
+[QA]
+versions = ["lts", "1"]

--- a/lib/SciCompDSL/test/test_groups.toml
+++ b/lib/SciCompDSL/test/test_groups.toml
@@ -1,0 +1,6 @@
+# Test groups and Julia version matrix for the SciCompDSL sublibrary.
+# Consumed by SciML/.github sublibrary-tests.yml (compute_affected_sublibraries.jl).
+# Mirrors the single "All" group matrix that previously lived in .github/workflows/Tests.yml.
+
+[All]
+versions = ["lts", "1", "pre"]


### PR DESCRIPTION
This routes ModelingToolkit.jl's bespoke GitHub Actions workflows through the centralized reusable workflows in [`SciML/.github`](https://github.com/SciML/.github) (`@v1`), preserving the repo's existing matrices, triggers, concurrency, coverage directories, and per-group/per-version configuration. No CI coverage is dropped.

### Converted to reusable callers

| Workflow | Now calls | Notes |
|---|---|---|
| `Tests.yml` | `tests.yml@v1` | Main ModelingToolkit groups only (`InterfaceI`, `InterfaceII`, `Initialization`, `SymbolicIndexingInterface`, `Extensions`, `Optimization`, `Downstream`, `FMI`). Versions `[1, lts, pre]`, coverage dirs `src,ext,lib/ModelingToolkitBase/src,lib/ModelingToolkitBase/ext`, self-hosted via `vars.USE_SELF_HOSTED`, and the original `on:`/`paths-ignore`/`concurrency` preserved. The local `lib/ModelingToolkitBase` + `lib/SciCompDSL` deps resolve automatically through the existing `[sources]` in `Project.toml`. |
| `SublibraryCI.yml` (new) | `sublibrary-tests.yml@v1` | Auto-discovers `lib/*`. The sublibrary test groups that previously lived inline in `Tests.yml` (the `ModelingToolkitBase/*` and `SciCompDSL/All` rows) are now expressed as `lib/<name>/test/test_groups.toml`, preserving the exact group + version matrix (incl. `QA` excluding `pre`). |
| `Downgrade.yml` | `downgrade.yml@v1` | `julia-version: 1.10`, `group: InterfaceI`, `skip: Pkg,TOML`, `allow-reresolve: false` carried over. The job remains intentionally disabled (`if: false`), matching current behavior. |
| `FormatCheck.yml` | `runic.yml@v1` | Repo already formats with Runic. |
| `SpellCheck.yml` | `spellcheck.yml@v1` | typos check. |

### `test_groups.toml` added (preserve sublibrary matrix)

- `lib/ModelingToolkitBase/test/test_groups.toml`: `InterfaceI, InterfaceII, Initialization, SymbolicIndexingInterface, Extended, RegressionI, Extensions, Optimization` on `[lts, 1, pre]`; `QA` on `[lts, 1]`.
- `lib/SciCompDSL/test/test_groups.toml`: `All` on `[lts, 1, pre]`.

### Intentionally left bespoke (no reusable can faithfully express them)

- **`Documentation.yml`** — installs `xorg/mesa/xvfb/GL` system packages and `dev`s all three packages (main + both sublibraries) into the docs env. `documentation.yml@v1` has no inputs for the GUI system deps or multi-package develop, so converting would break the docs build.
- **`Downstream.yml`** (IntegrationTest) — `dev`s `lib/ModelingToolkitBase` alongside the main package and conditionally `dev`s a downstream-repo subpackage (e.g. `StateSelection.jl`'s `ModelingToolkitTearing`). `downstream.yml@v1` cannot express the extra local-lib develop nor the per-entry `subpkg` mechanism.
- **`ReleaseTest.yml`** — adds the *registered* downstream package (`Pkg.add`) and tests it, which is a different pattern from `downstream.yml@v1` (clone the downstream repo + develop this PR).
- **`benchmark.yml`** — uses AirspeedVelocity with a `version` matrix (`[1, lts]`) and `extra-pkgs`. `benchmark.yml@v1` only exposes a single `julia-version` and no `extra-pkgs`, so converting would drop the lts run and the extra packages.
- **`TagBot.yml`**, **`CompatHelper.yml`** — non-CI automation; no reusable.

### NOTE: branch protection must be updated

Required-status-check **names change** to the reusable workflows' job names. Branch protection on `master` will need its required checks remapped (e.g. the old `Tests / Tests (...)` matrix names and the inline sublibrary check names are replaced by the reusable `tests.yml` / `sublibrary-tests.yml` job names). Until that is done, merges may be blocked on now-nonexistent checks.

Also note that `sublibrary-tests.yml@v1` runs only the sublibraries **affected by the changed files** (dependency-graph change detection), rather than always running every sublibrary group on every PR. This is the intended SciML monorepo behavior.

---

Please ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
