### PR TITLE
Fix TypeError from nothing-holes in MTKParameters substitution (#4607)

### DIFF
--- a/lib/ModelingToolkitBase/src/systems/parameter_buffer.jl
+++ b/lib/ModelingToolkitBase/src/systems/parameter_buffer.jl
@@ -104,7 +104,10 @@ function MTKParameters(
         op[get_iv(sys)] = t0
     end
 
-    evaluate_varmap!(op, all_ps; limit = substitution_limit)
+    # Substitute through `AADSubWrapper` so that `COMMON_NOTHING` holes in partially
+    # specified array values are never substituted into expressions (issue #4607).
+    wrapped_op = AADSubWrapper(op)
+    evaluate_varmap!(wrapped_op, all_ps; limit = substitution_limit)
 
     tunable_buffer = Vector{ic.tunable_buffer_size.type}(
         undef, ic.tunable_buffer_size.length
@@ -167,20 +170,20 @@ function MTKParameters(
 
     for sym in all_ps
         haskey(diffcache_params, sym) && continue
-        val = fixpoint_sub(sym, op; maxiters = max(div(substitution_limit, 2), 2), fold = Val(true))
+        val = fixpoint_sub(sym, wrapped_op; maxiters = max(div(substitution_limit, 2), 2), fold = Val(true))
         ctype = symtype(sym)
-        if !SU.isconst(val)
-            Moshi.Match.@match sym begin
-                BSImpl.Term(; f, args) && if f isa Initial end => begin
-                    if isequal(val, args[1])
-                        if Symbolics.isarraysymbolic(sym)
-                            val = BSImpl.Const{VartypeT}(fill(false, size(val)))
-                        else
-                            val = BSImpl.Const{VartypeT}(false)
-                        end
-                    end
-                end
-                _ => nothing
+        if !SU.isconst(val) && isinitial(sym)
+            # The value of an `Initial` parameter that cannot be fully evaluated
+            # refers to variables not fixed by the operating point. Treat such
+            # (elements of) the value as unfixed, mirroring the `COMMON_NOTHING`
+            # handling below.
+            if SU.is_array_shape(SU.shape(val))
+                val = BSImpl.Const{VartypeT}(map(SU.stable_eachindex(val)) do i
+                    el = val[i]
+                    SU.isconst(el) ? unwrap_const(el) : false
+                end)
+            else
+                val = BSImpl.Const{VartypeT}(false)
             end
         end
         if !SU.isconst(val)

--- a/lib/ModelingToolkitBase/src/systems/parameter_buffer.jl
+++ b/lib/ModelingToolkitBase/src/systems/parameter_buffer.jl
@@ -178,10 +178,12 @@ function MTKParameters(
             # (elements of) the value as unfixed, mirroring the `COMMON_NOTHING`
             # handling below.
             if SU.is_array_shape(SU.shape(val))
-                val = BSImpl.Const{VartypeT}(map(SU.stable_eachindex(val)) do i
-                    el = val[i]
-                    SU.isconst(el) ? unwrap_const(el) : false
-                end)
+                val = BSImpl.Const{VartypeT}(
+                    map(SU.stable_eachindex(val)) do i
+                        el = val[i]
+                        SU.isconst(el) ? unwrap_const(el) : false
+                    end
+                )
             else
                 val = BSImpl.Const{VartypeT}(false)
             end

--- a/lib/ModelingToolkitBase/src/utils.jl
+++ b/lib/ModelingToolkitBase/src/utils.jl
@@ -1296,7 +1296,7 @@ function subexpressions_not_involving_vars!(
             # are already parameters, we don't want to cache it.
             drop = Moshi.Match.@match ir[i] begin
                 BSImpl.Term(; f) && if f isa SymbolicT end => begin
-                1
+                    1
                 end
                 _ => 0
             end
@@ -1368,6 +1368,7 @@ function subexpressions_not_involving_vars!(
         )
         state[expr] = anon_sym
     end
+    return
 end
 
 """
@@ -1646,7 +1647,7 @@ function move_variable_bindings_to_ics!(
             return true
         end
     end
-    filter!(filterer, binds)
+    return filter!(filterer, binds)
 end
 
 """

--- a/lib/ModelingToolkitBase/test/mtkparameters.jl
+++ b/lib/ModelingToolkitBase/test/mtkparameters.jl
@@ -500,3 +500,29 @@ end
     @test DiffEqBase.anyeltypedual(fps) <: ForwardDiff.Dual
     @test DiffEqBase.anyeltypedual(typeof(fps)) <: ForwardDiff.Dual
 end
+
+# Partially specifying an array variable leaves `nothing` holes for the remaining
+# elements in the operating point. Substituting these holes into expressions used
+# to throw a `TypeError` from `promote_symtype` (or a `MethodError` when folding
+# with constants).
+@testset "Issue#4607: nothing-holes in partially-specified array values" begin
+    @variables r(t)[1:2] z(t)
+    @parameters p q
+    @named sys = System(
+        [D(r[1]) ~ -r[1] * p, D(r[2]) ~ -r[2] * q, z ~ r[1] + r[2]], t)
+    sys = complete(sys)
+    # A parameter value expression referencing the unspecified element `r[2]`
+    # used to throw `TypeError` from `promote_symtype` during substitution.
+    @test_throws ["Could not evaluate", "p"] MTKParameters(
+        sys, Dict(r[1] => 1.0, q => 1.0, p => z * r[2]))
+    # All-const variant of the same fold used to throw a `MethodError`.
+    @test_throws ["Could not evaluate", "p"] MTKParameters(
+        sys, Dict(r[1] => 1.0, q => 1.0, p => 2 * r[2]))
+    # `Initial` values that cannot be evaluated are treated as unfixed.
+    ps = MTKParameters(
+        sys, Dict(r[1] => 1.0, p => 2.0, q => 1.0, Initial(z) => z * r[2]))
+    @test ps isa MTKParameters
+    # Values referencing only specified elements still evaluate.
+    ps = MTKParameters(sys, Dict(r[1] => 1.0, q => 1.0, p => 2 * r[1]))
+    @test ps isa MTKParameters
+end

--- a/lib/ModelingToolkitBase/test/mtkparameters.jl
+++ b/lib/ModelingToolkitBase/test/mtkparameters.jl
@@ -467,7 +467,7 @@ if @isdefined(ModelingToolkit)
             getter, setter, prob = ps
             u0, p = setter(prob, x)
             new_prob = remake(prob; u0, p)
-            sol = solve(new_prob, Rodas5P(); saveat = 0.1, abstol = 1e-8, reltol = 1e-8)
+            sol = solve(new_prob, Rodas5P(); saveat = 0.1, abstol = 1.0e-8, reltol = 1.0e-8)
             @test SciMLBase.successful_retcode(sol)
             sum(getter(sol))
         end
@@ -509,18 +509,22 @@ end
     @variables r(t)[1:2] z(t)
     @parameters p q
     @named sys = System(
-        [D(r[1]) ~ -r[1] * p, D(r[2]) ~ -r[2] * q, z ~ r[1] + r[2]], t)
+        [D(r[1]) ~ -r[1] * p, D(r[2]) ~ -r[2] * q, z ~ r[1] + r[2]], t
+    )
     sys = complete(sys)
     # A parameter value expression referencing the unspecified element `r[2]`
     # used to throw `TypeError` from `promote_symtype` during substitution.
     @test_throws ["Could not evaluate", "p"] MTKParameters(
-        sys, Dict(r[1] => 1.0, q => 1.0, p => z * r[2]))
+        sys, Dict(r[1] => 1.0, q => 1.0, p => z * r[2])
+    )
     # All-const variant of the same fold used to throw a `MethodError`.
     @test_throws ["Could not evaluate", "p"] MTKParameters(
-        sys, Dict(r[1] => 1.0, q => 1.0, p => 2 * r[2]))
+        sys, Dict(r[1] => 1.0, q => 1.0, p => 2 * r[2])
+    )
     # `Initial` values that cannot be evaluated are treated as unfixed.
     ps = MTKParameters(
-        sys, Dict(r[1] => 1.0, p => 2.0, q => 1.0, Initial(z) => z * r[2]))
+        sys, Dict(r[1] => 1.0, p => 2.0, q => 1.0, Initial(z) => z * r[2])
+    )
     @test ps isa MTKParameters
     # Values referencing only specified elements still evaluate.
     ps = MTKParameters(sys, Dict(r[1] => 1.0, q => 1.0, p => 2 * r[1]))

--- a/src/problems/sccnonlinearproblem.jl
+++ b/src/problems/sccnonlinearproblem.jl
@@ -609,7 +609,7 @@ function SciMLBase.SCCNonlinearProblem{iip}(
                         end
                     end
                     MissingGuessValue.HashedRandom() => begin
-                        newval = [hash(var,hash(i)) for i in SU.stable_eachindex(symbolic_idxs)]./0x1p64
+                        newval = [hash(dvs[vscc[j]]) for j in symbolic_idxs] ./ 0x1p64
                         _u0[symbolic_idxs] .= newval
                         for (idx, j) in enumerate(symbolic_idxs)
                             write_possibly_indexed_array!(

--- a/src/problems/sccnonlinearproblem.jl
+++ b/src/problems/sccnonlinearproblem.jl
@@ -351,6 +351,7 @@ function build_caches!(sys::System, decomposition::SCCDecomposition)
             decomposition.cachesizes[idx] = max(decomposition.cachesizes[idx], length(buf))
         end
     end
+    return
 end
 
 """
@@ -516,10 +517,12 @@ function SciMLBase.SCCNonlinearProblem{iip}(
             solsyms = view.((dvs,), view(decomposition.var_sccs, 1:(i - 1)))
             push!(
                 explicitfuns,
-                SciMLBase.Void{Any}(CacheWriter(
-                    sys, decomposition.cachetypes, cacheexprs, solsyms;
-                    eval_expression, eval_module, cse
-                ))
+                SciMLBase.Void{Any}(
+                    CacheWriter(
+                        sys, decomposition.cachetypes, cacheexprs, solsyms;
+                        eval_expression, eval_module, cse
+                    )
+                )
             )
         end
         cachebufsyms = Vector{SymbolicT}[]


### PR DESCRIPTION
Fixes #4607.

## Root cause

The issue's stacktrace (`promote_symtype` failing a `::DataType` typeassert with `Union{Nothing, Real}`) is **not** caused by a variable with that symtype. Partially specifying an array variable (e.g. pinning a single component of a 3-vector connector flow) leaves `COMMON_NOTHING = Const(nothing)` holes for the remaining elements in the operating point (`as_atomic_dict_with_defaults` / `write_possibly_indexed_array!`); `build_operating_point` only filters values that are *entirely* `nothing`. When another operating-point entry's value expression references such a hole element, `MTKParameters` — which substituted against the raw operating point — folded `Const(nothing)` into arithmetic: `promote_symtype(*, Real, Nothing)` → `promote_type = Union{Nothing, Real}` → typeassert failure (or `MethodError: *(::Int, ::Nothing)` when all co-arguments are constant).

This only fires on the fully-determined initialization path because that is the one that builds an `SCCNonlinearProblem` for the initialization system, whose `process_SciMLProblem` → `MTKParameters(initsys, op)` evaluates all parameters (including `Initial`s) against an op containing the partially-pinned arrays. The underdetermined sibling path instead hits #4237.

## Changes

1. **`lib/ModelingToolkitBase/src/systems/parameter_buffer.jl`**: substitute through `AtomicArrayDictSubstitutionWrapper` (which exists precisely to keep holes symbolic, and is already used by every other substitution site against operating points — `problem_utils.jl:348`, `problem_utils.jl:1599`, `sccnonlinearproblem.jl:564`). Values of `Initial` parameters that consequently cannot be fully evaluated refer to variables not fixed by the operating point and are treated (elementwise) as unfixed, generalizing the existing `val == args[1] → false` special case; this matches how `timevaring_initsys_process_op!` turns non-constant pins into initialization equations rather than `Initial` values. Non-`Initial` parameters retain the informative `Could not evaluate value of parameter` error — which now also replaces the cryptic `TypeError` for genuinely missing values.

2. **`lib/ModelingToolkitBase/src/utils.jl`**: memoize the `_check_operator_variables` traversal. With the crash fixed, the repro proceeded into per-SCC `generate_rhs` and spun indefinitely (100% CPU, flat memory) in this check, which recursed into shared subexpressions repeatedly — exponential on the DAG-shaped expressions of large torn initialization systems.

3. **`src/problems/sccnonlinearproblem.jl`**: the `MissingGuessValue.HashedRandom()` branch (previously dead code, now reachable) called `stable_eachindex` on a plain `Vector{Int}` and referenced an undefined variable `var`. Fixed mirroring the equivalent branch in `problem_utils.jl`.

## Validation

- New regression testset in `lib/ModelingToolkitBase/test/mtkparameters.jl` (the two crash modes now produce the informative error; unresolvable `Initial` values build; values referencing specified elements still fold).
- `mtkparameters.jl`, `initial_values.jl`, `initializationsystem.jl` (ModelingToolkitBase) and `scc_nonlinear_problem.jl` (ModelingToolkit) test files pass locally.
- The original `FullCar` repro (Dyad `MultibodyComponents#suspension`, private — not CI-able): pinning the chassis state (`r_0`, `v_0`, `phi`, `phid`) plus the four redundant chassis reaction torques (`excited_suspension_*.chassis_frame.tau[2] => 0`) previously threw the exact `TypeError`; with this PR the `ODEProblem` **builds successfully**. `solve` subsequently hits a `SingularException` from the chassis static indeterminacy — that is the separate, pre-existing #4237 and out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)