### PR TITLE
Fix stale downstream test groups

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -13,7 +13,7 @@ concurrency:
   # Skip intermediate builds: always, but for the master branch.
   # Cancel intermediate builds: always, but for the master branch.
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/master' && github.refs != 'refs/tags/*'}}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' && github.ref_type != 'tag' }}
 
 jobs:
   build:

--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -12,7 +12,7 @@ concurrency:
   # Skip intermediate builds: always, but for the master branch and tags.
   # Cancel intermediate builds: always, but for the master branch and tags.
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/master' && github.refs != 'refs/tags/*' }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' && github.ref_type != 'tag' }}
 
 jobs:
   test:

--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -63,27 +63,17 @@ jobs:
         shell: julia --color=yes --project=downstream {0}
         run: |
           using Pkg
-          try
-            # force it to use this PR's version of the package
-            Pkg.develop(PackageSpec(path="./lib/ModelingToolkitBase"))  # resolver may fail with main deps
-            Pkg.develop(PackageSpec(path="."))  # resolver may fail with main deps
-            subpkg = "${{ matrix.package.subpkg }}"
-            if subpkg != ""
-              Pkg.develop(PackageSpec(path=joinpath("./downstream/lib", subpkg)))
-            end
-            Pkg.update()
-            if subpkg != ""
-              Pkg.test(subpkg)
-            else
-              Pkg.test(coverage=true)  # resolver may fail with test time deps
-            end
-          catch err
-            err isa Pkg.Resolve.ResolverError || rethrow()
-            # If we can't resolve that means this is incompatible by SemVer and this is fine
-            # It means we marked this as a breaking change, so we don't need to worry about
-            # Mistakenly introducing a breaking change, as we have intentionally made one
-            @info "Not compatible with this release. No problem." exception=err
-            exit(0)  # Exit immediately, as a success
+          Pkg.develop(PackageSpec(path="./lib/ModelingToolkitBase"))
+          Pkg.develop(PackageSpec(path="."))
+          subpkg = "${{ matrix.package.subpkg }}"
+          if subpkg != ""
+            Pkg.develop(PackageSpec(path=joinpath("./downstream/lib", subpkg)))
+          end
+          Pkg.update()
+          if subpkg != ""
+            Pkg.test(subpkg)
+          else
+            Pkg.test(coverage=true)
           end
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v7

--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -37,11 +37,12 @@ jobs:
           - {user: SciML, repo: SBMLToolkit.jl, group: All, subpkg: ""}
           - {user: SciML, repo: NeuralPDE.jl, group: NNPDE1, subpkg: ""}
           - {user: SciML, repo: NeuralPDE.jl, group: NNPDE2, subpkg: ""}
-          - {user: SciML, repo: DataDrivenDiffEq.jl, group: Downstream, subpkg: ""}
+          - {user: SciML, repo: DataDrivenDiffEq.jl, group: Core, subpkg: ""}
           - {user: SciML, repo: StructuralIdentifiability.jl, group: Core, subpkg: ""}
           - {user: SciML, repo: ModelingToolkitStandardLibrary.jl, group: Core, subpkg: ""}
           - {user: SciML, repo: ModelOrderReduction.jl, group: Core, subpkg: ""}
-          - {user: SciML, repo: MethodOfLines.jl, group: Interface, subpkg: ""}
+          - {user: SciML, repo: MethodOfLines.jl, group: MOL_Interface1, subpkg: ""}
+          - {user: SciML, repo: MethodOfLines.jl, group: MOL_Interface2, subpkg: ""}
           - {user: SciML, repo: MethodOfLines.jl, group: 2D_Diffusion, subpkg: ""}
           - {user: SciML, repo: MethodOfLines.jl, group: DAE, subpkg: ""}
           - {user: SciML, repo: ModelingToolkitNeuralNets.jl, group: Core, subpkg: ""}

--- a/.github/workflows/ReleaseTest.yml
+++ b/.github/workflows/ReleaseTest.yml
@@ -44,21 +44,11 @@ jobs:
         shell: julia --color=yes --project=downstream {0}
         run: |
           using Pkg
-          try
-            Pkg.activate("downstream")
-            # force it to use this PR's version of the package
-            Pkg.develop(PackageSpec(path="."))  # resolver may fail with main deps
-            Pkg.add("${{ matrix.package.package }}")
-            Pkg.update()
-            Pkg.test("${{ matrix.package.package }}"; coverage=true)  # resolver may fail with test time deps
-          catch err
-            err isa Pkg.Resolve.ResolverError || rethrow()
-            # If we can't resolve that means this is incompatible by SemVer and this is fine
-            # It means we marked this as a breaking change, so we don't need to worry about
-            # Mistakenly introducing a breaking change, as we have intentionally made one
-            @info "Not compatible with this release. No problem." exception=err
-            exit(0)  # Exit immediately, as a success
-          end
+          Pkg.activate("downstream")
+          Pkg.develop(PackageSpec(path="."))
+          Pkg.add("${{ matrix.package.package }}")
+          Pkg.update()
+          Pkg.test("${{ matrix.package.package }}"; coverage=true)
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v7
         with:

--- a/.github/workflows/ReleaseTest.yml
+++ b/.github/workflows/ReleaseTest.yml
@@ -12,7 +12,7 @@ concurrency:
   # Skip intermediate builds: always, but for the master branch and tags.
   # Cancel intermediate builds: always, but for the master branch and tags.
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/master' && github.refs != 'refs/tags/*' }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' && github.ref_type != 'tag' }}
 
 jobs:
   test:


### PR DESCRIPTION
## Summary

- select DataDrivenDiffEq's existing `Core` group instead of the nonexistent `Downstream` group
- replace MethodOfLines' nonexistent `Interface` group with its two current interface lanes, `MOL_Interface1` and `MOL_Interface2`

This is stacked on #4759 so the downstream workflow also propagates resolver and test failures. The extra #4755/#4759 commits will disappear from this diff as those prerequisites merge.

Ignore this PR until reviewed by @ChrisRackauckas.

## Local verification

Each corrected target was run with this ModelingToolkit branch developed into the downstream package:

- `DataDrivenDiffEq/Core`: passed; substantive Basis, DataDrivenProblem, DataDrivenSolution, Utilities, and CommonSolve summaries
- `MethodOfLines/MOL_Interface1`: passed after 18m58s; the lane executes its PDE construction and solve smoke cases but contains no explicit `@test` assertions
- `MethodOfLines/MOL_Interface2`: passed after 11m51s; 4 passed and 8 pre-existing broken assertions

Final stacked branch checks:

- `actionlint -color`
- `/home/crackauc/.juliaup/bin/julialauncher +1.12 --startup-file=no -m Runic --check .`
- `git diff --check agent/propagate-workflow-failures..HEAD`