### PR TITLE
Make toparam and tobrownian public

### DIFF
--- a/lib/ModelingToolkitBase/src/ModelingToolkitBase.jl
+++ b/lib/ModelingToolkitBase/src/ModelingToolkitBase.jl
@@ -405,6 +405,7 @@ const set_scalar_metadata = setmetadata
 @public convert_bindings_for_time_independent_system, get_w
 @public Both
 @public SymbolicADDisallowed, check_symbolic_ad_allowed
+@public tobrownian, toparam
 
 for prop in [SYS_PROPS; [:continuous_events, :discrete_events]]
     getter = Symbol(:get_, prop)


### PR DESCRIPTION
`isparameter`/`isbrownian` are public but their setters `toparam`/`tobrownian` aren't, so there's no public way to tag an existing symbolic as a parameter or brownian at runtime (the `@parameters`/`@brownians` macros only make fresh variables, and the `PARAMETER`/`BROWNIAN` metadata values aren't public either). 