### PR TITLE
fix: allow scalarizing `instream_rt`

### DIFF
--- a/lib/ModelingToolkitBase/src/systems/connectors.jl
+++ b/lib/ModelingToolkitBase/src/systems/connectors.jl
@@ -1336,6 +1336,13 @@ function instream_rt(
         vars::Vararg{Any, N}
     ) where {inner_n, outer_n, N}
     @assert N == 2 * (inner_n + outer_n)
+    if any(Base.Fix2(isa, SymbolicT), vars)
+        # In case `instream_rt` goes through `scalarize`.
+        return BSImpl.Term{VartypeT}(
+            instream_rt, Symbolics.SArgsT((ins, outs, vars...));
+            type = Real, shape = SU.ShapeVecT()
+        )
+    end
 
     # inner: mj.c.m_flow
     # outer: ck.m_flow

--- a/lib/ModelingToolkitBase/test/stream_connectors.jl
+++ b/lib/ModelingToolkitBase/test/stream_connectors.jl
@@ -1,8 +1,10 @@
 using Test
 using ModelingToolkitBase
 using ModelingToolkitBase: t_nounits as t, D_nounits as D
+using Symbolics
 using OrdinaryDiffEq
 using SciMLBase
+import SymbolicUtils as SU
 
 @connector function TwoPhaseFluidPort(; name, P = 0.0, m_flow = 0.0, h_outflow = 0.0)
     pars = @parameters begin
@@ -715,4 +717,10 @@ end
         sol = solve(prob, Tsit5())
         @test SciMLBase.successful_retcode(sol)
     end
+end
+
+@testset "`instream_rt` can go through `scalarize`" begin
+    @variables x(t) y(t) a(t) b(t)
+    term = Symbolics.STerm(ModelingToolkitBase.instream_rt, [Val(1), Val(1), x, y, a, b]; type = Real, shape = UnitRange{Int}[])
+    @test isequal(term, SU.scalarize(term))
 end


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
