### PR TITLE
style: apply Runic v1.7.0 formatting

### DIFF
--- a/ext/MTKFMIExt.jl
+++ b/ext/MTKFMIExt.jl
@@ -799,7 +799,7 @@ function (wrapper::Union{FMI2InstanceWrapper, FMI3InstanceWrapper})(
         y = outputs_buffer, y_refs = wrapper.output_value_references
     )
     wrapper.res_buffer[1:length(states_buffer)] .= states_buffer
-    wrapper.res_buffer[length(states_buffer)+1:end] .= outputs_buffer
+    wrapper.res_buffer[(length(states_buffer) + 1):end] .= outputs_buffer
     return wrapper.res_buffer
 end
 

--- a/ext/MTKOrdinaryDiffEqBDFExt.jl
+++ b/ext/MTKOrdinaryDiffEqBDFExt.jl
@@ -9,9 +9,14 @@ using ModelingToolkit: t_nounits, D_nounits
     @parameters a = 1.0 b = 1.0
     @variables x(t_nounits) y(t_nounits)
     prob = ODEProblem(
-        mtkcompile(System([D_nounits(x) ~ a * y, D_nounits(y) ~ -b * x],
-            t_nounits; name = :precompile_bdf)),
-        [x => 1.0, y => 0.0], (0.0, 1.0))
+        mtkcompile(
+            System(
+                [D_nounits(x) ~ a * y, D_nounits(y) ~ -b * x],
+                t_nounits; name = :precompile_bdf
+            )
+        ),
+        [x => 1.0, y => 0.0], (0.0, 1.0)
+    )
     @compile_workload begin
         solve(prob, FBDF())
     end

--- a/ext/MTKOrdinaryDiffEqDefaultExt.jl
+++ b/ext/MTKOrdinaryDiffEqDefaultExt.jl
@@ -9,9 +9,14 @@ using ModelingToolkit: t_nounits, D_nounits
     @parameters a = 1.0 b = 1.0
     @variables x(t_nounits) y(t_nounits)
     prob = ODEProblem(
-        mtkcompile(System([D_nounits(x) ~ a * y, D_nounits(y) ~ -b * x],
-            t_nounits; name = :precompile_default)),
-        [x => 1.0, y => 0.0], (0.0, 1.0))
+        mtkcompile(
+            System(
+                [D_nounits(x) ~ a * y, D_nounits(y) ~ -b * x],
+                t_nounits; name = :precompile_default
+            )
+        ),
+        [x => 1.0, y => 0.0], (0.0, 1.0)
+    )
     @compile_workload begin
         solve(prob)
     end

--- a/ext/MTKOrdinaryDiffEqRosenbrockExt.jl
+++ b/ext/MTKOrdinaryDiffEqRosenbrockExt.jl
@@ -9,9 +9,14 @@ using ModelingToolkit: t_nounits, D_nounits
     @parameters a = 1.0 b = 1.0
     @variables x(t_nounits) y(t_nounits)
     prob = ODEProblem(
-        mtkcompile(System([D_nounits(x) ~ a * y, D_nounits(y) ~ -b * x],
-            t_nounits; name = :precompile_rosenbrock)),
-        [x => 1.0, y => 0.0], (0.0, 1.0))
+        mtkcompile(
+            System(
+                [D_nounits(x) ~ a * y, D_nounits(y) ~ -b * x],
+                t_nounits; name = :precompile_rosenbrock
+            )
+        ),
+        [x => 1.0, y => 0.0], (0.0, 1.0)
+    )
     @compile_workload begin
         solve(prob, Rodas5P())
     end

