### PR TITLE
cache expression checks in `check_operator_variables`

### DIFF
--- a/lib/ModelingToolkitBase/src/utils.jl
+++ b/lib/ModelingToolkitBase/src/utils.jl
@@ -559,13 +559,15 @@ end
 """
 Check if difference/derivative operation occurs in the R.H.S. of an equation
 """
-function _check_operator_variables(eq, op::T, expr = eq.rhs) where {T}
+function _check_operator_variables(eq, op::T, expr = eq.rhs, visited = Base.IdSet{BasicSymbolic}()) where {T}
     iscall(expr) || return nothing
+    expr in visited && return nothing
+    push!(visited, expr)
     if operation(expr) isa op
         throw_invalid_operator(expr, eq, op)
     end
     return foreach(
-        expr -> _check_operator_variables(eq, op, expr),
+        arg -> _check_operator_variables(eq, op, arg, visited),
         SymbolicUtils.arguments(expr)
     )
 end
@@ -575,8 +577,9 @@ Check if all the LHS are unique
 function check_operator_variables(eqs, ::Type{op}) where {op}
     ops = Set{SymbolicT}()
     tmp = Set{SymbolicT}()
+    visited = Base.IdSet{BasicSymbolic}()
     for eq in eqs
-        _check_operator_variables(eq, op)
+        _check_operator_variables(eq, op, eq.rhs, visited)
         SU.search_variables!(tmp, eq.lhs; is_atomic = OperatorIsAtomic{Differential}())
         if length(tmp) == 1
             x = only(tmp)
@@ -597,6 +600,7 @@ function check_operator_variables(eqs, ::Type{op}) where {op}
             push!(ops, v)
         end
         empty!(tmp)
+        empty!(visited)
     end
     return
 end


### PR DESCRIPTION
Broken out from https://github.com/SciML/ModelingToolkit.jl/pull/4617.