### PR TITLE
fix: `Const` argument of operator is not considered a variable

### DIFF
--- a/lib/ModelingToolkitBase/src/utils.jl
+++ b/lib/ModelingToolkitBase/src/utils.jl
@@ -846,6 +846,7 @@ function collect_vars!(unknowns::OrderedSet{SymbolicT}, parameters::OrderedSet{S
     SU.search_variables!(vars, expr; is_atomic = OperatorIsAtomic{op}())
     for var in vars
         Moshi.Match.@match var begin
+            BSImpl.Const() => nothing
             BSImpl.Term(; f, args) && if f isa op end => begin
                 validate_operator(f, args, iv; context = expr)
                 isempty(args) && continue

--- a/lib/ModelingToolkitBase/test/system_building.jl
+++ b/lib/ModelingToolkitBase/test/system_building.jl
@@ -1,5 +1,6 @@
 using ModelingToolkitBase
 using ModelingToolkitBase: t_nounits as t, D_nounits as D
+import SymbolicUtils as SU
 
 @testset "`state_priorities` and `irreducibles` kwargs take priority over metadata" begin
     @variables x(t) [state_priority = 3] y(t) [irreducible = false]
@@ -61,4 +62,13 @@ end
     ics[y] = "Because I want to"
     sys = ModelingToolkitBase.set_necessary_initial_conditions(sys, ics)
     @test_throws ModelingToolkitBase.MissingNecessaryInitialConditionsError ODEProblem(sys, [x => 1], (0.0, 1.0))
+end
+
+struct MyOp <: SU.Operator end
+ModelingToolkitBase.validate_operator(::MyOp, args...; kws...) = nothing
+
+@testset "Const argument of operator is not considered a variable" begin
+    @variables x(t)
+    @named sys = System([D(x) ~ x + SU.term(MyOp(), [0.0]; type = Real, shape = SU.ShapeVecT())], t)
+    @test issetequal(unknowns(sys), [x])
 end


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
