### PR TITLE
 feat: add `discover_maybe_zeros`

### DIFF
--- a/lib/ModelingToolkitBase/src/atomic_array_dict.jl
+++ b/lib/ModelingToolkitBase/src/atomic_array_dict.jl
@@ -243,10 +243,16 @@ const AADSubWrapper{D} = AtomicArrayDictSubstitutionWrapper{D}
 
 Base.get(def::Base.Callable, dd::AADSubWrapper, k) = def()
 function Base.get(def::Base.Callable, dd::AADSubWrapper, k::SymbolicT)
-    arr, isarr = split_indexed_var(k)
     res = get_possibly_indexed(dd.dict, k, dd.default)
     if res === dd.default
+        arr, isarr = split_indexed_var(k)
         isarr && haskey(dd.dict, arr) && return k
+        return def()
+    end
+    if SU.is_array_shape(SU.shape(k)) && any(
+            Base.Fix2(===, dd.default) ∘ Base.Fix1(getindex, res),
+            SU.stable_eachindex(res)
+        )
         return def()
     end
     return res

--- a/lib/ModelingToolkitBase/src/systems/diffeqs/basic_transformations.jl
+++ b/lib/ModelingToolkitBase/src/systems/diffeqs/basic_transformations.jl
@@ -1300,3 +1300,31 @@ function truncate_constant_floats(sys::System, ::Type{FloatType}) where {FloatTy
 
     return ConstructionBase.setproperties(sys; eqs = eqs, observed = obs)
 end
+
+"""
+    $TYPEDSIGNATURES
+
+Use various heuristics to discover parameters that may be zero in `sys`. Useful when
+simplifying the system to avoid accidentally dividing by zero.
+"""
+function discover_maybe_zeros(sys::System)
+    defs = copy(parent(bindings(sys)))
+    left_merge!(defs, initial_conditions(sys))
+    filter!(Base.Fix2(!==, COMMON_MISSING) ∘ last, defs)
+    subber = Symbolics.FixpointSubstituter{true}(AADSubWrapper(defs))
+    mbzs = copy(maybe_zeros(sys))
+    for k in [parameters(sys); unknowns(sys)]
+        is_variable_numeric(k) || continue
+        sh = SU.shape(k)
+        sh isa SU.ShapeVecT || continue
+        if !SU.is_array_shape(sh)
+            SU._iszero(subber(k)) && push_as_atomic_array!(mbzs, k)
+            continue
+        end
+        if any(SU._iszero ∘ subber ∘ Base.Fix1(getindex, k), SU.stable_eachindex(k))
+            push_as_atomic_array!(mbzs, k)
+        end
+    end
+
+    return @set! sys.maybe_zeros = mbzs
+end

--- a/src/systems/systems.jl
+++ b/src/systems/systems.jl
@@ -30,6 +30,7 @@ function MTKBase.__mtkcompile(
     )
     sys, statemachines = extract_top_level_statemachines(sys)
     sys, source_info = expand_connections(sys, Val(true))
+    sys = MTKBase.discover_maybe_zeros(sys)
     state = TearingState(sys, source_info; sort_eqs)
     append!(state.statemachines, statemachines)
 


### PR DESCRIPTION
Useful in `mtkcompile` to automatically discover things that might be zero and guide simplification accordingly.