### PR TITLE
Propagate integration resolver failures

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -13,7 +13,7 @@ concurrency:
   # Skip intermediate builds: always, but for the master branch.
   # Cancel intermediate builds: always, but for the master branch.
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/master' && github.refs != 'refs/tags/*'}}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' && github.ref_type != 'tag' }}
 
 jobs:
   build:

--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -12,7 +12,7 @@ concurrency:
   # Skip intermediate builds: always, but for the master branch and tags.
   # Cancel intermediate builds: always, but for the master branch and tags.
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/master' && github.refs != 'refs/tags/*' }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' && github.ref_type != 'tag' }}
 
 jobs:
   test:

--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -63,27 +63,17 @@ jobs:
         shell: julia --color=yes --project=downstream {0}
         run: |
           using Pkg
-          try
-            # force it to use this PR's version of the package
-            Pkg.develop(PackageSpec(path="./lib/ModelingToolkitBase"))  # resolver may fail with main deps
-            Pkg.develop(PackageSpec(path="."))  # resolver may fail with main deps
-            subpkg = "${{ matrix.package.subpkg }}"
-            if subpkg != ""
-              Pkg.develop(PackageSpec(path=joinpath("./downstream/lib", subpkg)))
-            end
-            Pkg.update()
-            if subpkg != ""
-              Pkg.test(subpkg)
-            else
-              Pkg.test(coverage=true)  # resolver may fail with test time deps
-            end
-          catch err
-            err isa Pkg.Resolve.ResolverError || rethrow()
-            # If we can't resolve that means this is incompatible by SemVer and this is fine
-            # It means we marked this as a breaking change, so we don't need to worry about
-            # Mistakenly introducing a breaking change, as we have intentionally made one
-            @info "Not compatible with this release. No problem." exception=err
-            exit(0)  # Exit immediately, as a success
+          Pkg.develop(PackageSpec(path="./lib/ModelingToolkitBase"))
+          Pkg.develop(PackageSpec(path="."))
+          subpkg = "${{ matrix.package.subpkg }}"
+          if subpkg != ""
+            Pkg.develop(PackageSpec(path=joinpath("./downstream/lib", subpkg)))
+          end
+          Pkg.update()
+          if subpkg != ""
+            Pkg.test(subpkg)
+          else
+            Pkg.test(coverage=true)
           end
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v7

--- a/.github/workflows/ReleaseTest.yml
+++ b/.github/workflows/ReleaseTest.yml
@@ -44,21 +44,11 @@ jobs:
         shell: julia --color=yes --project=downstream {0}
         run: |
           using Pkg
-          try
-            Pkg.activate("downstream")
-            # force it to use this PR's version of the package
-            Pkg.develop(PackageSpec(path="."))  # resolver may fail with main deps
-            Pkg.add("${{ matrix.package.package }}")
-            Pkg.update()
-            Pkg.test("${{ matrix.package.package }}"; coverage=true)  # resolver may fail with test time deps
-          catch err
-            err isa Pkg.Resolve.ResolverError || rethrow()
-            # If we can't resolve that means this is incompatible by SemVer and this is fine
-            # It means we marked this as a breaking change, so we don't need to worry about
-            # Mistakenly introducing a breaking change, as we have intentionally made one
-            @info "Not compatible with this release. No problem." exception=err
-            exit(0)  # Exit immediately, as a success
-          end
+          Pkg.activate("downstream")
+          Pkg.develop(PackageSpec(path="."))
+          Pkg.add("${{ matrix.package.package }}")
+          Pkg.update()
+          Pkg.test("${{ matrix.package.package }}"; coverage=true)
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v7
         with:

--- a/.github/workflows/ReleaseTest.yml
+++ b/.github/workflows/ReleaseTest.yml
@@ -12,7 +12,7 @@ concurrency:
   # Skip intermediate builds: always, but for the master branch and tags.
   # Cancel intermediate builds: always, but for the master branch and tags.
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/master' && github.refs != 'refs/tags/*' }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' && github.ref_type != 'tag' }}
 
 jobs:
   test:


### PR DESCRIPTION
## Summary

- remove the `ResolverError` catches that converted incompatible environments into green jobs in both Downstream and ReleaseTest
- let dependency-resolution and selected-test failures propagate normally
- preserve the existing source-development, subpackage, update, and test behavior

This is stacked on #4755; review #4755 first. The branch was rebased onto current `upstream/master` before publishing.

## Local verification

- exact workflow-shaped `Catalyst/Modeling` run with current ModelingToolkit and ModelingToolkitBase developed reached substantive tests and exited 1 on the already-triaged `parent_sys` failure addressed by Catalyst#1509
- exact workflow-shaped `ModelingToolkitStandardLibrary/Core` run likewise reached substantive tests and exposed the existing failure addressed by MTSL#489
- `actionlint .github/workflows/Downstream.yml .github/workflows/ReleaseTest.yml` — passed
- `julia +1.12 -m Runic --check .` — passed
- `git diff upstream/master...HEAD --check` — passed

Those test failures were already rethrown by the old handler. This PR specifically changes resolver incompatibilities from successful exits to visible job failures and intentionally does not hide legitimate downstream failures.

Please ignore this PR until it has been reviewed by @ChrisRackauckas.