### PR TITLE
Fix Runic indentation in parse_variable

### DIFF
--- a/lib/ModelingToolkitBase/src/systems/abstractsystem.jl
+++ b/lib/ModelingToolkitBase/src/systems/abstractsystem.jl
@@ -3608,7 +3608,7 @@ function parse_variable(sys::AbstractSystem, str::AbstractString)
         for ident in eachsplit(str, ('.', NAMESPACE_SEPARATOR))
             ident = Symbol(ident)
             hasproperty(cur, ident) ||
-            throw(ArgumentError("System $(nameof(cur)) does not have a subsystem/variable named $(ident)"))
+                throw(ArgumentError("System $(nameof(cur)) does not have a subsystem/variable named $(ident)"))
             cur = getproperty(cur, ident)
         end
     else


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## Summary

- indent the continued `throw` expression in `parse_variable`
- restore the repository-wide Runic check after the nesting added by #4783

## Root cause

Runic 1.7.0 fails on clean master commit `80edc5dc9a831de7ae229b069134d03025991b41`. A `git bisect` between its first parent and the merge identifies `3ae5bc97d8283fefcbb5459663dc123d25836399` as the first bad commit: new `if`/`for` nesting moved the pre-existing boolean continuation inward without indenting the `throw`.

The branch was rebased onto current master `f6c5c80da6cfad33b152033604a5c57b4548814e` before publication.

## Local verification

- `timeout 3600 env JULIA_DEPOT_PATH=... julia +1.12 --project=.../audit/envs/runic-check -m Runic --check --diff .` — passed repository-wide with Runic 1.7.0
- `timeout 3600 env GROUP=InterfaceI julia +1.12 --project=lib/ModelingToolkitBase -e "using Pkg; Pkg.test()"` — 1495 passed, 5 pre-existing broken, 1500 total; rerun after rebase passed in 35m29s
- `git diff --check origin/master...HEAD` — passed