### PR TITLE
Bump version to 11.31.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ModelingToolkit"
 uuid = "961ee093-0014-501f-94e3-6117800e7a78"
-version = "11.31.0"
+version = "11.31.1"
 authors = ["Yingbo Ma <mayingbo5@gmail.com>", "Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
 
 [deps]


### PR DESCRIPTION
Automated patch version bump (11.31.0 -> 11.31.1) to release unreleased commits on `master` via JuliaRegistrator.