### PR TITLE
refactor: Convert `SemilinearODEFunction` to use `SciMLFunctionOptions`

### DIFF
--- a/src/problems/semilinearodeproblem.jl
+++ b/src/problems/semilinearodeproblem.jl
@@ -5,10 +5,35 @@
         eval_expression = false, eval_module = @__MODULE__,
         expression = Val{false}, sparse = false, check_compatibility = true,
         jac = false, checkbounds = false, initialization_data = nothing,
-        analytic = nothing, kwargs...
+        analytic = nothing, optimize = nothing,
+        compiler_options::CompilerOptions = CompilerOptions(), kwargs...
     ) where {iip, specialize}
+    opts = SciMLFunctionOptions(;
+        u0, p, t, jac, sparse, analytic, initialization_data,
+        expression, check_compatibility, eval_expression, eval_module, compiler_options,
+        checkbounds, optimize, kwargs...,
+    )
+    return SemilinearODEFunction{iip, specialize}(
+        sys, opts; semiquadratic_form, stiff_linear, stiff_quadratic, stiff_nonlinear
+    )
+end
+
+"""
+    SemilinearODEFunction{iip, specialize}(sys::System, opts::SciMLFunctionOptions; kwargs...)
+
+Public entry point that builds a `SemilinearODEFunction` directly from a pre-assembled
+[`SciMLFunctionOptions`](@ref), bypassing the `kwargs...` wrapper above.
+"""
+function SemilinearODEFunction{iip, specialize}(
+        sys::System, opts::SciMLFunctionOptions{E};
+        semiquadratic_form = nothing, stiff_linear::Bool = true, stiff_quadratic::Bool = false,
+        stiff_nonlinear::Bool = false
+    ) where {iip, specialize, E}
     check_complete(sys, SemilinearODEFunction)
-    check_compatibility && check_compatible_system(SemilinearODEFunction, sys)
+    opts.check_compatibility && check_compatible_system(SemilinearODEFunction, sys)
+
+    (; u0, p, jac, sparse, analytic, initialization_data) = opts
+    codegen_opts = opts.codegen
 
     if semiquadratic_form === nothing
         semiquadratic_form = calculate_semiquadratic_form(sys; sparse)
@@ -19,11 +44,6 @@
     M = calculate_massmatrix(sys)
     _M = concrete_massmatrix(M; sparse, u0)
     dvs = unknowns(sys)
-
-    codegen_opts = GeneratedFunctionOptions(;
-        expression, wrap_gfw = Val{true}, eval_expression, eval_module,
-        codegen_function_options = Symbolics.CodegenFunctionOptions(; checkbounds, kwargs...)
-    )
 
     f1,
         f2 = generate_semiquadratic_functions(
@@ -46,13 +66,11 @@
         W_prototype = nothing
     end
 
-    observedfun = ObservedFunctionCache(
-        sys; expression, steady_state = false, eval_expression, eval_module, checkbounds
-    )
+    observedfun = ObservedFunctionCache(sys, codegen_opts)
 
     args = (; f1)
     kwargs = (; jac = _jac, jac_prototype = W_prototype)
-    f1 = maybe_codegen_scimlfn(expression, ODEFunction{iip, specialize}, args; kwargs...)
+    f1 = maybe_codegen_scimlfn(Val{E}, ODEFunction{iip, specialize}, args; kwargs...)
 
     args = (; f1, f2)
     kwargs = (;
@@ -66,7 +84,7 @@
     )
 
     return maybe_codegen_scimlfn(
-        expression, SplitFunction{iip, specialize}, args; kwargs...
+        Val{E}, SplitFunction{iip, specialize}, args; kwargs...
     )
 end
 


### PR DESCRIPTION
Applies the ModelingToolkitBase.SciMLFunctionOptions pattern to SemilinearODEFunction, the one *Function constructor that lives in the top-level ModelingToolkit package rather than ModelingToolkitBase. Its kwargs... wrapper now assembles a SciMLFunctionOptions and delegates to a new public SemilinearODEFunction{iip,specialize}(sys, opts::SciMLFunctionOptions; kwargs...) method that does the real work without splatting arbitrary keywords, matching every other constructor in the family.

Like the rest of the family, the struct-accepting method branches directly on the struct's own `expression` type parameter (`if E`) instead of a separate `expression = Val{E}` local, and builds its ObservedFunctionCache by forwarding the nested GeneratedFunctionOptions directly rather than re-listing its fields as separate keywords.

## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
