### PR TITLE
Fix invalid vars

### DIFF
--- a/lib/ModelingToolkitBase/src/systems/imperative_affect.jl
+++ b/lib/ModelingToolkitBase/src/systems/imperative_affect.jl
@@ -154,20 +154,34 @@ function namespace_affect(affect::ImperativeAffect, s)
 end
 
 function invalid_variables(sys, expr)
-    valid = all_symbols(sys)
-    invalid = Set{Any}()
-    for var in SU.search_variables(expr)
-        # An array-valued variable (e.g. an array-valued observed handle in a
-        # reduce-style affect) is stored in a flattened system as its scalarized
-        # elements, not the bare array symbolic. Mirror `unassignable_variables`:
-        # accept the whole-array symbol if present, else check each element.
-        if Symbolics.isarraysymbolic(var)
-            var in valid && continue
-            for idx in SU.stable_eachindex(var)
-                var[idx] in valid || push!(invalid, var[idx])
+    # Mirror `unassignable_variables`: build the set of valid symbols, scalarizing any
+    # array-valued symbol into its elements (a flattened system stores arrays as their
+    # scalar elements, not the bare array symbolic). A `Set` is required so membership
+    # tests use `isequal`/hashing and return `Bool`; `x in all_symbols(sys)` would use
+    # symbolic `==` (`all_symbols` returns a `Vector`) and error in a boolean context.
+    valid = Set{SymbolicT}()
+    for sym in all_symbols(sys)
+        if Symbolics.isarraysymbolic(sym)
+            for idx in SU.stable_eachindex(sym)
+                push!(valid, sym[idx])
             end
         else
-            var in valid || push!(invalid, var)
+            push!(valid, sym)
+        end
+    end
+    vars = Set{SymbolicT}()
+    SU.search_variables!(vars, expr)
+    invalid = SymbolicT[]
+    for var in vars
+        if Symbolics.isarraysymbolic(var)
+            for idx in SU.stable_eachindex(var)
+                sym = var[idx]
+                sym in valid && continue
+                push!(invalid, sym)
+            end
+        else
+            var in valid && continue
+            push!(invalid, var)
         end
     end
     return invalid

--- a/lib/ModelingToolkitBase/src/systems/imperative_affect.jl
+++ b/lib/ModelingToolkitBase/src/systems/imperative_affect.jl
@@ -154,7 +154,23 @@ function namespace_affect(affect::ImperativeAffect, s)
 end
 
 function invalid_variables(sys, expr)
-    return setdiff!(SU.search_variables(expr), all_symbols(sys))
+    valid = all_symbols(sys)
+    invalid = Set{Any}()
+    for var in SU.search_variables(expr)
+        # An array-valued variable (e.g. an array-valued observed handle in a
+        # reduce-style affect) is stored in a flattened system as its scalarized
+        # elements, not the bare array symbolic. Mirror `unassignable_variables`:
+        # accept the whole-array symbol if present, else check each element.
+        if Symbolics.isarraysymbolic(var)
+            var in valid && continue
+            for idx in SU.stable_eachindex(var)
+                var[idx] in valid || push!(invalid, var[idx])
+            end
+        else
+            var in valid || push!(invalid, var)
+        end
+    end
+    return invalid
 end
 
 function unassignable_variables(sys, expr)

--- a/lib/ModelingToolkitBase/src/systems/imperative_affect.jl
+++ b/lib/ModelingToolkitBase/src/systems/imperative_affect.jl
@@ -154,11 +154,9 @@ function namespace_affect(affect::ImperativeAffect, s)
 end
 
 function invalid_variables(sys, expr)
-    # Mirror `unassignable_variables`: build the set of valid symbols, scalarizing any
-    # array-valued symbol into its elements (a flattened system stores arrays as their
-    # scalar elements, not the bare array symbolic). A `Set` is required so membership
-    # tests use `isequal`/hashing and return `Bool`; `x in all_symbols(sys)` would use
-    # symbolic `==` (`all_symbols` returns a `Vector`) and error in a boolean context.
+    # Mirror `unassignable_variables`: build the set of
+    #  valid symbols, scalarizing any array-valued symbol
+    #  into its elements.
     valid = Set{SymbolicT}()
     for sym in all_symbols(sys)
         if Symbolics.isarraysymbolic(sym)

--- a/lib/ModelingToolkitBase/test/symbolic_events.jl
+++ b/lib/ModelingToolkitBase/test/symbolic_events.jl
@@ -868,6 +868,39 @@ end
     @test sign.(cos.(3 * (required_crossings_c2 .+ 1.0e-6))) == sign.(last.(cr2))
 end
 
+@testset "ImperativeAffect with array-valued observed" begin
+    # An affect whose `observed` clause reads a whole array-valued variable must compile.
+    # A flattened system stores an array as its scalar elements, so `invalid_variables`
+    # has to scalarize the array symbol before checking it against the system's symbols
+    # (mirroring `unassignable_variables`); reading the bare array previously errored.
+    @variables x(t) = 1.0
+    @variables arr(t)[1:2] = [2.0, 3.0]
+    recorded = Vector{Float64}[]
+    function record_array(mod, obs, ctx, integ)
+        push!(ctx, collect(obs.a))
+        return (;)
+    end
+    evt = ModelingToolkitBase.SymbolicDiscreteCallback(
+        1.0, (f = record_array, observed = (; a = arr), ctx = recorded)
+    )
+    @named sys = System([D(x) ~ -x, D(arr) ~ -arr], t; discrete_events = [evt])
+    ssys = mtkcompile(sys)
+    prob = ODEProblem(ssys, [], (0.0, 3.0))
+    sol = solve(prob, @isdefined(ModelingToolkit) ? Tsit5() : Rodas5P())
+    @test SciMLBase.successful_retcode(sol)
+    # The affect fired and recorded the whole array (`arr(t) = [2, 3] .* exp(-t)`).
+    @test !isempty(recorded)
+    @test all(v -> length(v) == 2, recorded)
+    @test recorded[1] ≈ [2.0, 3.0] .* exp(-1.0) rtol = 1.0e-3
+
+    # Unit-level: `invalid_variables` scalarizes array symbols and only flags genuinely
+    # missing variables (and returns `Bool`-valued membership, not a symbolic `==`).
+    @variables missingvar(t)
+    @test isempty(ModelingToolkitBase.invalid_variables(ssys, Symbolics.unwrap(arr)))
+    @test isempty(ModelingToolkitBase.invalid_variables(ssys, Symbolics.unwrap(x)))
+    @test !isempty(ModelingToolkitBase.invalid_variables(ssys, Symbolics.unwrap(missingvar)))
+end
+
 if @isdefined(ModelingToolkit)
     @testset "Discrete event reinitialization (#3142)" begin
         @connector function LiquidPort(; name, p = nothing, Vdot = nothing)


### PR DESCRIPTION
`invalid_variables` incorrectly flags array variables as invalid, when they are very clearly in the system. Code changes mimicked the array handling in `unassignable_variables`

## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  