### PR TITLE
Fix HashedRandom guess in SCCNonlinearProblem (stable_eachindex MethodError)

### DIFF
--- a/src/problems/sccnonlinearproblem.jl
+++ b/src/problems/sccnonlinearproblem.jl
@@ -609,7 +609,7 @@ function SciMLBase.SCCNonlinearProblem{iip}(
                         end
                     end
                     MissingGuessValue.HashedRandom() => begin
-                        newval = [hash(var,hash(i)) for i in SU.stable_eachindex(symbolic_idxs)]./0x1p64
+                        newval = [hash(dvs[vscc[j]]) for j in symbolic_idxs]./0x1p64
                         _u0[symbolic_idxs] .= newval
                         for (idx, j) in enumerate(symbolic_idxs)
                             write_possibly_indexed_array!(

--- a/test/scc_nonlinear_problem.jl
+++ b/test/scc_nonlinear_problem.jl
@@ -402,3 +402,17 @@ end
     ModelingToolkitBase.subexpressions_not_involving_vars!(ir, [unwrap(expr)], banned_vars, state)
     @test issetequal(keys(state), [x[1], 2x[2], x[2]^2, f(x[2] + 1)])
 end
+
+@testset "HashedRandom missing guesses in init `SCCNonlinearProblem` (#4603)" begin
+    # Initialization decomposes into multiple SCCs and no guesses are provided,
+    # so the default `HashedRandom` missing-guess strategy is used for the SCC
+    # init problem. This previously errored with
+    # `MethodError: no method matching stable_eachindex(::Vector{Int64})`.
+    @variables a(t) b(t) c(t) d(t)
+    @mtkcompile sys = System(
+        [D(a) ~ b, 0 ~ b^3 + b + a - 2, 0 ~ c^3 + c - b, 0 ~ d - c * b], t)
+    prob = ODEProblem(sys, [a => 0.5], (0.0, 1.0))
+    @test prob.f.initialization_data.initializeprob isa SCCNonlinearProblem
+    sol = solve(prob, Rodas5P())
+    @test SciMLBase.successful_retcode(sol)
+end


### PR DESCRIPTION
## Fixes #4603

The `MissingGuessValue.HashedRandom()` branch in the SCC init-problem builder (`src/problems/sccnonlinearproblem.jl`) had two bugs on one line:

```julia
newval = [hash(var,hash(i)) for i in SU.stable_eachindex(symbolic_idxs)]./0x1p64
```

1. `symbolic_idxs` is a plain `Vector{Int64}` (from `findall`), but `stable_eachindex` is only defined for `BasicSymbolic`, producing the reported `MethodError: no method matching stable_eachindex(::Vector{Int64})`. This was introduced by a blanket `eachindex` → `stable_eachindex` rename that wrongly caught this loop over a regular vector.
2. `var` is undefined in this (non-`LinearFunction`) branch — it only exists in the `LinearFunction` branch. The line was a faulty copy of the array-symbolic `HashedRandom` code in `problem_utils.jl`.

For the SCC case, the missing-guess value for index `j` should derive from the corresponding scalar unknown `dvs[vscc[j]]`, matching the scalar `HashedRandom` form `hash(var)/0x1p64` and consistent with the sibling `Random` branch:

```julia
newval = [hash(dvs[vscc[j]]) for j in symbolic_idxs]./0x1p64
```

This branch only became reachable once `HashedRandom` became the default missing-guess strategy (#4445), which is why it surfaced as a regression.

## Verification

Reproduced with the `ParallelKinematicRobot` model from MultibodyComponents.jl (the case in #4603):
- Without the fix: `MethodError: no method matching stable_eachindex(::Vector{Int64})` during `ODEProblem` construction.
- With the fix: `ODEProblem` builds and `solve` returns `retcode: Success`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)