### PR TITLE
fix: retain `DiffCache` parameter info in SDE system simplification

### DIFF
--- a/lib/ModelingToolkitBase/test/sdesystem.jl
+++ b/lib/ModelingToolkitBase/test/sdesystem.jl
@@ -1188,3 +1188,19 @@ if !@isdefined(ModelingToolkit)
         @test isequal(ModelingToolkitBase.get_noise_eqs(ssys), noise_eqs)
     end
 end
+
+if @isdefined(ModelingToolkit)
+    @testset "MTK `mtkcompile` retains `DiffCache` param info" begin
+        @variables X(t) A(t)
+        @parameters p d k
+        eqs = [
+            D(X) ~ p - d * X
+            k + A^3 ~ 3 + 2 * X^2
+        ]
+        noise_eqs = [2p 1; 0 0]
+        @named sys = System(eqs, t; noise_eqs)
+        sys, dcp = ModelingToolkitBase.add_diffcache(sys, 3)
+        ssys = mtkcompile(sys)
+        @test SU.getmetadata(ssys, ModelingToolkitBase.DiffCacheParams, nothing)[dcp] == 3
+    end
+end

--- a/src/systems/systems.jl
+++ b/src/systems/systems.jl
@@ -132,6 +132,17 @@ function MTKBase.__mtkcompile(
             gui_metadata = get_gui_metadata(sys),
             tstops = symbolic_tstops(sys)
         )
+        diffcache_params = SU.getmetadata(
+            ode_sys, DiffCacheParams, Dict{SymbolicT, Int}()
+        )::Dict{SymbolicT, Int}
+        ssys = SU.setmetadata(ssys, DiffCacheParams, copy(diffcache_params))
+        # Reuse `LinearExpander` cache
+        linear_expansion_cache = check_mutable_cache(
+            ode_sys, LinearExpansionCache, LinearExpansionCacheT, nothing
+        )
+        if linear_expansion_cache !== nothing
+            store_to_mutable_cache!(ssys, LinearExpansionCache, linear_expansion_cache)
+        end
         return ssys
     end
 end


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
