### PR TITLE
Fix homotopy lambda spell check

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -1,3 +1,6 @@
+[default.extend-identifiers]
+LambaEulerHeun = "LambaEulerHeun"
+
 [default.extend-words]
 nin = "nin"
 nd = "nd"
@@ -13,5 +16,4 @@ fo = "fo"
 shs = "shs"
 setp = "setp"
 CMO = "CMO"
-Lambda = "Lamba"
 gam = "gam"


### PR DESCRIPTION
This PR should be ignored until reviewed by @ChrisRackauckas.

This fixes the current `Spell Check with Typos` failure on ModelingToolkit master after the homotopy operator added ordinary `lambda`/`LAMBDA` names.

The existing typos config used a word-level replacement:

```toml
Lambda = "Lamba"
```

That allowed the `LambaEulerHeun` solver token, but it also made normal `lambda` spellings fail once the homotopy operator landed. This PR scopes the exception to the actual identifier instead.

Local verification:

```text
typos-cli 1.48.0
timeout 3600 .typos-bin/extract/typos .
```

Result: passed with exit code 0.

Also ran:

```text
git diff --check
```

Result: passed.
