### PR TITLE
Fix initialization inference test on Julia 1.11

### DIFF
--- a/lib/ModelingToolkitBase/test/initializationsystem.jl
+++ b/lib/ModelingToolkitBase/test/initializationsystem.jl
@@ -1742,7 +1742,7 @@ end
             @inferred remake(prob; u0 = 2 .* prob.u0, p = prob.p)
             @inferred solve(prob)
         end
-    elseif v"1.12-" <= VERSION
+    elseif VERSION >= v"1.11"
         @inferred remake(prob; u0 = 2 .* prob.u0, p = prob.p)
         @inferred solve(prob)
     else


### PR DESCRIPTION
This PR should be ignored until reviewed by @ChrisRackauckas.

This unblocks a `SciML/BoundaryValueDiffEq.jl` downstream CI failure in the ModelingToolkit integration job. On Julia 1.11 the `@inferred remake(...)` and `@inferred solve(prob)` checks now infer successfully, so the old `@test_broken @inferred ...` branch errors with `Expression evaluated to non-Boolean` instead of recording a broken test.

The change moves the active inference-check branch from Julia 1.12+ to Julia 1.11+, while preserving the existing Julia 1.10 LTS broken expectation.

Local verification:

```bash
set -o pipefail; timeout 3600 env GROUP=Initialization /home/crackauc/.juliaup/bin/julia +1.11 --startup-file=no --project=. -e 'using Pkg; Pkg.test(; allow_reresolve=true, coverage=false)' 2>&1 | tee ../mtk_pr4725_init_julia111_after_rebase.log
```

Result:

```text
Test Summary:  | Pass  Broken  Total      Time
Initialization |  793      12    805  26m02.8s
     Testing ModelingToolkit tests passed
```

```bash
set -o pipefail; timeout 3600 env GROUP=Initialization /home/crackauc/.juliaup/bin/julia +1.10 --startup-file=no --project=. -e 'using Pkg; Pkg.test(; allow_reresolve=true, coverage=false)' 2>&1 | tee ../../mtk_pr4725_mtkbase_init_julia110_after_rebase.log
```

Run from `lib/ModelingToolkitBase`; result:

```text
Test Summary:             | Pass  Broken  Total      Time
InitializationSystem Test |  638      14    652  11m08.0s
Test Summary:       | Pass  Total     Time
Initial Values Test |   63     63  2m01.8s
     Testing ModelingToolkitBase tests passed
```

Also ran:

```text
git diff --check
timeout 3600 /home/crackauc/.juliaup/bin/julia +1 --startup-file=no --project=/home/crackauc/sandbox/tmp_20260708_121627_10236/runic_env -e 'using Runic; exit(Runic.main(["--check", "lib/ModelingToolkitBase/test/initializationsystem.jl"]))'
```

Full-repo Runic currently exits 1 on unrelated MTK master formatting issues; the changed file checks clean.