### PR TITLE
use the cached `reorder_parameters` in a few more places

### DIFF
--- a/lib/ModelingToolkitBase/src/systems/codegen.jl
+++ b/lib/ModelingToolkitBase/src/systems/codegen.jl
@@ -41,11 +41,10 @@ function generate_rhs(
         kwargs...
     )
     dvs = unknowns(sys)
-    ps = parameters(sys; initial_parameters = true)
     eqs = equations(sys)
     obs = observed(sys)
     u = dvs
-    p = reorder_parameters(sys, ps)
+    p = reorder_parameters(sys) # 1 arg to use the cached version
     if cachesyms isa Vector{Vector{SymbolicT}}
         append!(p, cachesyms)
     end

--- a/src/problems/sccnonlinearproblem.jl
+++ b/src/problems/sccnonlinearproblem.jl
@@ -15,8 +15,7 @@ function CacheWriter(
         exprs::SCCCacheVarsExprsElT, solsyms;
         eval_expression = false, eval_module = @__MODULE__, cse = true, sparse = false
     )
-    ps = parameters(sys; initial_parameters = true)
-    rps = reorder_parameters(sys, ps)
+    rps = reorder_parameters(sys)  # 1 arg to use the cached version
     cache_writes = SymbolicT[]
     for (i, T) in enumerate(buffer_types)
         regions = SU.RegionsT()


### PR DESCRIPTION
Only the 1 arg version uses the cached `reorder_parameters`. Follow up from #4685. On a large model this goes from

```
 12.897235 seconds (192.77 M allocations: 7.152 GiB, 23.57% gc time)
```

to

```
 11.219255 seconds (173.77 M allocations: 6.507 GiB, 19.11% gc time)
```