### PR TITLE
test: accept both valid tearing arrangements in reordered_matrix check

### DIFF
--- a/test/structural_transformation/tearing.jl
+++ b/test/structural_transformation/tearing.jl
@@ -108,13 +108,26 @@ if v"1.12" <= VERSION < v"1.13"
     let state = TearingState(sys)
         result, = tearing(state)
         S = StructuralTransformations.reordered_matrix(sys, result.var_eq_matching)
-        @test S == [
+        # Tearing `u5` or tearing `u1` (the two arrangements diagrammed above) are both
+        # valid maximal matchings; which one the heuristic picks depends on the
+        # lexicographic equation sort in `TearingState`, whose strings depend on the
+        # symbolic backend's term ordering (e.g. it flipped with a SymbolicUtils hashing
+        # change, see #4619). Accept either, like the `vars` test above does.
+        S_tear_u5 = [
             1 0 0 0 1
             1 1 0 0 0
             1 1 1 0 0
             0 1 1 1 0
             1 0 0 1 1
         ]
+        S_tear_u1 = [
+            1 0 0 1 1
+            0 1 0 0 1
+            0 1 1 0 1
+            0 1 1 1 0
+            1 0 0 0 1
+        ]
+        @test S == S_tear_u5 || S == S_tear_u1
     end
 end
 


### PR DESCRIPTION
> **Please ignore until reviewed by @ChrisRackauckas.** Opened as a draft.

Fixes #4619.

## Summary

`test/structural_transformation/tearing.jl`'s `reordered_matrix` assertion pinned the tear-`u5` arrangement, but this system has **two valid maximal matchings** — tear `u5` or tear `u1`, both diagrammed in the comment block right above the test, and both already accepted by the neighboring `vars` assertion via `||`. This PR gives the matrix assertion the same treatment: it now accepts exactly the two fully-specified matrices corresponding to those arrangements (still tight — anything else fails).

## Why

Which arrangement the heuristic picks is an environment-sensitive tie-break: `TearingState` sorts equations by `sortperm(string.(eqs))`, and those strings depend on the symbolic backend's internal term ordering. Concretely observed (see #4619 for the bisect):

- SymbolicUtils#963 (a `Term`-hashing change, on SymbolicUtils master, **not yet released**) flips the order — MTK master + SymbolicUtils master currently fails this test (first seen on SymbolicUtils' downstream CI), and will fail for everyone when the next SymbolicUtils version releases.
- The flip is not even a pure function of the SymbolicUtils version: in local testing the same SymbolicUtils commit picked different arrangements depending on environment details (registry tarball vs git checkout). Both outcomes were verified to be valid maximal matchings against the incidence graph.

## Verification (ran locally, Julia 1.12.6, MTK master + lib packages dev'd)

| SymbolicUtils | arrangement picked | new assertion |
|---|---|---|
| 4.35.0 (registry, current release) | tear `u1` | ✅ pass |
| master + #966 (= upcoming 4.36.0) | tear `u5` | ✅ pass |
| 4.35.0-content git worktree (bisect env) | tear `u5` | ✅ pass |
| master git worktree (bisect env) | tear `u1` | ✅ pass |

Across all eight runs in the #4619 investigation the computed matrix was always exactly one of these two — never a third pattern.

A deeper follow-up (out of scope here) would be sorting equations in `TearingState` by a hash-independent canonical key so the chosen tearing is stable across symbolic-backend changes; noted in #4619.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
