### PR TITLE
Release prep: batched version bumps for 1 package

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ModelingToolkit"
 uuid = "961ee093-0014-501f-94e3-6117800e7a78"
-version = "11.31.1"
+version = "11.31.2"
 authors = ["Yingbo Ma <mayingbo5@gmail.com>", "Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
 
 [deps]


### PR DESCRIPTION
## Summary

Routine release-scope sweep of the root package + lib/* subpackages in this monorepo, re-verified against the current General registry state (tree-sha comparison against last registered versions).

### Released in this PR

| Package | Old | New | Reason |
|---|---|---|---|
| ModelingToolkit (root) | 11.31.1 | 11.31.2 | Own changes, patch: safe/routine maintenance only |

**ModelingToolkit (root) 11.31.2** — changes since 11.31.1 (commit `52cb07fc`), scoped to non-`lib/` files:
- Raised `SciMLBase` compat floor `"3"` → `"3.19"` and `OrdinaryDiffEqCore` floor `"...,4"` → `"...,4.4"` (#4728) — downgrade-CI correctness fixes.
- Runic-reformatted `src/initialization.jl` / `test/initialization_jacobian_analysis.jl` (#4727) — whitespace/literal-style only (`1e-8` → `1.0e-8`), no behavior change.
- `.github/workflows/TagBot.yml` switched to the monorepo-aware `tagbot.yml` with a `package` dispatch input (#4722).
- `.typos.toml` / docs cleanup (#4726, #4729) — no runtime effect.

No compat-floor cascade was needed: no `lib/*` package is being released in this pass, so no dependent needs a floor raise.

### NOT released — flagged for review

**ModelingToolkitBase** (currently 1.51.0, registered tree matches `3b79461b` exactly) has unreleased commits mixing safe fixes with one change needing review:
- `fb716037` (DiffEqBase 7.x compat floor raise to 7.4.2 — downgrade-CI bug fix) — safe on its own.
- `ffc960e0` (fix `@nospecialize` comma-vs-space syntax in `wrap_symbolic_linear_interface`) — safe, compiler-hint-only, no exported API.
- `b53c42df` (avoid recompiling `build_function_wrapper` instances; `n_param_buffers` sentinel `nothing`→`-1`, internal-only, no caller passes `nothing` explicitly) — safe.
- `923e6a53` / PR #4601 "Add the homotopy operator and HomotopyProblem construction" — adds a new exported `homotopy` operator, a new `SciMLBase.HomotopyProblem` construction path, a new `SciMLBase.AbstractNonlinearProblem(sys, op)` auto-selection method, and changes to the shared `generate_rhs`/`build_function_wrapper` codegen internals (new `extra_args`/`p_end` threading, `output_type`/`n_param_buffers` signature changes). This is genuine new public API surface touching core codegen paths — flagged for maintainer review rather than bundled into a routine release, per release-sweep policy (flag rather than guess).

Because release granularity is per-package-at-HEAD, the safe MTKBase fixes above can't be cherry-picked out from the flagged feature commit without a manual backport; ModelingToolkitBase is left unreleased this round.

**SciCompDSL** (currently 1.0.1, registered tree matches exactly) — no unreleased changes, no action needed.

## Test plan
- [ ] CI matrix green (or pre-existing failures only, verified against default-branch HEAD)
- [ ] No other files touched besides `Project.toml` version bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)