### PR TITLE
ODENLStepData: forward outer ODEFunction's  flag to inner nlprob

### DIFF
--- a/lib/ModelingToolkitBase/src/problems/odeproblem.jl
+++ b/lib/ModelingToolkitBase/src/problems/odeproblem.jl
@@ -1,11 +1,15 @@
 """
-    generate_ODENLStepData(sys, u0, p, mm, nlstep_compile, nlstep_scc)
+    generate_ODENLStepData(sys, u0, p, mm, nlstep_compile, nlstep_scc; jac = false)
 
 Generate the NLStep data for implicit ODE solvers. This is a stub that throws an error
 if called without ModelingToolkit loaded. The actual implementation is provided by
 ModelingToolkit when it is loaded.
+
+When `jac = true`, the analytic Jacobian of the teared inner nonlinear system is
+generated symbolically and attached to `nlprob.f.jac`, so NonlinearSolve does not
+have to recompute it via AD/FD on every Newton iteration.
 """
-function generate_ODENLStepData(sys, u0, p, mm, nlstep_compile, nlstep_scc)
+function generate_ODENLStepData(sys, u0, p, mm, nlstep_compile, nlstep_scc; jac = false)
     error(
         """
         `nlstep=true` requires ModelingToolkit.jl to be loaded.
@@ -65,7 +69,7 @@ Base.@nospecializeinfer @fallback_iip_specialize function SciMLBase.ODEFunction{
     _M = concrete_massmatrix(M; sparse, u0)
 
     if nlstep
-        ode_nlstep = generate_ODENLStepData(sys, u0, p, M, nlstep_compile, nlstep_scc)
+        ode_nlstep = generate_ODENLStepData(sys, u0, p, M, nlstep_compile, nlstep_scc; jac)
     else
         ode_nlstep = nothing
     end

--- a/src/systems/solver_nlprob.jl
+++ b/src/systems/solver_nlprob.jl
@@ -1,6 +1,7 @@
 function MTKBase.generate_ODENLStepData(
         sys::System, u0, p, mm = calculate_massmatrix(sys),
-        nlstep_compile::Bool = true, nlstep_scc::Bool = false
+        nlstep_compile::Bool = true, nlstep_scc::Bool = false;
+        jac::Bool = false
     )
     nlsys, outer_tmp, inner_tmp = inner_nlsystem(sys, mm, nlstep_compile)
     state = ProblemState(; u = u0, p)
@@ -15,10 +16,13 @@ function MTKBase.generate_ODENLStepData(
         haskey(op, v) && continue
         op[v] = getsym(sys, v)(state)
     end
+    # Forward the outer ODEFunction's `jac` flag so the inner teared nonlinear
+    # problem also carries an analytic Jacobian. This lets NonlinearSolve.jl
+    # skip the per-iteration AD/FD Jacobian computation on the inner Newton.
     nlprob = if nlstep_scc
-        SCCNonlinearProblem(nlsys, op; build_initializeprob = false)
+        SCCNonlinearProblem(nlsys, op; build_initializeprob = false, jac)
     else
-        NonlinearProblem(nlsys, op; build_initializeprob = false)
+        NonlinearProblem(nlsys, op; build_initializeprob = false, jac)
     end
 
     subsetidxs = [findfirst(isequal(y), unknowns(sys)) for y in unknowns(nlsys)]


### PR DESCRIPTION
Closes #4570.

When a user writes ODEProblem(sys, ...; jac = true, nlstep = true), the outer ODEFunction gets an analytic Jacobian but the inner teared NonlinearProblem built by generate_ODENLStepData did not — its f.jac was nothing.

This threads the jac kwarg through generate_ODENLStepData and into the inner NonlinearProblem / SCCNonlinearProblem constructor. With jac = true, MTK now symbolically differentiates the teared inner system once at build time and attaches the result to nlprob.f.jac.

Repro

using ModelingToolkit, SciMLBase
using ModelingToolkit: t_nounits as t, D_nounits as D

@parameters k₁ k₂ k₃
@variables y₁(t) y₂(t) y₃(t)
@mtkcompile rober = System([
    D(y₁) ~ -k₁*y₁ + k₃*y₂*y₃,
    D(y₂) ~ k₁*y₁ - k₂*y₂^2 - k₃*y₂*y₃,
    D(y₃) ~ k₂*y₂^2,
], t)

prob = ODEProblem(rober,
    [[y₁,y₂,y₃] .=> [1.0,0.0,0.0]; [k₁,k₂,k₃] .=> (0.04, 3e7, 1e4)],
    (0.0, 1e5); jac = true, nlstep = true)

SciMLBase.has_jac(prob.f.nlstep_data.nlprob.f)  # false on master, true with this PR
Verified locally
nlprob.f.jac populated when jac = true, untouched (nothing) when jac = false
The attached function is a real MTK GeneratedFunctionWrapper
Solutions still converge with the same retcode and within tolerance of the master result
Motivation
This is a prerequisite for OrdinaryDiffEq.jl-side W-matrix reuse on the nlstep path (SciML/OrdinaryDiffEq.jl#3696). Standalone performance impact is small/mixed (the inner teared problem for benchmark-scale Robertson is 1D, so FD jac is already nearly free); the real wins are downstream when paired with #3696 and on larger MTK systems where the teared inner Jacobian is non-trivial.


## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
