### PR TITLE
test_groups: route FMI + Initialization to GitHub-hosted runners (fix OOM kills on pre)

### DIFF
--- a/lib/ModelingToolkitBase/test/test_groups.toml
+++ b/lib/ModelingToolkitBase/test/test_groups.toml
@@ -10,6 +10,10 @@ versions = ["lts", "1", "pre"]
 
 [Initialization]
 versions = ["lts", "1", "pre"]
+# Memory-heavy (OOM-killed on the 4vcpu/8GB self-hosted runners, esp. on `pre`).
+# Route to a GitHub-hosted runner (~16GB). `ubuntu-24.04` forces GitHub-hosted
+# since the self-hosted pool only carries the `ubuntu-latest` label.
+runner = "ubuntu-24.04"
 
 [SymbolicIndexingInterface]
 versions = ["lts", "1", "pre"]

--- a/test/test_groups.toml
+++ b/test/test_groups.toml
@@ -11,6 +11,10 @@ versions = ["lts", "1", "pre"]
 
 [Initialization]
 versions = ["lts", "1", "pre"]
+# Memory-heavy (OOM-killed on the 4vcpu/8GB self-hosted runners, esp. on `pre`).
+# Route to a GitHub-hosted runner (~16GB). `ubuntu-24.04` forces GitHub-hosted
+# since the self-hosted pool only carries the `ubuntu-latest` label.
+runner = "ubuntu-24.04"
 
 [SymbolicIndexingInterface]
 versions = ["lts", "1", "pre"]
@@ -26,6 +30,10 @@ versions = ["lts", "1", "pre"]
 
 [FMI]
 versions = ["lts", "1", "pre"]
+# Memory-heavy (OOM-killed on the 4vcpu/8GB self-hosted runners, esp. on `pre`).
+# Route to a GitHub-hosted runner (~16GB). `ubuntu-24.04` forces GitHub-hosted
+# since the self-hosted pool only carries the `ubuntu-latest` label.
+runner = "ubuntu-24.04"
 
 [QA]
 versions = ["lts", "1"]


### PR DESCRIPTION
Fixes the OOM kills @AayushSabharwal hit on the **FMI** and **Initialization** groups (esp. `pre`) — e.g. [run 27742584454](https://github.com/SciML/ModelingToolkit.jl/actions/runs/27742584454) jobs 82073267896 / 82073267635, both on `self-hosted-4vcpu-8gb-…` runners.

Per @ChrisRackauckas's `test_groups` runner-designation suggestion: set `runner = "ubuntu-24.04"` on **FMI** + **Initialization** (root) and the ModelingToolkitBase **Initialization** sublib group. GitHub-hosted ubuntu runners have ~16GB (2x the 8GB self-hosted), and `ubuntu-24.04` forces GitHub-hosted (the self-hosted pool only carries `ubuntu-latest`).

Note: `runner` is per-group, not per-version, so this applies to lts/1/pre for those groups (not pre-only) — harmless, just gives the lighter versions more headroom too. Verified locally via `compute_affected_sublibraries.jl --root-matrix`: FMI/Initialization emit `runner=ubuntu-24.04`, all other groups unchanged. The PR's own CI on those groups is the end-to-end confirmation. If 16GB still isn't enough on `pre`, the next step is a dedicated large runner (org config).