### PR TITLE
Canonical CI cleanup: TagBot thin-caller + downgrade-caller cleanup

### DIFF
--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -17,7 +17,6 @@ jobs:
     name: "Downgrade"
     uses: "SciML/.github/.github/workflows/downgrade.yml@v1"
     with:
-      julia-version: "1.10"
+      julia-version: "lts"
       group: "InterfaceI"
-      skip: "Pkg,TOML"
     secrets: "inherit"

--- a/.github/workflows/DowngradeSublibraries.yml
+++ b/.github/workflows/DowngradeSublibraries.yml
@@ -19,4 +19,3 @@ jobs:
     secrets: "inherit"
     with:
       julia-version: "lts"
-      skip: "Pkg,TOML,Statistics,LinearAlgebra,SparseArrays,InteractiveUtils,Random,Test,ModelingToolkit,ModelingToolkitBase,SciCompDSL"

--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -1,28 +1,20 @@
-name: TagBot
+name: "TagBot"
 on:
   issue_comment:
-    types:
-      - created
+    types: [created]
   workflow_dispatch:
 jobs:
-  TagBot:
-    if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Tag ModelingToolkit.jl
-        uses: JuliaRegistries/TagBot@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          ssh: ${{ secrets.DOCUMENTER_KEY }}
-      - name: Tag ModelingToolkitBase.jl
-        uses: JuliaRegistries/TagBot@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          ssh: ${{ secrets.DOCUMENTER_KEY }}
-          subdir: lib/ModelingToolkitBase
-      - name: Tag SciCompDSL.jl
-        uses: JuliaRegistries/TagBot@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          ssh: ${{ secrets.DOCUMENTER_KEY }}
-          subdir: lib/SciCompDSL
+  tagbot:
+    uses: "SciML/.github/.github/workflows/tagbot.yml@v1"
+    secrets: "inherit"
+  tagbot-subpackages:
+    strategy:
+      fail-fast: false
+      matrix:
+        subdir:
+          - "lib/ModelingToolkitBase"
+          - "lib/SciCompDSL"
+    uses: "SciML/.github/.github/workflows/tagbot.yml@v1"
+    with:
+      subdir: "${{ matrix.subdir }}"
+    secrets: "inherit"


### PR DESCRIPTION
Canonical CI cleanup:
- TagBot.yml: replaced inlined JuliaRegistries/TagBot with the canonical SciML thin caller (tagbot.yml@v1), plus a tagbot-subpackages matrix over the registered sublibraries lib/ModelingToolkitBase and lib/SciCompDSL (both confirmed registered in the General registry).
- Downgrade.yml: julia-version 1.10 -> lts; dropped the stdlib skip (Pkg, TOML). Kept group: InterfaceI.
- DowngradeSublibraries.yml: dropped skip entirely (all entries were stdlibs, the caller package ModelingToolkit, or in-repo sublibs ModelingToolkitBase/SciCompDSL, all now auto-populated by the central workflow). julia-version lts unchanged.
- .typos.toml already present; no SpellCheck change needed.

Ignore until reviewed by @ChrisRackauckas.