### PR TITLE
Require BifurcationKit 0.8 in docs

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -40,7 +40,7 @@ Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
 [compat]
 Attractors = "1.24"
 BenchmarkTools = "1.3"
-BifurcationKit = "0.5, 0.6, 0.7, 0.8"
+BifurcationKit = "0.8"
 CairoMakie = "0.15"
 CommonSolve = "0.2"
 ControlSystemsBase = "1.20"


### PR DESCRIPTION
This PR should be ignored until reviewed by @ChrisRackauckas.

## Summary

Follow-up to merged #4746. Restrict the documentation environment to BifurcationKit 0.8, the only BifurcationKit release line supported by current ModelingToolkitBase that also provides the `Collocation` API now used by the periodic-orbit tutorial.

This changes documentation-only compatibility metadata. It does not change ModelingToolkit's runtime dependencies or public API.

## Compatibility boundary

- BifurcationKit commit `542afa4e0d948ee6f74575d9d5d43d2e7fc1e6ec` renamed `PeriodicOrbitOCollProblem` to `Collocation`; the first containing release is v0.7.0.
- Current ModelingToolkitBase supports BifurcationKit `0.4, 0.5, 0.8`.
- Therefore 0.8 is the only supported release line that can execute the tutorial merged in #4746. The previous docs compat `0.5, 0.6, 0.7, 0.8` advertised versions that cannot all provide that API in the current package stack.

## Local verification

- Fresh docs resolution on the #4746 tree with this compat line selected BifurcationKit 0.8.0 and the local ModelingToolkit/ModelingToolkitBase packages: exit 0.
- Exact periodic-orbit tutorial path through `continuation(..., Collocation(20, 5))` and `get_periodic_orbit`: exit 0, 101 orbit points.
- Full Julia 1.10 documentation build with all examples, strict external link checks, and HTML rendering: exit 0. Documenter's documented `GITHUB_TOKEN` link-check hook was used after two unauthenticated runs completed all examples but GitHub throttled its own `NEWS.md` link with HTTP 429; no link was ignored and no check was downgraded.
- Runic 1.7.0 `--check --verbose` over every tracked Julia file: exit 0, 219/219 files.
- `git diff --check upstream/master...HEAD`: exit 0.
