### PR TITLE
ci: add sublibrary test_groups.toml so centralized SublibraryCI runs all groups

### DIFF
--- a/lib/ModelingToolkitBase/test/runtests.jl
+++ b/lib/ModelingToolkitBase/test/runtests.jl
@@ -2,7 +2,16 @@ using SafeTestsets, Pkg, Test
 # https://github.com/JuliaLang/julia/issues/54664
 import REPL
 
-const GROUP = get(ENV, "GROUP", "All")
+# The centralized SciML sublibrary CI (SublibraryCI.yml -> sublibrary-tests.yml@v1)
+# emits GROUP="ModelingToolkitBase" for the [Core] section and
+# GROUP="ModelingToolkitBase_<Section>" for every other section in test_groups.toml.
+# Strip that "<pkg>_" prefix so the bare section names below ("InterfaceI", "QA", …)
+# drive the dispatch. A bare "<pkg>" maps to "Core"; anything else (e.g. "All" for
+# local runs) is passed through unchanged.
+const _G = get(ENV, "GROUP", "All")
+const _SUB = "ModelingToolkitBase"
+const GROUP = _G == _SUB ? "Core" :
+              (startswith(_G, _SUB * "_") ? _G[(length(_SUB) + 2):end] : _G)
 
 function activate_extensions_env()
     Pkg.activate("extensions")

--- a/lib/SciCompDSL/test/test_groups.toml
+++ b/lib/SciCompDSL/test/test_groups.toml
@@ -1,6 +1,8 @@
 # Test groups and Julia version matrix for the SciCompDSL sublibrary.
 # Consumed by SciML/.github sublibrary-tests.yml (compute_affected_sublibraries.jl).
 # Mirrors the single "All" group matrix that previously lived in .github/workflows/Tests.yml.
+# runtests.jl runs every testset unconditionally, so the single always-on group is [Core]
+# (emits GROUP="SciCompDSL"); no GROUP gating is needed in runtests.jl.
 
-[All]
+[Core]
 versions = ["lts", "1", "pre"]


### PR DESCRIPTION
## What this does

This **keeps** the centralized sublibrary-CI form
(`.github/workflows/SublibraryCI.yml` -> `SciML/.github/.github/workflows/sublibrary-tests.yml@v1`)
and makes every group/version actually run, by fixing the `runtests.jl` GROUP parsing
to match what the reusable workflow emits. It does **not** revert to bespoke `CI_*.yml` /
`Tests.yml` matrices.

## The bug

`compute_affected_sublibraries.jl@v1` builds the matrix from `lib/<sub>/test/test_groups.toml`
and sets, per leg:

- `GROUP = "<pkg>"` for the `[Core]` section
- `GROUP = "<pkg>_<Section>"` for every other section

`lib/ModelingToolkitBase/test/runtests.jl` matched only the **bare** section names
(`All`/`InterfaceI`/`InterfaceII`/`Initialization`/`SymbolicIndexingInterface`/`Extended`/
`RegressionI`/`Extensions`/`Optimization`/`QA`). So the emitted
`GROUP="ModelingToolkitBase_InterfaceI"` etc. matched **no** `if`-branch and every leg ran
**zero** tests.

## The fix (fix-forward, stays centralized)

1. Add a GROUP-parsing shim at the top of `lib/ModelingToolkitBase/test/runtests.jl`:

   ```julia
   const _G = get(ENV, "GROUP", "All")
   const _SUB = "ModelingToolkitBase"
   const GROUP = _G == _SUB ? "Core" :
                 (startswith(_G, _SUB * "_") ? _G[(length(_SUB) + 2):end] : _G)
   ```

   so `GROUP="ModelingToolkitBase_InterfaceI"` -> `"InterfaceI"`, `GROUP="ModelingToolkitBase"`
   -> `"Core"`, and `"All"` (local runs) is preserved. The existing bare-name dispatch then
   runs unchanged.

2. Rename SciCompDSL's single group `[All]` -> `[Core]` in
   `lib/SciCompDSL/test/test_groups.toml` so it emits the clean `GROUP="SciCompDSL"`. Its
   `runtests.jl` runs every testset unconditionally, so no shim is needed there.

The `test_groups.toml` group/version encoding (already in the repo) mirrors the old
`Tests.yml` sublibrary matrix exactly:

| sublibrary | groups | versions | runner | threads |
|---|---|---|---|---|
| ModelingToolkitBase | InterfaceI, InterfaceII, Initialization, SymbolicIndexingInterface, Extended, RegressionI, Extensions, Optimization | `[lts, 1, pre]` | ubuntu-latest | 1 |
| ModelingToolkitBase | QA | `[lts, 1]` (excluded on `pre`) | ubuntu-latest | 1 |
| SciCompDSL | Core (was All) | `[lts, 1, pre]` | ubuntu-latest | 1 |

(The old CI had no macOS/GPU legs and set no `JULIA_NUM_THREADS`, so no `runner`/`num_threads`
overrides are needed.)

## Verification (no heavy suite run)

- Ran `compute_affected_sublibraries.jl@v1` against this tree and confirmed the emitted
  matrix: `ModelingToolkitBase_<group>` on the right versions (QA only lts/1), `SciCompDSL`
  on lts/1/pre, and SciCompDSL pulled in transitively at version `1` only when MTKBase `src`
  changes.
- Evaluated the `runtests.jl` GROUP shim + dispatch with `@safetestset`/`@testset`/`include`
  stubbed out (no test code executed) and confirmed every emitted group selects a
  **non-empty** set of test blocks, and that `GROUP="All"` (local) still selects all of them.
  Before the shim, all 9 emitted ModelingToolkitBase groups selected **zero** blocks.

This supersedes #4591 (which would have deleted `SublibraryCI.yml` + `test_groups.toml` and
restored the bespoke matrices — the opposite of the desired direction).

Please ignore until reviewed by @ChrisRackauckas.