### PR TITLE
Fix workflow tag concurrency checks

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -13,7 +13,7 @@ concurrency:
   # Skip intermediate builds: always, but for the master branch.
   # Cancel intermediate builds: always, but for the master branch.
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/master' && github.refs != 'refs/tags/*'}}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' && github.ref_type != 'tag' }}
 
 jobs:
   build:

--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -12,7 +12,7 @@ concurrency:
   # Skip intermediate builds: always, but for the master branch and tags.
   # Cancel intermediate builds: always, but for the master branch and tags.
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/master' && github.refs != 'refs/tags/*' }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' && github.ref_type != 'tag' }}
 
 jobs:
   test:

--- a/.github/workflows/ReleaseTest.yml
+++ b/.github/workflows/ReleaseTest.yml
@@ -12,7 +12,7 @@ concurrency:
   # Skip intermediate builds: always, but for the master branch and tags.
   # Cancel intermediate builds: always, but for the master branch and tags.
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/master' && github.refs != 'refs/tags/*' }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' && github.ref_type != 'tag' }}
 
 jobs:
   test:


### PR DESCRIPTION
Ignore this PR until reviewed by @ChrisRackauckas.

## Summary

- replace invalid github.refs references in Downstream, Documentation, and ReleaseTest workflows
- use github.ref_type to keep master and tag runs exempt from cancellation as documented

## Root cause

Clean-master reproduction with actionlint reports that github.refs is undefined. A focused git bisect identified 80f44bca96a18310bce2678c02176e641fe04ad4 as the first commit introducing the Downstream typo. A literal github.ref comparison against refs/tags/* would not implement wildcard matching, so the corrected condition checks ref_type instead.

## Validation

- actionlint -color .github/workflows/Downstream.yml
- actionlint -color .github/workflows/Downstream.yml .github/workflows/Documentation.yml .github/workflows/ReleaseTest.yml
- Julia Runic --check over the repository

All commands exited successfully locally on Julia 1.12.6.