### PR TITLE
refactor: ensure init system is in terms of unknowns of DAE

### DIFF
--- a/lib/ModelingToolkitBase/src/problems/initializationproblem.jl
+++ b/lib/ModelingToolkitBase/src/problems/initializationproblem.jl
@@ -122,6 +122,13 @@ All other keyword arguments are forwarded to the wrapped problem constructor.
         new_ps = copy(get_ps(isys))
         append!(new_ps, uninit)
         @set! isys.ps = new_ps
+        gs = ModelingToolkitBase.initial_conditions(isys)
+        sys_gs = ModelingToolkitBase.guesses(sys)
+        for k in uninit
+            haskey(gs, k) && continue
+            haskey(sys_gs, k) || continue
+            gs[k] = sys_gs[k]
+        end
         isys = complete(isys)
     end
 

--- a/lib/ModelingToolkitBase/src/problems/initializationproblem.jl
+++ b/lib/ModelingToolkitBase/src/problems/initializationproblem.jl
@@ -82,9 +82,16 @@ All other keyword arguments are forwarded to the wrapped problem constructor.
         binds[get_iv(sys)::SymbolicT] = Symbolics.COMMON_ZERO
         @set! isys.bindings = ROSymmapT(binds)
     end
+    pareqs, resteqs = find_all_parameter_equations(isys)
+    @set! isys.eqs = resteqs
     if simplify_system
         isys = mtkcompile(isys; fully_determined, split = is_split(sys), initsys_mtkcompile_kwargs...)
     end
+    for i in eachindex(pareqs)
+        eq = pareqs[i]
+        pareqs[i] = Symbolics.COMMON_ZERO ~ (eq.rhs - eq.lhs)
+    end
+    @set! isys.eqs = [equations(isys); pareqs]
 
     ts = get_tearing_state(isys)
     unassigned_vars = singular_check(ts)

--- a/lib/ModelingToolkitBase/src/problems/initializationproblem.jl
+++ b/lib/ModelingToolkitBase/src/problems/initializationproblem.jl
@@ -136,6 +136,9 @@ All other keyword arguments are forwarded to the wrapped problem constructor.
         op = copy(op)
         op[get_iv(sys)] = t
     end
