### PR TITLE
Support Symbol inputs for `bif_par` and `plot_var` in `BifurcationProblem`

### DIFF
--- a/lib/ModelingToolkitBase/ext/MTKBifurcationKitExt.jl
+++ b/lib/ModelingToolkitBase/ext/MTKBifurcationKitExt.jl
@@ -135,6 +135,8 @@ function BifurcationKit.BifurcationProblem(
     # Converts the input state guess.
     u0_bif = ModelingToolkitBase.to_varmap(u0_bif, unknowns(nsys))
     ps = ModelingToolkitBase.to_varmap(ps, ModelingToolkitBase.get_ps(nsys))
+    bif_par = ModelingToolkitBase.symbol_to_symbolic(nsys, bif_par)
+    plot_var = ModelingToolkitBase.symbol_to_symbolic(nsys, plot_var)
     op = merge(u0_bif, ps)
     f, u0_bif_vals, p_vals = ModelingToolkitBase.process_SciMLProblem(
         ModelingToolkitBase.EmptySciMLFunction{true}, nsys, op; build_initializeprob = true

--- a/lib/ModelingToolkitBase/test/extensions/bifurcationkit.jl
+++ b/lib/ModelingToolkitBase/test/extensions/bifurcationkit.jl
@@ -221,3 +221,31 @@ end
         nsys2, [X1 => 5.0, X2 => 8.0], [k1 => 8.0, k2 => 1.0, Γ => [13.0]], k1; plot_var = X1
     )
 end
+
+@testset "Symbol inputs (issue #4250)" begin
+    @variables x(t) y(t)
+    @parameters mu alpha
+    eqs = [
+        0 ~ mu * x - x^3 + alpha * y,
+        0 ~ -y,
+    ]
+    @named nsys = System(eqs, [x, y], [mu, alpha])
+    nsys = complete(nsys)
+
+    p_span = (-4.0, 6.0)
+    opts_br = ContinuationPar(max_steps = 500, p_min = p_span[1], p_max = p_span[2])
+
+    bprob_sym = BifurcationProblem(
+        nsys, [x => 1.0, y => 1.0], [mu => -1.0, alpha => 1.0], mu; plot_var = x
+    )
+    bprob_symbol = BifurcationProblem(
+        nsys, [:x => 1.0, :y => 1.0], [:mu => -1.0, :alpha => 1.0], :mu; plot_var = :x
+    )
+
+    dia_sym = bifurcationdiagram(bprob_sym, PALC(), 2, (args...) -> opts_br; bothside = true)
+    dia_symbol = bifurcationdiagram(bprob_symbol, PALC(), 2, (args...) -> opts_br; bothside = true)
+
+    @test getfield.(dia_symbol.γ.branch, :x) ≈ getfield.(dia_sym.γ.branch, :x)
+    @test getfield.(dia_symbol.γ.branch, :param) ≈ getfield.(dia_sym.γ.branch, :param)
+    @test dia_symbol.γ.specialpoint[1].param ≈ dia_sym.γ.specialpoint[1].param
+end


### PR DESCRIPTION
Fixes #4250.

## Problem

`BifurcationKit.BifurcationProblem(sys, u0, ps, bif_par; plot_var)` works with symbolic variables, but passing the bifurcation parameter (or `plot_var`) as a `Symbol` fails:

```julia
@variables X(t)
@parameters p d
@mtkcompile sys = System([0 ~ p - d*X])

BifurcationProblem(sys, [X => 1.0], [p => 1.0, d => 1.0], p)       # works
BifurcationProblem(sys, [:X => 1.0], [:p => 1.0, :d => 1.0], :p)   # errored
```

The state and parameter maps already tolerate `Symbol` keys, since they are routed through `process_SciMLProblem`, which resolves them via `symbols_to_symbolics!`. However, `bif_par` and `plot_var` were used as-is. A `Symbol` is never `isequal` to a symbolic variable, so `findfirst(isequal(bif_par), parameters(nsys))` returned `nothing` and the problem failed to build.

## Fix

Resolve `bif_par` and `plot_var` through `ModelingToolkitBase.symbol_to_symbolic`, which maps a `Symbol` to the matching symbolic variable and is a no-op for inputs that are already symbolic (or `nothing`, or unresolved). This makes symbol inputs behave consistently with the rest of the interface.

## Tests

Added a testset that builds the same `BifurcationProblem` with symbolic and `Symbol` inputs (`u0`, `ps`, `bif_par`, and `plot_var`) and checks the resulting bifurcation diagrams are identical. The BifurcationKit extension test file passes locally.