### PR TITLE
Fix ModelingToolkitBase julia compat floor: 1.9 -> 1.10

### DIFF
--- a/lib/ModelingToolkitBase/Project.toml
+++ b/lib/ModelingToolkitBase/Project.toml
@@ -192,7 +192,7 @@ TaskLocalValues = "0.1.3"
 Test = "1"
 Tracker = "0.2.30"
 UnPack = "0.1, 1.0"
-julia = "1.9"
+julia = "1.10"
 
 [extras]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"


### PR DESCRIPTION
AutoMerge caught this while registering ModelingToolkitBase v1.51.1 (JuliaRegistries/General#161092): `Pkg.add` at the lowest compatible julia version (1.9.4) fails with an unsatisfiable resolution — ModelingToolkitBase requires `DifferentiationInterface = "0.6.47, 0.7"`, and DifferentiationInterface >=0.6.8 itself requires julia >=1.10 (per its registered Compat.toml). The `julia = "1.9"` floor was stale and never actually installable. Bumping to `julia = "1.10"` fixes the resolution deadlock. Pre-existing bug, unrelated to the 1.51.1 version-string bump itself.