### PR TITLE
Fix initialization for array variables bound to constant array parameters

### DIFF
--- a/lib/ModelingToolkitBase/src/systems/problem_utils.jl
+++ b/lib/ModelingToolkitBase/src/systems/problem_utils.jl
@@ -817,6 +817,16 @@ function CopyParamsByTemplate(srcsys::AbstractSystem, syms::AbstractArray{Symbol
     iv = get_iv(srcsys)
     irinfo = get_ir_info(srcsys)
 
+    push_symbolic! = function (sym)
+        if !isempty(template) && template[end] isa Vector{SymbolicT}
+            push!(template[end], sym)
+        else
+            push!(elem_types, Vector{SymbolicT})
+            push!(template, SymbolicT[sym])
+        end
+        return
+    end
+
     for sym in syms
         if iv isa SymbolicT && isequal(iv, sym)
             push!(template, IV_TEMPLATE)
@@ -833,18 +843,7 @@ function CopyParamsByTemplate(srcsys::AbstractSystem, syms::AbstractArray{Symbol
                 symidx = variable_index(srcsys, irinfo.obs_subber(sym))
             end
             if symidx === nothing
-                if isempty(template)
-                    push!(elem_types, Vector{SymbolicT})
-                    push!(template, SymbolicT[sym])
-                    continue
-                end
-                prev = template[end]
-                if prev isa Vector{SymbolicT}
-                    push!(prev, sym)
-                else
-                    push!(elem_types, Vector{SymbolicT})
-                    push!(template, SymbolicT[sym])
-                end
+                push_symbolic!(sym)
                 continue
             end
             if isempty(template)
@@ -862,6 +861,10 @@ function CopyParamsByTemplate(srcsys::AbstractSystem, syms::AbstractArray{Symbol
             continue
         elseif symidx isa Int
             symidx = ParameterIndex(SciMLStructures.Tunable(), symidx)
+        end
+        if !(symidx.idx isa Union{Int, AbstractVector{Int}, NTuple{2, Int}})
+            push_symbolic!(sym)
+            continue
         end
         portion = symidx.portion
         _bufidx = symidx.idx

--- a/lib/ModelingToolkitBase/test/initializationsystem.jl
+++ b/lib/ModelingToolkitBase/test/initializationsystem.jl
@@ -2115,3 +2115,12 @@ end
 
     @test_nowarn ForwardDiff.gradient(Base.Fix2(loss2, (setter, prob)), [1, 2.])
 end
+
+@testset "Array variable bound to constant array parameter (issue #4641)" begin
+    @parameters x0[1:2] = [1.0, 2.0]
+    @variables xc(t)[1:2] = x0
+    sys = System([D(xc) ~ -(xc .- x0)], t; name = :sys)
+    sys2 = subset_tunables(mtkcompile(sys), [])
+    prob = ODEProblem(sys2, [], (0.0, 1.0))
+    @test prob[xc] == [1.0, 2.0]
+end


### PR DESCRIPTION
Fixes #4641.

## Problem

An `ArraySymbolic` variable bound to a constant array parameter errors during initialization:

```julia
using ModelingToolkitBase
using ModelingToolkitBase: t_nounits as t, D_nounits as D

@parameters x0[1:2] = [1.0, 2.0]
@variables xc(t)[1:2] = x0
sys  = System([D(xc) ~ -(xc .- x0)], t; name = :sys)
sys2 = ModelingToolkitBase.subset_tunables(mtkcompile(sys), [])
ODEProblem(sys2, [], (0.0, 1.0))
# ERROR: MethodError: Cannot `convert` an object of type Nothing to an object of type UnitRange{Int64}
```

## Root cause

`CopyParamsByTemplate` (used by `GetUpdatedU0` to copy values out of the initialization problem) builds a *batched* template of parameter indices. It only handled `Int`, `AbstractVector{Int}` and `NTuple{2, Int}` shapes for `ParameterIndex.idx`. The array variable above is, in the initialization system, a constant array-parameter element whose `ParameterIndex` has a **3-element** `idx` like `(1, 1, 1)` (meaning `p.constant[i][j][k]`, as handled by `_ducktyped_parameter_values`). That shape fell through to the `else` branch, producing `nothing`, which then hit the `bufidx::UnitRange{Int}` type assertion and threw.

## Fix

Route any index shape the batching template does not support to the **existing** per-symbol symbolic-getter fallback — the same `Vector{SymbolicT}` / `concrete_getu` path already used for symbols that aren't found as parameters or variables. This reads the value correctly regardless of buffer layout. The common `Int` / `Vector{Int}` / `NTuple{2, Int}` cases are unchanged.

## Tests

Added a regression testset in `initializationsystem.jl` building the MWE and checking `prob[xc] == [1.0, 2.0]`. Locally verified the fix plus regressions (scalar params, array tunable params, algebraic-equation guess initialization) all build with correct `u0`.