### PR TITLE
Document public API coverage gaps (docs-only)

### DIFF
--- a/docs/src/API/System.md
+++ b/docs/src/API/System.md
@@ -52,6 +52,8 @@ ModelingToolkit.has_unknowns
 ModelingToolkit.get_unknowns
 unknowns
 ModelingToolkit.unknowns_toplevel
+irreducibles
+maybe_zeros
 ModelingToolkit.has_ps
 ModelingToolkit.get_ps
 parameters

--- a/docs/src/API/dynamic_opt.md
+++ b/docs/src/API/dynamic_opt.md
@@ -24,11 +24,13 @@ InfiniteOptCollocation(Ipopt.Optimizer, OrthogonalCollocation(3))
 ```
 
 ```@docs; canonical = false
+AbstractCollocation
 JuMPCollocation
 InfiniteOptCollocation
 CasADiCollocation
 PyomoCollocation
 CommonSolve.solve(::AbstractDynamicOptProblem)
+DynamicOptSolution
 ```
 
 ### Problem constructors

--- a/docs/src/API/variables.md
+++ b/docs/src/API/variables.md
@@ -7,7 +7,6 @@ addition to `@variables`, ModelingToolkit defines `@parameters`, `@independent_v
 ModelingToolkit to attach additional metadata.
 
 ```@docs
-Symbolics.@variables
 @independent_variables
 @parameters
 @constants

--- a/docs/src/internals/structural_transformation.md
+++ b/docs/src/internals/structural_transformation.md
@@ -63,6 +63,7 @@ distribute_shift
 SystemStructure
 TearingState
 TransformationState
+mtkcompile!
 isdiffvar
 isdervar
 isalgvar

--- a/lib/ModelingToolkitBase/src/constants.jl
+++ b/lib/ModelingToolkitBase/src/constants.jl
@@ -23,7 +23,8 @@ $(SIGNATURES)
 
 Define one or more constants.
 
-See also [`@independent_variables`](@ref), [`@parameters`](@ref) and [`@variables`](@ref).
+See also [`@independent_variables`](@ref), [`@parameters`](@ref) and
+[`@variables`](https://docs.sciml.ai/Symbolics/stable/manual/variables/#Symbolics.@variables).
 """
 macro constants(xs...)
     return Symbolics.parse_vars(

--- a/lib/ModelingToolkitBase/src/discretes.jl
+++ b/lib/ModelingToolkitBase/src/discretes.jl
@@ -19,7 +19,9 @@ $(SIGNATURES)
 Define one or more discrete variables, for use in events of continuous systems. All
 symbolics declare with this macro must be dependent variables.
 
-See also [`@independent_variables`](@ref), [`@variables`](@ref) and [`@constants`](@ref).
+See also [`@independent_variables`](@ref),
+[`@variables`](https://docs.sciml.ai/Symbolics/stable/manual/variables/#Symbolics.@variables)
+and [`@constants`](@ref).
 """
 macro discretes(xs...)
     return Symbolics.parse_vars(

--- a/lib/ModelingToolkitBase/src/parameters.jl
+++ b/lib/ModelingToolkitBase/src/parameters.jl
@@ -103,7 +103,9 @@ $(SIGNATURES)
 Define one or more known parameters. A parameter is a non-time-dependent quantity
 in the model.
 
-See also [`@independent_variables`](@ref), [`@variables`](@ref) and [`@constants`](@ref).
+See also [`@independent_variables`](@ref),
+[`@variables`](https://docs.sciml.ai/Symbolics/stable/manual/variables/#Symbolics.@variables)
+and [`@constants`](@ref).
 """
 macro parameters(xs...)
     return Symbolics.parse_vars(

--- a/lib/ModelingToolkitBase/src/systems/abstractsystem.jl
+++ b/lib/ModelingToolkitBase/src/systems/abstractsystem.jl
@@ -1145,8 +1145,9 @@ end
 Apply function `f` to each variable in expression `ex`. `f` should be a function that takes
 a variable and returns the replacement to use. A "variable" in this context refers to a
 symbolic quantity created directly from a variable creation macro such as
-[`Symbolics.@variables`](@ref), [`@independent_variables`](@ref), [`@parameters`](@ref),
-[`@constants`](@ref) or [`@brownians`](@ref).
+[`@variables`](https://docs.sciml.ai/Symbolics/stable/manual/variables/#Symbolics.@variables),
+[`@independent_variables`](@ref), [`@parameters`](@ref), [`@constants`](@ref) or
+[`@brownians`](@ref).
 """
 apply_to_variables(f, ex) = _apply_to_variables(f, ex)
 apply_to_variables(f, ex::Num) = wrap(_apply_to_variables(f, unwrap(ex)))

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -3,10 +3,26 @@ using Aqua
 using JET
 using SciMLTesting
 
+# Public names that reach ModelingToolkit's API surface only through
+# `@reexport using Symbolics` in ModelingToolkitBase. They are owned (and undocumented) by
+# Symbolics/SymbolicUtils, so ModelingToolkit is not the right place to document them.
+const SYMBOLICS_OWNED_REEXPORTS = (
+    Symbol("@symbolic_wrap"),
+    Symbol("@wrapped"),
+    :RuleSet,
+    :get_canonical_expr,
+    :infimum,
+    :is_derivative,
+    :istree,
+    :solve_for,
+    :supremum,
+)
+
 run_qa(
     ModelingToolkit;
     Aqua = Aqua,
     JET = JET,
     jet = true,
     jet_kwargs = (; target_defined_modules = true),
+    api_docs_kwargs = (; ignore = SYMBOLICS_OWNED_REEXPORTS),
 )


### PR DESCRIPTION
This draft PR should be ignored until reviewed by @ChrisRackauckas.

Supersedes #4715, which grew from a docstring pass into a ~1000-line structural refactor and
was rejected in review. This is the docs-only rework, branched off current `master`.

## What is left of #4715

Most of #4715's docstring content already landed on `master` via #4758. Of the 28 undocumented
public names #4715 targeted, all 17 ModelingToolkit-owned ones — plus `DiscreteSystem` and
`ImplicitDiscreteSystem` — now carry docstrings at their definitions. There is no docstring text
left to carry over. What remains is the rendered `@docs` entries, the two removals asked for in
review, and the one real QA gap.

Audit on current `master` (Julia 1.11, `test/qa` env, SciMLTesting v2.4):

| module | public names | undocumented |
| --- | --- | --- |
| `ModelingToolkit` | 510 | 9 |
| `ModelingToolkitBase` | 476 | 9 |

The nine are the same in both, and every one is owned upstream: `@symbolic_wrap`, `@wrapped`,
`RuleSet`, `get_canonical_expr`, `infimum`, `is_derivative`, `istree`, `solve_for`, `supremum`.
They reach the public surface only through `@reexport using Symbolics` in ModelingToolkitBase.

## Changes

| File | Change |
| --- | --- |
| `docs/src/API/System.md` | render `irreducibles`, `maybe_zeros` |
| `docs/src/API/dynamic_opt.md` | render `AbstractCollocation`, `DynamicOptSolution` |
| `docs/src/internals/structural_transformation.md` | render `mtkcompile!` |
| `docs/src/API/variables.md` | drop the `Symbolics.@variables` entry |
| `lib/ModelingToolkitBase/src/{constants,parameters,discretes}.jl`, `src/systems/abstractsystem.jl` | repoint four `@variables` cross-references at the Symbolics manual (docstring text only) |
| `test/qa/qa.jl` | `api_docs_kwargs = (; ignore = SYMBOLICS_OWNED_REEXPORTS)` |

`git diff master...HEAD` is +32/-6 over 9 files. Every changed line under `lib/` and `src/` is
inside a docstring; there are no logic changes.

### Why the four docstring edits

Removing the `Symbolics.@variables` entry from the `@docs` block leaves four MTKBase docstrings
with `@ref` links that no longer resolve:

```
┌ Warning: Cannot resolve @ref for md"[`Symbolics.@variables`](@ref)" in docs/src/API/model_building.md.
┌ Warning: Cannot resolve @ref for md"[`@variables`](@ref)" in docs/src/API/variables.md.   (x2)
```

`makedocs` runs with `warnonly = [:cross_references]`, so this would have shipped dead links
rather than failed the build. They now point at
<https://docs.sciml.ai/Symbolics/stable/manual/variables/#Symbolics.@variables>, which also fits
the "stop routing Symbolics API through MTK" rationale from the review.

## Review comments from #4715

| Comment | Resolution |
| --- | --- |
| `docs/src/API/variables.md` — remove `Symbolics.@variables` (@ChrisRackauckas) | done, plus the four dangling `@ref`s repointed |
| `docs/src/API/System.md` — don't document deprecated `DiscreteSystem`/`ImplicitDiscreteSystem` (@AayushSabharwal) | not added |
| `docs/src/API/variables.md` — don't document the Symbolics/SU-owned names (@AayushSabharwal) | not added; see the open question below |
| `abstractsystem.jl:1295`, `ModelingToolkitBase.jl:97`, `alias_elimination.jl:289`, `if_lifting.jl:91` | reverted — this branch is off `master` and contains none of that code |
| `odeproblem.jl:134`, `jumpproblem.jl:257` (open questions) | left as `master`, untouched |

## Open question for @AayushSabharwal

Your note on `ModelingToolkitBase.jl:97` was that these Symbolics/SymbolicUtils names should not
be exposed as MTK API at all. I agree, but I could not do that without a breaking change: they
come in wholesale via `@reexport using Symbolics`, so dropping them means replacing that with an
explicit export list and removing names from the public surface. This PR therefore uses the
non-breaking option — an `ignore` list in `test/qa/qa.jl`, named and commented so it reads as a
deliberate exception rather than a skip.

Tell me which you want and I will follow up:

1. keep the ignore list (status quo of this PR), or
2. replace `@reexport using Symbolics` with an explicit export list in a separate breaking PR,
   with the ignore list removed at that point.

## Validation

Julia 1.10 (`lts`, matching `Documentation.yml`) for docs; Julia 1.11 for QA so that
`public`-marked names are visible to `names(...)`.

**Docs build** — `xvfb-run julia +1.10 --project=docs docs/make.jl`, after
`Pkg.develop([...]); Pkg.instantiate()` exactly as the workflow does it:

`docs/make.jl` unmodified (`linkcheck = true`) reaches `Populate`, then fails at `linkcheck`:

```
┌ Error: linkcheck 'https://github.com/SciML/ColPrac/blob/master/README.md' status: 429.
ERROR: LoadError: `makedocs` encountered an error [:linkcheck] -- terminating build before rendering.
```

That URL is untouched by this PR and returns `200` on a direct fetch; the 429 is GitHub
rate-limiting this build machine's IP, and it reproduced on two runs an hour apart. To confirm
the rest of the pipeline, I re-ran with an untracked local copy of `make.jl` with
`linkcheck = false` (**not committed** — `docs/make.jl` here is byte-identical to `master`, and
the copy has been deleted):

```
[ Info: CrossReferences: building cross-references.
[ Info: CheckDocument: running document checks.
[ Info: Populate: populating indices.
[ Info: RenderDocument: rendering document.
[ Info: HTMLWriter: rendering HTML pages.
```

54 HTML pages rendered, no errors. All five new entries are present in the output:

| name | anchor |
| --- | --- |
| `irreducibles` | `ModelingToolkitBase.irreducibles` in `API/System.html` |
| `maybe_zeros` | `ModelingToolkitBase.maybe_zeros` in `API/System.html` |
| `AbstractCollocation` | `ModelingToolkitBase.AbstractCollocation-API-dynamic_opt` |
| `DynamicOptSolution` | `ModelingToolkitBase.DynamicOptSolution-API-dynamic_opt` |
| `mtkcompile!` | `ModelingToolkit.mtkcompile!` in `internals/structural_transformation.html` |

Diffing the warning set before and after the `@variables` fix, this PR **removes** three
`Cannot resolve @ref` warnings and adds none. No warning in the build names any of the five
entries added above.

**Public API docs QA** — `test/qa/qa.jl`, full `run_qa`, Julia 1.11:

| testset | `master` | this branch |
| --- | --- | --- |
| **public API has docstrings** | **fail** | **pass** |
| public API is rendered in docs | pass | pass |
| Piracy (Aqua) | fail | fail |
| No unapproved public reexports | fail | fail |
| ExplicitImports (6) | error | error |
| **total** | 11 pass / 4 fail / 6 error | **12 pass / 3 fail / 6 error** |

Baseline on `master`:

```
public API has docstrings: Test Failed
  Evaluated: isempty([Symbol("@symbolic_wrap"), Symbol("@wrapped"), :RuleSet,
                      :get_canonical_expr, :infimum, :is_derivative, :istree,
                      :solve_for, :supremum])
```

On this branch:

```
Test Summary:            | Pass  Total   Time
Public API documentation |    2      2  17.0s
```

**Runic** passed on every touched `.jl` file.

## Not addressed

- **`run_qa` is still red on `master`** for the Aqua `Piracy` testset, `No unapproved public
  reexports`, and six `ExplicitImports` errors. Same failures as reported in #4758. This PR
  changes none of them; the only delta is the docstring testset.
- **The "rendered in docs" check is currently vacuous for this repo.** 208 of MTK's 510 public
  names appear in no `@docs` block, yet the check passes: SciMLTesting's `_rendered_doc_names`
  treats the presence of *any* ```` ```@autodocs ```` block anywhere under `docs_src` as
  "everything is rendered", and MTK has two (`tutorials/linear_analysis.md`,
  `tutorials/disturbance_modeling.md`, both scoped to `systems/analysis_points.jl`). Worth
  either narrowing that heuristic in SciMLTesting or rendering the remaining names, but both are
  out of scope here.
- **`lib/ModelingToolkitBase/test/qa/aqua.jl` still calls `Aqua.test_all` directly** rather than
  `run_qa`, so MTKBase gets no api-docs check of its own. Switching it over pulls in
  ExplicitImports and the reexport audit too, which is a bigger change than this PR should carry.
- **Julia 1.11 cannot instantiate the docs environment on `master`**: `NonlinearSolve = "4"` in
  `docs/Project.toml` resolves against a newer LinearSolve and `NonlinearSolveFirstOrder` fails to
  precompile (`objects of type NonlinearSolveBase.LinearSolveJLCache{...} are not callable`).
  Julia 1.10 is clean, and CI uses `lts`, so this is not urgent — but it will bite when docs move
  off the LTS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LkAQZga27nFEonDZT2FGJB
