### PR TITLE
fix: handle indexed non-tunable array params in `CopyParamsByTemplate`

### DIFF
--- a/lib/ModelingToolkitBase/src/systems/problem_utils.jl
+++ b/lib/ModelingToolkitBase/src/systems/problem_utils.jl
@@ -780,6 +780,12 @@ function __apply_copy_template(valp, template)
         return template(valp)
     elseif template isa IndepVarTemplate
         return current_time(valp)
+    elseif template isa ParameterIndex{SciMLStructures.Constants, <:Tuple{Vararg{Int}}}
+        i, j, rest... = template.idx
+        return p.constant[i][j][rest...]
+    elseif template isa ParameterIndex{SciMLStructures.Nonnumeric, <:Tuple{Vararg{Int}}}
+        i, j, rest... = template.idx
+        return p.nonnumeric[i][j][rest...]
     else
         # MethodError because this is a manual dispatch chain
         throw(MethodError(__apply_copy_template, (valp, template)))
@@ -875,6 +881,9 @@ function CopyParamsByTemplate(srcsys::AbstractSystem, syms::AbstractArray{Symbol
         elseif _bufidx isa NTuple{2, Int}
             subidx = _bufidx[1]
             _bufidx[2]:_bufidx[2]
+        elseif _bufidx isa Tuple{Vararg{Int}} # indexing into a non-tunable array parameter
+            push!(template, symidx)
+            continue
         else
             # Will error due to the typeassert on `bufidx`
             nothing
@@ -890,7 +899,12 @@ function CopyParamsByTemplate(srcsys::AbstractSystem, syms::AbstractArray{Symbol
             continue
         end
         prev = template[end]
-        if prev isa ParameterIndex && prev.portion === symidx.portion && (subidx === nothing && last(prev.idx) + 1 == first(bufidx) || subidx == prev.idx[1] && last(prev.idx[2]) + 1 == first(bufidx))
+        if prev isa ParameterIndex && prev.portion === symidx.portion && (
+                subidx === nothing && prev.idx isa UnitRange{Int} &&
+                    last(prev.idx) + 1 == first(bufidx) ||
+                    prev.idx isa Tuple{Int, UnitRange{Int}} && subidx == prev.idx[1] &&
+                    last(prev.idx[2]) + 1 == first(bufidx)
+            )
             if subidx === nothing
                 template[end] = ParameterIndex(prev.portion, first(prev.idx):last(bufidx))
             else

--- a/lib/ModelingToolkitBase/test/initial_values.jl
+++ b/lib/ModelingToolkitBase/test/initial_values.jl
@@ -460,4 +460,11 @@ if !@isdefined(ModelingToolkit)
         sim_cond = [X => 1.0, X => 2.0, p => 1.0, d => 2.0] # `X` provide twice, likely a mistake
         @test_throws ["duplicate entries", "X(t)"] ODEProblem(sys, sim_cond, (0.0, 10.0))
     end
+    @testset "Issue#4641" begin
+        @parameters x0[1:2] = [1.0, 2.0]
+        @variables xc(t)[1:2] = x0
+        sys  = System([D(xc) ~ -(xc .- x0)], t; name = :sys)
+        sys′ = ModelingToolkitBase.subset_tunables(mtkcompile(sys), [])
+        @test_nowarn ODEProblem(sys′, [], (0.0, 1.0))
+    end
 end


### PR DESCRIPTION
Close #4641 