### PR TITLE
feat: Introduce `GeneratedFunctionOptions` for the code-generation entry points

### DIFF
--- a/lib/ModelingToolkitBase/src/ModelingToolkitBase.jl
+++ b/lib/ModelingToolkitBase/src/ModelingToolkitBase.jl
@@ -195,6 +195,7 @@ include("systems/ir_info.jl")
 include("systems/codegen_utils.jl")
 include("problems/docs.jl")
 include("systems/codegen.jl")
+include("systems/codegen_compat.jl")
 include("systems/problem_utils.jl")
 # Operator + lowering layer; must load before the problem constructors that
 # consume it (problems/nonlinearproblem.jl selector + problems/homotopyproblem.jl).

--- a/lib/ModelingToolkitBase/src/ModelingToolkitBase.jl
+++ b/lib/ModelingToolkitBase/src/ModelingToolkitBase.jl
@@ -185,6 +185,11 @@ include("utils.jl")
 include("systems/index_cache.jl")
 include("systems/parameter_buffer.jl")
 include("systems/abstractsystem.jl")
+# codegen_utils.jl defines the codegen option structs (GeneratedFunctionOptions,
+# BuildFunctionWrapperOptions, CompilerOptions). It must precede any file whose method
+# *signatures* annotate those types (e.g. the `opts::GeneratedFunctionOptions` positional
+# in callbacks.jl), since signature type annotations are resolved at definition time.
+include("systems/codegen_utils.jl")
 include("systems/connectiongraph.jl")
 include("systems/connectors.jl")
 include("systems/imperative_affect.jl")
@@ -192,7 +197,6 @@ include("systems/callbacks.jl")
 include("systems/system.jl")
 include("systems/analysis_points.jl")
 include("systems/ir_info.jl")
-include("systems/codegen_utils.jl")
 include("problems/docs.jl")
 include("systems/codegen.jl")
 include("systems/codegen_compat.jl")

