### PR TITLE
Explicitly capture problem parameters in the tests

### DIFF
--- a/lib/ModelingToolkitBase/test/sciml_problem_inputs.jl
+++ b/lib/ModelingToolkitBase/test/sciml_problem_inputs.jl
@@ -39,7 +39,7 @@ begin
     ]
 
     # Create systems (without mtkcompile, since that might modify systems to affect intended tests).
-    osys = complete(System(diff_eqs, t; name = :osys))
+    osys = complete(System(diff_eqs, t, [X, Y, Z], [kp, kd, k1, k2, Z0]; name = :osys))
     ssys = complete(
         SDESystem(
             diff_eqs, noise_eqs, t, [X, Y, Z], [kp, kd, k1, k2]; name = :ssys


### PR DESCRIPTION
Fixes these failures seen in https://github.com/SciML/SciMLBase.jl/pull/1386:
```julia
SciML Problem Input Test: Error During Test at /home/runner/.julia/packages/SafeTestsets/raUNr/src/SafeTestsets.jl:30
  Got exception outside of a @test
  LoadError: ArgumentError: System osys: variable Z0 does not exist
  Stacktrace:
    [1] getvar(sys::ModelingToolkitBase.System, name::Symbol; namespace::Bool)
      @ ModelingToolkitBase ~/.julia/packages/ModelingToolkitBase/PHXso/src/systems/abstractsystem.jl:1168
    [2] getproperty(sys::ModelingToolkitBase.System, name::Symbol; namespace::Bool)
      @ ModelingToolkitBase ~/.julia/packages/ModelingToolkitBase/PHXso/src/systems/abstractsystem.jl:1109
    [3] getproperty(sys::ModelingToolkitBase.System, name::Symbol; namespace::Bool)
      @ ModelingToolkitBase ~/.julia/packages/ModelingToolkitBase/PHXso/src/systems/abstractsystem.jl:1107
    [4] getproperty(sys::ModelingToolkitBase.System, name::Symbol)
      @ ModelingToolkitBase ~/.julia/packages/ModelingToolkitBase/PHXso/src/systems/abstractsystem.jl:1103
    [5] top-level scope
      @ ~/.julia/packages/ModelingToolkitBase/PHXso/test/sciml_problem_inputs.jl:78
    [6] include(mod::Module, _path::String)
      @ Base ./Base.jl:495
    [7] include(x::String)
      @ Main.var"##SciML Problem Input Test#261" ~/.julia/packages/SafeTestsets/raUNr/src/SafeTestsets.jl:28
    [8] macro expansion
      @ ~/work/SciMLBase.jl/SciMLBase.jl/downstream/test/runtests.jl:39 [inlined]
    [9] macro expansion
      @ /opt/hostedtoolcache/julia/1.10.11/x64/share/julia/stdlib/v1.10/Test/src/Test.jl:1582 [inlined]
   [10] macro expansion
      @ ~/work/SciMLBase.jl/SciMLBase.jl/downstream/test/runtests.jl:37 [inlined]
   [11] top-level scope
      @ ~/.julia/packages/SafeTestsets/raUNr/src/SafeTestsets.jl:30
   [12] eval(m::Module, e::Any)
      @ Core ./boot.jl:385
   [13] macro expansion
      @ ~/.julia/packages/SafeTestsets/raUNr/src/SafeTestsets.jl:28 [inlined]
   [14] macro expansion
      @ ~/work/SciMLBase.jl/SciMLBase.jl/downstream/test/runtests.jl:36 [inlined]
   [15] macro expansion
      @ ./timing.jl:279 [inlined]
   [16] top-level scope
      @ ~/work/SciMLBase.jl/SciMLBase.jl/downstream/test/runtests.jl:269
   [17] include(fname::String)
      @ Base.MainInclude ./client.jl:487
   [18] top-level scope
      @ none:6
  in expression starting at /home/runner/.julia/packages/ModelingToolkitBase/PHXso/test/sciml_problem_inputs.jl:17
```

It only seems to fail on 1.10, not sure why. Maybe a different dependency somewhere? Here's a summary from Claude:

>   **Problem**                                                                                                                                                                                                                                      
>                                                                                                                                                                                                                                                
>   The SciMLBase downstream CI job ModelingToolkit.jl/Downstream failed in MTKBase's own test sciml_problem_inputs.jl:                                                                                                                          
>                                                                                                                                                                                                                                                
>   ArgumentError: System osys: variable Z0 does not exist                                                                                                                                                                                       
>                                                                                                                                                                                                                                                
>   The test builds osys = complete(System(diff_eqs, t; name = :osys)) and then accesses osys.Z0. Z0 is a parameter that appears only as the default of an unknown — `@variables Z(t) = Z0` — and never in diff_eqs.                               
>                                                                                                                                                                                                                                                
>   **Root cause**                                                                                                                                                                                                                                   
> 
>   - Z0 only reaches the system via collect_var! reading the default metadata off the Z(t) symbolic during construction.
>   - On Julia 1.10, SymbolicUtils hashconsing returns a canonical Z(t) instance with no default attached (the one built inside D(Z) ~ -Z). Which cached instance wins is GC/Julia-version-dependent, so collect_var! finds no default and Z0 is
>   never registered as a parameter.
>   - Verified with a minimal repro: with identical dependency versions (Symbolics 7.26.0, SymbolicUtils 4.35.0, TermInterface 2.0.0, Moshi 0.3.8), Z0 in parameters(osys) was false on Julia 1.10 but true on 1.13.
>                                                                                                                         
>   **Fix**
> 
>   Pass the parameter list explicitly so the system no longer depends on fragile implicit default-metadata discovery, in lib/ModelingToolkitBase/test/sciml_problem_inputs.jl:
>                                                                                                                         
>   osys = complete(System(diff_eqs, t, [X, Y, Z], [kp, kd, k1, k2, Z0]; name = :osys))
>                                                                                                                         
>   This is consistent with the sibling systems in the same test (ssys, jsys) which already pass explicit unknowns/parameters, and it makes the test deterministic across Julia versions. Confirmed passing on Julia 1.10.
> 

## Checklist

- [ ] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API