+    # Observed of `sys` aren't present in `isys` anymore, so this enables guess-propagation
+    # to work properly.
+    add_observed!(sys, ModelingToolkitBase.initial_conditions(isys))
     filter!(!Base.Fix2(===, COMMON_MISSING) ∘ last, op)
     TProb = get_initialization_problem_type(
         sys, isys; warn_initialize_determined,

--- a/lib/ModelingToolkitBase/src/problems/initializationproblem.jl
+++ b/lib/ModelingToolkitBase/src/problems/initializationproblem.jl
@@ -107,6 +107,10 @@ All other keyword arguments are forwarded to the wrapped problem constructor.
     end
 
     uninit = as_atomic_array_set(unknowns(sys))
+    for (k, v) in bindings(sys)
+        v === COMMON_MISSING || continue
+        push!(uninit, k)
+    end
     setdiff!(uninit, as_atomic_array_set(unknowns(isys)))
     setdiff!(uninit, as_atomic_array_set(observables(isys)))
 

--- a/lib/ModelingToolkitBase/src/problems/nonlinearproblem.jl
+++ b/lib/ModelingToolkitBase/src/problems/nonlinearproblem.jl
@@ -75,11 +75,25 @@ function generate_nonlinear_bounds(sys::AbstractSystem, op)
     isempty(dvs) && return nothing, nothing
     lb = first.(getbounds.(dvs))
     ub = last.(getbounds.(dvs))
+    if all(!Base.Fix2(isa, SymbolicT) ∘ unwrap, lb) && all(!Base.Fix2(isa, SymbolicT) ∘ unwrap, ub)
+        if all(==(-Inf), lb) && all(==(Inf), ub)
+            return nothing, nothing
+        end
+        return lb, ub
+    end
     op = build_operating_point(sys, op)
-    lbmap = as_atomic_dict_with_defaults(Dict{SymbolicT, SymbolicT}(dvs .=> lb), COMMON_NOTHING)
+    lbmap = SymmapT()
+    for (var, b) in zip(dvs, lb)
+        b === -Inf && continue
+        write_possibly_indexed_array!(lbmap, var, Symbolics.SConst(b), COMMON_NOTHING)
+    end
     left_merge!(lbmap, op)
     lb = varmap_to_vars(lbmap, dvs; tofloat = false)
-    ubmap = as_atomic_dict_with_defaults(Dict{SymbolicT, SymbolicT}(dvs .=> ub), COMMON_NOTHING)
+    ubmap = SymmapT()
+    for (var, b) in zip(dvs, lb)
+        b === -Inf && continue
+        write_possibly_indexed_array!(ubmap, var, Symbolics.SConst(b), COMMON_NOTHING)
+    end
     left_merge!(ubmap, op)
     ub = varmap_to_vars(ubmap, dvs; tofloat = false)
     if all(==(-Inf), lb) && all(==(Inf), ub)

--- a/lib/ModelingToolkitBase/src/systems/nonlinear/initializesystem.jl
+++ b/lib/ModelingToolkitBase/src/systems/nonlinear/initializesystem.jl
@@ -97,6 +97,7 @@ function generate_initializesystem_timevarying(
     # All bound parameters are solvable. The corresponding equation comes from the binding
     for v in bound_parameters(sys)
         push!(init_ps, v)
+        newbinds[v] = binds[v]
     end
     op::SymmapT = if fast_path
         op

--- a/lib/ModelingToolkitBase/src/systems/nonlinear/initializesystem.jl
+++ b/lib/ModelingToolkitBase/src/systems/nonlinear/initializesystem.jl
@@ -56,15 +56,11 @@ function generate_initializesystem_timevarying(
         name = nameof(sys), kwargs...
     )
     _sys = reverse_transformations_for_initialization(sys)
-    trueobs = observed(_sys)
-    eqs = equations(_sys)
-    # remove any observed equations that directly or indirectly contain
-    # delayed unknowns
-    isempty(trueobs) || filter_delay_equations_variables!(sys, trueobs)
+    eqs = full_equations(_sys)
 
-    # Firstly, all variables and observables are initialization unknowns
+    # Firstly, all variables are initialization unknowns
     init_vars_set = AtomicArraySet{OrderedDict{SymbolicT, Nothing}}()
-    add_trivial_initsys_vars!(init_vars_set, unknowns(_sys), trueobs)
+    foreach(Base.Fix1(push!, init_vars_set) ∘ first ∘ split_indexed_var, unknowns(_sys))
 
     eqs_ics = Equation[]
 
@@ -100,15 +96,20 @@ function generate_initializesystem_timevarying(
     newbinds = SymmapT()
     # All bound parameters are solvable. The corresponding equation comes from the binding
     for v in bound_parameters(sys)
-        push!(is_variable_floatingpoint(v) ? init_vars_set : init_ps, v)
+        push!(init_ps, v)
     end
     op::SymmapT = if fast_path
         op
     else
         build_operating_point(sys, op)
     end
-    initsys_sort_system_bindings!(init_vars_set, init_ps, eqs_ics, binds, newbinds, op, guesses)
+    subber = get_ir_info(_sys).obs_subber
+    obsvars = as_atomic_array_set(observables(_sys))
+    initsys_sort_system_bindings!(subber, init_vars_set, init_ps, obsvars, eqs_ics, binds, op, guesses)
 
+    # Derivative equations are added as-is instead of relying on `subber`. This allows
+    # properly handling singular systems. Without this, singular systems will always
+    # error as incomplete, since the system symbolically won't contain some unknowns.
     derivative_rules = DerivativeDict()
     dd_guess_sym = BSImpl.Const{VartypeT}(default_dd_guess)
     banned_derivatives = Set{SymbolicT}()
@@ -124,7 +125,9 @@ function generate_initializesystem_timevarying(
                 continue
             end
             push_as_atomic_array!(init_vars_set, ttk)
-            isequal(ttk, v) || push!(eqs_ics, ttk ~ v)
+            # Running `subber(ttk)` will make the LHS and RHS identical, so we
+            # avoid that.
+            isequal(ttk, v) || push!(eqs_ics, ttk ~ subber(v))
             derivative_rules[k] = ttk
         end
         merge!(derivative_rules, as_atomic_dict_with_defaults(Dict{SymbolicT, SymbolicT}(derivative_rules), COMMON_NOTHING))
@@ -142,7 +145,7 @@ function generate_initializesystem_timevarying(
                     write_possibly_indexed_array!(guesses, ttk, dd_guess_sym, COMMON_NOTHING)
                 end
                 push_as_atomic_array!(init_vars_set, ttk)
-                isequal(ttk, eq.rhs) || push!(eqs_ics, ttk ~ eq.rhs)
+                isequal(ttk, eq.rhs) || push!(eqs_ics, ttk ~ subber(eq.rhs))
                 ttk
             end
         else
@@ -150,7 +153,8 @@ function generate_initializesystem_timevarying(
         end
     end
     D = Differential(get_iv(sys))
-    for eq in trueobs
+    ir = get_irstructure(_sys)
+    for eq in observed(_sys)
         # Observed derivatives aren't added the same way as dummy_sub/diffeqs because
         # doing so would require all observed equations to be symbolically differentiable.
         get!(derivative_rules, D(eq.lhs), D(eq.rhs))
@@ -159,13 +163,20 @@ function generate_initializesystem_timevarying(
             write_possibly_indexed_array!(guesses, eq.lhs, eq.rhs, COMMON_NOTHING)
         end
     end
-    timevaring_initsys_process_op!(init_vars_set, init_ps, eqs_ics, op, derivative_rules, guesses)
+
+    # Always substitute `der_subber` and `subber` on any equations added to `eqs_ics`
+    der_subber = Symbolics.FixpointSubstituter(
+        SU.IRSubstituter{false}(
+            get_irstructure(sys), derivative_rules
+        ); maxiters = get_maxiters(derivative_rules)
+    )
+    timevaring_initsys_process_op!(subber, init_vars_set, init_ps, eqs_ics, op, der_subber, guesses)
 
     # process explicitly provided initialization equations
     if !algebraic_only
         initialization_eqs = [get_initialization_eqs(sys); initialization_eqs]
         for eq in initialization_eqs
-            eq = fixpoint_sub(eq, derivative_rules; maxiters = get_maxiters(derivative_rules)) # expand dummy derivatives
+            eq = subber(der_subber(eq))
             push!(eqs_ics, eq)
         end
     end
@@ -179,8 +190,6 @@ function generate_initializesystem_timevarying(
     #         #push!(guessed, eq.lhs) # should not encounter eq.lhs twice, so don't need to track it
     #     end
     # end
-
-    append!(eqs_ics, trueobs)
 
     vars = collect(init_vars_set)
     pars = collect(init_ps)
@@ -366,16 +375,6 @@ function generate_initializesystem_timeindependent(
     return isys
 end
 
-function add_trivial_initsys_vars!(init_vars_set::AtomicArraySet{OrderedDict{SymbolicT, Nothing}}, dvs::Vector{SymbolicT}, trueobs::Vector{Equation})
-    for v in dvs
-        push!(init_vars_set, split_indexed_var(v)[1])
-    end
-    for eq in trueobs
-        push!(init_vars_set, split_indexed_var(eq.lhs)[1])
-    end
-    return
-end
-
 function initsys_sort_system_parameters!(
         init_vars_set::AtomicArraySet{OrderedDict{SymbolicT, Nothing}},
         init_ps::AtomicArraySet{OrderedDict{SymbolicT, Nothing}},
@@ -390,10 +389,12 @@ function initsys_sort_system_parameters!(
 end
 
 function initsys_sort_system_bindings!(
+        subber::ObsSubberT,
         init_vars_set::AtomicArraySet{OrderedDict{SymbolicT, Nothing}},
         init_ps::AtomicArraySet{OrderedDict{SymbolicT, Nothing}},
+        obsvars::AtomicArraySet{Dict{SymbolicT, Nothing}},
         eqs_ics::Vector{Equation}, binds::ROSymmapT,
-        newbinds::SymmapT, op::SymmapT, guesses::SymmapT
+        op::SymmapT, guesses::SymmapT
     )
     # Anything with a binding of `missing` is solvable.
     for (k, v) in binds
@@ -404,21 +405,35 @@ function initsys_sort_system_bindings!(
             op[Initial(k)] = k
             continue
         end
-        if is_variable_floatingpoint(k)
-            push!(eqs_ics, k ~ v)
-            get!(guesses, k, v)
-        else
-            newbinds[k] = v
+        # Bindings for variables/observed are added as equations after
+        # substituting observed
+        if k in init_vars_set || k in obsvars
+            if SU.is_array_shape(SU.shape(k))
+                for (ki, vi) in zip(SU.stable_eachindex(k), SU.stable_eachindex(v))
+                    kki = subber(k[ki])
+                    vvi = subber(v[vi])
+                    # Ignore if identity
+                    isequal(kki, vvi) || push!(eqs_ics, kki ~ vvi)
+                end
+            else
+                kk = subber(k)
+                vv = subber(v)
+                isequal(kk, vv) || push!(eqs_ics, kk ~ vv)
+            end
+            continue
         end
+        delete!(init_ps, k)
     end
     return
 end
 
 function timevaring_initsys_process_op!(
+        subber::ObsSubberT,
         init_vars_set::AtomicArraySet{OrderedDict{SymbolicT, Nothing}},
         init_ps::AtomicArraySet{OrderedDict{SymbolicT, Nothing}},
         eqs_ics::Vector{Equation}, op::SymmapT,
-        derivative_rules::DerivativeDict, guesses::SymmapT
+        der_subber::Symbolics.FixpointSubstituter,
+        guesses::SymmapT
     )
     for (k, v) in op
         # Late binding `missing` also makes the key solvable
@@ -449,7 +464,8 @@ function timevaring_initsys_process_op!(
         In case neither of these is the case, please open an issue in ModelingToolkit.jl \
         with a reproducible example.
         """
-        subk = fixpoint_sub(k, derivative_rules; maxiters = get_maxiters(derivative_rules))
+        # Always
+        subk = subber(der_subber(k))
         # FIXME: DAEs can have initial conditions that require reducing the system
         # to index zero. If `isdifferential(y)`, an initial condition was given for the
         # derivative of an algebraic variable, so ignore it. Otherwise, the initialization
@@ -489,12 +505,12 @@ function timevaring_initsys_process_op!(
                     write_possibly_indexed_array!(op, ikk, vv, COMMON_FALSE)
                 else
                     write_possibly_indexed_array!(guesses, kk, vv, COMMON_FALSE)
-                    vv = fixpoint_sub(vv, derivative_rules; maxiters = get_maxiters(derivative_rules))
+                    vv = subber(der_subber(vv))
                     push!(eqs_ics, subkk ~ vv)
                 end
             end
         else
-            v = fixpoint_sub(v, derivative_rules; maxiters = get_maxiters(derivative_rules))
+            v = subber(der_subber(v))
             isequal(subk, v) || push!(eqs_ics, subk ~ v)
         end
     end

--- a/lib/ModelingToolkitBase/src/systems/problem_utils.jl
+++ b/lib/ModelingToolkitBase/src/systems/problem_utils.jl
@@ -1603,7 +1603,7 @@ function maybe_build_initialization_problem(
         update_initializeprob! = ModelingToolkitBase.update_initializeprob!
     end
 
-    missingvars = AtomicArraySet()
+    missingvars = Set{SymbolicT}()
     temp_op = copy(op)
     for (k, v) in op
         v === COMMON_MISSING || continue
@@ -1616,7 +1616,7 @@ function maybe_build_initialization_problem(
             has_possibly_indexed_key(parent(binds), v) && continue
             val = get_possibly_indexed(op, v, COMMON_NOTHING)
             if !SU.isconst(val) || val === COMMON_NOTHING
-                push_as_atomic_array!(missingvars, v)
+                push!(missingvars, v)
             end
         end
         if implicit_dae
@@ -1627,14 +1627,14 @@ function maybe_build_initialization_problem(
                         get_possibly_indexed(op, ttv, COMMON_NOTHING) === COMMON_NOTHING &&
                         # FIXME: Derivatives of algebraic variables aren't present
                         (is_variable(initsys, ttv) || has_observed_with_lhs(initsys, ttv))
-                    push_as_atomic_array!(missingvars, ttv)
+                    push!(missingvars, ttv)
                 end
             end
         end
     end
     for v in get_all_discretes_fast(sys)
         has_possibly_indexed_key(parent(binds), v) && continue
-        has_possibly_indexed_key(op, v) || push_as_atomic_array!(missingvars, v)
+        has_possibly_indexed_key(op, v) || push!(missingvars, v)
     end
     for (k, v) in binds
         v === COMMON_MISSING && !has_possibly_indexed_key(op, k) && push!(missingvars, k)
@@ -1652,7 +1652,7 @@ function maybe_build_initialization_problem(
     left_merge!(temp_op, ModelingToolkitBase.guesses(sys))
     subber = Symbolics.FixpointSubstituter{true}(AADSubWrapper(temp_op))
     for p in missingvars
-        op[p] = subber(p)
+        write_possibly_indexed_array!(op, p, subber(p), COMMON_NOTHING)
     end
 
     return (;

--- a/lib/ModelingToolkitBase/src/systems/systems.jl
+++ b/lib/ModelingToolkitBase/src/systems/systems.jl
@@ -545,7 +545,7 @@ struct ScalarizedArrayObserved <: ReversibleTransformations
     arrvars::Set{SymbolicT}
 end
 
-reverse_transformation_during_initialization(::ScalarizedArrayObserved) = true
+reverse_transformation_during_initialization(::ScalarizedArrayObserved) = false
 
 function add_array_observed!(obseqs::Vector{Equation}, unknowns::Vector{SymbolicT})
     # map of array observed variable (unscalarized) to number of its

--- a/lib/ModelingToolkitBase/src/utils.jl
+++ b/lib/ModelingToolkitBase/src/utils.jl
@@ -335,19 +335,18 @@ function check_no_parameter_equations_recurse(ex::SymbolicT)
 end
 
 """
-    $(TYPEDSIGNATURES)
+    $TYPEDSIGNATURES
 
-Validate that all equations of the system involve the unknowns/observables.
+Return a 2-tuple, where the first element is a list of all parameter-only equations
+in `sys`, and the second is all other equations.
 """
-function check_no_parameter_equations(sys::AbstractSystem)
-    if !isempty(get_systems(sys))
-        throw(ArgumentError("Expected flattened system"))
-    end
+function find_all_parameter_equations(sys::AbstractSystem)
     varsbuf = Set{SymbolicT}()
     pareqs = Equation[]
     allowed_vars = as_atomic_array_set(unknowns(sys))
     foreach(Base.Fix1(push_as_atomic_array!, allowed_vars), observables(sys))
     foreach(Base.Fix1(push_as_atomic_array!, allowed_vars), get_all_discretes_fast(sys))
+    rest_eqs = Equation[]
     for eq in equations(sys)
         empty!(varsbuf)
         Symbolics.search_variables!(
@@ -356,8 +355,22 @@ function check_no_parameter_equations(sys::AbstractSystem)
         )
         isempty(varsbuf) && (!SU.isconst(eq.lhs) || !SU.isconst(eq.rhs)) && continue
         intersect!(varsbuf, allowed_vars)
-        isempty(varsbuf) && push!(pareqs, eq)
+        push!(isempty(varsbuf) ? pareqs : rest_eqs, eq)
     end
+
+    return pareqs, rest_eqs
+end
+
+"""
+    $(TYPEDSIGNATURES)
+
+Validate that all equations of the system involve the unknowns/observables.
+"""
+function check_no_parameter_equations(sys::AbstractSystem)
+    if !isempty(get_systems(sys))
+        throw(ArgumentError("Expected flattened system"))
+    end
+    pareqs = find_all_parameter_equations(sys)[1]
 
     return if !isempty(pareqs)
         error(

--- a/lib/ModelingToolkitBase/test/guess_propagation.jl
+++ b/lib/ModelingToolkitBase/test/guess_propagation.jl
@@ -14,7 +14,6 @@ using Test
     tspan = (0.0, 0.2)
     prob = ODEProblem(sys, [], tspan)
 
-    @test prob.f.initializeprob[y] == 2.0
     @test prob.f.initializeprob[x] == 2.0
     sol = solve(prob.f.initializeprob; show_trace = Val(true))
 end

--- a/lib/ModelingToolkitBase/test/initial_values.jl
+++ b/lib/ModelingToolkitBase/test/initial_values.jl
@@ -137,10 +137,17 @@ end
     # `irreducible` to make sure they are unknowns of the initialization system
     @variables x(t) [irreducible = true] y(t) [irreducible = true]
     @mtkcompile sys = System(
-        [D(x) ~ x, D(y) ~ y], t; initialization_eqs = [x ~ 2y + 3, y ~ 2x],
-        guesses = [x => 2y, y => 2x]
+        [D(x) ~ x, D(y) ~ y], t
     )
-    @test_warn ["Cycle", "unknowns", "x", "y"] ODEProblem(sys, [], (0.0, 1.0), warn_cyclic_dependency = true)
+    @test_warn ["Cycle", "unknowns", "x", "y"] try
+        # This should error. The default substitution limit (100) hides the error because
+        # `2^100` evaluates to `0`, though the warning still prints.
+        ODEProblem(
+            sys, [x => 2y, y => 2x], (0.0, 1.0);
+            warn_cyclic_dependency = true, build_initializeprob = false, substitution_limit = 4
+        )
+    catch e
+    end
     @test_throws ModelingToolkitBase.MissingVariablesError ODEProblem(
         sys, [x => 2y + 1, y => 2x], (0.0, 1.0); build_initializeprob = false,
         substitution_limit = 10

--- a/lib/ModelingToolkitBase/test/initializationsystem.jl
+++ b/lib/ModelingToolkitBase/test/initializationsystem.jl
@@ -1344,7 +1344,7 @@ if @isdefined(ModelingToolkit)
         model = dc_motor()
         sys = mtkcompile(model)
 
-        prob = ODEProblem(sys, [sys.L1.i => 0.0], (0, 6.0); guesses = [sys.emf.flange.phi => 0])
+        prob = ODEProblem(sys, [sys.L1.i => 0.0, sys.emf.flange.phi => 0.0], (0, 6.0))
 
         @test_nowarn remake(prob, p = prob.p)
     end

--- a/lib/ModelingToolkitBase/test/initializationsystem.jl
+++ b/lib/ModelingToolkitBase/test/initializationsystem.jl
@@ -2125,3 +2125,14 @@ end
 
     @test_nowarn ForwardDiff.gradient(Base.Fix2(loss2, (setter, prob)), [1, 2.0])
 end
+
+@testset "Parameters with values determined by a bound parameter" begin
+    # To ensure that the initialization system handles this dependency correctly
+    @parameters p1 p2 p3
+    @variables x(t)
+    @mtkcompile sys = System(
+        [D(x) ~ p1 * x + p2 * t + p3], t;
+        bindings = [p2 => p1], initial_conditions = [p3 => p2]
+    )
+    @test_nowarn prob = ODEProblem(sys, [x => 1.0, p1 => 1.0], (0.0, 1.0))
+end

--- a/lib/ModelingToolkitBase/test/odesystem.jl
+++ b/lib/ModelingToolkitBase/test/odesystem.jl
@@ -650,7 +650,7 @@ let
     sol = solve(prob, IDA())
     @test isapprox(sol[x[1]][end], 2, atol = 1.0e-3)
 
-    prob = ODEProblem(sys, Pair[x[1] => 0], (0, 50); missing_guess_value, guesses = [y => 1.0])
+    prob = ODEProblem(sys, Pair[x[1] => 0, x[2] => 0], (0, 50); missing_guess_value, guesses = [y => 1.0])
     sol = solve(prob, Rosenbrock23())
     @test isapprox(sol[x[1]][end], 1, atol = 1.0e-3)
 end

--- a/test/downstream/inversemodel.jl
+++ b/test/downstream/inversemodel.jl
@@ -134,7 +134,7 @@ cm = complete(model)
 
 op = Dict(
     cm.filter.y.u => 0.8 * (1 - 0.42),
-    cm.controller.gainPI.u => 0,
+    cm.feedback.input2.u => 311.585,
     cm.noise_filter.x => nothing,
     cm.controller.int.x => nothing,
 )

--- a/test/downstream/linearization_dd.jl
+++ b/test/downstream/linearization_dd.jl
@@ -43,7 +43,7 @@ lin_inputs = [force.f.u]
 # => nothing to remove extra defaults
 op = Dict(
     cart.v => 0, link1.A => -pi / 2, link1.dA => 0, force.f.u => 0,
-    link1.x1 => nothing, link1.y1 => nothing, link1.x2 => nothing, link1.x_cm => nothing
+    link1.x1 => nothing, link1.y1 => nothing, link1.x2 => nothing, link1.x_cm => 0
 )
 guesses = [link1.fx1 => 0]
 @info "named_ss"

--- a/test/structural_transformation/utils.jl
+++ b/test/structural_transformation/utils.jl
@@ -67,8 +67,8 @@ end
     @test_nowarn prob.f(prob.u0, prob.p, 0.0)
 
     isys = ModelingToolkit.generate_initializesystem(sys)
-    @test length(unknowns(isys)) == 4
-    @test length(equations(isys)) == 5
+    @test length(unknowns(isys)) == 2
+    @test length(equations(isys)) == 1
     @test !any(equations(isys)) do eq
         iscall(eq.rhs) && operation(eq.rhs) in [MTKTearing.change_origin]
     end


### PR DESCRIPTION
This helps the unknowns of the simplified initialization system be more predictable.