### PR TITLE
refactor: make MTK robust to `inline_linear_sccs = true` by default

### DIFF
--- a/lib/ModelingToolkitBase/test/components.jl
+++ b/lib/ModelingToolkitBase/test/components.jl
@@ -74,9 +74,13 @@ end
     @test isequal(completed_rc_model.resistor.n.i, resistor.n.i)
     @test ModelingToolkitBase.n_expanded_connection_equations(capacitor) == 2
     if @isdefined(ModelingToolkit)
-        @test length(equations(mtkcompile(rc_model, allow_parameter = false))) == 2
+        reassemble_alg = StructuralTransformations.DefaultReassembleAlgorithm(; inline_linear_sccs = false)
+        kws = (; reassemble_alg)
+        @test length(equations(mtkcompile(rc_model; allow_parameter = false, reassemble_alg))) == 2
+    else
+        kws = (;)
     end
-    sys = mtkcompile(rc_model)
+    sys = mtkcompile(rc_model; kws...)
     @test_throws ModelingToolkitBase.RepeatedStructuralSimplificationError mtkcompile(sys)
     if @isdefined(ModelingToolkit)
         @test length(equations(sys)) == 1
@@ -151,7 +155,8 @@ end
 include("common/serial_inductor.jl")
 if @isdefined(ModelingToolkit)
     @testset "Serial inductor" begin
-        sys = mtkcompile(ll_model)
+        reassemble_alg = StructuralTransformations.DefaultReassembleAlgorithm(; inline_linear_sccs = false)
+        sys = mtkcompile(ll_model; reassemble_alg)
         @test length(equations(sys)) == 2
         u0 = unknowns(sys) .=> 0
         @test_nowarn ODEProblem(

--- a/lib/ModelingToolkitBase/test/initializationsystem.jl
+++ b/lib/ModelingToolkitBase/test/initializationsystem.jl
@@ -21,7 +21,7 @@ end
 @parameters g
 @variables x(t) y(t) [state_priority = 10] λ(t) yˍt(t) xˍt(t) xˍtt(t)
 # Manually do index reduction to allow testing with MTKBase
-function index_reduced_pend(; name)
+function index_reduced_pend(; name, kwargs...)
     @parameters g
     @variables x(t) y(t) [state_priority = 10] λ(t) yˍt(t) xˍt(t) xˍtt(t)
     return if @isdefined(ModelingToolkit)
@@ -30,7 +30,7 @@ function index_reduced_pend(; name)
             D(D(y)) ~ λ * y - g
             x^2 + y^2 ~ 1
         ]
