### PR TITLE
Add expression variable collector

### DIFF
--- a/docs/src/API/System.md
+++ b/docs/src/API/System.md
@@ -210,6 +210,7 @@ custom `AbstractSystem` subtypes.
 ```@docs
 ModelingToolkit.collect_scoped_vars!
 ModelingToolkit.collect_var_to_name!
+ModelingToolkitBase.collect_expression_vars!
 ModelingToolkit.collect_vars!
 ModelingToolkit.eqtype_supports_collect_vars
 ModelingToolkit.modified_unknowns!

--- a/lib/ModelingToolkitBase/src/ModelingToolkitBase.jl
+++ b/lib/ModelingToolkitBase/src/ModelingToolkitBase.jl
@@ -349,7 +349,8 @@ const set_scalar_metadata = setmetadata
 @public VariableType, MTKVariableTypeCtx, VariableBounds, VariableConnectType
 @public VariableDescription, VariableInput, VariableIrreducible, VariableMisc
 @public VariableOutput, VariableStatePriority, VariableUnit, collect_scoped_vars!
-@public collect_var_to_name!, collect_vars!, eqtype_supports_collect_vars, hasdefault
+@public collect_var_to_name!, collect_expression_vars!, collect_vars!
+@public eqtype_supports_collect_vars, hasdefault
 @public getdefault, setdefault, setguess, iscomplete, isparameter, modified_unknowns!
 @public renamespace, namespace_equations
 @public check_mutable_cache, store_to_mutable_cache!, should_invalidate_mutable_cache_entry

--- a/lib/ModelingToolkitBase/src/utils.jl
+++ b/lib/ModelingToolkitBase/src/utils.jl
@@ -883,6 +883,23 @@ function collect_vars!(unknowns::OrderedSet{SymbolicT}, parameters::OrderedSet{S
     return nothing
 end
 
+"""
+    $(TYPEDSIGNATURES)
+
+Search through arbitrary symbolic expression `expr` for symbolic variables, then populate
+`unknowns` with non-parameters and `parameters` with parameters. `iv` should be the
+independent variable of the system, or `nothing` for time-independent systems.
+
+This is intended for downstream packages that need MTKBase's variable classification for
+plain symbolic expressions that are not full equations or systems.
+"""
+function collect_expression_vars!(unknowns::OrderedSet{SymbolicT}, parameters::OrderedSet{SymbolicT}, expr, iv::Union{SymbolicT, Nothing}; depth = 0)
+    for var in Symbolics.get_variables(expr)
+        collect_var!(unknowns, parameters, unwrap(var), iv; depth)
+    end
+    return nothing
+end
+
 function collect_vars!(unknowns::OrderedSet{SymbolicT}, parameters::OrderedSet{SymbolicT}, expr::AbstractArray, iv::Union{SymbolicT, Nothing}, ::Type{op} = Symbolics.Operator; depth = 0) where {op}
     for var in expr
         collect_vars!(unknowns, parameters, var, iv, op; depth)

--- a/lib/ModelingToolkitBase/test/variable_utils.jl
+++ b/lib/ModelingToolkitBase/test/variable_utils.jl
@@ -1,7 +1,9 @@
 using ModelingToolkitBase, Test
 using ModelingToolkitBase: value, parse_variable
+using OrderedCollections: OrderedSet
 using SymbolicUtils: <ₑ
 import SymbolicUtils as SU
+import Symbolics
 
 @parameters α β δ
 expr = (((1 / β - 1) + δ) / α)^(1 / (α - 1))
@@ -9,6 +11,26 @@ ref = sort([β, δ, α], lt = <ₑ)
 sol = sort(Num.(ModelingToolkitBase.get_variables(expr)), lt = <ₑ)
 @test all(x -> x isa Num, sol[i] == ref[i] for i in 1:3)
 @test all(isequal(sol[i], ref[i]) for i in 1:3)
+
+@testset "collect_expression_vars!" begin
+    @independent_variables τ
+    @variables X(τ) Y(τ) Z(τ) = α
+    @parameters k_obs k_ratio eps_val
+
+    us = OrderedSet{Symbolics.SymbolicT}()
+    ps = OrderedSet{Symbolics.SymbolicT}()
+    ModelingToolkitBase.collect_expression_vars!(
+        us, ps, k_obs + k_ratio * (X + eps_val) + τ, Symbolics.unwrap(τ)
+    )
+    @test issetequal(us, Symbolics.unwrap.([X]))
+    @test issetequal(ps, Symbolics.unwrap.([k_obs, k_ratio, eps_val]))
+
+    empty!(us)
+    empty!(ps)
+    ModelingToolkitBase.collect_expression_vars!(us, ps, Y + Z, Symbolics.unwrap(τ))
+    @test issetequal(us, Symbolics.unwrap.([Y, Z]))
+    @test Symbolics.unwrap(α) in ps
+end
 
 @parameters γ
 s = α => γ


### PR DESCRIPTION
Please ignore until reviewed by @ChrisRackauckas.

## Summary
- add `ModelingToolkitBase.collect_expression_vars!` as a public helper for collecting variables from arbitrary symbolic expressions
- delegate classification to MTKBase's existing `collect_var!` logic so downstream packages do not need to duplicate parameter/unknown handling
- document the helper and cover parameter, unknown, independent-variable, and default-expression collection behavior

## Motivation
Catalyst needs to collect variables from expression leaves while preserving MTKBase's parameter/unknown classification behavior. Exposing this helper keeps that classification logic in MTKBase instead of copying it downstream.

## Validation
- `julia +1.10 --project=lib/ModelingToolkitBase -e 'cd("lib/ModelingToolkitBase/test"); include("variable_utils.jl")'` passed\n- `julia +1.10 --project=lib/ModelingToolkitBase -e 'using ModelingToolkitBase; @assert isdefined(ModelingToolkitBase, :collect_expression_vars!); println(ModelingToolkitBase.collect_expression_vars!)'` passed\n- Runic check passed on edited Julia files\n- `git diff --check` passed\n- `GROUP=ModelingToolkitBase_InterfaceII julia +1.10 --project=lib/ModelingToolkitBase -e 'using Pkg; Pkg.test()'` did not pass: `InterfaceII` reported 7153 passed, 2 errored, 4 broken, with both errors in `Optimal Control + Constraints Tests` BVP cases (`Lotka-Volterra` and `Cost function compilation`). The targeted `Variable Utils Test` section in that run passed with 139 tests.