### PR TITLE
ci: avoid `julia-actions/cache` in tests

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -46,4 +46,5 @@ jobs:
       group: "${{ matrix.group }}"
       self-hosted: ${{ vars.USE_SELF_HOSTED == 'true' }}
       coverage-directories: "src,ext,lib/ModelingToolkitBase/src,lib/ModelingToolkitBase/ext"
+      cache: false
     secrets: "inherit"


### PR DESCRIPTION
It does nothing and adds 1hr+ to jobs