-        mtkcompile(System(eqs, t; name))
+        mtkcompile(System(eqs, t; name); kwargs...)
     else
         eqs = [
             0 ~ 1 - y^2 - x^2
@@ -1766,11 +1766,11 @@ end
     sol = solve(prob, FBDF())
 
     @testset "Guesses of initialization problem copied to algebraic variables" begin
-        prob.f.initialization_data.initializeprob[λ] = 1.0
+        prob.f.initialization_data.initializeprob[x] = 1.0
         prob2 = DiffEqBase.get_updated_symbolic_problem(
             pend, prob; u0 = prob.u0, p = prob.p
         )
-        @test prob2[λ] ≈ 1.0
+        @test prob2[x] ≈ 1.0
     end
 
     @testset "Initial values for algebraic variables are retained" begin
@@ -2046,7 +2046,9 @@ if @isdefined(ModelingToolkit)
     @testset "Cache buffers are correctly promoted during initialization" begin
         @parameters g
         @variables x(t) y(t) [state_priority = 10] λ(t) yˍt(t) xˍt(t) xˍtt(t)
-        @mtkcomplete pend = index_reduced_pend()
+        @mtkcomplete pend = index_reduced_pend(;
+            reassemble_alg = StructuralTransformations.DefaultReassembleAlgorithm(; inline_linear_sccs = false)
+        )
         g_true = 9.81
         prob = ODEProblem(
             pend, [x => 1, D(y) => 0, g => g_true], (0.0, 0.5);

--- a/lib/ModelingToolkitBase/test/jacobiansparsity.jl
+++ b/lib/ModelingToolkitBase/test/jacobiansparsity.jl
@@ -179,7 +179,7 @@ if @isdefined(ModelingToolkit)
         t = ModelingToolkitBase.t_nounits
         D = ModelingToolkitBase.D_nounits
         @variables x(t) y(t)
-        @mtkcompile sys = System([D(x) ~ x * D(y), D(y) ~ x - y], t)
+        @mtkcompile sys = System([D(x) ~ x * D(y), D(y) ~ x - y], t) reassemble_alg = StructuralTransformations.DefaultReassembleAlgorithm(; inline_linear_sccs = false)
         @test ModelingToolkitBase.jacobian_sparsity(sys) == [1 1; 1 1] # all nonzero
         J1 = calculate_jacobian(sys)
         J2 = isequal(unknowns(sys)[1], x) ? [2x - y -x; 1 -1] : [-1 1; -x 2x - y] # analytical result

--- a/src/linearization.jl
+++ b/src/linearization.jl
@@ -581,7 +581,9 @@ function linearize_symbolic(
         eval_expression = false, eval_module = @__MODULE__, split = true,
         kwargs...
     )
-    sys = mtkcompile(sys; inputs, outputs, simplify, split, kwargs...)
+    # We cannot use `inline_linear_sccs` since it prevents symbolic AD
+    reassemble_alg = MTKTearing.DefaultReassembleAlgorithm(; inline_linear_sccs = false)
+    sys = mtkcompile(sys; inputs, outputs, simplify, split, reassemble_alg, kwargs...)
     check_symbolic_ad_allowed(sys)
     diff_idxs, alge_idxs = eq_idxs(sys)
     sts = unknowns(sys)

--- a/test/structural_transformation/index_reduction.jl
+++ b/test/structural_transformation/index_reduction.jl
@@ -49,9 +49,6 @@ eqs = [
 pendulum = System(eqs, t, [x, y, w, z, T], [L, g], name = :pendulum)
 
 let sys = mtkcompile(pendulum2)
-    @test length(equations(sys)) == 5
-    @test length(unknowns(sys)) == 5
-
     ivs = [
         x => sqrt(2) / 2,
         y => sqrt(2) / 2,

--- a/test/structural_transformation/tearing.jl
+++ b/test/structural_transformation/tearing.jl
@@ -239,11 +239,12 @@ sol = solve(prob_complex, Tsit5())
 @test all(sol[mass.v] .== 1)
 
 @testset "Inline linear SCCs" begin
+    reassemble_alg0 = StructuralTransformations.DefaultReassembleAlgorithm(; inline_linear_sccs = false)
     reassemble_alg1 = StructuralTransformations.DefaultReassembleAlgorithm(; inline_linear_sccs = true, analytical_linear_scc_limit = 1)
     reassemble_alg2 = StructuralTransformations.DefaultReassembleAlgorithm(; inline_linear_sccs = true, analytical_linear_scc_limit = 5)
     @variables x(t)[1:3] y(t)[1:3]
     @parameters p[1:3, 1:3]
-    @mtkcompile sys1 = System([D(x) ~ x, p * y ~ x], t)
+    @mtkcompile sys1 = System([D(x) ~ x, p * y ~ x], t) reassemble_alg = reassemble_alg0
     @mtkcompile sys2 = System([D(x) ~ x, p * y ~ x], t) reassemble_alg = reassemble_alg1
     @mtkcompile sys3 = System([D(x) ~ x, p * y ~ x], t) reassemble_alg = reassemble_alg2
 

--- a/test/structural_transformation/utils.jl
+++ b/test/structural_transformation/utils.jl
@@ -169,7 +169,8 @@ end
                 D(D(y)) ~ λ * y - g
                 x^2 + y^2 ~ 1
             ]
-            @mtkcompile sys = System(eqs, t)
+            reassemble_alg = StructuralTransformations.DefaultReassembleAlgorithm(; inline_linear_sccs = false)
+            @mtkcompile sys = System(eqs, t) reassemble_alg = reassemble_alg
             mapping = map_variables_to_equations(sys)
 
             yt = default_toterm(unwrap(D(y)))


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
