### PR TITLE
Release prep: bump ModelingToolkitBase to 1.51.1

### DIFF
--- a/lib/ModelingToolkitBase/Project.toml
+++ b/lib/ModelingToolkitBase/Project.toml
@@ -1,7 +1,7 @@
 name = "ModelingToolkitBase"
 uuid = "7771a370-6774-4173-bd38-47e70ca0b839"
 authors = ["Yingbo Ma <mayingbo5@gmail.com>", "Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
-version = "1.51.0"
+version = "1.51.1"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"


### PR DESCRIPTION
Registered 1.51.0 (homotopy operator/HomotopyProblem feature) unaffected. Releases the additional patch-level content since then: DiffEqBase 7.x compat floor raise (#4709) plus QA/docstring scaffolding. Root ModelingToolkit is already correctly at 11.31.2 in source (clean patch bump from registered 11.31.1) and needs no edit here, just a registration trigger after this merges.