--- a/lib/ModelingToolkitBase/src/inputoutput.jl
+++ b/lib/ModelingToolkitBase/src/inputoutput.jl
@@ -239,17 +239,14 @@ f[1](x, inputs, p, t)
 ```
 """
 function generate_control_function(
-        sys::AbstractSystem, inputs = default_codegen_inputs(sys),
-        disturbance_inputs = disturbances(sys);
+        sys::AbstractSystem, inputs, disturbance_inputs, opts::GeneratedFunctionOptions;
         known_disturbance_inputs = nothing,
         disturbance_argument = false,
         implicit_dae = false,
         simplify = false,
-        eval_expression = false,
-        eval_module = @__MODULE__,
-        split = true,
-        kwargs...
+        split = true
     )
+    (; eval_expression, eval_module) = opts
     isempty(inputs) && @warn("No unbound inputs were found in system.")
 
     # Handle backward compatibility for disturbance_argument
@@ -333,7 +330,7 @@ function generate_control_function(
         sys, rhss, collect(Any, args), BuildFunctionWrapperOptions(;
             u_arg = 1 + Int(implicit_dae), p_start = 3 + implicit_dae,
             p_end = length(p) + 2 + implicit_dae,
-            codegen_function_options = Symbolics.CodegenFunctionOptions(; kwargs...)
+            codegen_function_options = opts.codegen
         )
     )
     f = eval_or_rgf.(f; eval_expression, eval_module)

--- a/lib/ModelingToolkitBase/src/problems/bvproblem.jl
+++ b/lib/ModelingToolkitBase/src/problems/bvproblem.jl
@@ -24,16 +24,22 @@
     )
 
     fcost = generate_bvp_cost(
-        sys; expression = Val{false}, wrap_gfw = Val{false},
-        eval_expression, eval_module, checkbounds
+        sys,
+        GeneratedFunctionOptions(;
+            expression = Val{false}, wrap_gfw = Val{false}, eval_expression, eval_module,
+            codegen_function_options = Symbolics.CodegenFunctionOptions(; checkbounds)
+        )
     )
 
     stidxmap = Dict([v => i for (i, v) in enumerate(dvs)])
     u0_idxs = has_alg_eqs(sys) ? collect(1:length(dvs)) :
         [stidxmap[k] for (k, v) in op if haskey(stidxmap, k)]
     fbc = generate_boundary_conditions(
-        sys, u0, u0_idxs, tspan[1]; expression = Val{false},
-        wrap_gfw = Val{true}, checkbounds
+        sys, u0, u0_idxs, tspan[1],
+        GeneratedFunctionOptions(;
+            expression = Val{false}, wrap_gfw = Val{true},
+            codegen_function_options = Symbolics.CodegenFunctionOptions(; checkbounds)
+        )
     )
 
     n_controls = length(default_codegen_inputs(sys))

--- a/lib/ModelingToolkitBase/src/problems/daeproblem.jl
+++ b/lib/ModelingToolkitBase/src/problems/daeproblem.jl
@@ -8,11 +8,13 @@
     check_complete(sys, DAEFunction)
     check_compatibility && check_compatible_system(DAEFunction, sys)
 
-    f = generate_rhs(
-        sys; expression, wrap_gfw = Val{true},
-        implicit_dae = true, eval_expression, eval_module, checkbounds = checkbounds,
-        kwargs...
+    codegen_opts = GeneratedFunctionOptions(;
+        expression, wrap_gfw = Val{true}, eval_expression, eval_module,
+        compiler_options = get(kwargs, :compiler_options, CompilerOptions()),
+        codegen_function_options = Symbolics.CodegenFunctionOptions(; checkbounds, kwargs...)
     )
+
+    f = generate_rhs(sys, codegen_opts; implicit_dae = true)
 
     if spec === SciMLBase.FunctionWrapperSpecialize && iip
         if u0 === nothing || p === nothing || t === nothing
@@ -26,11 +28,7 @@
     end
 
     if jac
-        _jac = generate_dae_jacobian(
-            sys; expression,
-            wrap_gfw = Val{true}, simplify, sparse, eval_expression, eval_module,
-            checkbounds, kwargs...
-        )
+        _jac = generate_dae_jacobian(sys, codegen_opts; simplify, sparse)
     else
         _jac = nothing
     end

--- a/lib/ModelingToolkitBase/src/problems/ddeproblem.jl
+++ b/lib/ModelingToolkitBase/src/problems/ddeproblem.jl
@@ -7,11 +7,13 @@
     check_complete(sys, DDEFunction)
     check_compatibility && check_compatible_system(DDEFunction, sys)
 
-    f = generate_rhs(
-        sys; expression, wrap_gfw = Val{true},
-        eval_expression, eval_module, checkbounds = checkbounds,
-        kwargs...
+    codegen_opts = GeneratedFunctionOptions(;
+        expression, wrap_gfw = Val{true}, eval_expression, eval_module,
+        compiler_options = get(kwargs, :compiler_options, CompilerOptions()),
+        codegen_function_options = Symbolics.CodegenFunctionOptions(; checkbounds, kwargs...)
     )
+
+    f = generate_rhs(sys, codegen_opts)
 
     if spec === SciMLBase.FunctionWrapperSpecialize && iip
         if u0 === nothing || p === nothing || t === nothing
@@ -62,8 +64,11 @@ end
     )
 
     h = generate_history(
-        sys, u0; expression, wrap_gfw = Val{true}, eval_expression, eval_module,
-        checkbounds
+        sys, u0,
+        GeneratedFunctionOptions(;
+            expression, wrap_gfw = Val{true}, eval_expression, eval_module,
+            codegen_function_options = Symbolics.CodegenFunctionOptions(; checkbounds)
+        )
     )
 
     if expression == Val{true}

--- a/lib/ModelingToolkitBase/src/problems/discreteproblem.jl
+++ b/lib/ModelingToolkitBase/src/problems/discreteproblem.jl
@@ -8,11 +8,13 @@
     check_complete(sys, DiscreteFunction)
     check_compatibility && check_compatible_system(DiscreteFunction, sys)
 
-    f = generate_rhs(
-        sys; expression, wrap_gfw = Val{true},
-        eval_expression, eval_module, checkbounds = checkbounds,
-        kwargs...
+    codegen_opts = GeneratedFunctionOptions(;
+        expression, wrap_gfw = Val{true}, eval_expression, eval_module,
+        compiler_options = get(kwargs, :compiler_options, CompilerOptions()),
+        codegen_function_options = Symbolics.CodegenFunctionOptions(; checkbounds, kwargs...)
     )
+
+    f = generate_rhs(sys, codegen_opts)
 
     if spec === SciMLBase.FunctionWrapperSpecialize && iip
         if u0 === nothing || p === nothing || t === nothing

--- a/lib/ModelingToolkitBase/src/problems/implicitdiscreteproblem.jl
+++ b/lib/ModelingToolkitBase/src/problems/implicitdiscreteproblem.jl
@@ -11,11 +11,13 @@
 
     iv = get_iv(sys)
     dvs = unknowns(sys)
-    f = generate_rhs(
-        sys; expression, wrap_gfw = Val{true},
-        implicit_dae = true, eval_expression, eval_module, checkbounds = checkbounds,
-        override_discrete = true, kwargs...
+    codegen_opts = GeneratedFunctionOptions(;
+        expression, wrap_gfw = Val{true}, eval_expression, eval_module,
+        compiler_options = get(kwargs, :compiler_options, CompilerOptions()),
+        codegen_function_options = Symbolics.CodegenFunctionOptions(; checkbounds, kwargs...)
     )
+
+    f = generate_rhs(sys, codegen_opts; implicit_dae = true, override_discrete = true)
 
     if spec === SciMLBase.FunctionWrapperSpecialize && iip
         if u0 === nothing || p === nothing || t === nothing

--- a/lib/ModelingToolkitBase/src/problems/intervalnonlinearproblem.jl
+++ b/lib/ModelingToolkitBase/src/problems/intervalnonlinearproblem.jl
@@ -7,10 +7,13 @@ function SciMLBase.IntervalNonlinearFunction(
     check_complete(sys, IntervalNonlinearFunction)
     check_compatibility && check_compatible_system(IntervalNonlinearFunction, sys)
 
-    f = generate_rhs(
-        sys; expression, wrap_gfw = Val{true},
-        scalar = true, eval_expression, eval_module, checkbounds, kwargs...
+    codegen_opts = GeneratedFunctionOptions(;
+        expression, wrap_gfw = Val{true}, eval_expression, eval_module,
+        compiler_options = get(kwargs, :compiler_options, CompilerOptions()),
+        codegen_function_options = Symbolics.CodegenFunctionOptions(; checkbounds, kwargs...)
     )
+
+    f = generate_rhs(sys, codegen_opts; scalar = true)
 
     observedfun = ObservedFunctionCache(
         sys; steady_state = false, expression, eval_expression, eval_module, checkbounds

--- a/lib/ModelingToolkitBase/src/problems/jumpproblem.jl
+++ b/lib/ModelingToolkitBase/src/problems/jumpproblem.jl
@@ -69,7 +69,9 @@
     # Create SymbolicTstops for all paths and forward via JumpProblem kwargs.
     # Inner problems (SDEProblem/ODEProblem) are created with _skip_tstops = true
     # to avoid duplication.
-    tstops = SymbolicTstops(sys; eval_expression, eval_module)
+    tstops = SymbolicTstops(
+        sys, GeneratedFunctionOptions(; expression = Val{false}, eval_expression, eval_module)
+    )
 
     dvs = unknowns(sys)
     unknowntoid = Dict(value(unknown) => i for (i, unknown) in enumerate(dvs))

--- a/lib/ModelingToolkitBase/src/problems/linearproblem.jl
+++ b/lib/ModelingToolkitBase/src/problems/linearproblem.jl
@@ -37,14 +37,17 @@ function LinearFunction{iip}(
             BandedMatrix{SymbolicT, Matrix{SymbolicT}}(A, (lower_band_size, upper_band_size))
         end
     end
-    update_A = generate_update_A(
-        sys, A; expression, wrap_gfw = Val{true}, eval_expression,
-        eval_module, checkbounds, kwargs...
+    # `cachesyms` is a structural kwarg of the update generators (not a codegen option);
+    # in the SCC path it arrives via `kwargs`, so extract it rather than funnelling it
+    # into the codegen options where it would be dropped.
+    cachesyms = get(kwargs, :cachesyms, ())
+    codegen_opts = GeneratedFunctionOptions(;
+        expression, wrap_gfw = Val{true}, eval_expression, eval_module,
+        compiler_options = get(kwargs, :compiler_options, CompilerOptions()),
+        codegen_function_options = Symbolics.CodegenFunctionOptions(; checkbounds, kwargs...)
     )
-    update_b = generate_update_b(
-        sys, b; expression, wrap_gfw = Val{true}, eval_expression,
-        eval_module, checkbounds, kwargs...
-    )
+    update_A = generate_update_A(sys, A, codegen_opts; cachesyms)
+    update_b = generate_update_b(sys, b, codegen_opts; cachesyms)
     observedfun = ObservedFunctionCache(
         sys; steady_state = false, expression, eval_expression, eval_module, checkbounds
     )
@@ -239,10 +242,14 @@ function get_A_b_from_LinearFunction(
     (; A, b, interface) = f
     if expression == Val{true}
         get_A = build_explicit_observed_function(
-            sys, A; param_only = true, eval_expression, eval_module
+            sys, A,
+            GeneratedFunctionOptions(; expression = Val{false}, eval_expression, eval_module);
+            param_only = true
         )
         get_b = build_explicit_observed_function(
-            sys, b; param_only = true, eval_expression, eval_module
+            sys, b,
+            GeneratedFunctionOptions(; expression = Val{false}, eval_expression, eval_module);
+            param_only = true
         )
         A = u0_constructor(u0_eltype.(get_A(p)))
         b = u0_constructor(u0_eltype.(get_b(p)))

--- a/lib/ModelingToolkitBase/src/problems/nonlinearproblem.jl
+++ b/lib/ModelingToolkitBase/src/problems/nonlinearproblem.jl
@@ -9,11 +9,13 @@
     check_complete(sys, NonlinearFunction)
     check_compatibility && check_compatible_system(NonlinearFunction, sys)
 
-    f = generate_rhs(
-        sys; expression, wrap_gfw = Val{true},
-        eval_expression, eval_module, checkbounds = checkbounds,
-        kwargs...
+    codegen_opts = GeneratedFunctionOptions(;
+        expression, wrap_gfw = Val{true}, eval_expression, eval_module,
+        compiler_options = get(kwargs, :compiler_options, CompilerOptions()),
+        codegen_function_options = Symbolics.CodegenFunctionOptions(; checkbounds, kwargs...)
     )
+
+    f = generate_rhs(sys, codegen_opts)
 
     if spec === SciMLBase.FunctionWrapperSpecialize && iip
         if u0 === nothing || p === nothing
@@ -27,11 +29,7 @@
     end
 
     if jac
-        _jac = generate_jacobian(
-            sys; expression,
-            wrap_gfw = Val{true}, simplify, sparse, eval_expression, eval_module,
-            checkbounds, kwargs...
-        )
+        _jac = generate_jacobian(sys, codegen_opts; simplify, sparse)
     else
         _jac = nothing
     end

--- a/lib/ModelingToolkitBase/src/problems/odeproblem.jl
+++ b/lib/ModelingToolkitBase/src/problems/odeproblem.jl
@@ -29,11 +29,15 @@ Base.@nospecializeinfer @fallback_iip_specialize function SciMLBase.ODEFunction{
     check_complete(sys, ODEFunction)
     check_compatibility && check_compatible_system(ODEFunction, sys)
 
-    f = generate_rhs(
-        sys; expression, wrap_gfw = Val{true},
-        eval_expression, eval_module, checkbounds = checkbounds,
-        optimize, kwargs...
+    codegen_opts = GeneratedFunctionOptions(;
+        expression, wrap_gfw = Val{true}, eval_expression, eval_module,
+        compiler_options = get(kwargs, :compiler_options, CompilerOptions()),
+        codegen_function_options = Symbolics.CodegenFunctionOptions(;
+            checkbounds, optimize, kwargs...
+        )
     )
+
+    f = generate_rhs(sys, codegen_opts)
 
     if spec === SciMLBase.FunctionWrapperSpecialize && iip
         if u0 === nothing || p === nothing || t === nothing
@@ -47,20 +51,13 @@ Base.@nospecializeinfer @fallback_iip_specialize function SciMLBase.ODEFunction{
     end
 
     if tgrad
-        _tgrad = generate_tgrad(
-            sys; expression, wrap_gfw = Val{true},
-            simplify, eval_expression, eval_module, checkbounds, optimize, kwargs...
-        )
+        _tgrad = generate_tgrad(sys, codegen_opts; simplify)
     else
         _tgrad = nothing
     end
 
     if jac
-        _jac = generate_jacobian(
-            sys; expression, wrap_gfw = Val{true},
-            simplify, sparse, eval_expression, eval_module, checkbounds, optimize,
-            kwargs...
-        )
+        _jac = generate_jacobian(sys, codegen_opts; simplify, sparse)
     else
         _jac = nothing
     end

--- a/lib/ModelingToolkitBase/src/problems/optimizationproblem.jl
+++ b/lib/ModelingToolkitBase/src/problems/optimizationproblem.jl
@@ -15,25 +15,23 @@ function SciMLBase.OptimizationFunction{iip}(
 
     cstr = constraints(sys)
 
-    f = generate_cost(
-        sys; expression, wrap_gfw = Val{true}, eval_expression,
-        eval_module, checkbounds, kwargs...
+    codegen_opts = GeneratedFunctionOptions(;
+        expression, wrap_gfw = Val{true}, eval_expression, eval_module,
+        compiler_options = get(kwargs, :compiler_options, CompilerOptions()),
+        codegen_function_options = Symbolics.CodegenFunctionOptions(; checkbounds, kwargs...)
     )
 
+    f = generate_cost(sys, codegen_opts)
+
     if grad
-        _grad = generate_cost_gradient(
-            sys; expression, wrap_gfw = Val{true},
-            eval_expression, eval_module, checkbounds, kwargs...
-        )
+        _grad = generate_cost_gradient(sys, codegen_opts)
     else
         _grad = nothing
     end
     if hess
         _hess,
             hess_prototype = generate_cost_hessian(
-            sys; expression, wrap_gfw = Val{true}, eval_expression,
-            eval_module, checkbounds, sparse, simplify, return_sparsity = true,
-            kwargs...
+            sys, codegen_opts; sparse, simplify, return_sparsity = true
         )
     else
         _hess = hess_prototype = nothing
@@ -45,16 +43,11 @@ function SciMLBase.OptimizationFunction{iip}(
         cons = _cons_j = cons_jac_prototype = _cons_h = nothing
         cons_hess_prototype = cons_expr = nothing
     else
-        cons = generate_cons(
-            sys; expression, wrap_gfw = Val{true},
-            eval_expression, eval_module, checkbounds, kwargs...
-        )
+        cons = generate_cons(sys, codegen_opts)
         if cons_j
             _cons_j,
                 cons_jac_prototype = generate_constraint_jacobian(
-                sys; expression, wrap_gfw = Val{true}, eval_expression,
-                eval_module, checkbounds, simplify, sparse = cons_sparse,
-                return_sparsity = true, kwargs...
+                sys, codegen_opts; simplify, sparse = cons_sparse, return_sparsity = true
             )
         else
             _cons_j = cons_jac_prototype = nothing
@@ -62,9 +55,7 @@ function SciMLBase.OptimizationFunction{iip}(
         if cons_h
             _cons_h,
                 cons_hess_prototype = generate_constraint_hessian(
-                sys; expression, wrap_gfw = Val{true}, eval_expression,
-                eval_module, checkbounds, simplify, sparse = cons_sparse,
-                return_sparsity = true, kwargs...
+                sys, codegen_opts; simplify, sparse = cons_sparse, return_sparsity = true
             )
         else
             _cons_h = cons_hess_prototype = nothing

--- a/lib/ModelingToolkitBase/src/problems/sddeproblem.jl
+++ b/lib/ModelingToolkitBase/src/problems/sddeproblem.jl
@@ -7,14 +7,14 @@
     check_complete(sys, SDDEFunction)
     check_compatibility && check_compatible_system(SDDEFunction, sys)
 
-    f = generate_rhs(
-        sys; expression, wrap_gfw = Val{true},
-        eval_expression, eval_module, checkbounds = checkbounds, kwargs...
+    codegen_opts = GeneratedFunctionOptions(;
+        expression, wrap_gfw = Val{true}, eval_expression, eval_module,
+        compiler_options = get(kwargs, :compiler_options, CompilerOptions()),
+        codegen_function_options = Symbolics.CodegenFunctionOptions(; checkbounds, kwargs...)
     )
-    g = generate_diffusion_function(
-        sys; expression,
-        wrap_gfw = Val{true}, eval_expression, eval_module, checkbounds, kwargs...
-    )
+
+    f = generate_rhs(sys, codegen_opts)
+    g = generate_diffusion_function(sys, codegen_opts)
 
     if spec === SciMLBase.FunctionWrapperSpecialize && iip
         if u0 === nothing || p === nothing || t === nothing
@@ -66,8 +66,11 @@ end
     )
 
     h = generate_history(
-        sys, u0; expression, wrap_gfw = Val{true}, eval_expression, eval_module,
-        checkbounds
+        sys, u0,
+        GeneratedFunctionOptions(;
+            expression, wrap_gfw = Val{true}, eval_expression, eval_module,
+            codegen_function_options = Symbolics.CodegenFunctionOptions(; checkbounds)
+        )
     )
 
     if expression == Val{true}

--- a/lib/ModelingToolkitBase/src/problems/sdeproblem.jl
+++ b/lib/ModelingToolkitBase/src/problems/sdeproblem.jl
@@ -8,15 +8,14 @@
     check_complete(sys, SDEFunction)
     check_compatibility && check_compatible_system(SDEFunction, sys)
 
-    f = generate_rhs(
-        sys; expression, wrap_gfw = Val{true},
-        eval_expression, eval_module, checkbounds = checkbounds,
-        kwargs...
+    codegen_opts = GeneratedFunctionOptions(;
+        expression, wrap_gfw = Val{true}, eval_expression, eval_module,
+        compiler_options = get(kwargs, :compiler_options, CompilerOptions()),
+        codegen_function_options = Symbolics.CodegenFunctionOptions(; checkbounds, kwargs...)
     )
-    g = generate_diffusion_function(
-        sys; expression,
-        wrap_gfw = Val{true}, eval_expression, eval_module, checkbounds, kwargs...
-    )
+
+    f = generate_rhs(sys, codegen_opts)
+    g = generate_diffusion_function(sys, codegen_opts)
 
     if spec === SciMLBase.FunctionWrapperSpecialize && iip
         if u0 === nothing || p === nothing || t === nothing
@@ -30,21 +29,13 @@
     end
 
     if tgrad
-        _tgrad = generate_tgrad(
-            sys; expression,
-            wrap_gfw = Val{true}, simplify, eval_expression, eval_module, checkbounds,
-            kwargs...
-        )
+        _tgrad = generate_tgrad(sys, codegen_opts; simplify)
     else
         _tgrad = nothing
     end
 
     if jac
-        _jac = generate_jacobian(
-            sys; expression,
-            wrap_gfw = Val{true}, simplify, sparse, eval_expression, eval_module,
-            checkbounds, kwargs...
-        )
+        _jac = generate_jacobian(sys, codegen_opts; simplify, sparse)
     else
         _jac = nothing
     end

--- a/lib/ModelingToolkitBase/src/systems/abstractsystem.jl
+++ b/lib/ModelingToolkitBase/src/systems/abstractsystem.jl
@@ -8,67 +8,6 @@ end
 
 GUIMetadata(type) = GUIMetadata(type, nothing)
 
-"""
-```julia
-generate_custom_function(sys::AbstractSystem, exprs, dvs = unknowns(sys),
-                         ps = parameters(sys); kwargs...)
-```
-
-Generate a function to evaluate `exprs`. `exprs` is a symbolic expression or
-array of symbolic expression involving symbolic variables in `sys`. The symbolic variables
-may be subsetted using `dvs` and `ps`. All `kwargs` are passed to the internal
-[`build_function`](@ref) call. The returned function can be called as `f(u, p, t)` or
-`f(du, u, p, t)` for time-dependent systems and `f(u, p)` or `f(du, u, p)` for
-time-independent systems. If `split=true` (the default) was passed to [`complete`](@ref),
-[`mtkcompile`](@ref) or [`@mtkcompile`](@ref), `p` is expected to be an `MTKParameters`
-object.
-"""
-function generate_custom_function(
-        sys::AbstractSystem, exprs, dvs = unknowns(sys),
-        ps = parameters(sys; initial_parameters = true);
-        expression = Val{true}, eval_expression = false, eval_module = @__MODULE__,
-        cachesyms::Tuple = (), kwargs...
-    )
-    if !iscomplete(sys)
-        error("A completed system is required. Call `complete` or `mtkcompile` on the system.")
-    end
-    p = reorder_parameters(sys, unwrap.(ps))
-    isscalar = !(exprs isa AbstractArray)
-    fnexpr = if is_time_dependent(sys)
-        build_function_wrapper(
-            sys, exprs,
-            [Any[dvs]; p; collect(cachesyms); Any[get_iv(sys)]],
-            BuildFunctionWrapperOptions(;
-                u_arg = 1,
-                codegen_function_options = Symbolics.CodegenFunctionOptions(;
-                    kwargs...,
-                    expression = Val{true}
-                )
-            )
-        )
-    else
-        build_function_wrapper(
-            sys, exprs,
-            [Any[dvs]; p],
-            BuildFunctionWrapperOptions(;
-                u_arg = 1,
-                codegen_function_options = Symbolics.CodegenFunctionOptions(;
-                    kwargs...,
-                    expression = Val{true}
-                )
-            )
-        )
-    end
-    if expression == Val{true}
-        return fnexpr
-    end
-    if SU.is_array_shape(SU.shape(unwrap(exprs)))
-        return eval_or_rgf.(fnexpr; eval_expression, eval_module)
-    else
-        return eval_or_rgf(fnexpr[1]; eval_expression, eval_module)
-    end
-end
-
 function wrap_assignments(isscalar, assignments; let_block = false)
     function wrapper(expr)
         return Func(expr.args, [], Let(assignments, expr.body, let_block))

--- a/lib/ModelingToolkitBase/src/systems/abstractsystem.jl
+++ b/lib/ModelingToolkitBase/src/systems/abstractsystem.jl
@@ -241,7 +241,9 @@ function SymbolicIndexingInterface.timeseries_parameter_index(sys::AbstractSyste
 end
 
 function SymbolicIndexingInterface.parameter_observed(sys::AbstractSystem, sym)
-    return build_explicit_observed_function(sys, sym; param_only = true)
+    return build_explicit_observed_function(
+        sys, sym, GeneratedFunctionOptions(; expression = Val{false}); param_only = true
+    )
 end
 
 """
@@ -384,7 +386,11 @@ function SymbolicIndexingInterface.observed(
         end
     end
     return build_explicit_observed_function(
-        sys, sym; eval_expression, eval_module, checkbounds, optimize
+        sys, sym,
+        GeneratedFunctionOptions(;
+            expression = Val{false}, eval_expression, eval_module,
+            codegen_function_options = Symbolics.CodegenFunctionOptions(; checkbounds, optimize)
+        )
     )
 end
 

--- a/lib/ModelingToolkitBase/src/systems/callbacks.jl
+++ b/lib/ModelingToolkitBase/src/systems/callbacks.jl
@@ -1424,7 +1424,12 @@ Base.@nospecializeinfer function compile_equational_affect(
     end
     if isempty(equations(system(aff)))
         return compile_explicit_affect(
-            aff, sys; reset_jumps, eval_expression, eval_module, kwargs...
+            aff, sys,
+            GeneratedFunctionOptions(;
+                eval_expression, eval_module,
+                codegen_function_options = Symbolics.CodegenFunctionOptions(; kwargs...)
+            );
+            reset_jumps
         )
     else
         return compile_implicit_affect(

--- a/lib/ModelingToolkitBase/src/systems/callbacks.jl
+++ b/lib/ModelingToolkitBase/src/systems/callbacks.jl
@@ -1022,9 +1022,9 @@ Returns a function `condition(u,t,integrator)`, condition(out,u,t,integrator)` r
 """
 Base.@nospecializeinfer function compile_condition(
         @nospecialize(cbs::Union{AbstractCallback, Vector{<:AbstractCallback}}),
-        sys, @nospecialize(dvs), @nospecialize(ps);
-        eval_expression = false, eval_module = @__MODULE__, kwargs...
+        sys, @nospecialize(dvs), @nospecialize(ps), opts::GeneratedFunctionOptions
     )
+    (; eval_expression, eval_module) = opts
     u = map(value, dvs)
     p = map.(value, reorder_parameters(sys, ps))
     t = get_iv(sys)
@@ -1039,7 +1039,7 @@ Base.@nospecializeinfer function compile_condition(
     fs = build_function_wrapper(
         sys, condit, [Any[u]; p; Any[t]], BuildFunctionWrapperOptions(;
             u_arg = 1,
-            codegen_function_options = Symbolics.CodegenFunctionOptions(; kwargs...)
+            codegen_function_options = opts.codegen
         )
     )
     fs = GeneratedFunctionWrapper{(2, 3, is_split(sys))}(
@@ -1443,9 +1443,10 @@ variables and discrete parameters via `build_function_wrapper`.
 Called from [`compile_equational_affect`](@ref) when `isempty(equations(system(aff)))`.
 """
 Base.@nospecializeinfer function compile_explicit_affect(
-        @nospecialize(aff::AffectSystem), sys;
-        reset_jumps = false, eval_expression = false, eval_module = @__MODULE__, kwargs...
+        @nospecialize(aff::AffectSystem), sys, opts::GeneratedFunctionOptions;
+        reset_jumps = false
     )
