### PR TITLE
Lock SciCompDSL downgrade tests to in-repo sources

### DIFF
--- a/lib/SciCompDSL/Project.toml
+++ b/lib/SciCompDSL/Project.toml
@@ -19,28 +19,35 @@ URIs = "5c2747f8-b7ea-4ff2-ba2e-563bfd36b1d4"
 DynamicQuantities = "06fc5a27-2a28-4c7c-a15d-362465fb6821"
 
 [sources]
-ModelingToolkitBase = {subdir = "lib/ModelingToolkitBase"}
+ModelingToolkit = {path = "../.."}
+ModelingToolkitBase = {path = "../ModelingToolkitBase"}
 
 [extensions]
 SciCompDSLDynamicQuantitiesExt = "DynamicQuantities"
 
 [compat]
+Distributions = "0.25.88"
 DocStringExtensions = "0.9.5"
 DynamicQuantities = "^0.11.2, 0.12, 0.13, 1"
 MLStyle = "0.4.17"
+ModelingToolkit = "11"
 ModelingToolkitBase = "1"
 OrderedCollections = "1"
+OrdinaryDiffEqDefault = "1.3, 2"
+OrdinaryDiffEqTsit5 = "1.1, 2"
 PrecompileTools = "1.2.1"
+SafeTestsets = "0.0.1, 0.1"
 Setfield = "1"
-SymbolicIndexingInterface = "0.3"
-SymbolicUtils = "4"
-Symbolics = "7"
+SymbolicIndexingInterface = "0.3.46"
+SymbolicUtils = "4.35.3"
+Symbolics = "7.32.1"
 URIs = "1"
 julia = "1.10"
 
 [extras]
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 DynamicQuantities = "06fc5a27-2a28-4c7c-a15d-362465fb6821"
+ModelingToolkit = "961ee093-0014-501f-94e3-6117800e7a78"
 OrdinaryDiffEqDefault = "50262376-6c5a-4cf5-baba-aaf4f84d72d7"
 OrdinaryDiffEqTsit5 = "b1df2697-797e-41e3-8120-5422d3b24e4a"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
@@ -48,4 +55,4 @@ SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["SafeTestsets", "Test", "Pkg", "Distributions", "DynamicQuantities", "OrdinaryDiffEqDefault", "OrdinaryDiffEqTsit5"]
+test = ["SafeTestsets", "Test", "Pkg", "Distributions", "DynamicQuantities", "ModelingToolkit", "OrdinaryDiffEqDefault", "OrdinaryDiffEqTsit5"]

--- a/lib/SciCompDSL/test/runtests.jl
+++ b/lib/SciCompDSL/test/runtests.jl
@@ -6,7 +6,7 @@ const MTKBasePkgSpec = PackageSpec(; path = MTKBasePath)
 const MTKPath = dirname(dirname(dirname(@__DIR__)))
 const MTKPkgSpec = PackageSpec(; path = MTKPath)
 
-Pkg.develop([MTKBasePkgSpec, MTKPkgSpec])
+Pkg.develop([MTKBasePkgSpec, MTKPkgSpec]; preserve = Pkg.PRESERVE_ALL)
 
 @safetestset "Model parsing - MTKBase" include("model_parsing.jl")
 @safetestset "Model parsing - MTK" begin


### PR DESCRIPTION
> **Ignore this PR until it has been reviewed by @ChrisRackauckas.**

## Summary

- declare the in-repository ModelingToolkit and ModelingToolkitBase checkouts as SciCompDSL test sources
- record the jointly compatible test dependency floors needed by those local sources
- preserve the downgrade manifest when the test harness develops the two local packages

Without `Pkg.PRESERVE_ALL`, the test setup can silently replace the graph chosen by the downgrade job. In the control run, it upgraded ModelingToolkitBase 1.0 to 1.54, OrdinaryDiffEqTsit5 1.0 to 2.1, and SciMLBase 2.146 to 3.36 before running the tests.

With the source-aware graph, the resolved package floors remain unchanged across the controlled `Pkg.develop` step. Path entries and Julia-runtime stdlib/JLL patch metadata may be normalized, but the tested package graph is no longer silently upgraded.

## Prerequisites

This is one focused repository-side part of the downgrade fix and depends on:

- julia-actions/julia-downgrade-compat#56 (tested at `28fff4537e765348717821087862dc537353e6a3`) for recursive path-source-aware resolution
- SciML/.github#119 (tested at `4d16630091d8a7c4397f0fe3653d88beaad7b15c`) for promoting test targets before downgrade resolution

The shared workflow also needs to save the original Project.toml before the downgrade action mutates it; otherwise its current restore step preserves the action-mutated project rather than the checkout copy. That workflow follow-up is intentionally not included here.

## Local validation

Using Julia 1.10.11, pinned General `ebea3c922b48a58438335288df661a3b4b2f85ae`, and the exact prerequisite heads above:

- source-aware downgrade action — passed
- locked precompile before local development — passed
- `Pkg.develop([MTKBasePkgSpec, MTKPkgSpec]; preserve = Pkg.PRESERVE_ALL)` — passed, with key package versions preserved
- exact `julia-runtest@v1` invocation with `ALLOW_RERESOLVE=false` — passed:
  - Model parsing - MTKBase: 200 passed, 1 existing broken
  - Model parsing - MTK: 205 passed
- repository-wide Runic 1.7 check — passed
- `git diff --check` — passed
- SciCompDSL Project.toml parse on Julia 1.10.11 — passed

No test was skipped, silenced, or loosened.