### PR TITLE
fix: allow parameter-only equations after `mtkcompile`

### DIFF
--- a/lib/ModelingToolkitBase/src/systems/abstractsystem.jl
+++ b/lib/ModelingToolkitBase/src/systems/abstractsystem.jl
@@ -632,7 +632,8 @@ This namespacing functionality can also be toggled independently of `complete`
 using [`toggle_namespacing`](@ref).
 """
 function complete(
-        sys::T; split = true, flatten = true, add_initial_parameters = true
+        sys::T; split = true, flatten = true, add_initial_parameters = true,
+        allow_parameter_eqs = false
     ) where {T <: AbstractSystem}
     sys = discover_globalscoped(sys)
 
@@ -647,7 +648,7 @@ function complete(
             @set! newsys.parent = complete(sys; split = false, flatten = false)::T
         end
         sys = newsys
-        check_no_parameter_equations(sys)
+        allow_parameter_eqs || check_no_parameter_equations(sys)
         _unhack_sys = reverse_all_default_reversible_transformations(sys)
         if add_initial_parameters
             sys = add_initialization_parameters(sys; split, _unhack_sys)::T

--- a/lib/ModelingToolkitBase/src/systems/systems.jl
+++ b/lib/ModelingToolkitBase/src/systems/systems.jl
@@ -106,7 +106,8 @@ function mtkcompile(
         newsys = pass(newsys)
     end
     @set! newsys.parent = toggle_namespacing(sys, false)
-    newsys = complete(newsys; split)
+    # Singular systems may end up with parameter-only equations, which shouldn't error on `complete`
+    newsys = complete(newsys; split, allow_parameter_eqs = true)
     return newsys
 end
 


### PR DESCRIPTION
These can show up in singular systems, so it should not error

## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
