### PR TITLE
Correct alias elimination docstring typo

### DIFF
--- a/src/systems/alias_elimination.jl
+++ b/src/systems/alias_elimination.jl
@@ -491,7 +491,7 @@ end
 """
     $TYPEDSIGNATURES
 
-Create a parameter reprsenting the value of `var` at `t = 0`. Requires that `var` is
+Create a parameter representing the value of `var` at `t = 0`. Requires that `var` is
 of the form `x(t)` or `x(t)[i, j, ...]`.
 """
 function __create_t0_parameter_for(var::SymbolicT)


### PR DESCRIPTION
## Summary

- correct `reprsenting` to `representing` in the alias-elimination docstring
- restore the repository-wide `typos` spelling check

## Root cause

The typo entered in `0b01708ffb4c545b888f859bdcbc505350f723ef` when the zero-variable elimination pass was added. It is already present on `master`, so unrelated pull requests such as #4744 inherit the spelling-check failure.

## Validation

- `typos-cli 1.48.0`: passed repository-wide
- Runic 1.7.0 `--check .`: passed repository-wide
- `git diff --check`: passed

Please ignore this PR until it has been reviewed by @ChrisRackauckas.