+    (; eval_expression, eval_module) = opts
     affsys = system(aff)
     ps_to_update = discretes(aff)
     dvs_to_update = setdiff(unknowns(aff), getfield.(observed(sys), :lhs))
@@ -1491,9 +1492,11 @@ Base.@nospecializeinfer function compile_explicit_affect(
         sys, (@view rhss[is_u]), [Any[dvs]; _ps; Any[t]],
         BuildFunctionWrapperOptions(;
             u_arg = 1, wrap_mtkparameters,
-            codegen_function_options = Symbolics.CodegenFunctionOptions(;
-                wrap_code = add_integrator_header(sys, integ, :u),
-                outputidxs = u_idxs, iip_config = (false, true)
+            codegen_function_options = setproperties(
+                opts.codegen, (;
+                    wrap_code = add_integrator_header(sys, integ, :u),
+                    outputidxs = u_idxs, iip_config = (false, true),
+                )
             )
         )
     )
@@ -1502,9 +1505,11 @@ Base.@nospecializeinfer function compile_explicit_affect(
         sys, (@view rhss[is_p]), [Any[dvs]; _ps; Any[t]],
         BuildFunctionWrapperOptions(;
             u_arg = 1, wrap_mtkparameters,
-            codegen_function_options = Symbolics.CodegenFunctionOptions(;
-                wrap_code = add_integrator_header(sys, integ, :p),
-                outputidxs = p_idxs, iip_config = (false, true)
+            codegen_function_options = setproperties(
+                opts.codegen, (;
+                    wrap_code = add_integrator_header(sys, integ, :p),
+                    outputidxs = p_idxs, iip_config = (false, true),
+                )
             )
         )
     )

--- a/lib/ModelingToolkitBase/src/systems/codegen.jl
+++ b/lib/ModelingToolkitBase/src/systems/codegen.jl
@@ -38,13 +38,13 @@ $GENERATE_X_KWARGS
 All other keyword arguments are forwarded to [`build_function_wrapper`](@ref).
 """
 function generate_rhs(
-        sys::System; implicit_dae = false,
-        scalar = false, expression = Val{true}, wrap_gfw = Val{false},
-        eval_expression = false, eval_module = @__MODULE__, override_discrete = false,
-        cachesyms = nothing, extra_args::Tuple = (),
-        compiler_options::CompilerOptions = CompilerOptions(),
-        kwargs...
+        sys::System, opts::GeneratedFunctionOptions;
+        implicit_dae::Bool = false, scalar::Bool = false,
+        override_discrete::Bool = false, cachesyms = nothing, extra_args::Tuple = ()
     )
+    (; eval_expression, eval_module, compiler_options) = opts
+    expression = expression_val(opts)
+    wrap_gfw = wrap_gfw_val(opts)
     dvs = unknowns(sys)
     eqs = equations(sys)
     obs = observed(sys)
@@ -125,9 +125,7 @@ function generate_rhs(
     res = build_function_wrapper(
         sys, rhss, collect(Any, args), BuildFunctionWrapperOptions(;
             p_start, extra_assignments, u_arg, n_param_buffers, p_end_kw...,
-            codegen_function_options = Symbolics.CodegenFunctionOptions(;
-                expression = Val{true}, expression_module = eval_module, kwargs...
-            )
+            codegen_function_options = opts.codegen
         )
     )
     nargs = length(args) - length(p) + 1
@@ -152,11 +150,10 @@ $GENERATE_X_KWARGS
 
 All other keyword arguments are forwarded to [`build_function_wrapper`](@ref).
 """
-function generate_diffusion_function(
-        sys::System; expression = Val{true},
-        wrap_gfw = Val{false}, eval_expression = false,
-        eval_module = @__MODULE__, kwargs...
-    )
+function generate_diffusion_function(sys::System, opts::GeneratedFunctionOptions)
+    (; eval_expression, eval_module) = opts
+    expression = expression_val(opts)
+    wrap_gfw = wrap_gfw_val(opts)
     dvs = unknowns(sys)
     ps = parameters(sys; initial_parameters = true)
     eqs = get_noise_eqs(sys)
@@ -165,7 +162,7 @@ function generate_diffusion_function(
         eqs = vec(eqs)
     end
     p = reorder_parameters(sys, ps)
-    res = build_function_wrapper(sys, eqs, [Any[dvs]; p; Any[get_iv(sys)]], BuildFunctionWrapperOptions(; u_arg = 1, codegen_function_options = Symbolics.CodegenFunctionOptions(; kwargs...)))
+    res = build_function_wrapper(sys, eqs, [Any[dvs]; p; Any[get_iv(sys)]], BuildFunctionWrapperOptions(; u_arg = 1, codegen_function_options = opts.codegen))
     if expression == Val{true}
         return res
     end
@@ -259,16 +256,17 @@ $GENERATE_X_KWARGS
 All other keyword arguments are forwarded to [`build_function_wrapper`](@ref).
 """
 function generate_jacobian(
-        sys::System;
-        simplify = false, sparse = false, eval_expression = false,
-        eval_module = @__MODULE__, expression = Val{true}, wrap_gfw = Val{false},
-        checkbounds = false, compiler_options::CompilerOptions = CompilerOptions(), kwargs...
+        sys::System, opts::GeneratedFunctionOptions;
+        simplify::Bool = false, sparse::Bool = false
     )
+    (; eval_expression, eval_module, compiler_options) = opts
+    expression = expression_val(opts)
+    wrap_gfw = wrap_gfw_val(opts)
     dvs = unknowns(sys)
     jac = calculate_jacobian(sys; simplify, sparse, dvs)
     p = reorder_parameters(sys)
     t = get_iv(sys)
-    if t !== nothing && sparse && checkbounds
+    if t !== nothing && sparse && opts.codegen.checkbounds
         wrap_code = assert_jac_length_header(sys) # checking sparse J indices at runtime is expensive for large systems
     else
         wrap_code = (identity, identity)
@@ -282,10 +280,7 @@ function generate_jacobian(
     res = build_function_wrapper(
         sys, jac, collect(Any, args), BuildFunctionWrapperOptions(;
             u_arg = 1,
-            codegen_function_options = Symbolics.CodegenFunctionOptions(;
-                wrap_code, expression = Val{true}, expression_module = eval_module,
-                checkbounds, kwargs...
-            )
+            codegen_function_options = setproperties(opts.codegen, (; wrap_code))
         )
     )
     return maybe_compile_function(
@@ -320,11 +315,11 @@ $GENERATE_X_KWARGS
 All other keyword arguments are forwarded to [`build_function_wrapper`](@ref).
 """
 function generate_tgrad(
-        sys::System;
-        simplify = false, eval_expression = false, eval_module = @__MODULE__,
-        expression = Val{true}, wrap_gfw = Val{false},
-        compiler_options::CompilerOptions = CompilerOptions(), kwargs...
+        sys::System, opts::GeneratedFunctionOptions; simplify::Bool = false
     )
+    (; eval_expression, eval_module, compiler_options) = opts
+    expression = expression_val(opts)
+    wrap_gfw = wrap_gfw_val(opts)
     dvs = unknowns(sys)
     ps = parameters(sys; initial_parameters = true)
     tgrad = calculate_tgrad(sys, simplify = simplify)
@@ -334,11 +329,7 @@ function generate_tgrad(
         [Any[dvs]; p; Any[get_iv(sys)]],
         BuildFunctionWrapperOptions(;
             u_arg = 1,
-            codegen_function_options = Symbolics.CodegenFunctionOptions(;
-                expression = Val{true},
-                expression_module = eval_module,
-                kwargs...
-            )
+            codegen_function_options = opts.codegen
         )
     )
 
@@ -399,10 +390,12 @@ $GENERATE_X_KWARGS
 All other keyword arguments are forwarded to [`build_function_wrapper`](@ref).
 """
 function generate_W(
-        sys::System;
-        simplify = false, sparse = false, expression = Val{true}, wrap_gfw = Val{false},
-        eval_expression = false, eval_module = @__MODULE__, checkbounds = false, kwargs...
+        sys::System, opts::GeneratedFunctionOptions;
+        simplify::Bool = false, sparse::Bool = false
     )
+    (; eval_expression, eval_module) = opts
+    expression = expression_val(opts)
+    wrap_gfw = wrap_gfw_val(opts)
     dvs = unknowns(sys)
     ps = parameters(sys; initial_parameters = true)
     M = calculate_massmatrix(sys; simplify)
@@ -412,7 +405,7 @@ function generate_W(
     J = calculate_jacobian(sys; simplify, sparse, dvs)
     W = W_GAMMA * M + J
     t = get_iv(sys)
-    if t !== nothing && sparse && checkbounds
+    if t !== nothing && sparse && opts.codegen.checkbounds
         wrap_code = assert_jac_length_header(sys)
     else
         wrap_code = (identity, identity)
@@ -422,9 +415,7 @@ function generate_W(
     res = build_function_wrapper(
         sys, W, [Any[dvs]; p; Any[W_GAMMA, t]], BuildFunctionWrapperOptions(;
             u_arg = 1, p_end = 1 + length(p),
-            codegen_function_options = Symbolics.CodegenFunctionOptions(;
-                wrap_code, checkbounds, kwargs...
-            )
+            codegen_function_options = setproperties(opts.codegen, (; wrap_code))
         )
     )
     return maybe_compile_function(
@@ -447,11 +438,12 @@ $GENERATE_X_KWARGS
 All other keyword arguments are forwarded to [`build_function_wrapper`](@ref).
 """
 function generate_dae_jacobian(
-        sys::System; simplify = false, sparse = false,
-        expression = Val{true}, wrap_gfw = Val{false}, eval_expression = false,
-        eval_module = @__MODULE__,
-        compiler_options::CompilerOptions = CompilerOptions(), kwargs...
+        sys::System, opts::GeneratedFunctionOptions;
+        simplify::Bool = false, sparse::Bool = false
     )
+    (; eval_expression, eval_module, compiler_options) = opts
+    expression = expression_val(opts)
+    wrap_gfw = wrap_gfw_val(opts)
     dvs = unknowns(sys)
     ps = parameters(sys; initial_parameters = true)
     jac_u = calculate_jacobian(sys; simplify = simplify, sparse = sparse)
@@ -468,7 +460,7 @@ function generate_dae_jacobian(
         sys, jac, [Any[derivatives, dvs]; p; Any[W_GAMMA, t]],
         BuildFunctionWrapperOptions(;
             u_arg = 2, p_start = 3, p_end = 2 + length(p),
-            codegen_function_options = Symbolics.CodegenFunctionOptions(; kwargs...)
+            codegen_function_options = opts.codegen
         )
     )
     return maybe_compile_function(
@@ -489,18 +481,15 @@ $GENERATE_X_KWARGS
 
 All other keyword arguments are forwarded to [`build_function_wrapper`](@ref).
 """
-function generate_history(
-        sys::System, u0; expression = Val{true}, wrap_gfw = Val{false},
-        eval_expression = false, eval_module = @__MODULE__, kwargs...
-    )
+function generate_history(sys::System, u0, opts::GeneratedFunctionOptions)
+    (; eval_expression, eval_module) = opts
+    expression = expression_val(opts)
+    wrap_gfw = wrap_gfw_val(opts)
     p = reorder_parameters(sys)
     res = build_function_wrapper(
         sys, u0, [p; Any[get_iv(sys)]], BuildFunctionWrapperOptions(;
             p_start = 1, p_end = length(p), wrap_delays = false,
-            codegen_function_options = Symbolics.CodegenFunctionOptions(;
-                expression = Val{true}, expression_module = eval_module,
-                similarto = typeof(u0), kwargs...
-            )
+            codegen_function_options = setproperties(opts.codegen, (; similarto = typeof(u0)))
         )
     )
     return maybe_compile_function(
@@ -665,10 +654,11 @@ $GENERATE_X_KWARGS
 All other keyword arguments are forwarded to [`build_function_wrapper`](@ref).
 """
 function generate_boundary_conditions(
-        sys::System, u0, u0_idxs, t0; expression = Val{true},
-        wrap_gfw = Val{false}, eval_expression = false, eval_module = @__MODULE__,
-        kwargs...
+        sys::System, u0, u0_idxs, t0, opts::GeneratedFunctionOptions
     )
+    (; eval_expression, eval_module) = opts
+    expression = expression_val(opts)
+    wrap_gfw = wrap_gfw_val(opts)
     iv = get_iv(sys)
     sts = unknowns(sys)
     ps = parameters(sys)
@@ -699,7 +689,7 @@ function generate_boundary_conditions(
             output_type = Array,
             p_start = 1, histfn = (p, t) -> BVP_SOLUTION(t),
             histfn_symbolic = BVP_SOLUTION, wrap_delays = true,
-            codegen_function_options = Symbolics.CodegenFunctionOptions(; kwargs...)
+            codegen_function_options = opts.codegen
         )
     )
     return maybe_compile_function(
@@ -718,10 +708,10 @@ $GENERATE_X_KWARGS
 
 All other keyword arguments are forwarded to [`build_function_wrapper`](@ref).
 """
-function generate_cost(
-        sys::System; expression = Val{true}, wrap_gfw = Val{false},
-        eval_expression = false, eval_module = @__MODULE__, kwargs...
-    )
+function generate_cost(sys::System, opts::GeneratedFunctionOptions)
+    (; eval_expression, eval_module) = opts
+    expression = expression_val(opts)
+    wrap_gfw = wrap_gfw_val(opts)
     obj = cost(sys)
     dvs = unknowns(sys)
     ps = reorder_parameters(sys)
@@ -744,7 +734,7 @@ function generate_cost(
         sys, obj, collect(Any, args), BuildFunctionWrapperOptions(;
             p_start, p_end, wrap_delays, u_arg,
             histfn = (p, t) -> BVP_SOLUTION(t), histfn_symbolic = BVP_SOLUTION,
-            codegen_function_options = Symbolics.CodegenFunctionOptions(; expression = Val{true}, kwargs...)
+            codegen_function_options = opts.codegen
         )
     )[1]
     if expression == Val{true}
@@ -768,11 +758,10 @@ $GENERATE_X_KWARGS
 
 All other keyword arguments are forwarded to [`build_function_wrapper`](@ref).
 """
-function generate_bvp_cost(
-        sys::System; expression = Val{true}, wrap_gfw = Val{false},
-        eval_expression = false, eval_module = @__MODULE__,
-        checkbounds = false, kwargs...
-    )
+function generate_bvp_cost(sys::System, opts::GeneratedFunctionOptions)
+    (; eval_expression, eval_module) = opts
+    expression = expression_val(opts)
+    wrap_gfw = wrap_gfw_val(opts)
     obj = cost(sys)
     _iszero(obj) && return nothing
 
@@ -796,9 +785,7 @@ function generate_bvp_cost(
             wrap_delays = true,
             histfn = (p, t) -> BVP_SOLUTION(t),
             histfn_symbolic = BVP_SOLUTION,
-            codegen_function_options = Symbolics.CodegenFunctionOptions(;
-                expression = Val{true}, checkbounds, kwargs...
-            )
+            codegen_function_options = opts.codegen
         )
     )[1]
 
@@ -833,14 +820,16 @@ $GENERATE_X_KWARGS
 All other keyword arguments are forwarded to [`build_function_wrapper`](@ref).
 """
 function generate_cost_gradient(
-        sys::System; expression = Val{true}, wrap_gfw = Val{false},
-        eval_expression = false, eval_module = @__MODULE__, simplify = false, kwargs...
+        sys::System, opts::GeneratedFunctionOptions; simplify::Bool = false
     )
+    (; eval_expression, eval_module) = opts
+    expression = expression_val(opts)
+    wrap_gfw = wrap_gfw_val(opts)
     obj = cost(sys)
     dvs = unknowns(sys)
     ps = reorder_parameters(sys)
     exprs = calculate_cost_gradient(sys; simplify)
-    res = build_function_wrapper(sys, exprs, [Any[dvs]; ps], BuildFunctionWrapperOptions(; u_arg = 1, codegen_function_options = Symbolics.CodegenFunctionOptions(; expression = Val{true}, kwargs...)))
+    res = build_function_wrapper(sys, exprs, [Any[dvs]; ps], BuildFunctionWrapperOptions(; u_arg = 1, codegen_function_options = opts.codegen))
     return maybe_compile_function(
         expression, wrap_gfw, (2, 2, is_split(sys)), res; eval_expression, eval_module
     )
@@ -887,10 +876,12 @@ $GENERATE_X_KWARGS
 All other keyword arguments are forwarded to [`build_function_wrapper`](@ref).
 """
 function generate_cost_hessian(
-        sys::System; expression = Val{true}, wrap_gfw = Val{false},
-        eval_expression = false, eval_module = @__MODULE__, simplify = false,
-        sparse = false, return_sparsity = false, kwargs...
+        sys::System, opts::GeneratedFunctionOptions;
+        simplify::Bool = false, sparse::Bool = false, return_sparsity::Bool = false
     )
+    (; eval_expression, eval_module) = opts
+    expression = expression_val(opts)
+    wrap_gfw = wrap_gfw_val(opts)
     obj = cost(sys)
     dvs = unknowns(sys)
     ps = reorder_parameters(sys)
@@ -899,7 +890,7 @@ function generate_cost_hessian(
     if sparse
         sparsity = similar(exprs, Float64)
     end
-    res = build_function_wrapper(sys, exprs, [Any[dvs]; ps], BuildFunctionWrapperOptions(; u_arg = 1, codegen_function_options = Symbolics.CodegenFunctionOptions(; expression = Val{true}, kwargs...)))
+    res = build_function_wrapper(sys, exprs, [Any[dvs]; ps], BuildFunctionWrapperOptions(; u_arg = 1, codegen_function_options = opts.codegen))
     fn = maybe_compile_function(
         expression, wrap_gfw, (2, 2, is_split(sys)), res; eval_expression, eval_module
     )
@@ -924,14 +915,14 @@ $GENERATE_X_KWARGS
 
 All other keyword arguments are forwarded to [`build_function_wrapper`](@ref).
 """
-function generate_cons(
-        sys::System; expression = Val{true}, wrap_gfw = Val{false},
-        eval_expression = false, eval_module = @__MODULE__, kwargs...
-    )
+function generate_cons(sys::System, opts::GeneratedFunctionOptions)
+    (; eval_expression, eval_module) = opts
+    expression = expression_val(opts)
+    wrap_gfw = wrap_gfw_val(opts)
     cons = canonical_constraints(sys)
     dvs = unknowns(sys)
     ps = reorder_parameters(sys)
-    res = build_function_wrapper(sys, cons, [Any[dvs]; ps], BuildFunctionWrapperOptions(; u_arg = 1, codegen_function_options = Symbolics.CodegenFunctionOptions(; expression = Val{true}, kwargs...)))
+    res = build_function_wrapper(sys, cons, [Any[dvs]; ps], BuildFunctionWrapperOptions(; u_arg = 1, codegen_function_options = opts.codegen))
     return maybe_compile_function(
         expression, wrap_gfw, (2, 2, is_split(sys)), res; eval_expression, eval_module
     )
@@ -978,17 +969,19 @@ $GENERATE_X_KWARGS
 All other keyword arguments are forwarded to [`build_function_wrapper`](@ref).
 """
 function generate_constraint_jacobian(
-        sys::System; expression = Val{true}, wrap_gfw = Val{false},
-        eval_expression = false, eval_module = @__MODULE__, return_sparsity = false,
-        simplify = false, sparse = false, kwargs...
+        sys::System, opts::GeneratedFunctionOptions;
+        return_sparsity::Bool = false, simplify::Bool = false, sparse::Bool = false
     )
+    (; eval_expression, eval_module) = opts
+    expression = expression_val(opts)
+    wrap_gfw = wrap_gfw_val(opts)
     dvs = unknowns(sys)
     ps = reorder_parameters(sys)
     jac,
         sparsity = calculate_constraint_jacobian(
         sys; simplify, sparse, return_sparsity = true
     )
-    res = build_function_wrapper(sys, jac, [Any[dvs]; ps], BuildFunctionWrapperOptions(; u_arg = 1, codegen_function_options = Symbolics.CodegenFunctionOptions(; expression = Val{true}, kwargs...)))
+    res = build_function_wrapper(sys, jac, [Any[dvs]; ps], BuildFunctionWrapperOptions(; u_arg = 1, codegen_function_options = opts.codegen))
     fn = maybe_compile_function(
         expression, wrap_gfw, (2, 2, is_split(sys)), res; eval_expression, eval_module
     )
@@ -1037,17 +1030,19 @@ $GENERATE_X_KWARGS
 All other keyword arguments are forwarded to [`build_function_wrapper`](@ref).
 """
 function generate_constraint_hessian(
-        sys::System; expression = Val{true}, wrap_gfw = Val{false},
-        eval_expression = false, eval_module = @__MODULE__, return_sparsity = false,
-        simplify = false, sparse = false, kwargs...
+        sys::System, opts::GeneratedFunctionOptions;
+        return_sparsity::Bool = false, simplify::Bool = false, sparse::Bool = false
     )
+    (; eval_expression, eval_module) = opts
+    expression = expression_val(opts)
+    wrap_gfw = wrap_gfw_val(opts)
     dvs = unknowns(sys)
     ps = reorder_parameters(sys)
     hess,
         sparsity = calculate_constraint_hessian(
         sys; simplify, sparse, return_sparsity = true
     )
-    res = build_function_wrapper(sys, hess, [Any[dvs]; ps], BuildFunctionWrapperOptions(; u_arg = 1, codegen_function_options = Symbolics.CodegenFunctionOptions(; expression = Val{true}, kwargs...)))
+    res = build_function_wrapper(sys, hess, [Any[dvs]; ps], BuildFunctionWrapperOptions(; u_arg = 1, codegen_function_options = opts.codegen))
     fn = maybe_compile_function(
         expression, wrap_gfw, (2, 2, is_split(sys)), res; eval_expression, eval_module
     )
@@ -1092,15 +1087,17 @@ $GENERATE_X_KWARGS
 All other keyword arguments are forwarded to [`build_function_wrapper`](@ref).
 """
 function generate_control_jacobian(
-        sys::AbstractSystem;
-        expression = Val{true}, wrap_gfw = Val{false}, eval_expression = false,
-        eval_module = @__MODULE__, simplify = false, sparse = false, kwargs...
+        sys::AbstractSystem, opts::GeneratedFunctionOptions;
+        simplify::Bool = false, sparse::Bool = false
     )
+    (; eval_expression, eval_module) = opts
+    expression = expression_val(opts)
+    wrap_gfw = wrap_gfw_val(opts)
     dvs = unknowns(sys)
     ps = parameters(sys; initial_parameters = true)
     jac = calculate_control_jacobian(sys; simplify = simplify, sparse = sparse)
     p = reorder_parameters(sys, ps)
-    res = build_function_wrapper(sys, jac, [Any[dvs]; p; Any[get_iv(sys)]], BuildFunctionWrapperOptions(; u_arg = 1, codegen_function_options = Symbolics.CodegenFunctionOptions(; kwargs...)))
+    res = build_function_wrapper(sys, jac, [Any[dvs]; p; Any[get_iv(sys)]], BuildFunctionWrapperOptions(; u_arg = 1, codegen_function_options = opts.codegen))
     return maybe_compile_function(
         expression, wrap_gfw, (2, 3, is_split(sys)), res; eval_expression, eval_module
     )
@@ -1576,10 +1573,11 @@ $GENERATE_X_KWARGS
 All other keyword arguments are forwarded to [`build_function_wrapper`](@ref).
 """
 function generate_update_A(
-        sys::System, A::AbstractMatrix; expression = Val{true},
-        wrap_gfw = Val{false}, eval_expression = false, eval_module = @__MODULE__,
-        cachesyms = (), compiler_options::CompilerOptions = CompilerOptions(), kwargs...
+        sys::System, A::AbstractMatrix, opts::GeneratedFunctionOptions; cachesyms = ()
     )
+    (; eval_expression, eval_module, compiler_options) = opts
+    expression = expression_val(opts)
+    wrap_gfw = wrap_gfw_val(opts)
     ps = reorder_parameters(sys)
 
     regions = SU.RegionsT()
@@ -1598,9 +1596,7 @@ function generate_update_A(
     res = build_function_wrapper(
         sys, A, [Any[]; ps; collect(cachesyms)], BuildFunctionWrapperOptions(;
             p_start = 1, n_param_buffers = length(ps),
-            codegen_function_options = Symbolics.CodegenFunctionOptions(;
-                expression = Val{true}, similarto = typeof(A), kwargs...
-            )
+            codegen_function_options = setproperties(opts.codegen, (; similarto = typeof(A)))
         )
     )
     return maybe_compile_function(
@@ -1630,18 +1626,18 @@ function (f::DiagonalAMatrixWrapper{OOPArgs})(args::Vararg{Any, OOPArgs}) where 
 end
 
 function generate_update_A(
-        sys::System, A::Diagonal{SymbolicT, Vector{SymbolicT}}; expression = Val{true},
-        wrap_gfw = Val{false}, eval_expression = false, eval_module = @__MODULE__,
-        cachesyms = (), compiler_options::CompilerOptions = CompilerOptions(), kwargs...
+        sys::System, A::Diagonal{SymbolicT, Vector{SymbolicT}},
+        opts::GeneratedFunctionOptions; cachesyms = ()
     )
+    (; eval_expression, eval_module, compiler_options) = opts
+    expression = expression_val(opts)
+    wrap_gfw = wrap_gfw_val(opts)
     ps = reorder_parameters(sys)
 
     res = build_function_wrapper(
         sys, parent(A), [Any[]; ps; collect(cachesyms)], BuildFunctionWrapperOptions(;
             p_start = 1, n_param_buffers = length(ps),
-            codegen_function_options = Symbolics.CodegenFunctionOptions(;
-                expression = Val{true}, similarto = Vector{SymbolicT}, kwargs...
-            )
+            codegen_function_options = setproperties(opts.codegen, (; similarto = Vector{SymbolicT}))
         )
     )
     return DiagonalAMatrixWrapper(
@@ -1675,10 +1671,12 @@ function (f::BandedAMatrixWrapper{OOPArgs})(args::Vararg{Any, OOPArgs}) where {O
 end
 
 function generate_update_A(
-        sys::System, A::BandedMatrix{SymbolicT, Matrix{SymbolicT}}; expression = Val{true},
-        wrap_gfw = Val{false}, eval_expression = false, eval_module = @__MODULE__,
-        cachesyms = (), compiler_options::CompilerOptions = CompilerOptions(), kwargs...
+        sys::System, A::BandedMatrix{SymbolicT, Matrix{SymbolicT}},
+        opts::GeneratedFunctionOptions; cachesyms = ()
     )
+    (; eval_expression, eval_module, compiler_options) = opts
+    expression = expression_val(opts)
+    wrap_gfw = wrap_gfw_val(opts)
     ps = reorder_parameters(sys)
 
     parA = parent(A)
@@ -1689,9 +1687,7 @@ function generate_update_A(
     res = build_function_wrapper(
         sys, parA, [Any[]; ps; collect(cachesyms)], BuildFunctionWrapperOptions(;
             p_start = 1, n_param_buffers = length(ps),
-            codegen_function_options = Symbolics.CodegenFunctionOptions(;
-                expression = Val{true}, similarto = Matrix{SymbolicT}, kwargs...
-            )
+            codegen_function_options = setproperties(opts.codegen, (; similarto = Matrix{SymbolicT}))
         )
     )
     return BandedAMatrixWrapper(
@@ -1715,10 +1711,11 @@ $GENERATE_X_KWARGS
 All other keyword arguments are forwarded to [`build_function_wrapper`](@ref).
 """
 function generate_update_b(
-        sys::System, b::AbstractVector; expression = Val{true},
-        wrap_gfw = Val{false}, eval_expression = false, eval_module = @__MODULE__,
-        cachesyms = (), compiler_options::CompilerOptions = CompilerOptions(), kwargs...
+        sys::System, b::AbstractVector, opts::GeneratedFunctionOptions; cachesyms = ()
     )
+    (; eval_expression, eval_module, compiler_options) = opts
+    expression = expression_val(opts)
+    wrap_gfw = wrap_gfw_val(opts)
     ps = reorder_parameters(sys)
 
     regions = SU.RegionsT()
@@ -1737,13 +1734,65 @@ function generate_update_b(
     res = build_function_wrapper(
         sys, b, [Any[]; ps; collect(cachesyms)], BuildFunctionWrapperOptions(;
             p_start = 1, n_param_buffers = length(ps),
-            codegen_function_options = Symbolics.CodegenFunctionOptions(;
-                expression = Val{true}, similarto = typeof(b), kwargs...
-            )
+            codegen_function_options = setproperties(opts.codegen, (; similarto = typeof(b)))
         )
     )
     return maybe_compile_function(
         expression, wrap_gfw, (1, 1, is_split(sys)), res;
         compiler_options, eval_expression, eval_module
     )
+end
+"""
+```julia
+generate_custom_function(sys::AbstractSystem, exprs, dvs = unknowns(sys),
+                         ps = parameters(sys); kwargs...)
+```
+
+Generate a function to evaluate `exprs`. `exprs` is a symbolic expression or
+array of symbolic expression involving symbolic variables in `sys`. The symbolic variables
+may be subsetted using `dvs` and `ps`. All `kwargs` are passed to the internal
+[`build_function`](@ref) call. The returned function can be called as `f(u, p, t)` or
+`f(du, u, p, t)` for time-dependent systems and `f(u, p)` or `f(du, u, p)` for
+time-independent systems. If `split=true` (the default) was passed to [`complete`](@ref),
+[`mtkcompile`](@ref) or [`@mtkcompile`](@ref), `p` is expected to be an `MTKParameters`
+object.
+"""
+function generate_custom_function(
+        sys::AbstractSystem, exprs, dvs, ps, opts::GeneratedFunctionOptions;
+        cachesyms::Tuple = ()
+    )
+    (; eval_expression, eval_module) = opts
+    expression = expression_val(opts)
+    if !iscomplete(sys)
+        error("A completed system is required. Call `complete` or `mtkcompile` on the system.")
+    end
+    p = reorder_parameters(sys, unwrap.(ps))
+    isscalar = !(exprs isa AbstractArray)
+    fnexpr = if is_time_dependent(sys)
+        build_function_wrapper(
+            sys, exprs,
+            [Any[dvs]; p; collect(cachesyms); Any[get_iv(sys)]],
+            BuildFunctionWrapperOptions(;
+                u_arg = 1,
+                codegen_function_options = opts.codegen
+            )
+        )
+    else
+        build_function_wrapper(
+            sys, exprs,
+            [Any[dvs]; p],
+            BuildFunctionWrapperOptions(;
+                u_arg = 1,
+                codegen_function_options = opts.codegen
+            )
+        )
+    end
+    if expression == Val{true}
+        return fnexpr
+    end
+    if SU.is_array_shape(SU.shape(unwrap(exprs)))
+        return eval_or_rgf.(fnexpr; eval_expression, eval_module)
+    else
+        return eval_or_rgf(fnexpr[1]; eval_expression, eval_module)
+    end
 end

--- a/lib/ModelingToolkitBase/src/systems/codegen.jl
+++ b/lib/ModelingToolkitBase/src/systems/codegen.jl
@@ -1280,7 +1280,6 @@ Generates a function that computes the observed value(s) `ts` in the system `sys
 - `checkbounds`: whether to check bounds when destructuring parameters (defaults to
   `false`, i.e. generated code is wrapped in `@inbounds`)
 - `throw = true` if true, throw an error when generating a function for `ts` that reference variables that do not exist.
-- `mkarray`: only used if the output is an array (that is, `!isscalar(ts)`  and `ts` is not a tuple, in which case the result will always be a tuple). Called as `mkarray(ts, output_type)` where `ts` are the expressions to put in the array and `output_type` is the argument of the same name passed to build_explicit_observed_function.
 - `wrap_delays = is_dde(sys)`: Whether to add an argument for the history function and use
   it to calculate all delayed variables.
 
@@ -1322,8 +1321,6 @@ Base.@nospecializeinfer function build_explicit_observed_function(
         return_inplace = Val(false),
         param_only = false,
         throw = true,
-
-        mkarray = nothing,
         wrap_delays = is_dde(sys) && !param_only,
         force_time_independent = false,
         kwargs...
@@ -1441,7 +1438,7 @@ Base.@nospecializeinfer function build_explicit_observed_function(
     fns = build_function_wrapper(
         sys, ts, collect(Any, args), BuildFunctionWrapperOptions(;
             p_start, p_end,
-            output_type, mkarray, wrap_delays,
+            output_type, wrap_delays,
             codegen_function_options = Symbolics.CodegenFunctionOptions(;
                 try_namespaced = true, expression = Val{true}, checkbounds, kwargs...
             )

--- a/lib/ModelingToolkitBase/src/systems/codegen.jl
+++ b/lib/ModelingToolkitBase/src/systems/codegen.jl
@@ -1307,24 +1307,21 @@ For example, a function `g(op, unknowns, p..., inputs, t, known_disturbances)` w
 an array of inputs `inputs` is given, `known_disturbance_inputs` is provided, and `param_only` is false for a time-dependent system.
 """
 Base.@nospecializeinfer function build_explicit_observed_function(
-        sys, @nospecialize(ts);
+        sys, @nospecialize(ts), opts::GeneratedFunctionOptions;
         inputs = nothing,
         disturbance_inputs = nothing,
         known_disturbance_inputs = nothing,
         disturbance_argument = false,
-        expression = false,
-        eval_expression = false,
-        eval_module = @__MODULE__,
         output_type = Array,
-        checkbounds = false,
         ps = parameters(sys; initial_parameters = true),
         return_inplace = Val(false),
         param_only = false,
         throw = true,
         wrap_delays = is_dde(sys) && !param_only,
-        force_time_independent = false,
-        kwargs...
+        force_time_independent = false
     )
+    (; eval_expression, eval_module, compiler_options) = opts
+    expression = expression_val(opts)
     if inputs === nothing
         inputs = ()
     else
@@ -1438,17 +1435,13 @@ Base.@nospecializeinfer function build_explicit_observed_function(
     fns = build_function_wrapper(
         sys, ts, collect(Any, args), BuildFunctionWrapperOptions(;
             p_start, p_end,
-            output_type, wrap_delays,
-            codegen_function_options = Symbolics.CodegenFunctionOptions(;
-                try_namespaced = true, expression = Val{true}, checkbounds, kwargs...
-            )
+            output_type, wrap_delays, codegen_function_options = opts.codegen
         )
     )::NTuple{2, Expr}
-    if expression === true || expression === Val{true}
+    if expression === Val{true}
         return (return_inplace isa Val{true} || return_inplace isa Bool && return_inplace) ? fns : fns[1]
     end
 
-    compiler_options = get(kwargs, :compiler_options, CompilerOptions())
     oop = eval_or_rgf(fns[1]; eval_expression, eval_module, compiler_options)
     iip = eval_or_rgf(fns[2]; eval_expression, eval_module, compiler_options)
     f = GeneratedFunctionWrapper{

--- a/lib/ModelingToolkitBase/src/systems/codegen_compat.jl
+++ b/lib/ModelingToolkitBase/src/systems/codegen_compat.jl
@@ -1,0 +1,298 @@
+# Backwards-compatibility keyword-argument wrappers for the code-generation entry points.
+#
+# The primary methods (in `codegen.jl`) take a positional `GeneratedFunctionOptions` for the
+# output/compile options plus a strictly-typed set of function-specific keyword arguments.
+# Each wrapper here accepts the historical loose keyword arguments, bundles the
+# code-generation options into a `Symbolics.CodegenFunctionOptions` and the output/compile
+# options into a `GeneratedFunctionOptions`, and forwards to the corresponding primary
+# method. New code should construct a `GeneratedFunctionOptions` and call the primary method
+# directly.
+
+function generate_rhs(
+        sys::System; expression = Val{true}, wrap_gfw = Val{false},
+        eval_expression = false, eval_module = @__MODULE__,
+        compiler_options::CompilerOptions = CompilerOptions(),
+        implicit_dae = false, scalar = false, override_discrete = false,
+        cachesyms = nothing, extra_args::Tuple = (), kwargs...
+    )
+    return generate_rhs(
+        sys,
+        GeneratedFunctionOptions(;
+            expression, wrap_gfw, eval_expression, eval_module,
+            compiler_options,
+            codegen_function_options = Symbolics.CodegenFunctionOptions(; kwargs...)
+        );
+        implicit_dae, scalar, override_discrete, cachesyms, extra_args
+    )
+end
+
+function generate_diffusion_function(
+        sys::System; expression = Val{true}, wrap_gfw = Val{false},
+        eval_expression = false, eval_module = @__MODULE__, kwargs...
+    )
+    return generate_diffusion_function(
+        sys,
+        GeneratedFunctionOptions(;
+            expression, wrap_gfw, eval_expression, eval_module,
+            codegen_function_options = Symbolics.CodegenFunctionOptions(; kwargs...)
+        )
+    )
+end
+
+function generate_jacobian(
+        sys::System; expression = Val{true}, wrap_gfw = Val{false},
+        eval_expression = false, eval_module = @__MODULE__,
+        compiler_options::CompilerOptions = CompilerOptions(),
+        simplify = false, sparse = false, kwargs...
+    )
+    return generate_jacobian(
+        sys,
+        GeneratedFunctionOptions(;
+            expression, wrap_gfw, eval_expression, eval_module,
+            compiler_options,
+            codegen_function_options = Symbolics.CodegenFunctionOptions(; kwargs...)
+        );
+        simplify, sparse
+    )
+end
+
+function generate_tgrad(
+        sys::System; expression = Val{true}, wrap_gfw = Val{false},
+        eval_expression = false, eval_module = @__MODULE__,
+        compiler_options::CompilerOptions = CompilerOptions(),
+        simplify = false, kwargs...
+    )
+    return generate_tgrad(
+        sys,
+        GeneratedFunctionOptions(;
+            expression, wrap_gfw, eval_expression, eval_module,
+            compiler_options,
+            codegen_function_options = Symbolics.CodegenFunctionOptions(; kwargs...)
+        );
+        simplify
+    )
+end
+
+function generate_W(
+        sys::System; expression = Val{true}, wrap_gfw = Val{false},
+        eval_expression = false, eval_module = @__MODULE__,
+        simplify = false, sparse = false, kwargs...
+    )
+    return generate_W(
+        sys,
+        GeneratedFunctionOptions(;
+            expression, wrap_gfw, eval_expression, eval_module,
+            codegen_function_options = Symbolics.CodegenFunctionOptions(; kwargs...)
+        );
+        simplify, sparse
+    )
+end
+
+function generate_dae_jacobian(
+        sys::System; expression = Val{true}, wrap_gfw = Val{false},
+        eval_expression = false, eval_module = @__MODULE__,
+        compiler_options::CompilerOptions = CompilerOptions(),
+        simplify = false, sparse = false, kwargs...
+    )
+    return generate_dae_jacobian(
+        sys,
+        GeneratedFunctionOptions(;
+            expression, wrap_gfw, eval_expression, eval_module,
+            compiler_options,
+            codegen_function_options = Symbolics.CodegenFunctionOptions(; kwargs...)
+        );
+        simplify, sparse
+    )
+end
+
+function generate_cost(
+        sys::System; expression = Val{true}, wrap_gfw = Val{false},
+        eval_expression = false, eval_module = @__MODULE__, kwargs...
+    )
+    return generate_cost(
+        sys,
+        GeneratedFunctionOptions(;
+            expression, wrap_gfw, eval_expression, eval_module,
+            codegen_function_options = Symbolics.CodegenFunctionOptions(; kwargs...)
+        )
+    )
+end
+
+function generate_cons(
+        sys::System; expression = Val{true}, wrap_gfw = Val{false},
+        eval_expression = false, eval_module = @__MODULE__, kwargs...
+    )
+    return generate_cons(
+        sys,
+        GeneratedFunctionOptions(;
+            expression, wrap_gfw, eval_expression, eval_module,
+            codegen_function_options = Symbolics.CodegenFunctionOptions(; kwargs...)
+        )
+    )
+end
+
+function generate_bvp_cost(
+        sys::System; expression = Val{true}, wrap_gfw = Val{false},
+        eval_expression = false, eval_module = @__MODULE__, kwargs...
+    )
+    return generate_bvp_cost(
+        sys,
+        GeneratedFunctionOptions(;
+            expression, wrap_gfw, eval_expression, eval_module,
+            codegen_function_options = Symbolics.CodegenFunctionOptions(; kwargs...)
+        )
+    )
+end
+
+function generate_cost_gradient(
+        sys::System; expression = Val{true}, wrap_gfw = Val{false},
+        eval_expression = false, eval_module = @__MODULE__, simplify = false, kwargs...
+    )
+    return generate_cost_gradient(
+        sys,
+        GeneratedFunctionOptions(;
+            expression, wrap_gfw, eval_expression, eval_module,
+            codegen_function_options = Symbolics.CodegenFunctionOptions(; kwargs...)
+        );
+        simplify
+    )
+end
+
+function generate_cost_hessian(
+        sys::System; expression = Val{true}, wrap_gfw = Val{false},
+        eval_expression = false, eval_module = @__MODULE__, simplify = false,
+        sparse = false, return_sparsity = false, kwargs...
+    )
+    return generate_cost_hessian(
+        sys,
+        GeneratedFunctionOptions(;
+            expression, wrap_gfw, eval_expression, eval_module,
+            codegen_function_options = Symbolics.CodegenFunctionOptions(; kwargs...)
+        );
+        simplify, sparse, return_sparsity
+    )
+end
+
+function generate_constraint_jacobian(
+        sys::System; expression = Val{true}, wrap_gfw = Val{false},
+        eval_expression = false, eval_module = @__MODULE__, return_sparsity = false,
+        simplify = false, sparse = false, kwargs...
+    )
+    return generate_constraint_jacobian(
+        sys,
+        GeneratedFunctionOptions(;
+            expression, wrap_gfw, eval_expression, eval_module,
+            codegen_function_options = Symbolics.CodegenFunctionOptions(; kwargs...)
+        );
+        return_sparsity, simplify, sparse
+    )
+end
+
+function generate_constraint_hessian(
+        sys::System; expression = Val{true}, wrap_gfw = Val{false},
+        eval_expression = false, eval_module = @__MODULE__, return_sparsity = false,
+        simplify = false, sparse = false, kwargs...
+    )
+    return generate_constraint_hessian(
+        sys,
+        GeneratedFunctionOptions(;
+            expression, wrap_gfw, eval_expression, eval_module,
+            codegen_function_options = Symbolics.CodegenFunctionOptions(; kwargs...)
+        );
+        return_sparsity, simplify, sparse
+    )
+end
+
+function generate_control_jacobian(
+        sys::AbstractSystem; expression = Val{true}, wrap_gfw = Val{false},
+        eval_expression = false, eval_module = @__MODULE__, simplify = false,
+        sparse = false, kwargs...
+    )
+    return generate_control_jacobian(
+        sys,
+        GeneratedFunctionOptions(;
+            expression, wrap_gfw, eval_expression, eval_module,
+            codegen_function_options = Symbolics.CodegenFunctionOptions(; kwargs...)
+        );
+        simplify, sparse
+    )
+end
+
+function generate_history(
+        sys::System, u0; expression = Val{true}, wrap_gfw = Val{false},
+        eval_expression = false, eval_module = @__MODULE__, kwargs...
+    )
+    return generate_history(
+        sys, u0,
+        GeneratedFunctionOptions(;
+            expression, wrap_gfw, eval_expression, eval_module,
+            codegen_function_options = Symbolics.CodegenFunctionOptions(; kwargs...)
+        )
+    )
+end
+
+function generate_boundary_conditions(
+        sys::System, u0, u0_idxs, t0; expression = Val{true}, wrap_gfw = Val{false},
+        eval_expression = false, eval_module = @__MODULE__, kwargs...
+    )
+    return generate_boundary_conditions(
+        sys, u0, u0_idxs, t0,
+        GeneratedFunctionOptions(;
+            expression, wrap_gfw, eval_expression, eval_module,
+            codegen_function_options = Symbolics.CodegenFunctionOptions(; kwargs...)
+        )
+    )
+end
+
+for AType in (
+        :AbstractMatrix, :(Diagonal{SymbolicT, Vector{SymbolicT}}),
+        :(BandedMatrix{SymbolicT, Matrix{SymbolicT}}),
+    )
+    @eval function generate_update_A(
+            sys::System, A::$AType; expression = Val{true}, wrap_gfw = Val{false},
+            eval_expression = false, eval_module = @__MODULE__,
+            compiler_options::CompilerOptions = CompilerOptions(), cachesyms = (), kwargs...
+        )
+        return generate_update_A(
+            sys, A,
+            GeneratedFunctionOptions(;
+                expression, wrap_gfw, eval_expression, eval_module,
+                compiler_options,
+                codegen_function_options = Symbolics.CodegenFunctionOptions(; kwargs...)
+            );
+            cachesyms
+        )
+    end
+end
+
+function generate_update_b(
+        sys::System, b::AbstractVector; expression = Val{true}, wrap_gfw = Val{false},
+        eval_expression = false, eval_module = @__MODULE__,
+        compiler_options::CompilerOptions = CompilerOptions(), cachesyms = (), kwargs...
+    )
+    return generate_update_b(
+        sys, b,
+        GeneratedFunctionOptions(;
+            expression, wrap_gfw, eval_expression, eval_module,
+            compiler_options,
+            codegen_function_options = Symbolics.CodegenFunctionOptions(; kwargs...)
+        );
+        cachesyms
+    )
+end
+
+function generate_custom_function(
+        sys::AbstractSystem, exprs, dvs = unknowns(sys),
+        ps = parameters(sys; initial_parameters = true);
+        expression = Val{true}, eval_expression = false, eval_module = @__MODULE__,
+        cachesyms::Tuple = (), kwargs...
+    )
+    return generate_custom_function(
+        sys, exprs, dvs, ps,
+        GeneratedFunctionOptions(;
+            expression, eval_expression, eval_module,
+            codegen_function_options = Symbolics.CodegenFunctionOptions(; kwargs...)
+        );
+        cachesyms
+    )
+end

--- a/lib/ModelingToolkitBase/src/systems/codegen_compat.jl
+++ b/lib/ModelingToolkitBase/src/systems/codegen_compat.jl
@@ -296,3 +296,69 @@ function generate_custom_function(
         cachesyms
     )
 end
+
+Base.@nospecializeinfer function build_explicit_observed_function(
+        sys, @nospecialize(ts);
+        inputs = nothing, disturbance_inputs = nothing, known_disturbance_inputs = nothing,
+        disturbance_argument = false, expression = false, eval_expression = false,
+        eval_module = @__MODULE__, output_type = Array, checkbounds = false,
+        ps = parameters(sys; initial_parameters = true), return_inplace = Val(false),
+        param_only = false, throw = true, wrap_delays = is_dde(sys) && !param_only,
+        force_time_independent = false, compiler_options::CompilerOptions = CompilerOptions(),
+        kwargs...
+    )
+    return build_explicit_observed_function(
+        sys, ts,
+        GeneratedFunctionOptions(;
+            expression, eval_expression, eval_module, compiler_options,
+            codegen_function_options = Symbolics.CodegenFunctionOptions(; checkbounds, kwargs...)
+        );
+        inputs, disturbance_inputs, known_disturbance_inputs, disturbance_argument,
+        output_type, ps, return_inplace, param_only, throw, wrap_delays, force_time_independent
+    )
+end
+
+Base.@nospecializeinfer function compile_condition(
+        @nospecialize(cbs::Union{AbstractCallback, Vector{<:AbstractCallback}}),
+        sys, @nospecialize(dvs), @nospecialize(ps);
+        eval_expression = false, eval_module = @__MODULE__, kwargs...
+    )
+    return compile_condition(
+        cbs, sys, dvs, ps,
+        GeneratedFunctionOptions(;
+            eval_expression, eval_module,
+            codegen_function_options = Symbolics.CodegenFunctionOptions(; kwargs...)
+        )
+    )
+end
+
+Base.@nospecializeinfer function compile_explicit_affect(
+        @nospecialize(aff::AffectSystem), sys;
+        reset_jumps = false, eval_expression = false, eval_module = @__MODULE__, kwargs...
+    )
+    return compile_explicit_affect(
+        aff, sys,
+        GeneratedFunctionOptions(;
+            eval_expression, eval_module,
+            codegen_function_options = Symbolics.CodegenFunctionOptions(; kwargs...)
+        );
+        reset_jumps
+    )
+end
+
+function generate_control_function(
+        sys::AbstractSystem, inputs = default_codegen_inputs(sys),
+        disturbance_inputs = disturbances(sys);
+        known_disturbance_inputs = nothing, disturbance_argument = false,
+        implicit_dae = false, simplify = false, eval_expression = false,
+        eval_module = @__MODULE__, split = true, kwargs...
+    )
+    return generate_control_function(
+        sys, inputs, disturbance_inputs,
+        GeneratedFunctionOptions(;
+            eval_expression, eval_module,
+            codegen_function_options = Symbolics.CodegenFunctionOptions(; kwargs...)
+        );
+        known_disturbance_inputs, disturbance_argument, implicit_dae, simplify, split
+    )
+end

--- a/lib/ModelingToolkitBase/src/systems/codegen_utils.jl
+++ b/lib/ModelingToolkitBase/src/systems/codegen_utils.jl
@@ -49,6 +49,61 @@ end
 
 _has_options(co::CompilerOptions) = co.optlevel != -1 || co.compile != -1 || co.infer != -1
 
+# Normalize an `expression`/`wrap_gfw`-style option (`Val{true}`/`Val{false}` as a type or
+# instance, or a `Bool`) to a `Bool`.
+_gfo_bool(::Type{Val{B}}) where {B} = B::Bool
+_gfo_bool(::Val{B}) where {B} = B::Bool
+_gfo_bool(b::Bool) = b
+
+"""
+    GeneratedFunctionOptions{expression, wrap_gfw}(; kwargs...)
+
+Options for the code-generation entry points (`generate_rhs`, `generate_jacobian`, ...):
+the "output/compile" layer sitting one level above [`BuildFunctionWrapperOptions`](@ref).
+It controls how the generated code is realized (returned as an `Expr` vs compiled to a
+callable, and whether wrapped in a `GeneratedFunctionWrapper`) and holds a nested
+`Symbolics.CodegenFunctionOptions` (`codegen`) with the low-level code-generation options
+threaded down to `build_function_wrapper`.
+
+`expression` and `wrap_gfw` are `Bool` type parameters (each accepts `Val{true}`/`Val{false}`
+or a `Bool` in the keyword constructor). Both gate the return type of the generators —
+`expression` selects `Expr` vs a compiled callable, `wrap_gfw` selects wrapping in a
+`GeneratedFunctionWrapper` — so making them type parameters lets the generators branch on
+them statically. All other options are fields, so for a fixed `(expression, wrap_gfw)` the
+type is invariant to their values.
+
+# Keyword arguments
+
+- `expression`, `wrap_gfw`: as above (lifted into the type parameters).
+- `eval_expression`: whether to `eval` the generated code (vs `RuntimeGeneratedFunctions`).
+- `eval_module`: the module used to realize the generated code.
+- `compiler_options`: a [`CompilerOptions`](@ref).
+- `codegen_function_options`: a `Symbolics.CodegenFunctionOptions` with the code-generation
+  options forwarded down to `build_function_wrapper`.
+"""
+struct GeneratedFunctionOptions{expression, wrap_gfw}
+    eval_expression::Bool
+    eval_module::Module
+    compiler_options::CompilerOptions
+    codegen::Symbolics.CodegenFunctionOptions
+end
+
+function GeneratedFunctionOptions(;
+        expression = Val{true}, wrap_gfw = Val{false},
+        eval_expression = false, eval_module = @__MODULE__,
+        compiler_options::CompilerOptions = CompilerOptions(),
+        codegen_function_options::Symbolics.CodegenFunctionOptions = Symbolics.CodegenFunctionOptions()
+    )
+    return GeneratedFunctionOptions{_gfo_bool(expression), _gfo_bool(wrap_gfw)}(
+        eval_expression, eval_module, compiler_options, codegen_function_options
+    )
+end
+
+# Recover the `expression`/`wrap_gfw` switches as `Val` types for dispatch into
+# `maybe_compile_function` / for branching in generator bodies.
+expression_val(::GeneratedFunctionOptions{E}) where {E} = Val{E}
+wrap_gfw_val(::GeneratedFunctionOptions{E, W}) where {E, W} = Val{W}
+
 const _COMPILER_OPTIONS_SUPPORTED = isdefined(Base.Experimental, :set_compile!)
 
 # Fallback modules with module-level compiler options for Julia versions

--- a/lib/ModelingToolkitBase/src/systems/imperative_affect.jl
+++ b/lib/ModelingToolkitBase/src/systems/imperative_affect.jl
@@ -349,7 +349,7 @@ function compile_functional_affect(
     end
     obs_fun = build_explicit_observed_function(
         sys, Symbolics.scalarize.(obs_exprs);
-        mkarray = (es, _) -> MakeTuple(es)
+        output_type = Tuple
     )
     obs_sym_tuple = (obs_syms...,)
 
@@ -358,7 +358,7 @@ function compile_functional_affect(
     mod_names = (mod_syms...,)
     mod_og_val_fun = build_explicit_observed_function(
         sys, Symbolics.scalarize.(first.(mod_pairs));
-        mkarray = (es, _) -> MakeTuple(es)
+        output_type = Tuple
     )
 
     upd_funs = NamedTuple{mod_names}((setu.((sys,), first.(mod_pairs))...,))

--- a/lib/ModelingToolkitBase/src/systems/imperative_affect.jl
+++ b/lib/ModelingToolkitBase/src/systems/imperative_affect.jl
@@ -348,7 +348,8 @@ function compile_functional_affect(
         zeros(sz)
     end
     obs_fun = build_explicit_observed_function(
-        sys, Symbolics.scalarize.(obs_exprs);
+        sys, Symbolics.scalarize.(obs_exprs),
+        GeneratedFunctionOptions(; expression = Val{false});
         output_type = Tuple
     )
     obs_sym_tuple = (obs_syms...,)
@@ -357,7 +358,8 @@ function compile_functional_affect(
     mod_pairs = mod_exprs .=> mod_syms
     mod_names = (mod_syms...,)
     mod_og_val_fun = build_explicit_observed_function(
-        sys, Symbolics.scalarize.(first.(mod_pairs));
+        sys, Symbolics.scalarize.(first.(mod_pairs)),
+        GeneratedFunctionOptions(; expression = Val{false});
         output_type = Tuple
     )
 

--- a/lib/ModelingToolkitBase/src/systems/nonlinear/homotopy_continuation.jl
+++ b/lib/ModelingToolkitBase/src/systems/nonlinear/homotopy_continuation.jl
@@ -521,12 +521,18 @@ end
     )
     fn = remake(fn; sys = sys, observed = obsfn)
 
-    denominator = build_explicit_observed_function(sys2, denoms)
-    unpolynomialize = build_explicit_observed_function(sys2, all_solutions)
+    denominator = build_explicit_observed_function(
+        sys2, denoms, GeneratedFunctionOptions(; expression = Val{false})
+    )
+    unpolynomialize = build_explicit_observed_function(
+        sys2, all_solutions, GeneratedFunctionOptions(; expression = Val{false})
+    )
 
     inv_mapping = Dict(v => k for (k, v) in transformation.substitution_rules)
     polynomialize_terms = [get(inv_mapping, var, var) for var in unknowns(sys2)]
-    polynomialize = build_explicit_observed_function(sys, polynomialize_terms)
+    polynomialize = build_explicit_observed_function(
+        sys, polynomialize_terms, GeneratedFunctionOptions(; expression = Val{false})
+    )
 
     return HomotopyNonlinearFunction{iip, specialize}(
         fn; polynomialize, unpolynomialize, denominator

--- a/lib/ModelingToolkitBase/src/systems/optimal_control_interface.jl
+++ b/lib/ModelingToolkitBase/src/systems/optimal_control_interface.jl
@@ -142,40 +142,28 @@ is_explicit(tableau) = tableau isa DiffEqBase.ExplicitRKTableau
     )
     f = f[1]
 
+    # NOTE: the historical calls passed `expression_module = eval_module`, which was never a
+    # recognized keyword (it was silently dropped), so `eval_module` defaulted here. That
+    # behavior is preserved: `codegen_opts` does not set `eval_module`.
+    codegen_opts = GeneratedFunctionOptions(;
+        expression = Val{true}, wrap_gfw = Val{true},
+        codegen_function_options = Symbolics.CodegenFunctionOptions(; checkbounds, kwargs...)
+    )
+
     if tgrad
-        _tgrad = generate_tgrad(
-            sys;
-            simplify = simplify,
-            expression = Val{true},
-            wrap_gfw = Val{true},
-            expression_module = eval_module,
-            checkbounds = checkbounds, kwargs...
-        )
+        _tgrad = generate_tgrad(sys, codegen_opts; simplify)
     else
         _tgrad = nothing
     end
 
     if jac
-        _jac = generate_jacobian(
-            sys;
-            simplify = simplify, sparse = sparse,
-            expression = Val{true},
-            wrap_gfw = Val{true},
-            expression_module = eval_module,
-            checkbounds = checkbounds, kwargs...
-        )
+        _jac = generate_jacobian(sys, codegen_opts; simplify, sparse)
     else
         _jac = nothing
     end
 
     if controljac
-        _cjac = generate_control_jacobian(
-            sys;
-            simplify = simplify, sparse = sparse,
-            expression = Val{true}, wrap_gfw = Val{true},
-            expression_module = eval_module,
-            checkbounds = checkbounds, kwargs...
-        )
+        _cjac = generate_control_jacobian(sys, codegen_opts; simplify, sparse)
     else
         _cjac = nothing
     end

--- a/lib/ModelingToolkitBase/src/systems/problem_utils.jl
+++ b/lib/ModelingToolkitBase/src/systems/problem_utils.jl
@@ -2230,10 +2230,9 @@ function (st::SymbolicTstops)(p, tspan)
     end
 end
 
-function SymbolicTstops(
-        sys::AbstractSystem; expression = Val{false}, eval_expression = false,
-        eval_module = @__MODULE__
-    )
+function SymbolicTstops(sys::AbstractSystem, opts::GeneratedFunctionOptions)
+    expression = expression_val(opts)
+    (; eval_expression, eval_module) = opts
     tstops = symbolic_tstops(sys)
     isempty(tstops) && return nothing
     t0 = gensym(:t0)
@@ -2266,6 +2265,18 @@ function SymbolicTstops(
     else
         return SymbolicTstops(tstops)
     end
+end
+
+# Backward-compatibility keyword method. The positional `opts::GeneratedFunctionOptions`
+# method above is the primary; this wrapper preserves the historical keyword API. It must
+# be defined after `struct SymbolicTstops` so it registers as a method on that binding.
+function SymbolicTstops(
+        sys::AbstractSystem; expression = Val{false}, eval_expression = false,
+        eval_module = @__MODULE__
+    )
+    return SymbolicTstops(
+        sys, GeneratedFunctionOptions(; expression, eval_expression, eval_module)
+    )
 end
 
 """

--- a/lib/ModelingToolkitBase/src/systems/problem_utils.jl
+++ b/lib/ModelingToolkitBase/src/systems/problem_utils.jl
@@ -2199,7 +2199,9 @@ function process_kwargs(
         end
 
         if !_skip_tstops
-            tstops = SymbolicTstops(sys; expression, eval_expression, eval_module)
+            tstops = SymbolicTstops(
+                sys, GeneratedFunctionOptions(; expression, eval_expression, eval_module)
+            )
             if tstops !== nothing
                 kwargs1 = merge(kwargs1, (; tstops))
             end


### PR DESCRIPTION
In continuation of the series of PRs that aim to reduce unnecessarily splatting kwargs everywhere.