### PR TITLE
Resolve benchmark MTKBase before runner startup

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -24,3 +24,4 @@ jobs:
           julia-version: "${{ matrix.version }}"
           script: "benchmark/benchmarks.jl"
           extra-pkgs: "${{ github.event.pull_request.head.repo.clone_url }}#${{ github.event.pull_request.head.sha }}:lib/ModelingToolkitBase,ModelingToolkitStandardLibrary,OrdinaryDiffEqDefault"
+          job-summary: "${{ github.event.pull_request.head.repo.fork }}"

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -23,4 +23,4 @@ jobs:
         with:
           julia-version: "${{ matrix.version }}"
           script: "benchmark/benchmarks.jl"
-          extra-pkgs: "ModelingToolkitStandardLibrary,OrdinaryDiffEqDefault"
+          extra-pkgs: "${{ github.event.pull_request.head.repo.clone_url }}#${{ github.event.pull_request.head.sha }}:lib/ModelingToolkitBase,ModelingToolkitStandardLibrary,OrdinaryDiffEqDefault"

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -1,7 +1,3 @@
-import Pkg
-
-Pkg.develop(; path = joinpath(@__DIR__, "..", "lib", "ModelingToolkitBase"))
-
 using ModelingToolkit, BenchmarkTools
 using ModelingToolkitStandardLibrary
 using ModelingToolkitStandardLibrary.Electrical


### PR DESCRIPTION
Please ignore this PR until it has been reviewed by @ChrisRackauckas.

## Summary

- resolve ModelingToolkitBase from the pull request head repository and SHA before AirspeedVelocity launches the benchmark runner
- remove the late `Pkg.develop` mutation from `benchmark/benchmarks.jl`
- route fork-PR benchmark tables to the job summary, where the read-only fork token does not need comment-write access
- keep ModelingToolkitBase source changes in the benchmark environment through Pkg's supported `URL#revision:subdirectory` monorepo specification

## Dependency and current base

This fix depends on the typo correction in #4745. That PR merged while this PR was queued, so this branch is now rebased onto current `master` at `db56a6a7d174f44efc96511a9679fbca23c323d8`; #4745 is already in its ancestry. The PR therefore contains two focused benchmark commits on top of `master`, without duplicating the merged prerequisite.

## Root cause

AirspeedVelocity imports the benchmarked ModelingToolkit package before it includes the benchmark script. The script then called `Pkg.develop` for the local ModelingToolkitBase checkout after the registered ModelingToolkitBase module was already loaded. Julia retained the registered module while the manifest expected the local module, producing a loaded-path mismatch, missing-cache warnings, and eventually:

```
UndefVarError: analytically_integrated not defined in ModelingToolkit
```

A formal bisect from `6b5d6c6dcd` to `9e7dc990cb` identifies `9e7dc990cb04dae4f66e16d32bacd23e594ba32a` (`ci: use local MTKBase in benchmarks`) as the first bad commit. Its own historical benchmark run (Actions run 26644089638) already failed with an incompatible ModelingToolkit/ModelingToolkitBase precompile, so the late environment mutation never provided valid source resolution.

No existing open issue or PR covers this benchmark failure.

## Investigation notes

A local-path `extra-pkgs` candidate was rejected after the exact Airspeed runner showed that `Pkg.add` requires the supplied path to be a Git repository; `lib/ModelingToolkitBase` is a monorepo subdirectory. The final workflow uses the pull request head clone URL and SHA with Pkg's supported monorepo syntax, so both fork and same-repository pull requests resolve the intended source before any package is loaded.

## Validation

Using Julia 1.12.4, AirspeedVelocity 0.6.5, and an isolated workspace depot and temporary directory:

- clean `master` reproduction: exit 1, with registered/local ModelingToolkitBase loaded-path mismatch followed by the exact `analytically_integrated` error
- corrected Airspeed run with `https://github.com/SciML/ModelingToolkit.jl.git#master:lib/ModelingToolkitBase`: exit 0
- benchmark output:
  ```
  [runner] Running benchmarks for ModelingToolkit@master.
  (1/1) benchmarking "mtkcompile"...
  done (took 6.492992116 seconds)
  [runner] Benchmark runner exited.
  [Info] Finished.
  ```
- fork-head resolution check for `ChrisRackauckas-Claude/ModelingToolkit.jl` at `94efb41cdb1423c7d35f42140a88e503bd554183`: exit 0; Pkg status reported ModelingToolkitBase from that repository, subdirectory, and SHA
- Typos CLI 1.48.0 repository check: exit 0
- Runic 1.7.0 repository-wide `--check .`: exit 0
- actionlint workflow validation: exit 0
- exact `extra-pkgs` and fork `job-summary` assertions: exit 0
- `git diff --check upstream/master...HEAD`: exit 0
- stable patch ID before and after the base-only rebase: `93b2db3b6ee5a0f707b244264605225984eaf398`

The Airspeed filter is applied after the benchmark script is included, so the full script setup and first-call workloads were exercised; only the measured benchmark group was narrowed to `mtkcompile` for the local before/after run. ASV was not rerun after rebasing because the benchmark patch is unchanged; the exact earlier ASV result is reported above.