### PR TITLE
Fix ModelingToolkitBase Aqua unbound arguments

### DIFF
--- a/lib/ModelingToolkitBase/src/systems/parameter_buffer.jl
+++ b/lib/ModelingToolkitBase/src/systems/parameter_buffer.jl
@@ -780,9 +780,9 @@ end
 # For type-inference when using `SII.setp_oop`
 @generated function _remake_buffer(
         indp, oldbuf::MTKParameters{T, I, D, C, N, H},
-        idxs::Union{Tuple{Vararg{ParameterIndex}}, AbstractArray{<:ParameterIndex{P}}},
+        idxs::Union{Tuple{Vararg{ParameterIndex}}, AbstractArray{<:ParameterIndex}},
         vals::Union{AbstractArray, Tuple}; validate = true
-    ) where {T, I, D, C, N, H, P}
+    ) where {T, I, D, C, N, H}
 
     # fallback to non-generated method if values aren't type-stable
     if vals <: AbstractArray && !isconcretetype(eltype(vals))
@@ -1008,10 +1008,8 @@ end
 Base.size(::NestedGetIndex) = ()
 
 function SymbolicIndexingInterface.with_updated_parameter_timeseries_values(
-        ::AbstractSystem, ps::MTKParameters, args::Pair{A, B}...
-    ) where {
-        A, B <: NestedGetIndex,
-    }
+        ::AbstractSystem, ps::MTKParameters, args::Pair{<:Any, <:NestedGetIndex}...
+    )
     for (i, ngi) in args
         for (j, val) in enumerate(ngi.x)
             copyto!(view(ps.discrete[j], Block(i)), val)

--- a/lib/ModelingToolkitBase/src/systems/problem_utils.jl
+++ b/lib/ModelingToolkitBase/src/systems/problem_utils.jl
@@ -1767,9 +1767,6 @@ function maybe_build_initialization_problem(
     )
 end
 
-rm_union(::Type{Union{T, Nothing}}) where {T} = T
-rm_union(::Type{T}) where {T} = T
-
 """
     $(TYPEDSIGNATURES)
 
@@ -1783,8 +1780,7 @@ function float_type_from_varmap(varmap, floatT = Bool)
         is_array_of_symbolics(v) && continue
         v = unwrap_const(v)
         if v isa AbstractArray
-            # Remove union in case some elements of the array are `nothing`
-            floatT = promote_type(floatT, rm_union(eltype(unwrap_const(v))))
+            floatT = promote_type(floatT, typeintersect(eltype(v), Number))
         elseif v isa Number
             floatT = promote_type(floatT, typeof(unwrap_const(v)))
         end

--- a/lib/ModelingToolkitBase/test/variable_utils.jl
+++ b/lib/ModelingToolkitBase/test/variable_utils.jl
@@ -3,6 +3,14 @@ using ModelingToolkitBase: value, parse_variable
 using SymbolicUtils: <ₑ
 import SymbolicUtils as SU
 
+@variables x
+@test ModelingToolkitBase.float_type_from_varmap(
+    [x => Union{Nothing, BigFloat}[nothing]]
+) == BigFloat
+@test ModelingToolkitBase.float_type_from_varmap(
+    [x => Union{Nothing, Float32}[nothing]]
+) == Float32
+
 @parameters α β δ
 expr = (((1 / β - 1) + δ) / α)^(1 / (α - 1))
 ref = sort([β, δ, α], lt = <ₑ)


### PR DESCRIPTION
## Summary

- remove unused static parameters from the parameter-buffer signatures reported by Aqua
- replace the two unbound `rm_union` methods with public `typeintersect` while preserving numeric array element types
- add regression coverage for `Union{Nothing, BigFloat}` and `Union{Nothing, Float32}` arrays

This is a focused part of #4670. It does not suppress or ignore Aqua findings.

## Local verification

- `GROUP=SymbolicIndexingInterface`: 64/64 SymbolicIndexingInterface, 1804/1804 SciML problem inputs, 118/118 MTKParameters; exit 0
- direct `variable_utils.jl`: parse-variable testsets 54/54 and 54/54, isinitial 7/7, At 13/13; exit 0
- focused `Aqua.test_unbound_args(ModelingToolkitBase)`: exit 0
- official `GROUP=QA`: JET 54/54; Aqua 7 pass / 4 fail, with unbound-argument checks passing. The full QA command exits 1 because this independent branch intentionally leaves the ambiguity, stale-dependency, missing-compat, and piracy classes for separate fixes.
- Runic.jl 1.7.0 over the full repository: exit 0

Ignore this PR until it has been reviewed by @ChrisRackauckas.