### PR TITLE
Add `deepcopy_internal method` for GeneratedFunctionWrappers

### DIFF
--- a/lib/ModelingToolkitBase/src/systems/codegen_utils.jl
+++ b/lib/ModelingToolkitBase/src/systems/codegen_utils.jl
@@ -781,6 +781,11 @@ function GeneratedFunctionWrapper{P}(foop::O, fiip::I) where {P, O, I}
     return GeneratedFunctionWrapper{P, O, I}(foop, fiip)
 end
 
+# The wrapped functions are stateless generated functions, so there is nothing to
+# deep-copy. Overriding this as the identity avoids `deepcopy` recursing into the
+# function internals, which improves `juliac` trimmability.
+Base.deepcopy_internal(gfw::GeneratedFunctionWrapper, ::IdDict) = gfw
+
 function GeneratedFunctionWrapper{P}(::Type{Val{true}}, foop, fiip; kwargs...) where {P}
     return :($(GeneratedFunctionWrapper{P})($foop, $fiip))
 end


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context
The wrapped functions are stateless, so there's nothing to deepcopy, so just return the input. This should preserve trimmability while still giving users the option to alias / not alias their functions using the aliasing interface. 