### PR TITLE
Run Runic on initialization diagnostics

### DIFF
--- a/lib/ModelingToolkitBase/src/systems/codegen.jl
+++ b/lib/ModelingToolkitBase/src/systems/codegen.jl
@@ -1197,7 +1197,7 @@ end
 
 function should_invalidate_mutable_cache_entry(::Type{NamespaceMap}, patch::NamedTuple)
     return haskey(patch, :name) || haskey(patch, :observed) || haskey(patch, :unknowns) ||
-           haskey(patch, :ps) || haskey(patch, :systems)
+        haskey(patch, :ps) || haskey(patch, :systems)
 end
 
 function _build_namespace_map(sys)

--- a/lib/ModelingToolkitBase/src/systems/index_cache.jl
+++ b/lib/ModelingToolkitBase/src/systems/index_cache.jl
@@ -597,9 +597,11 @@ function should_invalidate_mutable_cache_entry(::Type{ReorderedDefaultParameters
 end
 
 function _copy_reordered(v::ReorderedParametersT)
-    return ReorderedParametersT(map(v) do inner
-        inner isa Vector{SymbolicT} ? copy(inner) : map(copy, inner)
-    end)
+    return ReorderedParametersT(
+        map(v) do inner
+            inner isa Vector{SymbolicT} ? copy(inner) : map(copy, inner)
+        end
+    )
 end
 
 function reorder_parameters(sys::AbstractSystem; kwargs...)

--- a/src/initialization.jl
+++ b/src/initialization.jl
@@ -106,10 +106,13 @@ unknowns); a `redundancy` of `0` means full row rank (no redundant equations).
     rank deficient at a particular operating point, and vice versa.
 """
 function analyze_initialization_jacobian(
-        prob; rtol = 1e-8, atol = 0.0, threshold = 1e-3, verbose = true)
-    empty_result = (; jacobian = nothing, singular_values = Float64[], rank = 0,
+        prob; rtol = 1.0e-8, atol = 0.0, threshold = 1.0e-3, verbose = true
+    )
+    empty_result = (;
+        jacobian = nothing, singular_values = Float64[], rank = 0,
         nullity = 0, redundancy = 0, underdetermined_unknowns = Pair[],
-        redundant_equations = Pair[])
+        redundant_equations = Pair[],
+    )
     iprob = _initialization_problem(prob)
     if iprob === nothing
         verbose &&
@@ -148,24 +151,28 @@ function analyze_initialization_jacobian(
     # Participation = diagonal of the null-space projector (squared row norm over an
     # orthonormal null-space basis), invariant to the arbitrary basis within the null space.
     col_w = nullity == 0 ? zeros(ncols) :
-            vec(sum(abs2, @view(fact.V[:, col_isnull]); dims = 2))
+        vec(sum(abs2, @view(fact.V[:, col_isnull]); dims = 2))
     row_w = redundancy == 0 ? zeros(nrows) :
-            vec(sum(abs2, @view(fact.U[:, row_isnull]); dims = 2))
+        vec(sum(abs2, @view(fact.U[:, row_isnull]); dims = 2))
     syms = variable_symbols(iprob)
     eqs = _initialization_equations(iprob)
     underdetermined_unknowns = sort(
         [syms[i] => col_w[i] for i in 1:ncols if col_w[i] > threshold];
-        by = last, rev = true)
+        by = last, rev = true
+    )
     redundant_equations = sort(
         [(eqs === nothing ? i : eqs[i]) => row_w[i] for i in 1:nrows if row_w[i] > threshold];
-        by = last, rev = true)
+        by = last, rev = true
+    )
     if verbose
         println("Initialization Jacobian rank analysis")
         println("  residual Jacobian: $(nrows)×$(ncols), rank ≈ $rank, nullity ≈ $nullity, redundancy ≈ $redundancy")
         if !isempty(S)
             k = min(5, length(S))
-            println("  smallest $k singular value(s): ",
-                round.(S[(end - k + 1):end], sigdigits = 3))
+            println(
+                "  smallest $k singular value(s): ",
+                round.(S[(end - k + 1):end], sigdigits = 3)
+            )
         end
         if nullity == 0
             println("  Full column rank at u0 — no underdetermined unknowns.")
@@ -184,8 +191,10 @@ function analyze_initialization_jacobian(
             end
         end
     end
-    return (; jacobian = J, singular_values = S, rank, nullity, redundancy,
-        underdetermined_unknowns, redundant_equations)
+    return (;
+        jacobian = J, singular_values = S, rank, nullity, redundancy,
+        underdetermined_unknowns, redundant_equations,
+    )
 end
 
 # Symbolic equations of an initialization problem, in residual order, or `nothing` if not

--- a/test/initialization_jacobian_analysis.jl
+++ b/test/initialization_jacobian_analysis.jl
@@ -8,13 +8,15 @@ using ModelingToolkit: t_nounits as t, D_nounits as D
 @variables x(t) y(t)
 @named sys = System([D(x) ~ y, 0 ~ x^2 + y^2 - 1], t)
 sys = mtkcompile(sys)
-prob = ODEProblem(sys, [], (0.0, 1.0); guesses = [x => 0.6, y => 0.8],
-    warn_initialize_determined = false)
+prob = ODEProblem(
+    sys, [], (0.0, 1.0); guesses = [x => 0.6, y => 0.8],
+    warn_initialize_determined = false
+)
 res = analyze_initialization_jacobian(prob; verbose = false)
 @test res.nullity ≥ 1
 @test !isempty(res.underdetermined_unknowns)
 @test res.jacobian !== nothing
-@test all(0 .≤ last.(res.underdetermined_unknowns) .≤ 1 + 1e-8)
+@test all(0 .≤ last.(res.underdetermined_unknowns) .≤ 1 + 1.0e-8)
 @test res.rank + res.nullity == size(res.jacobian, 2)
 
 # Overdetermined initialization with a redundant equation: two consistent initial
@@ -22,12 +24,14 @@ res = analyze_initialization_jacobian(prob; verbose = false)
 @variables z(t)
 @named sys2 = System([D(z) ~ -z], t; initialization_eqs = [log(exp(z)) ~ 1.0, z^2 ~ 1.0])
 sys2 = mtkcompile(sys2)
-prob2 = ODEProblem(sys2, [], (0.0, 1.0); guesses = [z => 0.9],
-    warn_initialize_determined = false)
+prob2 = ODEProblem(
+    sys2, [], (0.0, 1.0); guesses = [z => 0.9],
+    warn_initialize_determined = false
+)
 res2 = analyze_initialization_jacobian(prob2; verbose = false)
 @test res2.redundancy ≥ 1
 @test !isempty(res2.redundant_equations)
-@test all(0 .≤ last.(res2.redundant_equations) .≤ 1 + 1e-8)
+@test all(0 .≤ last.(res2.redundant_equations) .≤ 1 + 1.0e-8)
 
 # Determined initialization: an algebraic unknown uniquely fixed by a pinned state has a
 # full-rank initialization Jacobian — no underdetermined unknowns and no redundant


### PR DESCRIPTION
This PR should be ignored until reviewed by @ChrisRackauckas.

Runic currently fails on `SciML/ModelingToolkit.jl` master after the initialization Jacobian diagnostic work. This PR applies the formatter output only, with no intended behavior changes.

Root cause:

```text
578932c484fe48a3807b88b162b229c255b05a57 is the first bad commit
Add `report_initialization_nullspace` init-Jacobian diagnostic
```

Current master also has formatting drift in cache-helper files touched later, so this PR includes the four files reported by full Runic.

Local verification:

```bash
timeout 3600 /home/crackauc/.juliaup/bin/julia +1 --startup-file=no --project=/home/crackauc/sandbox/tmp_20260708_121627_10236/runic_env -e 'using Runic; exit(Runic.main(["--check", "--verbose", "."]))'
```

Result: exit code 0, all 219 files checked successfully.

```bash
git diff --check
```

Result: exit code 0.

```bash
set -o pipefail; timeout 3600 /home/crackauc/.juliaup/bin/julia +1 --startup-file=no --project=. -e 'using Pkg; Pkg.instantiate(); include("test/initialization_jacobian_analysis.jl")' 2>&1 | tee ../mtk_runic_init_jacobian_analysis_test.log
```

Result: exit code 0.
