### PR TITLE
fix: handle non-`mtkcompile` systems in `full_equations` initialization

### DIFF
--- a/lib/ModelingToolkitBase/src/systems/nonlinear/initializesystem.jl
+++ b/lib/ModelingToolkitBase/src/systems/nonlinear/initializesystem.jl
@@ -56,6 +56,18 @@ function generate_initializesystem_timevarying(
         name = nameof(sys), kwargs...
     )
     _sys = reverse_transformations_for_initialization(sys)
+    # Systems that haven't gone through `mtkcompile` won't have this transformation applied.
+    # We rely on this to substitute `X => [X[1], X[2]]` in case e.g. `X[1]` is an observed and
+    # `X[2]` is an unknown. Ordinarily, `X[1]` shouldn't be an unknown and should be substituted
+    # away completely.
+    if !any_reversible_transformation(Base.Fix2(isa, ScalarizedArrayObserved), _sys)
+        _obs = copy(observed(_sys))
+        _dvs = unknowns(_sys)
+        tf = add_array_observed!(_obs, _dvs)
+        _sys = with_reversible_transformation(_sys, tf)
+        _obs = topsort_equations(_sys, _obs, [eq.lhs for eq in _obs])
+        @set! _sys.observed = _obs
+    end
     eqs = full_equations(_sys)
 
     # Firstly, all variables are initialization unknowns

--- a/lib/ModelingToolkitBase/src/systems/system.jl
+++ b/lib/ModelingToolkitBase/src/systems/system.jl
@@ -1715,6 +1715,16 @@ end
 """
     $TYPEDSIGNATURES
 
+Check if any of the reversible transformations applied to `sys` satisfy the predicate `f`.
+"""
+function any_reversible_transformation(f::F, sys::System) where {F}
+    tfs = getmetadata(sys, ReversibleTransformations, nothing)::Union{Nothing, Vector{Any}}
+    return any(f, tfs)
+end
+
+"""
+    $TYPEDSIGNATURES
+
 Filter the reversible transformations applied to `sys`. Return a new system with the
 updated list of transformations.
 """

--- a/lib/ModelingToolkitBase/test/initializationsystem.jl
+++ b/lib/ModelingToolkitBase/test/initializationsystem.jl
@@ -2145,3 +2145,17 @@ end
     )
     @test_nowarn prob = ODEProblem(sys, [x => 1.0, p1 => 1.0], (0.0, 1.0))
 end
+
+@testset "`full_equations` initialization correctly handles non-mtkcompile systems" begin
+    @parameters T = missing
+    @variables X(t)[1:2]
+    @mtkcomplete sys = System([D(X[1]) ~ X[1] + X[2]], t, [X[1]], [T]; observed = [X[2] ~ T - X[1]])
+
+    # Prior to the fix which runs `ScalarizedArrayObserved` if it isn't already run, the init system
+    # would contain the equation `X ~ [1.0, 2.0]` despite `X[2]` being eliminated as an observed. This
+    # is underdetermined, and would result in essentially random values for `X[2]` and `T`.
+    prob = ODEProblem(sys, [X => [1.0, 2.0]], (0.0, 1.0))
+    integ = init(prob, Tsit5())
+    @test integ[X] ≈ [1.0, 2.0]
+    @test integ.ps[T] ≈ 3.0
+end


### PR DESCRIPTION
The test and comments describe the error. This arises from a failure in Catalyst.