### PR TITLE
Fix Runic format-check on master (ModelingToolkitBase)

### DIFF
--- a/lib/ModelingToolkitBase/src/discretedomain.jl
+++ b/lib/ModelingToolkitBase/src/discretedomain.jl
@@ -189,10 +189,10 @@ $(TYPEDEF)
 at the inferred clock for that equation.
 """
 struct SampleTime <: Operator
-    init::Union{Nothing,Real}
+    init::Union{Nothing, Real}
 end
 
-SampleTime(; init::Union{Nothing,Real} = nothing) = SampleTime(init)()
+SampleTime(; init::Union{Nothing, Real} = nothing) = SampleTime(init)()
 (D::SampleTime)() = STerm(D, SArgsT(()); type = Real, shape = SU.ShapeVecT())
 SymbolicUtils.promote_symtype(::SampleTime, ::Type{T}) where {T} = Real
 SymbolicUtils.promote_shape(::SampleTime, @nospecialize(x::SU.ShapeT)) = x

--- a/lib/ModelingToolkitBase/src/systems/optimal_control_interface.jl
+++ b/lib/ModelingToolkitBase/src/systems/optimal_control_interface.jl
@@ -223,7 +223,7 @@ function SciMLBase.ODEInputFunction{iip, specialize}(
         controljac_prototype = nothing
     end
 
-    ODEInputFunction{iip, specialize}(
+    return ODEInputFunction{iip, specialize}(
         f;
         sys = sys,
         jac = _jac === nothing ? nothing : _jac,


### PR DESCRIPTION
**This PR should be ignored until reviewed by @ChrisRackauckas.**

## Summary

Master `format-check` (Runic) is red on the latest push (`11b86e7` / ModelingToolkitBase v1.56.1 bump):

- Run: https://github.com/SciML/ModelingToolkit.jl/actions/runs/30036006924
- Job: Runic / Runic Format Check

Two files fail Runic 1.7:

1. `lib/ModelingToolkitBase/src/discretedomain.jl` — `Union{Nothing,Real}` → `Union{Nothing, Real}`
2. `lib/ModelingToolkitBase/src/systems/optimal_control_interface.jl` — explicit `return` on final `ODEInputFunction{...}(`

## Verification

- Diff matches the CI Runic suggested patch exactly
- Local `Runic.format_string(...; filemode=true)` reports both files OK after the change

No semantic / API changes.

Co-Authored-By: Chris Rackauckas <accounts@chrisrackauckas.com>