### PR TITLE
Bump ModelingToolkitBase to v1.56.1

### DIFF
--- a/lib/ModelingToolkitBase/Project.toml
+++ b/lib/ModelingToolkitBase/Project.toml
@@ -1,7 +1,7 @@
 name = "ModelingToolkitBase"
 uuid = "7771a370-6774-4173-bd38-47e70ca0b839"
 authors = ["Yingbo Ma <mayingbo5@gmail.com>", "Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
-version = "1.56.0"
+version = "1.56.1"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"


### PR DESCRIPTION
Bumps `ModelingToolkitBase` **v1.56.0 → v1.56.1** (patch) so the accumulated unreleased `src/` changes on `master` can be registered.

**Rationale:** Merge pull request #4819 from SciML/as/ordered-collections-compat (docs/QA/compat/internal; no public API or behavior break)

Part of a sweep of SciML packages whose source changed since their last registered version without a version bump.

> [!NOTE]
> Please ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)