### PR TITLE
feat: Introduce `BuildFunctionWrapperOptions` for `build_function_wrapper`

### DIFF
--- a/lib/ModelingToolkitBase/src/inputoutput.jl
+++ b/lib/ModelingToolkitBase/src/inputoutput.jl
@@ -330,8 +330,11 @@ function generate_control_function(
         args = (ddvs, args...)
     end
     f = build_function_wrapper(
-        sys, rhss, args...; u_arg = 1 + Int(implicit_dae), p_start = 3 + implicit_dae,
-        p_end = length(p) + 2 + implicit_dae, kwargs...
+        sys, rhss, collect(Any, args), BuildFunctionWrapperOptions(;
+            u_arg = 1 + Int(implicit_dae), p_start = 3 + implicit_dae,
+            p_end = length(p) + 2 + implicit_dae,
+            codegen_function_options = Symbolics.CodegenFunctionOptions(; kwargs...)
+        )
     )
     f = eval_or_rgf.(f; eval_expression, eval_module)
     f = GeneratedFunctionWrapper{

--- a/lib/ModelingToolkitBase/src/systems/abstractsystem.jl
+++ b/lib/ModelingToolkitBase/src/systems/abstractsystem.jl
@@ -32,26 +32,31 @@ function generate_custom_function(
     if !iscomplete(sys)
         error("A completed system is required. Call `complete` or `mtkcompile` on the system.")
     end
-    p = (reorder_parameters(sys, unwrap.(ps))..., cachesyms...)
+    p = reorder_parameters(sys, unwrap.(ps))
     isscalar = !(exprs isa AbstractArray)
     fnexpr = if is_time_dependent(sys)
         build_function_wrapper(
             sys, exprs,
-            dvs,
-            p...,
-            get_iv(sys);
-            u_arg = 1,
-            kwargs...,
-            expression = Val{true}
+            [Any[dvs]; p; collect(cachesyms); Any[get_iv(sys)]],
+            BuildFunctionWrapperOptions(;
+                u_arg = 1,
+                codegen_function_options = Symbolics.CodegenFunctionOptions(;
+                    kwargs...,
+                    expression = Val{true}
+                )
+            )
         )
     else
         build_function_wrapper(
             sys, exprs,
-            dvs,
-            p...;
-            u_arg = 1,
-            kwargs...,
-            expression = Val{true}
+            [Any[dvs]; p],
+            BuildFunctionWrapperOptions(;
+                u_arg = 1,
+                codegen_function_options = Symbolics.CodegenFunctionOptions(;
+                    kwargs...,
+                    expression = Val{true}
+                )
+            )
         )
     end
     if expression == Val{true}

--- a/lib/ModelingToolkitBase/src/systems/callbacks.jl
+++ b/lib/ModelingToolkitBase/src/systems/callbacks.jl
@@ -1037,7 +1037,10 @@ Base.@nospecializeinfer function compile_condition(
     end
 
     fs = build_function_wrapper(
-        sys, condit, u, p..., t; u_arg = 1, kwargs...
+        sys, condit, [Any[u]; p; Any[t]], BuildFunctionWrapperOptions(;
+            u_arg = 1,
+            codegen_function_options = Symbolics.CodegenFunctionOptions(; kwargs...)
+        )
     )
     fs = GeneratedFunctionWrapper{(2, 3, is_split(sys))}(
         Val{false}, fs...; eval_expression, eval_module
@@ -1485,15 +1488,25 @@ Base.@nospecializeinfer function compile_explicit_affect(
 
     u_up,
         u_up! = build_function_wrapper(
-        sys, (@view rhss[is_u]), dvs, _ps..., t;
-        u_arg = 1, wrap_code = add_integrator_header(sys, integ, :u),
-        outputidxs = u_idxs, wrap_mtkparameters, iip_config = (false, true)
+        sys, (@view rhss[is_u]), [Any[dvs]; _ps; Any[t]],
+        BuildFunctionWrapperOptions(;
+            u_arg = 1, wrap_mtkparameters,
+            codegen_function_options = Symbolics.CodegenFunctionOptions(;
+                wrap_code = add_integrator_header(sys, integ, :u),
+                outputidxs = u_idxs, iip_config = (false, true)
+            )
+        )
     )
     p_up,
         p_up! = build_function_wrapper(
-        sys, (@view rhss[is_p]), dvs, _ps..., t;
-        u_arg = 1, wrap_code = add_integrator_header(sys, integ, :p),
-        outputidxs = p_idxs, wrap_mtkparameters, iip_config = (false, true)
+        sys, (@view rhss[is_p]), [Any[dvs]; _ps; Any[t]],
+        BuildFunctionWrapperOptions(;
+            u_arg = 1, wrap_mtkparameters,
+            codegen_function_options = Symbolics.CodegenFunctionOptions(;
+                wrap_code = add_integrator_header(sys, integ, :p),
+                outputidxs = p_idxs, iip_config = (false, true)
+            )
+        )
     )
 
     u_up! = eval_or_rgf(u_up!; eval_expression, eval_module)

--- a/lib/ModelingToolkitBase/src/systems/codegen.jl
+++ b/lib/ModelingToolkitBase/src/systems/codegen.jl
@@ -123,8 +123,12 @@ function generate_rhs(
 
     u_arg = scalar ? -1 : (implicit_dae ? 2 : 1)
     res = build_function_wrapper(
-        sys, rhss, args...; p_start, extra_assignments, u_arg, n_param_buffers, p_end_kw...,
-        expression = Val{true}, expression_module = eval_module, kwargs...
+        sys, rhss, collect(Any, args), BuildFunctionWrapperOptions(;
+            p_start, extra_assignments, u_arg, n_param_buffers, p_end_kw...,
+            codegen_function_options = Symbolics.CodegenFunctionOptions(;
+                expression = Val{true}, expression_module = eval_module, kwargs...
+            )
+        )
     )
     nargs = length(args) - length(p) + 1
     if is_dde(sys)
@@ -161,7 +165,7 @@ function generate_diffusion_function(
         eqs = vec(eqs)
     end
     p = reorder_parameters(sys, ps)
-    res = build_function_wrapper(sys, eqs, dvs, p..., get_iv(sys); u_arg = 1, kwargs...)
+    res = build_function_wrapper(sys, eqs, [Any[dvs]; p; Any[get_iv(sys)]], BuildFunctionWrapperOptions(; u_arg = 1, codegen_function_options = Symbolics.CodegenFunctionOptions(; kwargs...)))
     if expression == Val{true}
         return res
     end
@@ -276,8 +280,13 @@ function generate_jacobian(
         nargs = 3
     end
     res = build_function_wrapper(
-        sys, jac, args...; wrap_code, u_arg = 1, expression = Val{true},
-        expression_module = eval_module, checkbounds, kwargs...
+        sys, jac, collect(Any, args), BuildFunctionWrapperOptions(;
+            u_arg = 1,
+            codegen_function_options = Symbolics.CodegenFunctionOptions(;
+                wrap_code, expression = Val{true}, expression_module = eval_module,
+                checkbounds, kwargs...
+            )
+        )
     )
     return maybe_compile_function(
         expression, wrap_gfw, (2, nargs, is_split(sys)), res;
@@ -322,13 +331,15 @@ function generate_tgrad(
     p = reorder_parameters(sys, ps)
     res = build_function_wrapper(
         sys, tgrad,
-        dvs,
-        p...,
-        get_iv(sys);
-        u_arg = 1,
-        expression = Val{true},
-        expression_module = eval_module,
-        kwargs...
+        [Any[dvs]; p; Any[get_iv(sys)]],
+        BuildFunctionWrapperOptions(;
+            u_arg = 1,
+            codegen_function_options = Symbolics.CodegenFunctionOptions(;
+                expression = Val{true},
+                expression_module = eval_module,
+                kwargs...
+            )
+        )
     )
 
     return maybe_compile_function(
@@ -409,8 +420,12 @@ function generate_W(
 
     p = reorder_parameters(sys, ps)
     res = build_function_wrapper(
-        sys, W, dvs, p..., W_GAMMA, t; wrap_code,
-        u_arg = 1, p_end = 1 + length(p), checkbounds, kwargs...
+        sys, W, [Any[dvs]; p; Any[W_GAMMA, t]], BuildFunctionWrapperOptions(;
+            u_arg = 1, p_end = 1 + length(p),
+            codegen_function_options = Symbolics.CodegenFunctionOptions(;
+                wrap_code, checkbounds, kwargs...
+            )
+        )
     )
     return maybe_compile_function(
         expression, wrap_gfw, (2, 4, is_split(sys)), res; eval_expression, eval_module
@@ -450,8 +465,11 @@ function generate_dae_jacobian(
     jac = W_GAMMA * jac_du + jac_u
     p = reorder_parameters(sys, ps)
     res = build_function_wrapper(
-        sys, jac, derivatives, dvs, p..., W_GAMMA, t;
-        u_arg = 2, p_start = 3, p_end = 2 + length(p), kwargs...
+        sys, jac, [Any[derivatives, dvs]; p; Any[W_GAMMA, t]],
+        BuildFunctionWrapperOptions(;
+            u_arg = 2, p_start = 3, p_end = 2 + length(p),
+            codegen_function_options = Symbolics.CodegenFunctionOptions(; kwargs...)
+        )
     )
     return maybe_compile_function(
         expression, wrap_gfw, (3, 5, is_split(sys)), res;
@@ -477,9 +495,13 @@ function generate_history(
     )
     p = reorder_parameters(sys)
     res = build_function_wrapper(
-        sys, u0, p..., get_iv(sys); expression = Val{true},
-        expression_module = eval_module, p_start = 1, p_end = length(p),
-        similarto = typeof(u0), wrap_delays = false, kwargs...
+        sys, u0, [p; Any[get_iv(sys)]], BuildFunctionWrapperOptions(;
+            p_start = 1, p_end = length(p), wrap_delays = false,
+            codegen_function_options = Symbolics.CodegenFunctionOptions(;
+                expression = Val{true}, expression_module = eval_module,
+                similarto = typeof(u0), kwargs...
+            )
+        )
     )
     return maybe_compile_function(
         expression, wrap_gfw, (1, 2, is_split(sys)), res; eval_expression, eval_module
@@ -673,9 +695,12 @@ function generate_boundary_conditions(
     _p = reorder_parameters(sys, ps)
 
     res = build_function_wrapper(
-        sys, exprs, _p..., iv; output_type = Array,
-        p_start = 1, histfn = (p, t) -> BVP_SOLUTION(t),
-        histfn_symbolic = BVP_SOLUTION, wrap_delays = true, kwargs...
+        sys, exprs, [_p; Any[iv]], BuildFunctionWrapperOptions(;
+            output_type = Array,
+            p_start = 1, histfn = (p, t) -> BVP_SOLUTION(t),
+            histfn_symbolic = BVP_SOLUTION, wrap_delays = true,
+            codegen_function_options = Symbolics.CodegenFunctionOptions(; kwargs...)
+        )
     )
     return maybe_compile_function(
         expression, wrap_gfw, (2, 3, is_split(sys)), res; eval_expression, eval_module
@@ -716,8 +741,11 @@ function generate_cost(
     end
     u_arg = is_time_dependent(sys) ? -1 : 1
     res = build_function_wrapper(
-        sys, obj, args...; expression = Val{true}, p_start, p_end, wrap_delays, u_arg,
-        histfn = (p, t) -> BVP_SOLUTION(t), histfn_symbolic = BVP_SOLUTION, kwargs...
+        sys, obj, collect(Any, args), BuildFunctionWrapperOptions(;
+            p_start, p_end, wrap_delays, u_arg,
+            histfn = (p, t) -> BVP_SOLUTION(t), histfn_symbolic = BVP_SOLUTION,
+            codegen_function_options = Symbolics.CodegenFunctionOptions(; expression = Val{true}, kwargs...)
+        )
     )[1]
     if expression == Val{true}
         return res
@@ -761,14 +789,17 @@ function generate_bvp_cost(
     # Build function with signature (sol, p) where sol = BVP_SOLUTION
     # The histfn mechanism replaces BVP_SOLUTION with the sol argument
     res = build_function_wrapper(
-        sys, obj, ps...;
-        expression = Val{true},
-        p_start = 1,  # sol goes before parameters
-        p_end = length(ps),
-        wrap_delays = true,
-        histfn = (p, t) -> BVP_SOLUTION(t),
-        histfn_symbolic = BVP_SOLUTION,
-        checkbounds, kwargs...
+        sys, obj, Vector{Any}(ps),
+        BuildFunctionWrapperOptions(;
+            p_start = 1,  # sol goes before parameters
+            p_end = length(ps),
+            wrap_delays = true,
+            histfn = (p, t) -> BVP_SOLUTION(t),
+            histfn_symbolic = BVP_SOLUTION,
+            codegen_function_options = Symbolics.CodegenFunctionOptions(;
+                expression = Val{true}, checkbounds, kwargs...
+            )
+        )
     )[1]
 
     # (2, 2, is_split) means: 2 args out-of-place, 2 original args, split status
@@ -809,7 +840,7 @@ function generate_cost_gradient(
     dvs = unknowns(sys)
     ps = reorder_parameters(sys)
     exprs = calculate_cost_gradient(sys; simplify)
-    res = build_function_wrapper(sys, exprs, dvs, ps...; u_arg = 1, expression = Val{true}, kwargs...)
+    res = build_function_wrapper(sys, exprs, [Any[dvs]; ps], BuildFunctionWrapperOptions(; u_arg = 1, codegen_function_options = Symbolics.CodegenFunctionOptions(; expression = Val{true}, kwargs...)))
     return maybe_compile_function(
         expression, wrap_gfw, (2, 2, is_split(sys)), res; eval_expression, eval_module
     )
@@ -868,7 +899,7 @@ function generate_cost_hessian(
     if sparse
         sparsity = similar(exprs, Float64)
     end
-    res = build_function_wrapper(sys, exprs, dvs, ps...; u_arg = 1, expression = Val{true}, kwargs...)
+    res = build_function_wrapper(sys, exprs, [Any[dvs]; ps], BuildFunctionWrapperOptions(; u_arg = 1, codegen_function_options = Symbolics.CodegenFunctionOptions(; expression = Val{true}, kwargs...)))
     fn = maybe_compile_function(
         expression, wrap_gfw, (2, 2, is_split(sys)), res; eval_expression, eval_module
     )
@@ -900,7 +931,7 @@ function generate_cons(
     cons = canonical_constraints(sys)
     dvs = unknowns(sys)
     ps = reorder_parameters(sys)
-    res = build_function_wrapper(sys, cons, dvs, ps...; u_arg = 1, expression = Val{true}, kwargs...)
+    res = build_function_wrapper(sys, cons, [Any[dvs]; ps], BuildFunctionWrapperOptions(; u_arg = 1, codegen_function_options = Symbolics.CodegenFunctionOptions(; expression = Val{true}, kwargs...)))
     return maybe_compile_function(
         expression, wrap_gfw, (2, 2, is_split(sys)), res; eval_expression, eval_module
     )
@@ -957,7 +988,7 @@ function generate_constraint_jacobian(
         sparsity = calculate_constraint_jacobian(
         sys; simplify, sparse, return_sparsity = true
     )
-    res = build_function_wrapper(sys, jac, dvs, ps...; u_arg = 1, expression = Val{true}, kwargs...)
+    res = build_function_wrapper(sys, jac, [Any[dvs]; ps], BuildFunctionWrapperOptions(; u_arg = 1, codegen_function_options = Symbolics.CodegenFunctionOptions(; expression = Val{true}, kwargs...)))
     fn = maybe_compile_function(
         expression, wrap_gfw, (2, 2, is_split(sys)), res; eval_expression, eval_module
     )
@@ -1016,7 +1047,7 @@ function generate_constraint_hessian(
         sparsity = calculate_constraint_hessian(
         sys; simplify, sparse, return_sparsity = true
     )
-    res = build_function_wrapper(sys, hess, dvs, ps...; u_arg = 1, expression = Val{true}, kwargs...)
+    res = build_function_wrapper(sys, hess, [Any[dvs]; ps], BuildFunctionWrapperOptions(; u_arg = 1, codegen_function_options = Symbolics.CodegenFunctionOptions(; expression = Val{true}, kwargs...)))
     fn = maybe_compile_function(
         expression, wrap_gfw, (2, 2, is_split(sys)), res; eval_expression, eval_module
     )
@@ -1069,7 +1100,7 @@ function generate_control_jacobian(
     ps = parameters(sys; initial_parameters = true)
     jac = calculate_control_jacobian(sys; simplify = simplify, sparse = sparse)
     p = reorder_parameters(sys, ps)
-    res = build_function_wrapper(sys, jac, dvs, p..., get_iv(sys); u_arg = 1, kwargs...)
+    res = build_function_wrapper(sys, jac, [Any[dvs]; p; Any[get_iv(sys)]], BuildFunctionWrapperOptions(; u_arg = 1, codegen_function_options = Symbolics.CodegenFunctionOptions(; kwargs...)))
     return maybe_compile_function(
         expression, wrap_gfw, (2, 3, is_split(sys)), res; eval_expression, eval_module
     )
@@ -1078,11 +1109,14 @@ end
 function generate_rate_function(js::System, rate)
     p = reorder_parameters(js)
     return build_function_wrapper(
-        js, rate, unknowns(js), p...,
-        get_iv(js),
-        u_arg = 1,
-        expression = Val{true},
-        iip_config = (true, false),
+        js, rate, [Any[unknowns(js)]; p; Any[get_iv(js)]],
+        BuildFunctionWrapperOptions(;
+            u_arg = 1,
+            codegen_function_options = Symbolics.CodegenFunctionOptions(;
+                expression = Val{true},
+                iip_config = (true, false)
+            )
+        )
     )[1]
 end
 
@@ -1408,9 +1442,13 @@ Base.@nospecializeinfer function build_explicit_observed_function(
     p_start = length(dvs) + length(inputs) + 1
     p_end = length(dvs) + length(inputs) + length(rps)
     fns = build_function_wrapper(
-        sys, ts, args...; p_start, p_end,
-        output_type, mkarray, try_namespaced = true, expression = Val{true},
-        wrap_delays, checkbounds, kwargs...
+        sys, ts, collect(Any, args), BuildFunctionWrapperOptions(;
+            p_start, p_end,
+            output_type, mkarray, wrap_delays,
+            codegen_function_options = Symbolics.CodegenFunctionOptions(;
+                try_namespaced = true, expression = Val{true}, checkbounds, kwargs...
+            )
+        )
     )::NTuple{2, Expr}
     if expression === true || expression === Val{true}
         return (return_inplace isa Val{true} || return_inplace isa Bool && return_inplace) ? fns : fns[1]
@@ -1558,8 +1596,12 @@ function generate_update_A(
     A = SU.ArrayMaker{VartypeT}(regions, values; shape = first(regions))
 
     res = build_function_wrapper(
-        sys, A, ps..., cachesyms...; p_start = 1, expression = Val{true},
-        similarto = typeof(A), n_param_buffers = length(ps), kwargs...
+        sys, A, [Any[]; ps; collect(cachesyms)], BuildFunctionWrapperOptions(;
+            p_start = 1, n_param_buffers = length(ps),
+            codegen_function_options = Symbolics.CodegenFunctionOptions(;
+                expression = Val{true}, similarto = typeof(A), kwargs...
+            )
+        )
     )
     return maybe_compile_function(
         expression, wrap_gfw, (1, 1, is_split(sys)), res;
@@ -1595,8 +1637,12 @@ function generate_update_A(
     ps = reorder_parameters(sys)
 
     res = build_function_wrapper(
-        sys, parent(A), ps..., cachesyms...; p_start = 1, expression = Val{true},
-        similarto = Vector{SymbolicT}, n_param_buffers = length(ps), kwargs...
+        sys, parent(A), [Any[]; ps; collect(cachesyms)], BuildFunctionWrapperOptions(;
+            p_start = 1, n_param_buffers = length(ps),
+            codegen_function_options = Symbolics.CodegenFunctionOptions(;
+                expression = Val{true}, similarto = Vector{SymbolicT}, kwargs...
+            )
+        )
     )
     return DiagonalAMatrixWrapper(
         maybe_compile_function(
@@ -1641,8 +1687,12 @@ function generate_update_A(
         parA[i] = Symbolics.COMMON_ZERO
     end
     res = build_function_wrapper(
-        sys, parA, ps..., cachesyms...; p_start = 1, expression = Val{true},
-        similarto = Matrix{SymbolicT}, n_param_buffers = length(ps), kwargs...
+        sys, parA, [Any[]; ps; collect(cachesyms)], BuildFunctionWrapperOptions(;
+            p_start = 1, n_param_buffers = length(ps),
+            codegen_function_options = Symbolics.CodegenFunctionOptions(;
+                expression = Val{true}, similarto = Matrix{SymbolicT}, kwargs...
+            )
+        )
     )
     return BandedAMatrixWrapper(
         maybe_compile_function(
@@ -1685,8 +1735,12 @@ function generate_update_b(
     b = SU.ArrayMaker{VartypeT}(regions, values; shape = first(regions))
 
     res = build_function_wrapper(
-        sys, b, ps..., cachesyms...; p_start = 1, expression = Val{true},
-        similarto = typeof(b), n_param_buffers = length(ps), kwargs...
+        sys, b, [Any[]; ps; collect(cachesyms)], BuildFunctionWrapperOptions(;
+            p_start = 1, n_param_buffers = length(ps),
+            codegen_function_options = Symbolics.CodegenFunctionOptions(;
+                expression = Val{true}, similarto = typeof(b), kwargs...
+            )
+        )
     )
     return maybe_compile_function(
         expression, wrap_gfw, (1, 1, is_split(sys)), res;

--- a/lib/ModelingToolkitBase/src/systems/codegen_utils.jl
+++ b/lib/ModelingToolkitBase/src/systems/codegen_utils.jl
@@ -550,7 +550,7 @@ Base.@nospecializeinfer function build_function_wrapper(
         wrap_mtkparameters, extra_assignments, n_param_buffers,
         codegen_function_options = Symbolics.CodegenFunctionOptions(; wrap_code, optimize, kwargs...)
     )
-    return build_function_wrapper(sys, expr, args, opts)
+    return build_function_wrapper(sys, expr, collect(Any, args), opts)
 end
 
 """
@@ -558,7 +558,7 @@ end
 
 A wrapper around `build_function` which performs the necessary transformations for
 code generation of all types of systems. `expr` is the expression returned from the
-generated functions, and `args` is the collection (tuple or vector) of arguments.
+generated functions, and `args` is the `Vector{Any}` of arguments.
 
 Options are supplied as a [`BuildFunctionWrapperOptions`](@ref); see its docstring for the
 available options. This is the primary method — the keyword-argument form of
@@ -566,7 +566,7 @@ available options. This is the primary method — the keyword-argument form of
 `BuildFunctionWrapperOptions` and calls this method.
 """
 Base.@nospecializeinfer function build_function_wrapper(
-        sys::AbstractSystem, @nospecialize(expr), @nospecialize(args),
+        sys::AbstractSystem, @nospecialize(expr), args::Vector{Any},
         opts::BuildFunctionWrapperOptions
     )
     (;
@@ -583,7 +583,9 @@ Base.@nospecializeinfer function build_function_wrapper(
     # `n_param_buffers` as `nothing`; normalize it to the sentinel here.
     n_param_buffers = n_param_buffers === nothing ? -1 : n_param_buffers
     isscalar = !(expr isa AbstractArray || symbolic_type(expr) == ArraySymbolic())
-    args = Vector{Any}(collect(args))
+    # Copy so the in-place mutations below (`insert!`, `deleteat!`, `setindex!`) do not
+    # affect the caller's vector.
+    args = copy(args)
     assignments = Assignment[]
 
     if u_arg != -1

--- a/lib/ModelingToolkitBase/src/systems/codegen_utils.jl
+++ b/lib/ModelingToolkitBase/src/systems/codegen_utils.jl
@@ -406,11 +406,26 @@ function find_arrvars_is_atomic(ex::SymbolicT)
 end
 
 """
-    $(TYPEDSIGNATURES)
+    BuildFunctionWrapperOptions(; kwargs...)
 
-A wrapper around `build_function` which performs the necessary transformations for
-code generation of all types of systems. `expr` is the expression returned from the
-generated functions, and `args` are the arguments.
+Options for [`build_function_wrapper`](@ref). Bundles the wrapper-specific options
+together with a nested `Symbolics.CodegenFunctionOptions` (the `codegen` field)
+holding the code-generation options that are ultimately forwarded to
+`codegen_function`.
+
+Threading a single `BuildFunctionWrapperOptions` (one concrete type) instead of a
+`kwargs...` bundle means the body of `build_function_wrapper` is compiled once
+regardless of which options are set. Keeping the code-generation options in a
+nested `CodegenFunctionOptions` means that if `codegen_function` gains new options
+this struct does not need to change — they ride along inside `codegen`.
+
+The keyword constructor mirrors the historical keyword arguments of
+`build_function_wrapper`. The code-generation options (including `wrap_code` and
+`optimize`) are collected into the nested `codegen`. `build_function_wrapper` reads
+`wrap_code`/`optimize` from `codegen` and writes the transformed values back — the
+composed `wrap_code`, the resolved `optimize`, and the `output_type`-derived
+`similarto` — before calling `codegen_function`. Keywords not recognized by
+`CodegenFunctionOptions` are ignored, matching the previous behaviour.
 
 # Keyword Arguments
 
@@ -434,7 +449,6 @@ generated functions, and `args` are the arguments.
   term `x(expr)`, this is called as `histfn(p, expr)` where `p` is the parameter object.
 - `histfn_symbolic`: The symbolic history function variable to add as an argument to the
   generated function.
-- `wrap_code`: Forwarded to `build_function`.
 - `create_bindings`: Whether to explicitly destructure arrays of symbolics present in
   `args` in the generated code. If `false`, all usages of the individual symbolics will
   instead call `getindex` on the relevant argument. This is useful if the generated
@@ -452,18 +466,122 @@ generated functions, and `args` are the arguments.
   argument.
 - `extra_assignments`: Extra `Assignment` statements to prefix to `expr`, after all other
   assignments.
+- `codegen_function_options`: A [`Symbolics.CodegenFunctionOptions`](@ref) holding the
+  code-generation options forwarded to `codegen_function`. `build_function_wrapper` reads
+  `wrap_code` and `optimize` from it and writes the transformed values back (the composed
+  `wrap_code`, the resolved `optimize`, and the `output_type`-derived `similarto`) before
+  generating code. The backwards-compatible keyword form of `build_function_wrapper`
+  assembles this from loose keyword arguments; direct callers of this constructor must pass
+  a fully-formed `CodegenFunctionOptions` (the constructor accepts no other keywords).
+"""
+struct BuildFunctionWrapperOptions
+    p_start::Int
+    # `nothing` means "resolve from `sys`/`args` in the struct-based method"
+    p_end::Union{Nothing, Int}
+    compress_args::Vector{UnitRange{Int}}
+    non_standard_param_layout::Bool
+    u_arg::Int
+    # `nothing` means "resolve to `is_dde(sys)` in the struct-based method"
+    wrap_delays::Union{Nothing, Bool}
+    histfn::Any
+    histfn_symbolic::SymbolicT
+    create_bindings::Bool
+    output_type::Any
+    mkarray::Any
+    wrap_mtkparameters::Bool
+    extra_assignments::Vector{Assignment}
+    n_param_buffers::Union{Nothing, Int}
+    codegen::Symbolics.CodegenFunctionOptions
+end
 
-All other keyword arguments are forwarded to `build_function`.
+function BuildFunctionWrapperOptions(;
+        p_start::Integer = 2, p_end = nothing, compress_args = UnitRange{Int}[],
+        non_standard_param_layout = false, u_arg::Integer = -1, wrap_delays = nothing,
+        histfn = DDE_HISTORY_FUN, histfn_symbolic = histfn,
+        create_bindings = false, output_type = nothing, mkarray = nothing,
+        wrap_mtkparameters = true, extra_assignments = Assignment[],
+        n_param_buffers = nothing,
+        codegen_function_options::Symbolics.CodegenFunctionOptions = Symbolics.CodegenFunctionOptions()
+    )
+    # The constructor only accepts valid `build_function_wrapper` options; there is no
+    # `kwargs...` sink. Code-generation options are supplied as a fully-formed
+    # `CodegenFunctionOptions` via `codegen_function_options` (`build_function_wrapper` reads
+    # `wrap_code`/`optimize` from it and writes the transformed values back before calling
+    # `codegen_function`). The backwards-compatible keyword form of `build_function_wrapper`
+    # is responsible for assembling that `CodegenFunctionOptions` from loose keywords.
+    return BuildFunctionWrapperOptions(
+        p_start, p_end, compress_args, non_standard_param_layout, u_arg, wrap_delays,
+        histfn, histfn_symbolic, create_bindings, output_type, mkarray,
+        wrap_mtkparameters, extra_assignments, n_param_buffers, codegen_function_options
+    )
+end
+
+"""
+    build_function_wrapper(sys::AbstractSystem, expr, args...; kwargs...)
+
+Backwards-compatibility keyword-argument form of `build_function_wrapper`. The keyword
+arguments (documented on [`BuildFunctionWrapperOptions`](@ref)) are bundled into a
+`BuildFunctionWrapperOptions` and forwarded to the primary method,
+[`build_function_wrapper(sys, expr, args, opts::BuildFunctionWrapperOptions)`](@ref). This
+method exists only for backwards compatibility; new code should construct a
+`BuildFunctionWrapperOptions` and call that method directly.
 """
 Base.@nospecializeinfer function build_function_wrapper(
         sys::AbstractSystem, @nospecialize(expr), @nospecialize(args...); p_start = 2,
-        p_end = is_time_dependent(sys) ? length(args) - 1 : length(args), compress_args = UnitRange{Int}[],
+        p_end = nothing, compress_args = UnitRange{Int}[],
         non_standard_param_layout = false, u_arg::Integer = -1,
-        wrap_delays = is_dde(sys), histfn = DDE_HISTORY_FUN, histfn_symbolic = histfn, wrap_code = identity,
+        wrap_delays = is_dde(sys), histfn = DDE_HISTORY_FUN, histfn_symbolic = histfn,
+        wrap_code = (identity, identity),
         create_bindings = false, @nospecialize(output_type::Union{Nothing, Type} = nothing), mkarray = nothing,
         wrap_mtkparameters = true, extra_assignments = Assignment[],
         n_param_buffers::Int = -1, optimize = nothing, @nospecialize(kwargs...)
     )
+    # Thin, backwards-compatible keyword entry point: bundle the options into a single
+    # `BuildFunctionWrapperOptions` (computing the `sys`-dependent defaults here, where
+    # `sys`/`args` are in scope) and dispatch to the struct-based method below, whose body
+    # is compiled once regardless of the options. This shim is the one place that accepts
+    # loose code-generation keywords: `wrap_code` and `optimize` (which the struct-based
+    # method reads back out of `codegen`) together with any other keywords in `kwargs...`
+    # ride into a `CodegenFunctionOptions` (which drops any it does not recognize) passed
+    # via `codegen_function_options`.
+    opts = BuildFunctionWrapperOptions(;
+        p_start, p_end, compress_args, non_standard_param_layout, u_arg, wrap_delays,
+        histfn, histfn_symbolic, create_bindings, output_type, mkarray,
+        wrap_mtkparameters, extra_assignments, n_param_buffers,
+        codegen_function_options = Symbolics.CodegenFunctionOptions(; wrap_code, optimize, kwargs...)
+    )
+    return build_function_wrapper(sys, expr, args, opts)
+end
+
+"""
+    build_function_wrapper(sys::AbstractSystem, expr, args, opts::BuildFunctionWrapperOptions)
+
+A wrapper around `build_function` which performs the necessary transformations for
+code generation of all types of systems. `expr` is the expression returned from the
+generated functions, and `args` is the collection (tuple or vector) of arguments.
+
+Options are supplied as a [`BuildFunctionWrapperOptions`](@ref); see its docstring for the
+available options. This is the primary method — the keyword-argument form of
+`build_function_wrapper` is a backwards-compatibility shim that bundles its keywords into a
+`BuildFunctionWrapperOptions` and calls this method.
+"""
+Base.@nospecializeinfer function build_function_wrapper(
+        sys::AbstractSystem, @nospecialize(expr), @nospecialize(args),
+        opts::BuildFunctionWrapperOptions
+    )
+    (;
+        p_start, p_end, compress_args, non_standard_param_layout, u_arg, wrap_delays,
+        histfn_symbolic, create_bindings, output_type, mkarray, wrap_mtkparameters,
+        extra_assignments, n_param_buffers,
+    ) = opts
+    # Resolve the `sys`/`args`-dependent defaults (left as `nothing` when constructing the
+    # options without a `sys` in scope). `length(args)` here is the original argument count,
+    # before `wrap_delays` may insert the history-function argument below.
+    p_end = p_end === nothing ? (is_time_dependent(sys) ? length(args) - 1 : length(args)) : p_end
+    wrap_delays = wrap_delays === nothing ? is_dde(sys) : wrap_delays
+    # `-1` is the "unset" sentinel used below (`pbuf_end`). Direct callers may leave
+    # `n_param_buffers` as `nothing`; normalize it to the sentinel here.
+    n_param_buffers = n_param_buffers === nothing ? -1 : n_param_buffers
     isscalar = !(expr isa AbstractArray || symbolic_type(expr) == ArraySymbolic())
     args = Vector{Any}(collect(args))
     assignments = Assignment[]
@@ -614,26 +732,29 @@ Base.@nospecializeinfer function build_function_wrapper(
         append!(assignments, pref)
     end
 
-    wrap_code = wrap_code .∘ wrap_assignments(false, assignments)
+    wrap_code = opts.codegen.wrap_code .∘ wrap_assignments(false, assignments)
 
-    # handling of `output_type` and `mkarray`
-    similarto = nothing
+    # handling of `output_type` and `mkarray`. A `similarto` already present on
+    # `opts.codegen` (set directly via `codegen_function_options` by callers such as
+    # `generate_history`, bypassing the `output_type` wrapper option) takes precedence over
+    # the `output_type`-derived value, matching the pre-`BuildFunctionWrapperOptions`
+    # behaviour where such an explicit `similarto` was passed as a later keyword argument.
+    similarto = opts.codegen.similarto
     if output_type === Tuple
         expr = MakeTuple(Tuple(expr))
     elseif mkarray === nothing
-        similarto = output_type
+        similarto = similarto === nothing ? output_type : similarto
     else
         expr = mkarray(expr, output_type)
     end
 
-    optimize = resolve_optimize_option(optimize)
-    # Bundle the code-generation options into a single `Symbolics.CodegenFunctionOptions` rather than
-    # splatting them (and any stray forwarded keyword arguments) as `kwargs...`. Because
-    # `CodegenFunctionOptions` is one concrete type regardless of the option values, `codegen_function`
-    # only needs to be compiled once instead of once per distinct set of keyword arguments.
-    # Unknown keyword arguments are ignored by the `CodegenFunctionOptions` constructor, matching the
-    # previous behaviour where `codegen_function` silently dropped them.
-    codegen_options = Symbolics.CodegenFunctionOptions(; wrap_code, similarto, optimize, kwargs...)
+    optimize = resolve_optimize_option(opts.codegen.optimize)
+    # Write the wrapper-derived code-generation options (the composed `wrap_code`, the
+    # `output_type`-derived `similarto`, and the resolved `optimize`) into the nested
+    # `CodegenFunctionOptions`. `setproperties` overrides only these fields and preserves the
+    # rest (`nanmath`, `checkbounds`, `iip_config`, ...), so `codegen_function` still sees a
+    # single concrete `CodegenFunctionOptions` type and is compiled once.
+    codegen_options = setproperties(opts.codegen, (; wrap_code, similarto, optimize))
     return Symbolics.codegen_function(ir, expr, args, codegen_options)
 end
 

--- a/lib/ModelingToolkitBase/src/systems/problem_utils.jl
+++ b/lib/ModelingToolkitBase/src/systems/problem_utils.jl
@@ -2249,11 +2249,13 @@ function SymbolicTstops(
     tstops,
         _ = build_function_wrapper(
         sys, Symbolics.SConst(tstops),
-        rps...,
-        t0,
-        t1;
-        expression = Val{true},
-        p_start = 1, p_end = length(rps), force_SA = true
+        [rps; Any[t0, t1]],
+        BuildFunctionWrapperOptions(;
+            p_start = 1, p_end = length(rps),
+            codegen_function_options = Symbolics.CodegenFunctionOptions(;
+                expression = Val{true}, force_SA = true
+            )
+        )
     )
     tstops = GeneratedFunctionWrapper{(1, 3, is_split(sys))}(
         expression, tstops, nothing; eval_expression, eval_module


### PR DESCRIPTION
This ensures we don't repeatedly compile `build_function_wrapper` for different sets of kwargs that don't make a behavioral difference and/or don't need to be specialized on.