### PR TITLE
Fix flattened array lookup in parse_variable

### DIFF
--- a/lib/ModelingToolkitBase/src/systems/abstractsystem.jl
+++ b/lib/ModelingToolkitBase/src/systems/abstractsystem.jl
@@ -3587,12 +3587,14 @@ function parse_variable(sys::AbstractSystem, str::AbstractString)
     sym = nothing
     # This case handles when `sys` is a flattened system without a parent
     for v in get_unknowns(sys)
+        v = split_indexed_var(v)[1]
         if hasname(v) && getname(v) === sym_name
             sym = v
             break
         end
     end
     for v in get_ps(sys)
+        v = split_indexed_var(v)[1]
         if hasname(v) && getname(v) === sym_name
             sym = v
             break

--- a/lib/ModelingToolkitBase/test/variable_utils.jl
+++ b/lib/ModelingToolkitBase/test/variable_utils.jl
@@ -44,6 +44,18 @@ aov = ModelingToolkitBase.collect_applied_operators(eq, Differential)
 ts = collect_ivs([eq])
 @test ts == Set([t])
 
+@testset "parse_variable with scalarized arrays" begin
+    @variables scalarized_x(t)[1:2]
+    @parameters scalarized_p[1:2]
+    scalarized_sys = System(
+        Equation[], t, collect(scalarized_x), collect(scalarized_p); name = :scalarized
+    )
+    @test isequal(parse_variable(scalarized_sys, "scalarized_x"), scalarized_x)
+    @test isequal(parse_variable(scalarized_sys, "scalarized_x[2]"), scalarized_x[2])
+    @test isequal(parse_variable(scalarized_sys, "scalarized_p"), scalarized_p)
+    @test isequal(parse_variable(scalarized_sys, "scalarized_p[2]"), scalarized_p[2])
+end
+
 @testset "parse_variable with iv: $iv" for iv in [t, only(@independent_variables tt)]
     D = Differential(iv)
     function Lorenz(; name)


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## Summary

- normalize flattened unknown and parameter candidates with `split_indexed_var` before matching their names in `parse_variable`
- preserve whole-array lookup while retaining indexed lookup for scalarized systems
- add regression coverage for whole and indexed scalarized array unknowns and parameters

## Root cause

With SymbolicUtils 4.37.0, a flattened system can expose an array as scalarized entries such as `x[1]` and `x[2]`. The fallback added in 3ae5bc97d8283fefcbb5459663dc123d25836399 selected the first matching scalar entry for `parse_variable(sys, "x")`, so whole-array lookup returned `x[1]`; downstream StableIndex construction then asserted for some indexed queries. Normalizing each candidate to its base array before the name comparison preserves the flattened-system fallback without discarding the array shape.

## Local validation

- Julia 1.10.11, SymbolicUtils 4.37.0, post-rebase focused `variable_utils.jl`: scalarized arrays 4/4; parse-variable `t` 54/54; parse-variable `tt` 54/54; `isinitial` 7/7; `At` 13/13
- Julia 1.10.11, SymbolicUtils 4.40.2 focused `variable_utils.jl`: the same summaries passed
- `GROUP=ModelingToolkitBase_InterfaceII` with the exact SymbolicUtils 4.37.0 locked environment and the same patch: 7,240 passed, 0 failed, 2 errored, 4 broken; Variable Utils Test 141/141
- Runic 1.7.0 `--check` across the repository after the rebase: 221/221 files formatted
- `git diff --check` passed; all 14 tracked TOML files parsed

The two InterfaceII errors are the pre-existing BoundaryValueDiffEqMIRK 1.17.2 `Float64(::ForwardDiff.Dual)` failures in `Lotka-Volterra` and `Cost function compilation`. They are unrelated to this lookup change and reproduce outside this patch's scope.
