### PR TITLE
Bump ModelingToolkit and ModelingToolkitBase for release

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ModelingToolkit"
 uuid = "961ee093-0014-501f-94e3-6117800e7a78"
-version = "11.35.0"
+version = "11.35.1"
 authors = ["Yingbo Ma <mayingbo5@gmail.com>", "Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
 
 [deps]

--- a/lib/ModelingToolkitBase/Project.toml
+++ b/lib/ModelingToolkitBase/Project.toml
@@ -1,7 +1,7 @@
 name = "ModelingToolkitBase"
 uuid = "7771a370-6774-4173-bd38-47e70ca0b839"
 authors = ["Yingbo Ma <mayingbo5@gmail.com>", "Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
-version = "1.54.1"
+version = "1.54.2"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"


### PR DESCRIPTION
Releases unreleased fixes on master:
- **ModelingToolkitBase** 1.54.1 → 1.54.2 (allow parameter-only equations after `mtkcompile`; unbound-variable fix (#4738))
- **ModelingToolkit** 11.35.0 → 11.35.1 (avoid eliminating irreducibles in `eliminate_zero_variables!`)

Detected by comparing the `git-tree-sha1` of the latest live registered version in General against the `src` subtree on the default branch. Only the `version` field in `Project.toml` is changed. **No local test run** — CI on this PR is the check. Please ignore until reviewed by @ChrisRackauckas.