### PR TITLE
build: restore accidentally removed `sources` entries

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -50,6 +50,10 @@ OrdinaryDiffEqBDF = "6ad6398a-0878-4a85-9266-38940aa047c8"
 OrdinaryDiffEqDefault = "50262376-6c5a-4cf5-baba-aaf4f84d72d7"
 OrdinaryDiffEqRosenbrock = "43230ef6-c299-4910-a778-202eb28ce4ce"
 
+[sources]
+ModelingToolkitBase = {path = "lib/ModelingToolkitBase"}
+SciCompDSL = {path = "lib/SciCompDSL"}
+
 [extensions]
 MTKFMIExt = "FMIImport"
 MTKOrdinaryDiffEqBDFExt = "OrdinaryDiffEqBDF"


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
