### PR TITLE
Declare public API (unlock downstream ExplicitImports allow-lists)

### DIFF
--- a/lib/ModelingToolkitBase/src/ModelingToolkitBase.jl
+++ b/lib/ModelingToolkitBase/src/ModelingToolkitBase.jl
@@ -345,12 +345,12 @@ const set_scalar_metadata = setmetadata
 @public unbound_outputs, is_bound
 @public AbstractSystem, CheckAll, CheckNone, CheckComponents, CheckUnits
 @public t, D, t_nounits, D_nounits
-@public SymbolicContinuousCallback, SymbolicDiscreteCallback
+@public SymbolicContinuousCallback, SymbolicDiscreteCallback, ImperativeAffect
 @public VariableType, MTKVariableTypeCtx, VariableBounds, VariableConnectType
 @public VariableDescription, VariableInput, VariableIrreducible, VariableMisc
 @public VariableOutput, VariableStatePriority, VariableUnit, collect_scoped_vars!
 @public collect_var_to_name!, collect_vars!, eqtype_supports_collect_vars, hasdefault
-@public getdefault, setdefault, iscomplete, isparameter, modified_unknowns!
+@public getdefault, setdefault, setguess, iscomplete, isparameter, modified_unknowns!
 @public renamespace, namespace_equations
 @public check_mutable_cache, store_to_mutable_cache!, should_invalidate_mutable_cache_entry
 @public convert_bindings_for_time_independent_system, get_w


### PR DESCRIPTION
## Declare public API (unlock downstream ExplicitImports allow-lists)

We've enabled the ExplicitImports QA check fleet-wide, and ~92 downstream repos carry allow-lists (`ei_kwargs` ignores for `check_all_qualified_accesses_are_public` / `check_all_explicit_imports_are_public`) ignoring non-public names that are accessed/imported from ModelingToolkit. The right fix is to mark the legitimately-public ones `public` here so downstream can drop those ignores.

This PR marks the two candidate names that are **(a) defined in this monorepo, (b) genuinely user-facing API (docstringed), and (c) not already public/exported**:

### Made public
- **`setguess`** (owned by `ModelingToolkitBase`, `lib/ModelingToolkitBase/src/variables.jl`) — docstringed setter for a variable's initialization guess; the public counterpart of the already-public `getdefault`/`setdefault`. Added to the existing `@public getdefault, setdefault, ...` line.
- **`ImperativeAffect`** (owned by `ModelingToolkitBase`, `lib/ModelingToolkitBase/src/systems/imperative_affect.jl`) — docstringed, user-facing callback-affect helper. Added to the existing `@public SymbolicContinuousCallback, SymbolicDiscreteCallback` line.

Both are declared with the existing `@public` (SciMLPublic) convention in `ModelingToolkitBase`. The `@import_mtkbase` macro in `ModelingToolkit` propagates this so the names are public from the top-level `ModelingToolkit` module too — which is what downstream EI checks against.

### Verification (run locally)
- **Julia 1.12.6**: after the change, `Base.ispublic(ModelingToolkitBase, :setguess) == true` and `Base.ispublic(ModelingToolkit, :setguess) == true`; same for `ImperativeAffect`; neither is exported in either module.
- **Julia 1.10.11** (LTS floor): `ModelingToolkit` + `ModelingToolkitBase` precompile and load cleanly; both names remain reachable. (`@public`/SciMLPublic is parse-safe and a no-op on 1.10.)
- Runic: clean.

### Skipped (vetted, not made public)
Of the originally-surveyed candidates, the rest are intentionally left alone:

| Name | Reason skipped |
|------|----------------|
| `SymbolicContinuousCallback` | Already `@public` in `ModelingToolkitBase` (propagated to MTK). |
| `SymbolicDiscreteCallback` | Already `@public` in `ModelingToolkitBase`. |
| `getdefault` | Already `@public` in `ModelingToolkitBase`. |
| `setdefault` | Already `@public` in `ModelingToolkitBase`. |
| `isparameter` | Already `@public` in `ModelingToolkitBase`. |
| `t_nounits` | Already `@public` in `ModelingToolkitBase`. |
| `hasmetadata` | Not owned here — owned and **exported** by `SymbolicUtils` (already public). |
| `value` | Not owned here — owned by `Symbolics` (re-exported). Declare upstream in Symbolics if needed. |
| `Constant` | Not a top-level MTK name. It's `DifferentiationInterface.Constant` (used in `linearization.jl`) and a `Moshi @data` variant `MissingGuessValue.Constant` inside MTKBase; neither is a public MTK API name. |

### Downstream impact
Once released, downstream repos can drop the matching `ei_kwargs` ignore entries for `ModelingToolkit.setguess` and `ModelingToolkit.ImperativeAffect`. The other ignores remain governed by their true owners (SymbolicUtils/Symbolics/etc.) or are already handled.

---

Please ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
