### PR TITLE
refactor: bug fixes, pass `GeneratedFunctionOptions` to `ObservedFunctionCache`

### DIFF
--- a/lib/ModelingToolkitBase/src/problems/ddeproblem.jl
+++ b/lib/ModelingToolkitBase/src/problems/ddeproblem.jl
@@ -1,5 +1,5 @@
 @fallback_iip_specialize function SciMLBase.DDEFunction{iip, spec}(
-        sys::System; u0 = nothing, p = nothing, eval_expression = false,
+        sys::System; u0 = nothing, p = nothing, t = nothing, eval_expression = false,
         eval_module = @__MODULE__, expression = Val{false}, checkbounds = false,
         initialization_data = nothing, check_compatibility = true,
         sparse = false, simplify = false, analytic = nothing, kwargs...

--- a/lib/ModelingToolkitBase/src/problems/sddeproblem.jl
+++ b/lib/ModelingToolkitBase/src/problems/sddeproblem.jl
@@ -1,5 +1,5 @@
 @fallback_iip_specialize function SciMLBase.SDDEFunction{iip, spec}(
-        sys::System; u0 = nothing, p = nothing, expression = Val{false},
+        sys::System; u0 = nothing, p = nothing, t = nothing, expression = Val{false},
         eval_expression = false, eval_module = @__MODULE__, checkbounds = false,
         initialization_data = nothing, check_compatibility = true,
         sparse = false, simplify = false, analytic = nothing, kwargs...

--- a/lib/ModelingToolkitBase/src/systems/abstractsystem.jl
+++ b/lib/ModelingToolkitBase/src/systems/abstractsystem.jl
@@ -2334,24 +2334,9 @@ struct ObservedFunctionCache{S, O}
     optimize::O
 end
 
-function ObservedFunctionCache(
-        sys; expression = Val{false}, steady_state = false, eval_expression = false,
-        eval_module = @__MODULE__, checkbounds = true, optimize = nothing,
-    )
-    return if expression == Val{true}
-        :(
-            $ObservedFunctionCache(
-                $sys, Dict(), $steady_state, $eval_expression,
-                $eval_module, $checkbounds, $optimize
-            )
-        )
-    else
-        ObservedFunctionCache(
-            sys, Dict(), steady_state, eval_expression, eval_module, checkbounds,
-            optimize,
-        )
-    end
-end
+# Constructors (taking a `GeneratedFunctionOptions` directly, and a backward-compatible
+# keyword wrapper around it) are defined in `codegen_utils.jl`, since they need
+# `GeneratedFunctionOptions` to already exist.
 
 # This is hit because ensemble problems do a deepcopy
 function Base.deepcopy_internal(ofc::ObservedFunctionCache, stackdict::IdDict)

--- a/lib/ModelingToolkitBase/src/systems/codegen_utils.jl
+++ b/lib/ModelingToolkitBase/src/systems/codegen_utils.jl
@@ -104,6 +104,55 @@ end
 expression_val(::GeneratedFunctionOptions{E}) where {E} = Val{E}
 wrap_gfw_val(::GeneratedFunctionOptions{E, W}) where {E, W} = Val{W}
 
+"""
+    ObservedFunctionCache(sys, opts::GeneratedFunctionOptions; steady_state = false)
+
+Build an `ObservedFunctionCache` for `sys`, taking `eval_expression`, `eval_module`,
+`checkbounds`, and `optimize` from `opts` (its own `expression` type parameter decides
+whether an `Expr` or a live `ObservedFunctionCache` is returned) rather than as separate
+keywords. This is the form to use wherever a `GeneratedFunctionOptions` is already on
+hand (e.g. nested inside a higher-level options struct), instead of re-listing its
+fields as separate keywords.
+"""
+function ObservedFunctionCache(
+        sys, opts::GeneratedFunctionOptions{E}; steady_state::Bool = false
+    ) where {E}
+    (; eval_expression, eval_module) = opts
+    checkbounds = opts.codegen.checkbounds
+    optimize = opts.codegen.optimize
+    return if E
+        :(
+            $ObservedFunctionCache(
+                $sys, Dict(), $steady_state, $eval_expression,
+                $eval_module, $checkbounds, $optimize
+            )
+        )
+    else
+        ObservedFunctionCache(
+            sys, Dict(), steady_state, eval_expression, eval_module, checkbounds,
+            optimize,
+        )
+    end
+end
+
+"""
+    ObservedFunctionCache(sys; expression, steady_state, eval_expression, eval_module, checkbounds, optimize)
+
+Backward-compatible keyword constructor, kept for callers that don't have a
+`GeneratedFunctionOptions` on hand. Assembles one from the given keywords and forwards to
+[`ObservedFunctionCache(sys, ::GeneratedFunctionOptions)`](@ref).
+"""
+function ObservedFunctionCache(
+        sys; expression = Val{false}, steady_state::Bool = false, eval_expression = false,
+        eval_module = @__MODULE__, checkbounds = true, optimize = nothing,
+    )
+    opts = GeneratedFunctionOptions(;
+        expression, eval_expression, eval_module,
+        codegen_function_options = Symbolics.CodegenFunctionOptions(; checkbounds, optimize)
+    )
+    return ObservedFunctionCache(sys, opts; steady_state)
+end
+
 const _COMPILER_OPTIONS_SUPPORTED = isdefined(Base.Experimental, :set_compile!)
 
 # Fallback modules with module-level compiler options for Julia versions

--- a/lib/ModelingToolkitBase/src/systems/problem_utils.jl
+++ b/lib/ModelingToolkitBase/src/systems/problem_utils.jl
@@ -2362,7 +2362,10 @@ macro fallback_iip_specialize(ex)
     call_kwargs = map(call_args[1].args) do arg
         Meta.isexpr(arg, :...) && return arg
         @assert Meta.isexpr(arg, :kw) "Expected keyword argument, got $(arg)"
-        return Expr(:kw, arg.args[1], arg.args[1])
+        # `arg.args[1]` is the kwarg's name, optionally type-annotated (`name` or
+        # `name::T`). Forwarding calls need the bare name either way.
+        name = Meta.isexpr(arg.args[1], :(::)) ? arg.args[1].args[1] : arg.args[1]
+        return Expr(:kw, name, name)
     end
     call_args[1] = Expr(:parameters, call_kwargs...)
 

--- a/src/problems/semilinearodeproblem.jl
+++ b/src/problems/semilinearodeproblem.jl
@@ -22,7 +22,7 @@
 
     codegen_opts = GeneratedFunctionOptions(;
         expression, wrap_gfw = Val{true}, eval_expression, eval_module,
-        codegen_function_options = Symbolics.CodegenFunctionOptions(; kwargs...)
+        codegen_function_options = Symbolics.CodegenFunctionOptions(; checkbounds, kwargs...)
     )
 
     f1,


### PR DESCRIPTION
This is in preparation of a larger change adding a `SciMLFunctionOptions` struct.