### PR TITLE
Memoize `split_indexed_var` and `get_stable_index`

### DIFF
--- a/lib/ModelingToolkitBase/src/utils.jl
+++ b/lib/ModelingToolkitBase/src/utils.jl
@@ -1549,7 +1549,11 @@ const DEFAULT_STABLE_INDEX = SU.StableIndex(Int[])
 Given a symbolic variable `x`, check whether it is an indexed array symbolic. If it is,
 return the array and `true`. Otherwise, return `x, false`.
 """
-function split_indexed_var(x::SymbolicT)
+SU.@cache limit = 500_000 function split_indexed_var(x::SymbolicT)::Tuple{SymbolicT, Bool}
+    return _split_indexed_var(x)
+end
+
+function _split_indexed_var(x::SymbolicT)
     return Moshi.Match.@match x begin
         BSImpl.Term(; f, args) && if f === getindex end => (args[1], true)
         BSImpl.Term(; f, args) && if f isa Operator && length(args) == 1 end => begin
@@ -1572,7 +1576,11 @@ end
 Given a symbolic variable `x`, assume `split_indexed_var(x)[2]` is `true`. Return the
 corresponding `SymbolicUtils.StableIndex`.
 """
-function get_stable_index(x::SymbolicT)
+SU.@cache limit = 500_000 function get_stable_index(x::SymbolicT)::SU.StableIndex{Int}
+    return _get_stable_index(x)
+end
+
+function _get_stable_index(x::SymbolicT)
     return Moshi.Match.@match x begin
         BSImpl.Term(; f, args) && if f === getindex end => return SU.StableIndex{Int}(x)
         BSImpl.Term(; f, args) && if f isa Operator end => return get_stable_index(args[1])


### PR DESCRIPTION
This makes `ODEProblem` creation for a somewhat large model to go from

```
9.323569 seconds (149.84 M allocations: 5.572 GiB, 20.05% gc time)
```

to

```
7.796214 seconds (137.43 M allocations: 5.137 GiB, 10.10% gc time)
```

The limit chosen is the same as for `occursin_info` in Symbolics.