### PR TITLE
Fix QA undefined export + SCCNonlinearProblem ambiguity, update map_variables_to_equations test

### DIFF
--- a/src/problems/sccnonlinearproblem.jl
+++ b/src/problems/sccnonlinearproblem.jl
@@ -422,8 +422,8 @@ function SCCNonlinearFunction{iip}(
     return NonlinearFunction{iip}(f; sys = subsys)
 end
 
-function SciMLBase.SCCNonlinearProblem(sys::System, args...; kwargs...)
-    return SCCNonlinearProblem{true}(sys, args...; kwargs...)
+function SciMLBase.SCCNonlinearProblem(sys::System, op; kwargs...)
+    return SCCNonlinearProblem{true}(sys, op; kwargs...)
 end
 
 function SciMLBase.SCCNonlinearProblem{iip}(

--- a/src/structural_transformation/StructuralTransformations.jl
+++ b/src/structural_transformation/StructuralTransformations.jl
@@ -52,7 +52,7 @@ using DocStringExtensions
 
 import ModelingToolkitBase as MTKBase
 import StateSelection
-import StateSelection: CLIL, SelectedState
+import StateSelection: CLIL, SelectedState, find_solvables!
 import ModelingToolkitTearing as MTKTearing
 using ModelingToolkitTearing: TearingState, SystemStructure, ReassembleAlgorithm,
     DefaultReassembleAlgorithm

--- a/test/structural_transformation/utils.jl
+++ b/test/structural_transformation/utils.jl
@@ -179,7 +179,8 @@ end
             @test mapping[D(y)] == (D(yt) ~ -g + y * λ)
             @test mapping[D(x)] == (0 ~ -2xt * x - 2yt * y)
             @test mapping[D(D(x))] == (xtt ~ x * λ)
-            @test length(mapping) == 5
+            @test mapping[λ] == (0 ~ -2yt^2 - 2x * xtt - 2xt^2 - 2(-g + y * λ) * y)
+            @test length(mapping) == 6
 
             @testset "`rename_dummy_derivatives = false`" begin
                 mapping = map_variables_to_equations(sys; rename_dummy_derivatives = false)
@@ -189,7 +190,8 @@ end
                 @test mapping[yt] == (D(yt) ~ -g + y * λ)
                 @test mapping[xt] == (0 ~ -2xt * x - 2yt * y)
                 @test mapping[xtt] == (xtt ~ x * λ)
-                @test length(mapping) == 5
+                @test mapping[λ] == (0 ~ -2yt^2 - 2x * xtt - 2xt^2 - 2(-g + y * λ) * y)
+                @test length(mapping) == 6
             end
         end
         @testset "DDEs" begin


### PR DESCRIPTION
## What

Three independent fixes for failing `master` checks.

### Tests - QA (Aqua) — fixes 2 of 3 reported failures

1. **Undefined export `find_solvables!`.** `StructuralTransformations` had `export ... find_solvables!` but never defined or imported it — it is only ever called as `StateSelection.find_solvables!`. Aqua's `test_undefined_exports` therefore flagged `ModelingToolkit.find_solvables!` and `ModelingToolkit.StructuralTransformations.find_solvables!`. Fixed by importing it from `StateSelection` so the export binds to the real function.

2. **`SCCNonlinearProblem` ambiguity (2).** MTK's `SCCNonlinearProblem(sys::System, args...; kwargs...)` was ambiguous with SciMLBase 3.21's positional constructor `SCCNonlinearProblem(probs, explicitfuns!, parameter_object, parameters_alias::Union{Bool, Val})`. The `args...` is only ever invoked as `(sys, op)`, so the signature is tightened to `(sys::System, op; kwargs...)`, removing both ambiguities. Verified locally: `Aqua.test_ambiguities([ModelingToolkit]; broken=false)` now passes and `detect_ambiguities(ModelingToolkit)` is empty.

> Note: a third undefined export, `ModelingToolkit.Variable`, remains and is **not** fixed here — it originates upstream in Symbolics, which has `export @variables, Variable` while `Variable` is not defined (`:Variable in names(Symbolics)` is `true` but `isdefined(Symbolics, :Variable)` is `false`). MTK inherits it through `@reexport using Symbolics`. That needs a Symbolics-side fix (remove the dead export); QA will stay red on this one line until then.

### Tests - InterfaceI — fixes all 3 (julia 1 / lts / pre)

The pendulum-DAE testset for `map_variables_to_equations` asserted `length(mapping) == 5`. After the recent alias-elimination / solvability refactor, the algebraic variable `λ` is now correctly matched to the doubly-differentiated constraint equation that determines it. The compiled system genuinely has 5 unknowns (`xˍt, y, x, yˍt, λ`) and 5 equations; the mapping now also includes the second-derivative dummy key, giving 6 entries. The previous `== 5` silently omitted `λ`, which is a real unknown the function is meant to map. Updated the count to 6 and added an explicit assertion for `mapping[λ]` so the test is **stricter**, not weaker.

## Verification (local, Julia 1.12.6, resolved deps matching CI: SciMLBase 3.21.0, ModelingToolkitBase 1.44.0, Symbolics 7.28.1, StateSelection 1.10.0, ModelingToolkitTearing 1.15.0)

- `Aqua.test_ambiguities([ModelingToolkit]; broken=false)` → Pass (was 2 ambiguities).
- After the import, `StructuralTransformations` has 0 undefined exports and `MTK.find_solvables!` is defined.
- The two `map_variables_to_equations` testsets (`rename_dummy_derivatives` true and false) pass 7/7 each with the new `λ` assertion and `length == 6`.
- All three changed `.jl` files are Runic-clean.

## Not addressed here (separate root causes, reported upstream / out of scope)

- `Tests - Optimization` and the docs `build` fail to resolve because **NLSolversBase 8.0.0** was released; **NLsolve** (pulled transitively via SteadyStateDiffEq / DiffEqCallbacks) caps NLSolversBase to 7.x, while `Optim 2.x` (required by `OptimizationOptimJL ≥ 0.4.9`, in turn forced by `Optimization 5` + `SciMLBase 3.21`) requires NLSolversBase 8.0.0. There is no MTK-side cap that satisfies both — this needs an upstream NLsolve/NLSolversBase compat release.
- `Downgrade Tests - InterfaceI` (BoundsError in `ModelingToolkitTearing.rm_eqs_vars!` under old resolved deps) and `downgrade-sublibraries` (ModelingToolkitBase precompile cache failure, "Module IR does not contain specified entry function" / SymbolicIndexingInterface) are downgrade-floor issues.
- `Runic Format Check` is handled by #4647.
- `MethodOfLines.jl/DAE`, `ModelingToolkitStandardLibrary.jl/Core` are downstream-package failures.

Please ignore until reviewed by @ChrisRackauckas