### PR TITLE
Propagate `ParameterArrayAssignments` to SCC subsystems

### DIFF
--- a/lib/ModelingToolkitBase/src/systems/codegen.jl
+++ b/lib/ModelingToolkitBase/src/systems/codegen.jl
@@ -45,6 +45,7 @@ function generate_rhs(
     obs = observed(sys)
     u = dvs
     p = reorder_parameters(sys) # 1 arg to use the cached version
+    n_param_buffers = length(p)  # # of parameter buffers, BEFORE any cachesyms are appended
     if cachesyms isa Vector{Vector{SymbolicT}}
         append!(p, cachesyms)
     end
@@ -109,7 +110,7 @@ function generate_rhs(
 
     u_arg = scalar ? -1 : (implicit_dae ? 2 : 1)
     res = build_function_wrapper(
-        sys, rhss, args...; p_start, extra_assignments, u_arg,
+        sys, rhss, args...; p_start, extra_assignments, u_arg, n_param_buffers,
         expression = Val{true}, expression_module = eval_module, kwargs...
     )
     nargs = length(args) - length(p) + 1
@@ -1545,7 +1546,7 @@ function generate_update_A(
 
     res = build_function_wrapper(
         sys, A, ps..., cachesyms...; p_start = 1, expression = Val{true},
-        similarto = typeof(A), add_observed = false, kwargs...
+        similarto = typeof(A), add_observed = false, n_param_buffers = length(ps), kwargs...
     )
     return maybe_compile_function(
         expression, wrap_gfw, (1, 1, is_split(sys)), res;
@@ -1582,7 +1583,7 @@ function generate_update_A(
 
     res = build_function_wrapper(
         sys, parent(A), ps..., cachesyms...; p_start = 1, expression = Val{true},
-        similarto = Vector{SymbolicT}, add_observed = false, kwargs...
+        similarto = Vector{SymbolicT}, add_observed = false, n_param_buffers = length(ps), kwargs...
     )
     return DiagonalAMatrixWrapper(
         maybe_compile_function(
@@ -1628,7 +1629,7 @@ function generate_update_A(
     end
     res = build_function_wrapper(
         sys, parA, ps..., cachesyms...; p_start = 1, expression = Val{true},
-        similarto = Matrix{SymbolicT}, add_observed = false, kwargs...
+        similarto = Matrix{SymbolicT}, add_observed = false, n_param_buffers = length(ps), kwargs...
     )
     return BandedAMatrixWrapper(
         maybe_compile_function(
@@ -1672,7 +1673,7 @@ function generate_update_b(
 
     res = build_function_wrapper(
         sys, b, ps..., cachesyms...; p_start = 1, expression = Val{true},
-        similarto = typeof(b), add_observed = false, kwargs...
+        similarto = typeof(b), add_observed = false, n_param_buffers = length(ps), kwargs...
     )
     return maybe_compile_function(
         expression, wrap_gfw, (1, 1, is_split(sys)), res;

--- a/lib/ModelingToolkitBase/src/systems/codegen_utils.jl
+++ b/lib/ModelingToolkitBase/src/systems/codegen_utils.jl
@@ -467,7 +467,7 @@ Base.@nospecializeinfer function build_function_wrapper(
         add_observed = true, obsidxs_to_use = nothing,
         create_bindings = false, output_type = nothing, mkarray = nothing,
         wrap_mtkparameters = true, extra_assignments = Assignment[], cse = true,
-        optimize = nothing, kwargs...
+        n_param_buffers = nothing, optimize = nothing, kwargs...
     )
     isscalar = !(expr isa AbstractArray || symbolic_type(expr) == ArraySymbolic())
     obs = observed(sys)
@@ -547,12 +547,33 @@ Base.@nospecializeinfer function build_function_wrapper(
     if non_standard_param_layout
         append!(assignments, array_variable_assignments(args...; filter_vars = required_arrvars, argument_name = u_argument_name))
     else
+        # `n_param_buffers` marks the boundary between the `reorder_parameters` buffers and
+        # any `cachesyms` the caller appended to the parameter slice (cachesyms are always a
+        # suffix). When it is `nothing` the whole slice is parameters (no cachesym tail). The
+        # cache always stores the PARAM-ONLY decomposition (shared, propagated to SCC
+        # subsystems); the per-call cachesym tail is decomposed fresh and merged below.
+        pbuf_end = n_param_buffers === nothing ? p_end : (p_start + n_param_buffers - 1)
         cached = check_mutable_cache(sys, ParameterArrayAssignments, ParameterArrayAssignments, nothing)
         if cached isa ParameterArrayAssignments
             param_var_to_arridxs = cached.var_to_arridxs
         else
-            param_var_to_arridxs = compute_array_variable_buffer_idxs(args[p_start:p_end])
+            param_var_to_arridxs = compute_array_variable_buffer_idxs(args[p_start:pbuf_end])
             store_to_mutable_cache!(sys, ParameterArrayAssignments, ParameterArrayAssignments(param_var_to_arridxs))
+        end
+        # Merge the cachesym tail, shifting its slice-relative buffer indices past the
+        # parameter buffers. cachesyms are prior-SCC unknowns / CSE temporaries -- never array
+        # parameters -- so their array-variable keyset is disjoint from the params'. The
+        # merged dict is identical to decomposing the whole `args[p_start:p_end]` slice.
+        if pbuf_end < p_end
+            merged = copy(param_var_to_arridxs)
+            tail = compute_array_variable_buffer_idxs(
+                args[(pbuf_end + 1):p_end]; ignore_vars = keys(merged)
+            )
+            shift = pbuf_end - p_start + 1
+            for (arrvar, idxs) in tail
+                merged[arrvar] = [(i + shift, j) for (i, j) in idxs]
+            end
+            param_var_to_arridxs = merged
         end
         append!(
             assignments, array_variable_buffer_idxs_to_assignments(

--- a/src/problems/sccnonlinearproblem.jl
+++ b/src/problems/sccnonlinearproblem.jl
@@ -553,6 +553,24 @@ function SciMLBase.SCCNonlinearProblem{iip}(
 
     build_caches!(sys, decomposition)
 
+    # Every SCC subsystem is derived from `sys` via `subset_unknowns_observed`, which shares
+    # the entire parameter portion of the index cache by reference, and none of the subsystem
+    # constructions (`subset_system`, `_collapse_into!`) touch `ps`. The default parameter
+    # reordering is therefore identical between `sys` and every (merged or unmerged) subsystem.
+    if get_index_cache(sys) !== nothing
+        reorder_parameters(sys)
+        cached_reorder = check_mutable_cache(
+            sys, MTKBase.ReorderedDefaultParameters, MTKBase.ReorderedDefaultParameters, nothing
+        )
+        if cached_reorder isa MTKBase.ReorderedDefaultParameters
+            for subsys in decomposition.subsystems
+                store_to_mutable_cache!(
+                    subsys, MTKBase.ReorderedDefaultParameters, cached_reorder
+                )
+            end
+        end
+    end
+
     for i in eachindex(decomposition.subsystems)
         cachevars = decomposition.scc_cachevars[i]
         cacheexprs = decomposition.scc_cacheexprs[i]

--- a/src/problems/sccnonlinearproblem.jl
+++ b/src/problems/sccnonlinearproblem.jl
@@ -558,16 +558,24 @@ function SciMLBase.SCCNonlinearProblem{iip}(
     # constructions (`subset_system`, `_collapse_into!`) touch `ps`. The default parameter
     # reordering is therefore identical between `sys` and every (merged or unmerged) subsystem.
     if get_index_cache(sys) !== nothing
-        reorder_parameters(sys)
+        rp = reorder_parameters(sys)
         cached_reorder = check_mutable_cache(
             sys, MTKBase.ReorderedDefaultParameters, MTKBase.ReorderedDefaultParameters, nothing
         )
-        if cached_reorder isa MTKBase.ReorderedDefaultParameters
-            for subsys in decomposition.subsystems
+        # The parameter array decomposition (`ParameterArrayAssignments`) is likewise a pure
+        # function of the shared parameter layout. Compute it once (param-only) and propagate
+        # to every subsystem; `build_function_wrapper` decomposes each subsystem's small
+        # cachesym tail on top of it (see the `n_param_buffers` handling there).
+        param_paa = MTKBase.ParameterArrayAssignments(
+            MTKBase.compute_array_variable_buffer_idxs(rp)
+        )
+        for subsys in decomposition.subsystems
+            if cached_reorder isa MTKBase.ReorderedDefaultParameters
                 store_to_mutable_cache!(
                     subsys, MTKBase.ReorderedDefaultParameters, cached_reorder
                 )
             end
+            store_to_mutable_cache!(subsys, MTKBase.ParameterArrayAssignments, param_paa)
         end
     end
 


### PR DESCRIPTION
This PR is on top of https://github.com/SciML/ModelingToolkit.jl/pull/4697 because it is kind of the same idea. The difference here is that we need to do a little bit of bookkeeping to keep track of the extra `cachesyms` that each subsystem appends. 

This takes `ODEProblem` construction for a somewhat large model from

```
6.921406 seconds (108.02 M allocations: 4.142 GiB, 13.60% gc time)
```

to

```
  5.740030 seconds (93.43 M allocations: 3.779 GiB, 10.40% gc time)
```

AI-generated commit message:

---------------------

:robot: 

The parameter array-variable decomposition computed by
`compute_array_variable_buffer_idxs` is, like the parameter reordering, a pure
function of the shared parameter layout. Compute the param-only decomposition
once and propagate it to every SCC subsystem.

The per-SCC callers (`generate_rhs`, `generate_update_A`, `generate_update_b`)
append `cachesyms` as a suffix of the parameter slice, so the cache stores only
the parameter buffers and `build_function_wrapper` decomposes the (small)
cachesym tail on top of the cached result, shifting its slice-relative buffer
indices past the parameter buffers. The callers pass `n_param_buffers` (the
number of `reorder_parameters` buffers before the cachesyms) to mark the
boundary. cachesyms are prior-SCC unknowns / CSE temporaries -- never array
parameters -- so their array-variable keyset is disjoint from the parameters',
making the split identical to decomposing the whole slice.

--------------