### PR TITLE
Drop ArrayInterface 6 support from ModelingToolkitBase

### DIFF
--- a/lib/ModelingToolkitBase/Project.toml
+++ b/lib/ModelingToolkitBase/Project.toml
@@ -93,7 +93,7 @@ MTKTrackerExt = "Tracker"
 [compat]
 ADTypes = "1.14.0"
 AbstractTrees = "0.3, 0.4"
-ArrayInterface = "6, 7"
+ArrayInterface = "7"
 BoundaryValueDiffEqAscher = "1.6.0"
 BoundaryValueDiffEqMIRK = "1.7.0"
 BandedMatrices = "1.11.0"


### PR DESCRIPTION
> Ignore this PR until it has been reviewed by @ChrisRackauckas.

## Summary

- remove ArrayInterface 6 from ModelingToolkitBase's supported dependency range
- retain ArrayInterface 7, available since February 2023

## Motivation

ArrayInterface 6 was superseded in 2023. The exact Julia 1.10 minimum graph already resolves ArrayInterface 7.19.0 after this one-line metadata change, so the old major no longer represents a distinct exercised compatibility path.

## Local validation

- exact Julia 1.10 ModelingToolkitBase `InterfaceI`: 1,403 passed, 1 errored, and 4 pre-existing broken; the sole error is the independently reproduced OptimizationOptimJL 0.4.12 / SciMLBase 3 incompatibility addressed by PR #4788
- current Julia 1.12.6 ModelingToolkitBase `InterfaceI`: 1,468 passed and 5 pre-existing broken
- current broad `All` run reached 7,235 passes, 3 errors, and 4 pre-existing broken tests; all three errors match the separately investigated clean-base BoundaryValueDiffEqMIRK failures
- Runic: 221/221 files passed
- `git diff --check`: passed

Apart from the local source path and the changed compat declaration, the exact candidate graph matches the clean-base graph.