--- a/lib/ModelingToolkitBase/ext/MTKCasADiDynamicOptExt.jl
+++ b/lib/ModelingToolkitBase/ext/MTKCasADiDynamicOptExt.jl
@@ -170,7 +170,7 @@ function MTK.set_variable_bounds!(m::CasADiModel, sys, pmap, tf, tunable_params,
         subject_to!(m.model, m.P[i] >= lo)
         subject_to!(m.model, m.P[i] <= hi)
     end
-    if !isnothing(tf_bounds)
+    return if !isnothing(tf_bounds)
         subject_to!(m.model, m.tₛ >= tf_bounds[1])
         subject_to!(m.model, m.tₛ <= tf_bounds[2])
     end

--- a/lib/ModelingToolkitBase/ext/MTKInfiniteOptExt.jl
+++ b/lib/ModelingToolkitBase/ext/MTKInfiniteOptExt.jl
@@ -129,7 +129,7 @@ function MTK.set_variable_bounds!(m::InfiniteOptModel, sys, pmap, tf, tunable_pa
         set_lower_bound(m.P[i], lo)
         set_upper_bound(m.P[i], hi)
     end
-    if !isnothing(tf_bounds)
+    return if !isnothing(tf_bounds)
         set_lower_bound(m.tₛ, tf_bounds[1])
         set_upper_bound(m.tₛ, tf_bounds[2])
     end

--- a/lib/ModelingToolkitBase/ext/MTKPyomoDynamicOptExt.jl
+++ b/lib/ModelingToolkitBase/ext/MTKPyomoDynamicOptExt.jl
@@ -194,7 +194,7 @@ function MTK.set_variable_bounds!(m::PyomoDynamicOptModel, sys, pmap, tf, tunabl
         MTK.add_constraint!(m, p_var ≳ lo)
         MTK.add_constraint!(m, p_var ≲ hi)
     end
-    if !isnothing(tf_bounds)
+    return if !isnothing(tf_bounds)
         tₛ_sym = pysym_getproperty(m.model_sym, :tₛ)
         MTK.add_constraint!(m, tₛ_sym ≳ tf_bounds[1])
         MTK.add_constraint!(m, tₛ_sym ≲ tf_bounds[2])

--- a/lib/ModelingToolkitBase/ext/MTKTrackerExt.jl
+++ b/lib/ModelingToolkitBase/ext/MTKTrackerExt.jl
@@ -8,11 +8,11 @@ function MTKBase.promote_type_with_nothing(::Type{Tracker.TrackedReal{T}}, x::Tr
 end
 
 function MTKBase.promote_with_nothing(::Type{Tracker.TrackedReal{T}}, x::Tracker.TrackedArray{T}) where {T}
-    return x 
+    return x
 end
 
 function MTKBase.__iip_u0_ad_wrapper(u0::Tracker.TrackedVector)
-    convert(Vector{eltype(u0)}, u0)
+    return convert(Vector{eltype(u0)}, u0)
 end
 
 end

--- a/lib/ModelingToolkitBase/src/problems/jumpproblem.jl
+++ b/lib/ModelingToolkitBase/src/problems/jumpproblem.jl
@@ -7,9 +7,12 @@
     check_complete(sys, JumpProblem)
     check_compatibility && check_compatible_system(JumpProblem, sys)
     if haskey(kwargs, :tstops)
-        throw(ArgumentError(
-            "Passing `tstops` directly to `JumpProblem(::System, ...)` is not supported. " *
-            "Define tstops on the `System` via the `tstops` keyword instead."))
+        throw(
+            ArgumentError(
+                "Passing `tstops` directly to `JumpProblem(::System, ...)` is not supported. " *
+                    "Define tstops on the `System` via the `tstops` keyword instead."
+            )
+        )
     end
 
     has_vrjs = any(x -> x isa VariableRateJump, jumps(sys))

--- a/lib/ModelingToolkitBase/src/systems/abstractsystem.jl
+++ b/lib/ModelingToolkitBase/src/systems/abstractsystem.jl
@@ -631,7 +631,7 @@ Returns true if the parameter `p` is of the form `Initial(x)`.
 """
 function isinitial(p::SymbolicT)
     p, _ = split_indexed_var(p)
-    Moshi.Match.@match p begin
+    return Moshi.Match.@match p begin
         BSImpl.Term(; f) => f isa Initial
         _ => false
     end
@@ -2975,7 +2975,7 @@ sys = mtkcompile(sys)
 ```
 """
 macro mtkcompile(exprs...)
-    _named_and_call(mtkcompile, exprs)
+    return _named_and_call(mtkcompile, exprs)
 end
 
 """
@@ -2995,7 +2995,7 @@ sys = complete(sys)
 ```
 """
 macro mtkcomplete(exprs...)
-    _named_and_call(complete, exprs)
+    return _named_and_call(complete, exprs)
 end
 
 """

--- a/lib/ModelingToolkitBase/src/systems/analysis_points.jl
+++ b/lib/ModelingToolkitBase/src/systems/analysis_points.jl
@@ -558,7 +558,7 @@ function apply_transformation(tf::Break, sys::AbstractSystem)
                 if tf.outputs_to_params
                     namespace = namespace_hierarchy(getname(out_var))
                     insert!(namespace, 1, nameof(breaksys))
-                    breaksys, _ = modify_nested_subsystem(breaksys, @view(namespace[1:end-1])) do apsys
+                    breaksys, _ = modify_nested_subsystem(breaksys, @view(namespace[1:(end - 1)])) do apsys
                         new_dvs = copy(get_unknowns(apsys))
                         var_in_apsys = getvar(apsys, namespace[end]; namespace = false)
                         deleteat!(new_dvs, findfirst(isequal(var_in_apsys), new_dvs)::Int)

--- a/lib/ModelingToolkitBase/src/systems/callbacks.jl
+++ b/lib/ModelingToolkitBase/src/systems/callbacks.jl
@@ -1125,10 +1125,10 @@ function generate_callback(cbs::Vector{SymbolicContinuousCallback}, sys; kwargs.
     eqs = reduce(vcat, eqs)
 
     @static if pkgversion(SciMLBase) < v"3"
-        affect     = VectorAffect(eq2affect, compiled.affects)
+        affect = VectorAffect(eq2affect, compiled.affects)
         affect_neg = VectorAffect(eq2affect, compiled.affect_negs)
         initialize = wrap_vector_optional_affect(compiled.inits, SciMLBase.INITIALIZE_DEFAULT)
-        finalize   = wrap_vector_optional_affect(compiled.finals, SciMLBase.FINALIZE_DEFAULT)
+        finalize = wrap_vector_optional_affect(compiled.finals, SciMLBase.FINALIZE_DEFAULT)
 
         return VectorContinuousCallback(
             trigger, affect, affect_neg, length(eqs); initialize, finalize,
@@ -1137,9 +1137,9 @@ function generate_callback(cbs::Vector{SymbolicContinuousCallback}, sys; kwargs.
             initialize_save_discretes = cbs[1].initialize_save_discretes
         )
     else
-        affect     = VectorAffect(eq2affect, compiled.affects, compiled.affect_negs)
+        affect = VectorAffect(eq2affect, compiled.affects, compiled.affect_negs)
         initialize = wrap_vector_optional_affect(compiled.inits, SciMLBase.INITIALIZE_DEFAULT)
-        finalize   = wrap_vector_optional_affect(compiled.finals, SciMLBase.FINALIZE_DEFAULT)
+        finalize = wrap_vector_optional_affect(compiled.finals, SciMLBase.FINALIZE_DEFAULT)
 
         return VectorContinuousCallback(
             trigger, affect, length(eqs); initialize, finalize,
@@ -1234,7 +1234,7 @@ function generate_callback(cb, sys; tspan = nothing, kwargs...)
     )
 
     initialize = isnothing(cb.initialize) ? init : InitFinalizeWrapper(init)
-    finalize   = isnothing(cb.finalize) ? final : InitFinalizeWrapper(final)
+    finalize = isnothing(cb.finalize) ? final : InitFinalizeWrapper(final)
 
     saved_clock_partitions = if is_split(sys)
         get(get_index_cache(sys).callback_to_clocks, cb, ())
@@ -1493,14 +1493,14 @@ Base.@nospecializeinfer function compile_implicit_affect(
     dvs_to_access = unknowns(affsys)
     ps_to_access = [unPre(p) for p in parameters(affsys)]
 
-    affu_getter  = getsym(sys, dvs_to_access)
-    affp_getter  = getsym(sys, ps_to_access)
+    affu_getter = getsym(sys, dvs_to_access)
+    affp_getter = getsym(sys, ps_to_access)
     affu_setter! = setsym(affsys, unknowns(affsys))
     affp_setter! = setsym(affsys, parameters(affsys))
-    u_setter!    = setsym(sys, dvs_to_update)
-    p_setter!    = setsym(sys, ps_to_update)
-    u_getter     = getsym(affsys, dvs_to_update)
-    p_getter     = getsym(affsys, ps_to_update)
+    u_setter! = setsym(sys, dvs_to_update)
+    p_setter! = setsym(sys, ps_to_update)
+    u_getter = getsym(affsys, dvs_to_update)
+    p_getter = getsym(affsys, ps_to_update)
 
     affprob = ImplicitDiscreteProblem(
         affsys, op, (0, 0);

--- a/lib/ModelingToolkitBase/src/systems/codegen.jl
+++ b/lib/ModelingToolkitBase/src/systems/codegen.jl
@@ -273,7 +273,7 @@ function generate_jacobian(
 end
 
 function assert_jac_length(arr::SparseMatrixCSC, I::Vector{<:Integer}, J::Vector{<:Integer})
-    @assert findnz(arr)[1:2] == (I, J)
+    return @assert findnz(arr)[1:2] == (I, J)
 end
 
 function assert_jac_length_header(sys)
@@ -1103,8 +1103,10 @@ end
 function assemble_maj(majv::Vector{U}, unknowntoid, pmapper) where {U <: MassActionJump}
     rs = [numericrstoich(maj.reactant_stoch, unknowntoid) for maj in majv]
     ns = [numericnstoich(maj.net_stoch, unknowntoid) for maj in majv]
-    return MassActionJump(rs, ns; param_mapper = pmapper, nocopy = true,
-        scale_rates = false, rescale_rates_on_update = false)
+    return MassActionJump(
+        rs, ns; param_mapper = pmapper, nocopy = true,
+        scale_rates = false, rescale_rates_on_update = false
+    )
 end
 
 function numericrstoich(mtrs::Vector{Pair{V, W}}, unknowntoid) where {V, W}
@@ -1389,8 +1391,8 @@ Base.@nospecializeinfer function build_explicit_observed_function(
             p_start + wrap_delays, length(args) - length(rps) + 1 + wrap_delays, is_split(sys),
         ),
     }(
-            oop, iip
-        )
+        oop, iip
+    )
     return (return_inplace isa Val{true} || return_inplace isa Bool && return_inplace) ? (f, f) : f
 end
 

--- a/lib/ModelingToolkitBase/src/systems/codegen_utils.jl
+++ b/lib/ModelingToolkitBase/src/systems/codegen_utils.jl
@@ -25,11 +25,13 @@ struct CompilerOptions
     infer::Int
 end
 
-function CompilerOptions(; optlevel::Int = -1, compile::Union{Int, Symbol} = :default,
-                           infer::Union{Int, Bool, Symbol} = :default)
+function CompilerOptions(;
+        optlevel::Int = -1, compile::Union{Int, Symbol} = :default,
+        infer::Union{Int, Bool, Symbol} = :default
+    )
     _compile = if compile isa Symbol
         compile === :default ? -1 : get(_COMPILE_OPTIONS, compile) do
-            throw(ArgumentError("Invalid compile option: $compile. Valid options: :default, :off, :on, :all, :min"))
+                throw(ArgumentError("Invalid compile option: $compile. Valid options: :default, :off, :on, :all, :min"))
         end
     else
         compile
@@ -59,21 +61,21 @@ const _COMPILER_OPTIONS_SUPPORTED = isdefined(Base.Experimental, :set_compile!)
 # but without any special compiler options (they are never used in that case).
 module _EvalModuleOpt0
     @static if !isdefined(Base.Experimental, :set_compile!)
-        Base.Experimental.@compiler_options optimize=0
+        Base.Experimental.@compiler_options optimize = 0
         using RuntimeGeneratedFunctions
         RuntimeGeneratedFunctions.init(@__MODULE__)
     end
 end
 module _EvalModuleOpt1
     @static if !isdefined(Base.Experimental, :set_compile!)
-        Base.Experimental.@compiler_options optimize=1
+        Base.Experimental.@compiler_options optimize = 1
         using RuntimeGeneratedFunctions
         RuntimeGeneratedFunctions.init(@__MODULE__)
     end
 end
 module _EvalModuleOpt0NoInfer
     @static if !isdefined(Base.Experimental, :set_compile!)
-        Base.Experimental.@compiler_options optimize=0 infer=false
+        Base.Experimental.@compiler_options optimize = 0 infer = false
         using RuntimeGeneratedFunctions
         RuntimeGeneratedFunctions.init(@__MODULE__)
     end
@@ -89,9 +91,12 @@ unsupported combinations will throw an error.
 """
 function _resolve_fallback_eval_module(co::CompilerOptions)
     if co.compile != -1
-        throw(ArgumentError(
-            "Non-default `compile` compiler option is not supported on Julia $VERSION. " *
-            "Per-method compiler options require Julia with `Base.Experimental.set_compile!` support."))
+        throw(
+            ArgumentError(
+                "Non-default `compile` compiler option is not supported on Julia $VERSION. " *
+                    "Per-method compiler options require Julia with `Base.Experimental.set_compile!` support."
+            )
+        )
     end
     if co.optlevel == 0 && co.infer == -1
         return _EvalModuleOpt0
@@ -100,10 +105,13 @@ function _resolve_fallback_eval_module(co::CompilerOptions)
     elseif co.optlevel == 0 && co.infer == 0
         return _EvalModuleOpt0NoInfer
     else
-        throw(ArgumentError(
-            "The compiler option combination (optlevel=$(co.optlevel), infer=$(co.infer)) " *
-            "is not supported on Julia $VERSION without per-method compiler options. " *
-            "Supported fallback combinations: (optlevel=0), (optlevel=1), (optlevel=0, infer=false)."))
+        throw(
+            ArgumentError(
+                "The compiler option combination (optlevel=$(co.optlevel), infer=$(co.infer)) " *
+                    "is not supported on Julia $VERSION without per-method compiler options. " *
+                    "Supported fallback combinations: (optlevel=0), (optlevel=1), (optlevel=0, infer=false)."
+            )
+        )
     end
 end
 
@@ -120,16 +128,21 @@ Given a function expression `expr`, return a callable version of it.
 - `compiler_options`: A [`CompilerOptions`](@ref) controlling LLVM optimization level,
   compilation mode, and type inference for the generated function.
 """
-function eval_or_rgf(expr::Expr; eval_expression = false, eval_module = @__MODULE__,
-                     compiler_options::CompilerOptions = CompilerOptions())
+function eval_or_rgf(
+        expr::Expr; eval_expression = false, eval_module = @__MODULE__,
+        compiler_options::CompilerOptions = CompilerOptions()
+    )
     if _has_options(compiler_options)
         if _COMPILER_OPTIONS_SUPPORTED
             expr = _inject_compiler_options_meta(expr, compiler_options)
         else
             if eval_module !== @__MODULE__
-                throw(ArgumentError(
-                    "Cannot use both a non-default `eval_module` and non-default `compiler_options` " *
-                    "on Julia $VERSION. Per-method compiler options require `Base.Experimental.set_compile!` support."))
+                throw(
+                    ArgumentError(
+                        "Cannot use both a non-default `eval_module` and non-default `compiler_options` " *
+                            "on Julia $VERSION. Per-method compiler options require `Base.Experimental.set_compile!` support."
+                    )
+                )
             end
             eval_module = _resolve_fallback_eval_module(compiler_options)
         end
@@ -170,7 +183,7 @@ function generated_argument_name(i::Int)
 end
 
 function compute_array_variable_buffer_idxs(@nospecialize(args); ignore_vars = Set{SymbolicT}())
-    _compute_array_variable_buffer_idxs(args isa Vector ? args : collect(args), ignore_vars)
+    return _compute_array_variable_buffer_idxs(args isa Vector ? args : collect(args), ignore_vars)
 end
 
 function _compute_array_variable_buffer_idxs(args::Vector, ignore_vars)
@@ -385,7 +398,7 @@ function should_invalidate_mutable_cache_entry(::Type{ParameterArrayAssignments}
 end
 
 function find_arrvars_is_atomic(ex::SymbolicT)
-    SU.default_is_atomic(ex) && Symbolics.isarraysymbolic(ex)
+    return SU.default_is_atomic(ex) && Symbolics.isarraysymbolic(ex)
 end
 
 """
@@ -521,7 +534,7 @@ Base.@nospecializeinfer function build_function_wrapper(
     # var"##cse#1234" = var"p2"
     # var"##cse#1235" = var"##cse#1234"[1]
     # ```
-    
+
     required_arrvars = Set{SymbolicT}()
     search_buffer = SU.IRStructureSearchBuffer(ir, required_arrvars)
     SU.search_variables!(search_buffer, expr; is_atomic = find_arrvars_is_atomic, recurse = !SU.default_is_atomic)
@@ -623,10 +636,14 @@ function GeneratedFunctionWrapper{P}(::Type{Val{true}}, foop, fiip; kwargs...) w
     return :($(GeneratedFunctionWrapper{P})($foop, $fiip))
 end
 
-function GeneratedFunctionWrapper{P}(::Type{Val{false}}, foop, fiip;
-        compiler_options::CompilerOptions = CompilerOptions(), kws...) where {P}
-    return GeneratedFunctionWrapper{P}(eval_or_rgf(foop; compiler_options, kws...),
-                                       eval_or_rgf(fiip; compiler_options, kws...))
+function GeneratedFunctionWrapper{P}(
+        ::Type{Val{false}}, foop, fiip;
+        compiler_options::CompilerOptions = CompilerOptions(), kws...
+    ) where {P}
+    return GeneratedFunctionWrapper{P}(
+        eval_or_rgf(foop; compiler_options, kws...),
+        eval_or_rgf(fiip; compiler_options, kws...)
+    )
 end
 
 function (gfw::GeneratedFunctionWrapper)(args...)

--- a/lib/ModelingToolkitBase/src/systems/connectors.jl
+++ b/lib/ModelingToolkitBase/src/systems/connectors.jl
@@ -871,6 +871,7 @@ function Base.showerror(io::IO, err::CausalConnectionSetNoSourceError)
     for cvar in err.cset
         println(io, "  ", cvar, " ", cvar.type === InputVar ? "(Input)" : "(Output)")
     end
+    return
 end
 
 """

--- a/lib/ModelingToolkitBase/src/systems/diffeqs/basic_transformations.jl
+++ b/lib/ModelingToolkitBase/src/systems/diffeqs/basic_transformations.jl
@@ -1170,7 +1170,7 @@ end
 DiffCacheAllocatorAPIWrapper{T}(dcapiw::DiffCacheAllocatorAPIWrapper{T}) where {T} = dcapiw
 
 function DiffCacheAllocatorAPIWrapper{T}(dcapiw::DiffCacheAllocatorAPIWrapper) where {T}
-    convert(DiffCacheAllocatorAPIWrapper{T}, dcapiw)
+    return convert(DiffCacheAllocatorAPIWrapper{T}, dcapiw)
 end
 
 function (dcapiw::DiffCacheAllocatorAPIWrapper)(reference, sz::NTuple{N, Int}) where {N}
@@ -1255,14 +1255,14 @@ Does nothing to integers or other number types.  Does affect Complex numbers.
 """
 struct LiteralRewriter{FloatType <: AbstractFloat} end
 
-(::LiteralRewriter{FT})(x::AbstractFloat) where FT = convert(FT, x)
+(::LiteralRewriter{FT})(x::AbstractFloat) where {FT} = convert(FT, x)
 function (rw::LiteralRewriter{FT})(x::Complex{F}) where {FT, F <: AbstractFloat}
     return convert(Complex{typeof(rw(one(F)))}, x)
 end
 function (rw::LiteralRewriter{FT})(x::AbstractArray{F}) where {FT, F <: Union{AbstractFloat, Complex{<:AbstractFloat}}}
     return map(rw, x)
 end
-(::LiteralRewriter{FT})(x) where FT = x
+(::LiteralRewriter{FT})(x) where {FT} = x
 
 function (rw::LiteralRewriter)(x::SymbolicT)
     return Moshi.Match.@match x begin

--- a/lib/ModelingToolkitBase/src/systems/optimal_control_interface.jl
+++ b/lib/ModelingToolkitBase/src/systems/optimal_control_interface.jl
@@ -421,8 +421,10 @@ function extract_variable_bounds(sys, pmap, tf, tunable_params, user_bounds = Di
     end
     tf_bounds = if symbolic_type(tf) === ScalarSymbolic() && hasbounds(tf)
         lo, hi = getbounds(tf)
-        (SymbolicUtils.unwrap_const(unwrap(Symbolics.fixpoint_sub(lo, pmap))),
-            SymbolicUtils.unwrap_const(unwrap(Symbolics.fixpoint_sub(hi, pmap))))
+        (
+            SymbolicUtils.unwrap_const(unwrap(Symbolics.fixpoint_sub(lo, pmap))),
+            SymbolicUtils.unwrap_const(unwrap(Symbolics.fixpoint_sub(hi, pmap))),
+        )
     else
         nothing
     end

--- a/lib/ModelingToolkitBase/src/systems/problem_utils.jl
+++ b/lib/ModelingToolkitBase/src/systems/problem_utils.jl
@@ -376,9 +376,9 @@ function varmap_to_vars(
             MissingGuessValue.HashedRandom() => begin
                 for var in missing_vars
                     if Symbolics.isarraysymbolic(var)
-                        varmap[var] = [hash(var,hash(i)) for i in SU.stable_eachindex(var)]./0x1p64
+                        varmap[var] = [hash(var, hash(i)) for i in SU.stable_eachindex(var)] ./ 0x1p64
                     else
-                        write_possibly_indexed_array!(varmap, var, Symbolics.SConst(hash(var)/0x1p64), COMMON_NOTHING)
+                        write_possibly_indexed_array!(varmap, var, Symbolics.SConst(hash(var) / 0x1p64), COMMON_NOTHING)
                     end
                 end
             end
@@ -787,7 +787,7 @@ function __apply_copy_template(valp, template)
 end
 
 function (cp::CopyParamsByTemplate{IsRoot})(src) where {IsRoot}
-    if IsRoot
+    return if IsRoot
         reshape(mapreduce(Base.Fix1(__apply_copy_template, src), vcat, cp.template), cp.size)
     else
         buffers = map(Base.Fix1(__apply_copy_template, src), cp.template)
@@ -1398,7 +1398,7 @@ function (p::PromoteToTunableEltype{F, floatT})(nlsol) where {F, floatT}
     raw isa AbstractArray || return raw
     isempty(raw) && return raw
     T = promote_type(eltype(raw), _tunable_eltype(parameter_values(nlsol)), floatT)
-    T === eltype(raw) ? raw : convert(AbstractArray{T}, raw)
+    return T === eltype(raw) ? raw : convert(AbstractArray{T}, raw)
 end
 
 _tunable_eltype(p::MTKParameters) = isempty(p.tunable) ? Bool : eltype(p.tunable)
@@ -1454,7 +1454,7 @@ function maybe_build_initialization_problem(
     initsys = initializeprob.f.sys::System
     needs_remake = false
     _u0 = state_values(initializeprob)
-     if _u0 !== nothing
+    if _u0 !== nothing
         if ArrayInterface.ismutable(_u0)
             __u0 = floatT.(_u0)
         else

--- a/lib/ModelingToolkitBase/src/systems/system.jl
+++ b/lib/ModelingToolkitBase/src/systems/system.jl
@@ -44,7 +44,7 @@ Check whether `sys` supports symbolic automatic differentiation. Throws an `Argu
 if the system has been marked with [`SymbolicADDisallowed`](@ref).
 """
 function check_symbolic_ad_allowed(sys::AbstractSystem)
-    if SymbolicUtils.hasmetadata(sys, SymbolicADDisallowed)
+    return if SymbolicUtils.hasmetadata(sys, SymbolicADDisallowed)
         reason = SymbolicUtils.getmetadata(sys, SymbolicADDisallowed, nothing)
         msg = "System $(nameof(sys)) does not support symbolic automatic differentiation."
         if reason isa AbstractString && !isempty(reason)
@@ -669,11 +669,14 @@ function System(
     # JumpProcesses must not re-apply factorial scaling on parameter updates.
     for j in jumps
         if j isa MassActionJump && j.rescale_rates_on_update
-            throw(ArgumentError(
-                "MassActionJump with rescale_rates_on_update = true is not supported " *
-                "in Systems with jumps or JumpSystems. Rate expressions must be pre-scaled (e.g. " *
-                "k/factorial(n) for n-th order reactions). Use SymbolicMassActionJump " *
-                "or pass scale_rates = false when constructing the MassActionJump."))
+            throw(
+                ArgumentError(
+                    "MassActionJump with rescale_rates_on_update = true is not supported " *
+                        "in Systems with jumps or JumpSystems. Rate expressions must be pre-scaled (e.g. " *
+                        "k/factorial(n) for n-th order reactions). Use SymbolicMassActionJump " *
+                        "or pass scale_rates = false when constructing the MassActionJump."
+                )
+            )
         end
     end
 
@@ -1329,15 +1332,20 @@ Construct a `MassActionJump` with `scale_rates = false`, suitable for use in a
 
 Returns a `MassActionJump` — this is a convenience constructor, not a new type.
 """
-function SymbolicMassActionJump(rate, reactant_stoch, net_stoch; scale_rates = false,
-        kwargs...)
+function SymbolicMassActionJump(
+        rate, reactant_stoch, net_stoch; scale_rates = false,
+        kwargs...
+    )
     if scale_rates
-        throw(ArgumentError(
-            "SymbolicMassActionJump requires pre-scaled rate expressions " *
-            "(scale_rates = false). scale_rates = true is not supported in " *
-            "ModelingToolkitBase."))
+        throw(
+            ArgumentError(
+                "SymbolicMassActionJump requires pre-scaled rate expressions " *
+                    "(scale_rates = false). scale_rates = true is not supported in " *
+                    "ModelingToolkitBase."
+            )
+        )
     end
-    MassActionJump(rate, reactant_stoch, net_stoch; scale_rates = false, kwargs...)
+    return MassActionJump(rate, reactant_stoch, net_stoch; scale_rates = false, kwargs...)
 end
 
 """
@@ -1678,5 +1686,5 @@ end
 Get the `IRStructure` associated with the system.
 """
 function get_irstructure(sys::System)
-    get_irstructure_tlv(sys)[]::IRStructure{SymReal}
+    return get_irstructure_tlv(sys)[]::IRStructure{SymReal}
 end

--- a/lib/ModelingToolkitBase/src/systems/systems.jl
+++ b/lib/ModelingToolkitBase/src/systems/systems.jl
@@ -1008,5 +1008,5 @@ end
 # Deprecation path
 function topsort_equations(eqs::Vector{Equation}, unknowns::Vector{SymbolicT}; check = true)
     @named misc = System(eqs, unknowns, [])
-    topsort_equations(misc, eqs, unknowns; check)
+    return topsort_equations(misc, eqs, unknowns; check)
 end

--- a/lib/ModelingToolkitBase/src/utils.jl
+++ b/lib/ModelingToolkitBase/src/utils.jl
@@ -1292,7 +1292,7 @@ function subexpressions_not_involving_vars!(
             # are already parameters, we don't want to cache it.
             drop = Moshi.Match.@match ir[i] begin
                 BSImpl.Term(; f) && if f isa SymbolicT end => begin
-                1
+                    1
                 end
                 _ => 0
             end
@@ -1364,6 +1364,7 @@ function subexpressions_not_involving_vars!(
         )
         state[expr] = anon_sym
     end
+    return
 end
 
 """
@@ -1642,7 +1643,7 @@ function move_variable_bindings_to_ics!(
             return true
         end
     end
-    filter!(filterer, binds)
+    return filter!(filterer, binds)
 end
 
 """

--- a/lib/ModelingToolkitBase/src/variables.jl
+++ b/lib/ModelingToolkitBase/src/variables.jl
@@ -482,7 +482,7 @@ Create variables with a nominal value like this
 getnominal(x::Union{Num, Symbolics.Arr}) = getnominal(unwrap(x))
 function getnominal(x::SymbolicT)
     s = Symbolics.getmetadata_maybe_indexed(x, VariableNominal, nothing)
-    s === nothing ? 1.0 : s
+    return s === nothing ? 1.0 : s
 end
 
 """
@@ -492,7 +492,7 @@ Determine whether symbolic variable `x` has a nominal value associated with it.
 See also [`getnominal`](@ref).
 """
 function hasnominal(x)
-    Symbolics.getmetadata_maybe_indexed(unwrap(x), VariableNominal, nothing) !== nothing
+    return Symbolics.getmetadata_maybe_indexed(unwrap(x), VariableNominal, nothing) !== nothing
 end
 
 function setnominal(x::Num, val)

--- a/lib/ModelingToolkitBase/test/analysis_points.jl
+++ b/lib/ModelingToolkitBase/test/analysis_points.jl
@@ -628,7 +628,7 @@ if @isdefined(ModelingToolkit)
         @test isequal(reference.B, value.B) || isequal(reverse(reference.B), value.B)
         roworder = isequal(reference.B, value.B) ? [1, 2] : [2, 1]
         @test isequal(reference.D, value.D)
-        @test isequal(reference.A[roworder, colorder], value.A)
+        return @test isequal(reference.A[roworder, colorder], value.A)
     end
 
     @testset "Analysis point overriding part of connection - normal connect" begin

--- a/lib/ModelingToolkitBase/test/basic_transformations.jl
+++ b/lib/ModelingToolkitBase/test/basic_transformations.jl
@@ -463,10 +463,10 @@ end
 @testset "`truncate_constant_floats`" begin
     @variables x(t) y(t)
     eqs = [
-        D(x) ~ sum(Symbolics.SConst([1.23456, 2.34567])) ^ y
+        D(x) ~ sum(Symbolics.SConst([1.23456, 2.34567]))^y,
     ]
     obs = [
-        y ~ norm(Symbolics.SConst(2.3564 + 12.34345im))
+        y ~ norm(Symbolics.SConst(2.3564 + 12.34345im)),
     ]
     @named sys = System(eqs, t; observed = obs)
 

--- a/lib/ModelingToolkitBase/test/components.jl
+++ b/lib/ModelingToolkitBase/test/components.jl
@@ -132,7 +132,7 @@ end
     sol_inner_outer = solve(prob, Rodas4(); saveat = sol.t)
     @test SciMLBase.successful_retcode(sol_inner_outer)
     if @isdefined(ModelingToolkit)
-        @test sol[sys.capacitor.v] ≈ sol_inner_outer[rc_comp.capacitor.v] atol = 1e-6
+        @test sol[sys.capacitor.v] ≈ sol_inner_outer[rc_comp.capacitor.v] atol = 1.0e-6
 
         prob = ODEProblem(sys, [sys.capacitor.v => 0.0], (0, 10.0))
         sol = solve(prob, Tsit5())

--- a/lib/ModelingToolkitBase/test/debugging.jl
+++ b/lib/ModelingToolkitBase/test/debugging.jl
@@ -60,7 +60,7 @@ end
 end
 
 @testset "Empty system doesn't error when generating assertions" begin
-        @variables x(t) y(t)
+    @variables x(t) y(t)
     eqs = [
         0 ~ x - y
         0 ~ 2y - x

--- a/lib/ModelingToolkitBase/test/extensions/bifurcationkit.jl
+++ b/lib/ModelingToolkitBase/test/extensions/bifurcationkit.jl
@@ -212,7 +212,7 @@ end
     @variables X1(t) X2(t)
     @parameters k1 k2 Γ[1:1]
     eqs = [
-        0 ~ -k1*X1 + k2*(-X1 + Γ[1])
+        0 ~ -k1 * X1 + k2 * (-X1 + Γ[1])
         0 ~ X2 + X1 - Γ[1]
     ]
     @mtkcompile nsys2 = System(eqs)

--- a/lib/ModelingToolkitBase/test/guess_propagation.jl
+++ b/lib/ModelingToolkitBase/test/guess_propagation.jl
@@ -103,7 +103,7 @@ prob = ODEProblem(sys, [x0 => 1.0], (0.0, 1.0))
 
     @component function Parent(; name)
         @named child = Child()
-        System(Equation[], t; systems=[child], guesses=[child.x => 0.9], name)
+        System(Equation[], t; systems = [child], guesses = [child.x => 0.9], name)
     end
 
     @named parent = Parent()

--- a/lib/ModelingToolkitBase/test/index_cache.jl
+++ b/lib/ModelingToolkitBase/test/index_cache.jl
@@ -174,14 +174,14 @@ function costfn(theta, ps)
     setter, prob, getter = ps
     p = setter(prob, theta)
     newprob = SciMLBase.remake(prob; p)
-    sol = solve(newprob, Rodas5P(); saveat=0.1)
-    sum(abs2, getter(sol))
+    sol = solve(newprob, Rodas5P(); saveat = 0.1)
+    return sum(abs2, getter(sol))
 end
 
 @testset "gradients with special `DiffCache` params" begin
     @variables x(t)
-    @parameters p1=2.0 p2=3.0
-    @named sys = System([D(x) ~ -p1*x + p2*t], t)
+    @parameters p1 = 2.0 p2 = 3.0
+    @named sys = System([D(x) ~ -p1 * x + p2 * t], t)
     sys, _ = ModelingToolkitBase.add_diffcache(sys, 4)
     sys = complete(sys)
 

--- a/lib/ModelingToolkitBase/test/initial_values.jl
+++ b/lib/ModelingToolkitBase/test/initial_values.jl
@@ -216,8 +216,8 @@ end
     eqs = [D(a) ~ b, D(b) ~ c, D(c) ~ d, D(d) ~ e, D(e) ~ 1]
     @mtkcompile sys = System(eqs, t)
     @test_throws ["Cyclic guesses detected"] ODEProblem(
-        sys, [e => 2, a => b, b => a^2 + 1, c => d, d => c^2 + 1], (0, 1); use_scc=false,
-        missing_guess_value=MissingGuessValue.Error()
+        sys, [e => 2, a => b, b => a^2 + 1, c => d, d => c^2 + 1], (0, 1); use_scc = false,
+        missing_guess_value = MissingGuessValue.Error()
     )
 end
 
@@ -368,7 +368,7 @@ end
     @test prob.u0 isa SVector
     @test prob.p.tunable isa SVector
     @test prob.p.initials isa SVector
-    initdata = prob.f.initialization_data;
+    initdata = prob.f.initialization_data
     @test state_values(initdata.initializeprob) isa SVector
     if @isdefined(ModelingToolkit)
         @test initdata.initializeprob isa SCCNonlinearProblem

--- a/lib/ModelingToolkitBase/test/initializationsystem.jl
+++ b/lib/ModelingToolkitBase/test/initializationsystem.jl
@@ -914,7 +914,7 @@ end
         @parameters p = 10.0
 
         eqs = [
-            0 ~ x^2 + 2p * x + 3p
+            0 ~ x^2 + 2p * x + 3p,
         ]
         @mtkcompile ns = System(eqs, [x], [p])
 
@@ -1532,7 +1532,7 @@ end
     prob.ps[Initial(x)] = 0.5
     integ = init(prob, Tsit5(); abstol = 1.0e-6, reltol = 1.0e-6)
     @test integ[x] ≈ 0.5
-    @test abs.(integ[y]) ≈ [1.0, sqrt(2.75)] atol = 1e-6
+    @test abs.(integ[y]) ≈ [1.0, sqrt(2.75)] atol = 1.0e-6
     prob.ps[Initial(y[1])] = 0.5
     integ = init(prob, Tsit5(); abstol = 1.0e-6, reltol = 1.0e-6)
     @test integ[x] ≈ 0.5
@@ -1956,15 +1956,18 @@ end
     if @isdefined(ModelingToolkit)
         @parameters g
         @variables x(t) y(t) [state_priority = 10] λ(t)
-        eqs = [D(D(x)) ~ λ * x
-               D(D(y)) ~ λ * y - g
-               x^2 + y^2 ~ 1]
+        eqs = [
+            D(D(x)) ~ λ * x
+            D(D(y)) ~ λ * y - g
+            x^2 + y^2 ~ 1
+        ]
         @mtkcompile pend = System(eqs, t)
 
         iprob = ModelingToolkit.InitializationProblem(
             pend, 0.0,
             [x => 1.0, D(y) => 0.0, g => 1],
-            guesses = [λ => 1, y => 0.0])
+            guesses = [λ => 1, y => 0.0]
+        )
         isol = solve(iprob)
 
         # previous behavior was `==` for these
@@ -1984,8 +1987,10 @@ end
     # should produce a LinearProblem instead of a NonlinearProblem.
     @variables u(t)
     # initialization_eqs = [2u ~ 1] is linear in u, so x(0) = 0.5
-    @named linsys = System([D(u) ~ -u], t;
-        initialization_eqs = [2u ~ 1], guesses = [u => 0.5])
+    @named linsys = System(
+        [D(u) ~ -u], t;
+        initialization_eqs = [2u ~ 1], guesses = [u => 0.5]
+    )
     linsys = mtkcompile(linsys)
 
     if @isdefined(ModelingToolkit)
@@ -2007,7 +2012,7 @@ end
     @test prob.f.initializeprob.probs isa Tuple{<:LinearProblem}
     sol = solve(prob, Tsit5())
     @test SciMLBase.successful_retcode(sol)
-    @test sol[u][1] ≈ 0.5 atol = 1e-10
+    @test sol[u][1] ≈ 0.5 atol = 1.0e-10
 
     @testset "Is not used for underdetermined system" begin
         @mtkcompile linsys = System([D(u) ~ -u], t; guesses = [u => 0.5])
@@ -2049,7 +2054,7 @@ end
 
 @testset "Output arrays from constant RHS under ForwardDiff" begin
     # Issue #4457
-    @parameters m=1.5 d=9.0
+    @parameters m = 1.5 d = 9.0
     @variables s(t) v(t)
 
     eqs = [
@@ -2057,10 +2062,13 @@ end
         D(v) ~ (1 - d * v) / m
     ]
 
-    sys = mtkcompile(System(eqs, t;
-        name = :model,
-        initialization_eqs = [s ~ 0, v ~ 0],
-    ))
+    sys = mtkcompile(
+        System(
+            eqs, t;
+            name = :model,
+            initialization_eqs = [s ~ 0, v ~ 0],
+        )
+    )
 
     prob = ODEProblem(sys, [], (0.0, 200.0))
     sol = solve(prob, Tsit5(); saveat = 0.1)
@@ -2082,20 +2090,22 @@ end
         @parameters p1 = 0.5 [tunable = true] (p23[1:2] = [1, 3.0]) [tunable = true] p4 = 3 * p1 [tunable = false] y0 = 1.2 [tunable = true]
         @variables x(t) = 2p1 y(t) = y0 z(t) = x + y
 
-        eqs = [D(x) ~ p1 * x - p23[1] * x * y
+        eqs = [
+            D(x) ~ p1 * x - p23[1] * x * y
             D(y) ~ -p23[2] * y + p4 * x * y
-            z ~ x + y]
+            z ~ x + y
+        ]
 
-        mtkcompile(System(eqs, t, name=:sys))
+        mtkcompile(System(eqs, t, name = :sys))
     end
 
     sys = create_sys()
 
     sub_sys = subset_tunables(sys, [sys.p23])
 
-    prob = ODEProblem(sub_sys, [], (0, 1.))
+    prob = ODEProblem(sub_sys, [], (0, 1.0))
 
-    setter = setsym_oop(prob, Symbolics.scalarize(sys.p23));
+    setter = setsym_oop(prob, Symbolics.scalarize(sys.p23))
 
     function loss2(x, ps)
         setter, prob = ps
@@ -2105,7 +2115,7 @@ end
         sum(sol)
     end
 
-    @test_nowarn loss2([1., 2], (setter, prob))
+    @test_nowarn loss2([1.0, 2], (setter, prob))
 
-    @test_nowarn ForwardDiff.gradient(Base.Fix2(loss2, (setter, prob)), [1, 2.])
+    @test_nowarn ForwardDiff.gradient(Base.Fix2(loss2, (setter, prob)), [1, 2.0])
 end

--- a/lib/ModelingToolkitBase/test/input_output_handling.jl
+++ b/lib/ModelingToolkitBase/test/input_output_handling.jl
@@ -501,19 +501,19 @@ if @isdefined(ModelingToolkit)
 
         @named motor_dynamics = Blocks.FirstOrder(T = 0.001)
 
-        x0 = [0.85, 1, π/12, π/2]
+        x0 = [0.85, 1, π / 12, π / 2]
 
-        @variables  u(t)[1:2]=zeros(2)
-        @variables y(t)=0.85 v(t)=1 ϕ(t)=π/12 ω(t)=π/2
+        @variables  u(t)[1:2] = zeros(2)
+        @variables y(t) = 0.85 v(t) = 1 ϕ(t) = π / 12 ω(t) = π / 2
 
         eqs = [
             D(y) ~ v,
-            D(v) ~ -gravity + gain_u1 * cos(ϕ)*(motor_dynamics.output.u + gravity/gain_u1),
+            D(v) ~ -gravity + gain_u1 * cos(ϕ) * (motor_dynamics.output.u + gravity / gain_u1),
             D(ϕ) ~ ω,
             D(ω) ~ -d0 * ϕ - d1 * ω + n0 * u[2],
             motor_dynamics.input.u ~ u[1],
         ]
-        @named model = System(eqs, t; systems=[motor_dynamics])
+        @named model = System(eqs, t; systems = [motor_dynamics])
 
         f, x, p, simplified_system = ModelingToolkit.generate_control_function(model, [u;])
 

--- a/lib/ModelingToolkitBase/test/jumpsystem.jl
+++ b/lib/ModelingToolkitBase/test/jumpsystem.jl
@@ -1341,11 +1341,15 @@ end
         crj = ConstantRateJump(k, [X ~ Pre(X) - 1])
         ev1 = (t == t1) => [X ~ Pre(X) + 1000]
         ev2 = (t == t1 + t2) => [X ~ Pre(X) + 2000]
-        @mtkcompile jsys = System(Equation[], t, [X], [k, t1, t2]; jumps = [crj],
-            discrete_events = [ev1, ev2], tstops = [[t1], [t1 + t2]])
+        @mtkcompile jsys = System(
+            Equation[], t, [X], [k, t1, t2]; jumps = [crj],
+            discrete_events = [ev1, ev2], tstops = [[t1], [t1 + t2]]
+        )
 
-        jprob = JumpProblem(jsys, [X => 100, k => 0.1, t1 => 3.0, t2 => 4.0],
-            (0.0, 10.0); aggregator = Direct(), rng)
+        jprob = JumpProblem(
+            jsys, [X => 100, k => 0.1, t1 => 3.0, t2 => 4.0],
+            (0.0, 10.0); aggregator = Direct(), rng
+        )
 
         @test jprob.prob isa DiscreteProblem
         @test haskey(jprob.kwargs, :tstops)
@@ -1371,11 +1375,15 @@ end
         maj = SymbolicMassActionJump(k, [X => 1], [X => -1])
         ev1 = (t == t1) => [X ~ Pre(X) + 500]
         ev2 = (t == t2) => [X ~ Pre(X) + 500]
-        @mtkcompile jsys = System(Equation[], t, [X], [k, t1, t2]; jumps = [maj],
-            discrete_events = [ev1, ev2], tstops = [[t1], [t2]])
+        @mtkcompile jsys = System(
+            Equation[], t, [X], [k, t1, t2]; jumps = [maj],
+            discrete_events = [ev1, ev2], tstops = [[t1], [t2]]
+        )
 
-        jprob = JumpProblem(jsys, [X => 100, k => 0.1, t1 => 2.0, t2 => 6.0],
-            (0.0, 10.0); aggregator = Direct(), rng)
+        jprob = JumpProblem(
+            jsys, [X => 100, k => 0.1, t1 => 2.0, t2 => 6.0],
+            (0.0, 10.0); aggregator = Direct(), rng
+        )
 
         @test jprob.prob isa DiscreteProblem
         @test haskey(jprob.kwargs, :tstops)
@@ -1401,11 +1409,15 @@ end
         vrj = VariableRateJump(k * (1 + sin(t)), [X ~ Pre(X) + 1])
         ev1 = (t == t1) => [X ~ Pre(X) + 1000]
         ev2 = (t == t1 + t2) => [X ~ Pre(X) + 2000]
-        @mtkcompile jsys = System(Equation[], t, [X], [k, t1, t2]; jumps = [vrj],
-            discrete_events = [ev1, ev2], tstops = [[t1], [t1 + t2]])
+        @mtkcompile jsys = System(
+            Equation[], t, [X], [k, t1, t2]; jumps = [vrj],
+            discrete_events = [ev1, ev2], tstops = [[t1], [t1 + t2]]
+        )
 
-        jprob = JumpProblem(jsys, [X => 0, k => 1.0, t1 => 2.0, t2 => 3.0],
-            (0.0, 8.0); rng)
+        jprob = JumpProblem(
+            jsys, [X => 0, k => 1.0, t1 => 2.0, t2 => 3.0],
+            (0.0, 8.0); rng
+        )
 
         @test jprob.prob isa ODEProblem
         @test haskey(jprob.kwargs, :tstops)
@@ -1433,12 +1445,16 @@ end
         crj = ConstantRateJump(b, [X ~ Pre(X) - 1])
         ev1 = (t == t1) => [X ~ Pre(X) + 100.0]
         ev2 = (t == t1 * t2) => [X ~ Pre(X) + 200.0]
-        @mtkcompile jsys = System([eq], t, [X], [a, b, t1, t2]; jumps = [crj],
-            discrete_events = [ev1, ev2], tstops = [[t1], [t1 * t2]])
+        @mtkcompile jsys = System(
+            [eq], t, [X], [a, b, t1, t2]; jumps = [crj],
+            discrete_events = [ev1, ev2], tstops = [[t1], [t1 * t2]]
+        )
 
-        jprob = JumpProblem(jsys,
+        jprob = JumpProblem(
+            jsys,
             [X => 10.0, a => 1.0, b => 0.01, t1 => 2.0, t2 => 3.0],
-            (0.0, 10.0); rng)
+            (0.0, 10.0); rng
+        )
 
         @test jprob.prob isa ODEProblem
         # tstops are created at JumpProblem level; inner problem has _skip_tstops
@@ -1465,12 +1481,16 @@ end
         crj = ConstantRateJump(k, [X ~ Pre(X) - 1])
         ev1 = (t == t1) => [X ~ Pre(X) + 100.0]
         ev2 = (t == t1 + t2) => [X ~ Pre(X) + 200.0]
-        @mtkcompile jsys = System(eqs, t, [X], [k, σ_noise, t1, t2], [B]; jumps = [crj],
-            discrete_events = [ev1, ev2], tstops = [[t1], [t1 + t2]])
+        @mtkcompile jsys = System(
+            eqs, t, [X], [k, σ_noise, t1, t2], [B]; jumps = [crj],
+            discrete_events = [ev1, ev2], tstops = [[t1], [t1 + t2]]
+        )
 
-        jprob = JumpProblem(jsys,
+        jprob = JumpProblem(
+            jsys,
             [X => 10.0, k => 0.5, σ_noise => 0.01, t1 => 1.0, t2 => 2.0],
-            (0.0, 5.0); rng)
+            (0.0, 5.0); rng
+        )
 
         @test jprob.prob isa SDEProblem
         # tstops are created at JumpProblem level; inner problem has _skip_tstops
@@ -1497,11 +1517,15 @@ end
         ev2 = (t == 2 * t1) => [X ~ Pre(X) + 200]
         ev3 = (t == 3 * t1) => [X ~ Pre(X) + 300]
         # Scalar tstop t1 → periodic range (tspan[1]+t1):t1:tspan[2]
-        @mtkcompile jsys = System(Equation[], t, [X], [k, t1]; jumps = [crj],
-            discrete_events = [ev1, ev2, ev3], tstops = [t1])
+        @mtkcompile jsys = System(
+            Equation[], t, [X], [k, t1]; jumps = [crj],
+            discrete_events = [ev1, ev2, ev3], tstops = [t1]
+        )
 
-        jprob = JumpProblem(jsys, [X => 1000, k => 0.1, t1 => 3.0],
-            (0.0, 10.0); aggregator = Direct(), rng)
+        jprob = JumpProblem(
+            jsys, [X => 1000, k => 0.1, t1 => 3.0],
+            (0.0, 10.0); aggregator = Direct(), rng
+        )
 
         tstop_vals = jprob.kwargs[:tstops](jprob.prob.p, (0.0, 10.0))
         @test Set(tstop_vals) == Set(3.0:3.0:10.0)
@@ -1525,11 +1549,15 @@ end
         ev1 = (t == t1) => [X ~ Pre(X) + 500]
         ev2 = (t == t2) => [X ~ Pre(X) + 700]
         # t1 as scalar (periodic range), [t2] as array (exact time)
-        @mtkcompile jsys = System(Equation[], t, [X], [k, t1, t2]; jumps = [crj],
-            discrete_events = [ev1, ev2], tstops = [t1, [t2]])
+        @mtkcompile jsys = System(
+            Equation[], t, [X], [k, t1, t2]; jumps = [crj],
+            discrete_events = [ev1, ev2], tstops = [t1, [t2]]
+        )
 
-        jprob = JumpProblem(jsys, [X => 1000, k => 0.1, t1 => 2.0, t2 => 5.0],
-            (0.0, 10.0); aggregator = Direct(), rng)
+        jprob = JumpProblem(
+            jsys, [X => 1000, k => 0.1, t1 => 2.0, t2 => 5.0],
+            (0.0, 10.0); aggregator = Direct(), rng
+        )
 
         tstop_vals = jprob.kwargs[:tstops](jprob.prob.p, (0.0, 10.0))
         # t1=2.0 periodic → 2:2:10, t2=5.0 exact → [5.0]
@@ -1553,10 +1581,14 @@ end
         crj = ConstantRateJump(k, [X ~ Pre(X) - 1])
         @mtkcompile jsys = System(Equation[], t, [X], [k]; jumps = [crj])
 
-        err = @test_throws ArgumentError JumpProblem(jsys, [X => 100, k => 1.0], (0.0, 10.0);
-            aggregator = Direct(), rng, tstops = [1.0, 2.0])
-        @test contains(err.value.msg,
-            "Passing `tstops` directly to `JumpProblem(::System, ...)` is not supported")
+        err = @test_throws ArgumentError JumpProblem(
+            jsys, [X => 100, k => 1.0], (0.0, 10.0);
+            aggregator = Direct(), rng, tstops = [1.0, 2.0]
+        )
+        @test contains(
+            err.value.msg,
+            "Passing `tstops` directly to `JumpProblem(::System, ...)` is not supported"
+        )
     end
 
     # Test that systems with no tstops don't break anything
@@ -1566,8 +1598,10 @@ end
         crj = ConstantRateJump(k, [X ~ Pre(X) - 1])
         @mtkcompile jsys = System(Equation[], t, [X], [k]; jumps = [crj])
 
-        jprob = JumpProblem(jsys, [X => 100, k => 1.0], (0.0, 10.0);
-            aggregator = Direct(), rng)
+        jprob = JumpProblem(
+            jsys, [X => 100, k => 1.0], (0.0, 10.0);
+            aggregator = Direct(), rng
+        )
         @test !haskey(jprob.kwargs, :tstops)
 
         sol = solve(jprob, SSAStepper())
@@ -1605,8 +1639,10 @@ end
     @test jprob3.massaction_jump.scaled_rates[1] ≈ 6.0 / factorial(3)
 
     # callback with reset_aggregated_jumps!
-    jprob_cb = JumpProblem(js, [u0; ps], (0.0, 200.0);
-        save_positions = (false, false))
+    jprob_cb = JumpProblem(
+        js, [u0; ps], (0.0, 200.0);
+        save_positions = (false, false)
+    )
     condit(u, t, integrator) = t == 100.0
     function affect!(integrator)
         integrator.ps[:k] = 24.0
@@ -1639,5 +1675,6 @@ end
     @variables X(t) Y(t)
 
     @test_throws ArgumentError SymbolicMassActionJump(
-        k, [X => 3], [X => -3, Y => 1]; scale_rates = true)
+        k, [X => 3], [X => -3, Y => 1]; scale_rates = true
+    )
 end

--- a/lib/ModelingToolkitBase/test/mtkparameters.jl
+++ b/lib/ModelingToolkitBase/test/mtkparameters.jl
@@ -467,7 +467,7 @@ if @isdefined(ModelingToolkit)
             getter, setter, prob = ps
             u0, p = setter(prob, x)
             new_prob = remake(prob; u0, p)
-            sol = solve(new_prob, Rodas5P(); saveat = 0.1, abstol = 1e-8, reltol = 1e-8)
+            sol = solve(new_prob, Rodas5P(); saveat = 0.1, abstol = 1.0e-8, reltol = 1.0e-8)
             @test SciMLBase.successful_retcode(sol)
             sum(getter(sol))
         end

--- a/lib/ModelingToolkitBase/test/nonlinearsystem.jl
+++ b/lib/ModelingToolkitBase/test/nonlinearsystem.jl
@@ -314,7 +314,7 @@ end
         0 ~ x * y - β * z
     ]
     obs = [
-        y ~ x * (ρ - z)
+        y ~ x * (ρ - z),
     ]
     guesses = [x => 1.0, z => 0.0]
     ps = [σ => 10.0, ρ => 26.0, β => 8 / 3]
@@ -340,7 +340,7 @@ end
     # system that contains a chain of observed variables when simplified
     @variables x y z
     eqs = [
-        0 ~ y - z
+        0 ~ y - z,
     ]
     obs = [
         y ~ x
@@ -349,7 +349,7 @@ end
     @named ns = System(eqs, [x], []; observed = obs) # solve for y with observed chain z -> y -> x
     ns = complete(ns)
     mtkjac = expand.(calculate_jacobian(ns))
-    jac1 = unwrap.([3//2 + x;;])
+    jac1 = unwrap.([3 // 2 + x;;])
     @test isequal(mtkjac, jac1)
     mtkhess = calculate_hessian(ns)
     hess1 = [Num[1;;]]

--- a/lib/ModelingToolkitBase/test/optimization/dynamic_optimization.jl
+++ b/lib/ModelingToolkitBase/test/optimization/dynamic_optimization.jl
@@ -215,7 +215,8 @@ end
     # With u ∈ (-0.5, 0.5) instead of (-1, 1), optimal x(1) = 0.125
     jprob_b = JuMPDynamicOptProblem(
         block, [u0map; parammap], tspan;
-        dt = 0.01, bounds = Dict(u(t) => (-0.5, 0.5)))
+        dt = 0.01, bounds = Dict(u(t) => (-0.5, 0.5))
+    )
     jsol_b = solve(jprob_b, JuMPCollocation(Ipopt.Optimizer, constructVerner8()))
     @test ≈(jsol_b.sol[x(t)][end], 0.125, rtol = 1.0e-4)
 
@@ -228,7 +229,8 @@ end
 
     iprob = InfiniteOptDynamicOptProblem(
         block, [u0map; parammap], tspan;
-        dt = 0.01, bounds = Dict(u(t) => (-0.5, 0.5)))
+        dt = 0.01, bounds = Dict(u(t) => (-0.5, 0.5))
+    )
     isol = solve(iprob, InfiniteOptCollocation(Ipopt.Optimizer))
     @test ≈(isol.sol[x(t)][end], 0.125, rtol = 1.0e-4)
 
@@ -239,15 +241,19 @@ end
     @test InfiniteOpt.upper_bound(m.V[1]) == 0.5
 
     if ENABLE_CASADI
-        cprob = CasADiDynamicOptProblem(block, [u0map; parammap], tspan;
-            dt = 0.01, bounds = Dict(u(t) => (-0.5, 0.5)))
+        cprob = CasADiDynamicOptProblem(
+            block, [u0map; parammap], tspan;
+            dt = 0.01, bounds = Dict(u(t) => (-0.5, 0.5))
+        )
         csol = solve(cprob, CasADiCollocation("ipopt", constructTsitouras5()))
         @test ≈(csol.sol[x(t)][end], 0.125, rtol = 1.0e-4)
     end
 
     if @isdefined(Pyomo)
-        pprob = PyomoDynamicOptProblem(block, [u0map; parammap], tspan;
-            dt = 0.01, bounds = Dict(u(t) => (-0.5, 0.5)))
+        pprob = PyomoDynamicOptProblem(
+            block, [u0map; parammap], tspan;
+            dt = 0.01, bounds = Dict(u(t) => (-0.5, 0.5))
+        )
         psol = solve(pprob, PyomoCollocation("ipopt", BackwardEuler()))
         @test ≈(psol.sol[x(t)][end], 0.125, rtol = 1.0e-4)
     end
@@ -409,7 +415,8 @@ end
     @named gain = System([y ~ v], t)
 
     @named composed = System(
-        [connect(gain.y, plant.u)], t; systems = [plant, gain])
+        [connect(gain.y, plant.u)], t; systems = [plant, gain]
+    )
     sys = mtkcompile(composed; inputs = [gain.v])
 
     # After mtkcompile with connect, the input is bound but should still be a control
@@ -419,7 +426,7 @@ end
     jprob = JuMPDynamicOptProblem(sys, [plant.x => 1.0, gain.v => 0.0], (0.0, 2.0); dt = 0.1)
     jsol = solve(jprob, JuMPCollocation(Ipopt.Optimizer, constructRadauIIA5()))
     # Minimizing x(2)² with D(x) = u, x(0) = 1 → x(2) = 0 is achievable and optimal
-    @test jsol.sol[plant.x][end] ≈ 0.0 atol=1e-5
+    @test jsol.sol[plant.x][end] ≈ 0.0 atol = 1.0e-5
 end
 
 @testset "Free final time problems" begin
@@ -750,7 +757,7 @@ end
     # but observed equations may reference it.
     eqs = [
         D(x) ~ -k * x + u,
-        obs_val ~ q * x  # observed equation references bound parameter q
+        obs_val ~ q * x,  # observed equation references bound parameter q
     ]
     cost = [-EvalAt(1.0)(obs_val)]
 
@@ -813,7 +820,7 @@ end
 
     eqs = [
         D(x) ~ -k * x + u,
-        obs_val ~ q * x
+        obs_val ~ q * x,
     ]
 
     # Fixed-time constraint using observed variable with bound parameter

--- a/lib/ModelingToolkitBase/test/pdesystem.jl
+++ b/lib/ModelingToolkitBase/test/pdesystem.jl
@@ -123,8 +123,10 @@ end
     eq_outer = [Dt(q(t, s2)) ~ Ds2(q(t, s2))]
     bcs_outer = [q(0, s2) ~ cos(s2), q(t, 0) ~ 1, q(t, 1) ~ 1]
     domains_outer = [t ∈ (0.0, 1.0), s2 ∈ (0.0, 1.0)]
-    @named outer = PDESystem(eq_outer, bcs_outer, domains_outer, [t, s2], [q], [γ];
-        systems = [inner])
+    @named outer = PDESystem(
+        eq_outer, bcs_outer, domains_outer, [t, s2], [q], [γ];
+        systems = [inner]
+    )
 
     # Subsystem should be listed in propertynames
     @test :inner ∈ propertynames(outer)

--- a/lib/ModelingToolkitBase/test/runtests.jl
+++ b/lib/ModelingToolkitBase/test/runtests.jl
@@ -11,7 +11,7 @@ import REPL
 const _G = get(ENV, "GROUP", "All")
 const _SUB = "ModelingToolkitBase"
 const GROUP = _G == _SUB ? "Core" :
-              (startswith(_G, _SUB * "_") ? _G[(length(_SUB) + 2):end] : _G)
+    (startswith(_G, _SUB * "_") ? _G[(length(_SUB) + 2):end] : _G)
 
 function activate_extensions_env()
     Pkg.activate("extensions")

--- a/lib/ModelingToolkitBase/test/sdesystem.jl
+++ b/lib/ModelingToolkitBase/test/sdesystem.jl
@@ -1118,12 +1118,16 @@ end
     eqs = [D(X) ~ k + σ_noise * B]
     ev1 = (tt == t1) => [X ~ Pre(X) + 50.0]
     ev2 = (tt == t1 * t2) => [X ~ Pre(X) + 100.0]
-    @mtkcompile sys = System(eqs, tt, [X], [k, σ_noise, t1, t2], [B];
-        discrete_events = [ev1, ev2], tstops = [[t1], [t1 * t2]])
+    @mtkcompile sys = System(
+        eqs, tt, [X], [k, σ_noise, t1, t2], [B];
+        discrete_events = [ev1, ev2], tstops = [[t1], [t1 * t2]]
+    )
 
-    sprob = SDEProblem(sys,
+    sprob = SDEProblem(
+        sys,
         [X => 0.0, k => 1.0, σ_noise => 0.01, t1 => 2.0, t2 => 3.0],
-        (0.0, 10.0))
+        (0.0, 10.0)
+    )
 
     @test haskey(sprob.kwargs, :tstops)
     @test sprob.kwargs[:tstops] isa ModelingToolkitBase.SymbolicTstops
@@ -1148,12 +1152,16 @@ end
     # Single event with symbolic periodic condition: fires at every multiple of t1
     ev = (mod(tt, t1) == 0) => [X ~ Pre(X) + 50.0]
     # Scalar tstop t1 → periodic range (tspan[1]+t1):t1:tspan[2]
-    @mtkcompile sys = System(eqs, tt, [X], [k, σ_noise, t1], [B];
-        discrete_events = [ev], tstops = [t1])
+    @mtkcompile sys = System(
+        eqs, tt, [X], [k, σ_noise, t1], [B];
+        discrete_events = [ev], tstops = [t1]
+    )
 
-    sprob = SDEProblem(sys,
+    sprob = SDEProblem(
+        sys,
         [X => 0.0, k => 1.0, σ_noise => 0.01, t1 => 3.0],
-        (0.0, 10.0))
+        (0.0, 10.0)
+    )
 
     @test haskey(sprob.kwargs, :tstops)
     @test sprob.kwargs[:tstops] isa ModelingToolkitBase.SymbolicTstops

--- a/lib/ModelingToolkitBase/test/simple_mtkcompile.jl
+++ b/lib/ModelingToolkitBase/test/simple_mtkcompile.jl
@@ -11,9 +11,9 @@ using ModelingToolkitBase: t_nounits as t, D_nounits as D
         @variables X1(t) X2(t) X3(t)
         @parameters Γ[1:1] k1 k2 k3 k4
         nleqs = [
-           0 ~ -k1*X1 + k2*X2 - k3*X2*X1 + (1//2)*k4*(X3^2),
-           0 ~ k1*X1 - k2*X2 - k3*X2*X1 + (1//2)*k4*(X3^2),
-       ]
+            0 ~ -k1 * X1 + k2 * X2 - k3 * X2 * X1 + (1 // 2) * k4 * (X3^2),
+            0 ~ k1 * X1 - k2 * X2 - k3 * X2 * X1 + (1 // 2) * k4 * (X3^2),
+        ]
         @mtkcompile sys = System(nleqs; observed = [X3 ~ Γ[1] - X1 - X2])
         @test issetequal(equations(sys), nleqs)
         @test isequal(only(observed(sys)), X3 ~ Γ[1] - X1 - X2)

--- a/lib/ModelingToolkitBase/test/symbolic_events.jl
+++ b/lib/ModelingToolkitBase/test/symbolic_events.jl
@@ -1856,7 +1856,7 @@ if !@isdefined(ModelingToolkit)
         @variables x(t) y(t)
         @discretes d(t)
 
-        aff = AssignmentAffect([y => y + 1, d => d+y+1])
+        aff = AssignmentAffect([y => y + 1, d => d + y + 1])
         @test aff isa ModelingToolkitBase.SymbolicAffect
         @test issetequal(aff.affect, [y ~ Pre(y) + 1, d ~ Pre(d) + Pre(y) + 1])
         @test issetequal(aff.discrete_parameters, [d])
@@ -1883,7 +1883,7 @@ if @isdefined(ModelingToolkit)
                 arr[2] ~ 2s
             ]
             continuous_events = [
-                [s ~ 0.5] => Symbolics.Equation[]
+                [s ~ 0.5] => Symbolics.Equation[],
             ]
             System(eqs, t, [s; collect(arr)], []; name, continuous_events)
         end

--- a/lib/SciCompDSL/src/model_parsing.jl
+++ b/lib/SciCompDSL/src/model_parsing.jl
@@ -1345,9 +1345,9 @@ function check_event_syntax(line)
     if line.args[1] == :(=>)
         return true
     elseif (line.head == :(...)) ||
-           (line.head == :generator) ||
-           (line.head == :comprehension)||
-           (line.head == :if)
+            (line.head == :generator) ||
+            (line.head == :comprehension)||
+            (line.head == :if)
         return check_event_syntax(line.args[1])
     else
         return false

--- a/lib/SciCompDSL/test/model_parsing.jl
+++ b/lib/SciCompDSL/test/model_parsing.jl
@@ -532,11 +532,13 @@ using ModelingToolkitBase: D_nounits
 
     @mtkcompile model = M()
 
-    u0 = [model.x => 10,
-          model.y => 0,
-          model.z => 0,
-          model.c => 0,
-          model.d => 0]
+    u0 = [
+        model.x => 10,
+        model.y => 0,
+        model.z => 0,
+        model.c => 0,
+        model.d => 0,
+    ]
 
     prob = ODEProblem(model, u0, (0, 5.0))
     sol = solve(prob, Tsit5(), tstops = [1.5, 2.5])

--- a/src/ModelingToolkit.jl
+++ b/src/ModelingToolkit.jl
@@ -176,7 +176,7 @@ function __init__()
     SU.hashcons(unwrap(ODE_GAMMA[2]), true)
     SU.hashcons(unwrap(ODE_GAMMA[3]), true)
     SU.hashcons(unwrap(ODE_C), true)
-    SU.hashcons(SCC_EXPLICITFUN_CACHE_OUT, true)
+    return SU.hashcons(SCC_EXPLICITFUN_CACHE_OUT, true)
 end
 
 end # module

--- a/src/problems/sccnonlinearproblem.jl
+++ b/src/problems/sccnonlinearproblem.jl
@@ -351,6 +351,7 @@ function build_caches!(sys::System, decomposition::SCCDecomposition)
             decomposition.cachesizes[idx] = max(decomposition.cachesizes[idx], length(buf))
         end
     end
+    return
 end
 
 """
@@ -516,10 +517,12 @@ function SciMLBase.SCCNonlinearProblem{iip}(
             solsyms = view.((dvs,), view(decomposition.var_sccs, 1:(i - 1)))
             push!(
                 explicitfuns,
-                SciMLBase.Void{Any}(CacheWriter(
-                    sys, decomposition.cachetypes, cacheexprs, solsyms;
-                    eval_expression, eval_module, cse
-                ))
+                SciMLBase.Void{Any}(
+                    CacheWriter(
+                        sys, decomposition.cachetypes, cacheexprs, solsyms;
+                        eval_expression, eval_module, cse
+                    )
+                )
             )
         end
         cachebufsyms = Vector{SymbolicT}[]
@@ -609,7 +612,7 @@ function SciMLBase.SCCNonlinearProblem{iip}(
                         end
                     end
                     MissingGuessValue.HashedRandom() => begin
-                        newval = [hash(var,hash(i)) for i in SU.stable_eachindex(symbolic_idxs)]./0x1p64
+                        newval = [hash(var, hash(i)) for i in SU.stable_eachindex(symbolic_idxs)] ./ 0x1p64
                         _u0[symbolic_idxs] .= newval
                         for (idx, j) in enumerate(symbolic_idxs)
                             write_possibly_indexed_array!(

--- a/src/systems/alias_elimination.jl
+++ b/src/systems/alias_elimination.jl
@@ -156,7 +156,7 @@ function find_perfect_aliases!(
     parent = Dict{Int, Int}()
     parity = Dict{Int, Int8}()
     members = Dict{Int, Vector{Int}}()
-    # Candidate alias equations `(ieq, v1_idx, v2_idx, edge_sign)`. 
+    # Candidate alias equations `(ieq, v1_idx, v2_idx, edge_sign)`.
     # `edge_sign == ±1` encodes `v1 ~ edge_sign*v2`.
     # Removal is decided below once each group's target is known:
     # equations with a non-target irreducible endpoint must stay so
@@ -297,7 +297,7 @@ function find_perfect_aliases!(
     #
     # Conflict groups: every variable is forced to `0`.
     # Take the first `length(irrs)` eq in the group to force the irrs to 0
-    # (overwriting the eq and replacing its graph row with the edge to `irr`). 
+    # (overwriting the eq and replacing its graph row with the edge to `irr`).
     # Remaining conflict eqs become `0 ~ 0` and are queued for removal.
     # Pinned eqs end up in `eqs_to_substitute` from the var-elim pass above
     # but `subber` leaves `irr ~ 0` untouched (irreducibles aren't in `subs`).
@@ -360,7 +360,7 @@ function find_perfect_aliases!(
     # direct alias between the sticky variable and the target (since the
     # zero-priority variable was redirected to the target in the graph). Remove
     # all but the first copy of each (v_a, v_b) variable pair.
-    let seen = Set{Tuple{Int,Int}}()
+    let seen = Set{Tuple{Int, Int}}()
         eqs_rm_set = Set(eqs_to_rm)
         removed_additional_eqs = false
         for (ieq, _, _, _) in candidate_eqs
@@ -384,8 +384,10 @@ function find_perfect_aliases!(
     return aliases
 end
 
-function alias_elimination!(state::TearingState; fully_determined = true,
-                            print_underconstrained_variables = false, kwargs...)
+function alias_elimination!(
+        state::TearingState; fully_determined = true,
+        print_underconstrained_variables = false, kwargs...
+    )
     StateSelection.complete!(state.structure)
     eqs_to_rm = Int[]
     vars_to_rm = Int[]

--- a/test/downstream/inversemodel.jl
+++ b/test/downstream/inversemodel.jl
@@ -198,7 +198,7 @@ nsys = get_named_comp_sensitivity(model, :y; op)
     #
     # Printing `lin_fun` in a tuple (so it doesn't hit the pretty-printing method)
     # will likely segfault Julia. Somehow.
-    lin_fun, ssys = get_sensitivity_function(model, output; op = op1);
+    lin_fun, ssys = get_sensitivity_function(model, output; op = op1)
     matrices1, extras1 = linearize(ssys, lin_fun, op = op1)
     matrices2, extras2 = linearize(ssys, lin_fun, op = op2)
     @test extras1.x != extras2.x

--- a/test/downstream/linearization_dd.jl
+++ b/test/downstream/linearization_dd.jl
@@ -18,7 +18,7 @@ using OrdinaryDiffEq
 connect = ModelingToolkit.connect
 
 function rm_bindings(sys)
-    @set sys.bindings = empty(bindings(sys))
+    return @set sys.bindings = empty(bindings(sys))
 end
 
 @independent_variables t
@@ -79,4 +79,4 @@ lsyss2 = (;
     C = integ[lsyss.C], D = integ[lsyss.D],
 )
 
-@test tf(ss(lsyss2...)) ≈ tf(ss(lsys...)) atol = 1e-8
+@test tf(ss(lsyss2...)) ≈ tf(ss(lsys...)) atol = 1.0e-8

--- a/test/linearize.jl
+++ b/test/linearize.jl
@@ -129,7 +129,7 @@ function compare_matrices(reference, value)
     @test isapprox(reference.B, value.B) || isapprox(reference.B[[2, 1], :], value.B)
     roworder = isapprox(reference.B, value.B) ? [1, 2] : [2, 1]
     @test isapprox(reference.D, value.D)
-    @test isapprox(reference.A[roworder, colorder], value.A)
+    return @test isapprox(reference.A[roworder, colorder], value.A)
 end
 lsys, ssys = linearize(cl, [f.u], [p.x])
 lsys2, ssys = linearize(cl, [f.u], [p.x]; autodiff = AutoFiniteDiff())
@@ -145,7 +145,7 @@ lsyss, ssys = ModelingToolkit.linearize_symbolic(cl, [f.u], [p.x])
 _substituter(M, sys) = value.(ModelingToolkit.fixpoint_sub(M, ModelingToolkit.initial_conditions_and_guesses(sys); fold = Val(true)))
 lsys_m = (;
     A = _substituter(lsyss.A, cl), B = _substituter(lsyss.B, cl),
-    C = _substituter(lsyss.C, cl), D = _substituter(lsyss.D, cl)
+    C = _substituter(lsyss.C, cl), D = _substituter(lsyss.D, cl),
 )
 compare_matrices(lsys, lsys_m)
 ##
@@ -174,7 +174,7 @@ lsyss0,
 )
 lsyss = (;
     A = _substituter(lsyss0.A, pid), B = _substituter(lsyss0.B, pid),
-    C = _substituter(lsyss0.C, pid), D = _substituter(lsyss0.D, pid)
+    C = _substituter(lsyss0.C, pid), D = _substituter(lsyss0.D, pid),
 )
 compare_matrices(lsys, lsyss)
 

--- a/test/reduction.jl
+++ b/test/reduction.jl
@@ -368,13 +368,15 @@ end
     #   * {c, d, y}  -- two irreducibles + one non-irreducible. `y` is eliminated, both
     #                   irreducibles remain unknowns, bound by the surviving alias
     #                   equation between them.
-    @mtkcompile sys = System([
+    @mtkcompile sys = System(
+        [
             D(x) ~ x,
             D(c) ~ -c,
             e ~ x,
             c ~ d,
-            y ~ c
-        ], t)
+            y ~ c,
+        ], t
+    )
 
     @test Set(unknowns(sys)) == Set([e, c, d])
 end
@@ -384,7 +386,7 @@ end
     @mtkcompile sys = System([D(x) ~ x, y[1] ~ y[2], dot(x, y) ~ 1], t)
     @test any(equations(sys)) do eq
         isequal(eq, 0 ~ 1 - dot(x, Symbolics.SConst([y[2], y[2]]))) ||
-        isequal(eq, 0 ~ 1 - dot(x, Symbolics.SConst([y[1], y[1]])))
+            isequal(eq, 0 ~ 1 - dot(x, Symbolics.SConst([y[1], y[1]])))
     end
 end
 
@@ -423,7 +425,8 @@ end
     @testset "mixed chain `x ~ y, y ~ -z`" begin
         @variables x(t) y(t) z(t)
         @named sys = System(
-            [D(x) ~ -x, x ~ y, y ~ -z], t; state_priorities = [x => 10])
+            [D(x) ~ -x, x ~ y, y ~ -z], t; state_priorities = [x => 10]
+        )
         state = TearingState(sys)
         ModelingToolkit.eliminate_perfect_aliases!(state)
         # y ~ x (sign +1) and z ~ -x (sign -1: y has +1, z has -1 via `y ~ -z`)
@@ -434,7 +437,8 @@ end
     @testset "double-negation transitivity `x ~ -y, y ~ -z` ⇒ `x ~ z`" begin
         @variables x(t) y(t) z(t)
         @named sys = System(
-            [D(x) ~ -x, x ~ -y, y ~ -z], t; state_priorities = [x => 10])
+            [D(x) ~ -x, x ~ -y, y ~ -z], t; state_priorities = [x => 10]
+        )
         state = TearingState(sys)
         ModelingToolkit.eliminate_perfect_aliases!(state)
         # y ~ -x (sign -1), z ~ x (sign +1: two negations cancel)
@@ -490,7 +494,8 @@ end
         eqs = equations(state.sys)
         for v in (a, b, c)
             @test any(
-                eq -> isequal(eq.lhs, unwrap(v)) && iszero(Symbolics.value(eq.rhs)), eqs)
+                eq -> isequal(eq.lhs, unwrap(v)) && iszero(Symbolics.value(eq.rhs)), eqs
+            )
         end
         @test any(eq -> isequal(eq.lhs, D(w)), eqs)
     end
@@ -528,7 +533,8 @@ end
         # is annihilated and its edge to that eq must be dropped even though
         # `b` itself wasn't substituted.
         @named sys = System(
-            [D(a) ~ x * b + a, D(b) ~ b, x ~ y, x ~ -y], t)
+            [D(a) ~ x * b + a, D(b) ~ b, x ~ y, x ~ -y], t
+        )
         state = TearingState(sys)
 
         eqs_before = collect(ModelingToolkit.equations(state))
@@ -547,8 +553,10 @@ end
         # `x ~ y` is a consistent alias. `x` gets eliminated in favor of `y`.
         # The non-alias eq `D(w) ~ x - y + w` becomes `D(w) ~ w`, so `y` is no
         # longer in the equation even though it was the alias *target*.
-        @named sys = System([D(w) ~ x - y + w, x ~ y], t;
-            state_priorities = [y => 10])
+        @named sys = System(
+            [D(w) ~ x - y + w, x ~ y], t;
+            state_priorities = [y => 10]
+        )
         state = TearingState(sys)
 
         eqs_before = collect(ModelingToolkit.equations(state))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -119,7 +119,9 @@ end
         activate_optimization_env()
         @mtktestset("OptimizationSystem Test", "optimization/optimizationsystem.jl")
         @mtktestset("InfiniteOpt Extension Test", "optimization/test_infiniteopt.jl")
-        @mtktestset("Dynamic Optimization Collocation Solvers",
-            "optimization/dynamic_optimization.jl")
+        @mtktestset(
+            "Dynamic Optimization Collocation Solvers",
+            "optimization/dynamic_optimization.jl"
+        )
     end
 end


### PR DESCRIPTION
## Summary

The **Runic Format Check** is currently failing on `master` because the codebase is not conformant to the Runic version CI uses (`fredrikekre/runic-action@v1`, which resolves to **Runic v1.7.0**, invoked via `SciML/.github` `runic.yml`).

This PR is a pure formatting change that runs **Runic v1.7.0 in-place** over all tracked `.jl` files (including the `lib/` subprojects in this monorepo) to make the check pass.

## What was done

- Installed the exact CI Runic version (`Pkg.add(name="Runic", version="1.7.0")`).
- Ran `Runic.format_string` in-place over every tracked `.jl` file (`git ls-files '*.jl'`, 202 files).
- Verified a subsequent Runic `--check` pass reports **no remaining diffs** across all 202 files.
- 51 files were reformatted.

**No logic changes** — only whitespace, line-wrapping, trailing-comma, and other Runic-style transforms. No non-`.jl` files were touched (no CI, no `Project.toml`, no docs config).

## Note

This is a standalone, self-contained formatting PR so it can be reviewed and merged independently of any other work.

**Please ignore until reviewed by @ChrisRackauckas.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)