### PR TITLE
Build a HomotopyProblem for a single-block homotopy init system

### DIFF
--- a/src/problems/sccnonlinearproblem.jl
+++ b/src/problems/sccnonlinearproblem.jl
@@ -561,7 +561,13 @@ function SciMLBase.SCCNonlinearProblem{iip}(
             end
             return SCCNonlinearProblem((linprob,), (Returns(nothing),), parameter_values(linprob), true; sys)
         else
-            return NonlinearProblem{iip}(
+            # A single nonlinear block is solved directly rather than wrapped in an
+            # `SCCNonlinearProblem`. When it carries Modelica `homotopy(actual, simplified)`
+            # nodes this must be a `HomotopyProblem` so the block is solved by continuation
+            # (the multi-block path below already builds `HomotopyProblem` blocks); a plain
+            # `NonlinearProblem` would drop the λ-sweep and Newton-solve the target directly.
+            TProb = MTKBase.get_nonlinear_problem_type(sys)
+            return TProb{iip}(
                 sys, op; eval_expression, eval_module, u0_constructor, missing_guess_value, kwargs...
             )
         end

--- a/test/homotopy_initialization_scc.jl
+++ b/test/homotopy_initialization_scc.jl
@@ -71,6 +71,36 @@ end
     @test !any(p -> p isa SciMLBase.HomotopyProblem, iprob.probs)
 end
 
+@testset "single-block homotopy init degrades to a HomotopyProblem" begin
+    # A one-equation init system is solved directly by the `SCCNonlinearProblem` constructor
+    # rather than wrapped; with a `homotopy` node it must degrade to a `HomotopyProblem`, not
+    # a plain `NonlinearProblem`, so the λ-sweep is kept.
+    @variables x(t) y(t)
+    @mtkcompile sys = System(
+        [D(x) ~ -x, 0 ~ homotopy(atan(y - 3), y)], t; guesses = [y => 12.0]
+    )
+    iprob = ModelingToolkit.InitializationProblem(
+        sys, 0.0, [x => 1.0]; warn_initialize_determined = false
+    )
+    @test iprob isa SciMLBase.HomotopyProblem
+    @test !(iprob isa SciMLBase.SCCNonlinearProblem)
+    sol = solve(iprob; abstol = 1.0e-12, reltol = 1.0e-12)
+    @test SciMLBase.successful_retcode(sol)
+    @test sol[y] ≈ 3.0 atol = 1.0e-6
+end
+
+@testset "non-homotopy single-block init stays a plain NonlinearProblem" begin
+    @variables x(t) y(t)
+    @mtkcompile sys = System(
+        [D(x) ~ -x, 0 ~ atan(y - 3)], t; guesses = [y => 0.5]
+    )
+    iprob = ModelingToolkit.InitializationProblem(
+        sys, 0.0, [x => 1.0]; warn_initialize_determined = false
+    )
+    @test iprob isa SciMLBase.NonlinearProblem
+    @test !(iprob isa SciMLBase.HomotopyProblem)
+end
+
 @testset "use_scc = false falls back to a whole-system HomotopyProblem" begin
     # with no SCC decomposition to hang per-block continuation off, the whole init system
     # is solved as a single HomotopyProblem


### PR DESCRIPTION
> **Draft — please ignore until reviewed by @ChrisRackauckas.**

## Summary

Follow-up to #4766 (merged): fixes a single-block regression it left, found while reworking the NonlinearSolve companion.

The `SCCNonlinearProblem` constructor solves a **single** non-linear SCC block directly rather than wrapping it, and returned a plain `NonlinearProblem` for it. #4766 removed the whole-system homotopy bypass in favor of per-SCC handling, but the per-SCC path only builds `HomotopyProblem` blocks in the *multi-block* loop — a one-equation homotopy init system takes the single-block degrade and so lost the λ-sweep (my 3-block test in #4766 didn't cover the degrade path).

Now the single-block degrade routes through `get_nonlinear_problem_type`, building a `HomotopyProblem` exactly when the block carries `homotopy` nodes.

## Why it matters

Combined with the companion SciML/NonlinearSolve.jl#1085 (merged — `solve(::HomotopyProblem, ::standard_alg)` solves the target-λ system) and SciML/OrdinaryDiffEq.jl#3989 (`default_nlsolve → nothing` for homotopy init), a single-equation homotopy init would otherwise be Newton-solved on the target system. End-to-end on branch selection (`homotopy(m² − 1, 2(m−1))`, guess `m = −3`) that returns a `Success` retcode on the **unphysical** root `−1` instead of the physical `+1`.

## Tests

Adds single-block testsets to `test/homotopy_initialization_scc.jl` (single-block homotopy → `HomotopyProblem`; non-homotopy single-block → `NonlinearProblem`). The file is 20/20 locally (Julia 1.12).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
