### PR TITLE
[NOT FOR MERGE — archived prototype] Erase nonnumeric buffer element types from MTKParameters

### DIFF
--- a/lib/ModelingToolkitBase/src/systems/parameter_buffer.jl
+++ b/lib/ModelingToolkitBase/src/systems/parameter_buffer.jl
@@ -3,6 +3,48 @@ symconvert(::Type{T}, ::Type{F}, x::V) where {T <: Real, F, V} = convert(T, x)
 symconvert(::Type{Real}, ::Type{F}, x::Integer) where {F} = convert(F, x)
 symconvert(::Type{V}, ::Type{F}, x) where {V <: AbstractArray, F} = symconvert.(eltype(V), F, x)
 
+"""
+    OpaqueNonnumeric{K}
+
+Type-erasing wrapper around the `K` nonnumeric parameter buffers.
+
+The nonnumeric buffers are the only part of `MTKParameters` whose element types
+come from user-declared parameter types (a `CubicSpline`, a callable, an arbitrary
+struct). Storing them concretely puts those types into the `MTKParameters` type,
+which makes every solver specialization keyed on the parameter object unique per
+nonnumeric type — so two models differing only in, say, `CubicSpline` vs
+`LinearInterpolation` share no compiled code and each pays a full first-solve
+compilation.
+
+Holding them behind a `Ref{Any}` keeps the *buffer count* `K` in the type (the
+generated parameter-path dispatch needs it) while erasing the element types, so
+those models share one `MTKParameters` type. The payload is held by reference, so
+in-place writes to the buffers remain visible.
+
+`nonnumeric` is the only slot that can be erased this way: `tunable` and
+`initials` must stay concrete because AD differentiates through them, and the AD
+extensions already treat the nonnumeric slot as non-differentiable (Mooncake's
+`increment_and_get_rdata!` skips it outright).
+"""
+struct OpaqueNonnumeric{K}
+    ref::Base.RefValue{Any}
+end
+
+OpaqueNonnumeric(t::Tuple) = OpaqueNonnumeric{length(t)}(Ref{Any}(t))
+OpaqueNonnumeric(o::OpaqueNonnumeric) = o
+
+"""
+    nonnumeric_payload(o::OpaqueNonnumeric) -> Tuple
+
+The concrete nonnumeric buffers. Deliberately not type-stable; call sites that
+need inference (generated parameter access) must assert the concrete tuple type,
+which the index cache knows at codegen time.
+"""
+nonnumeric_payload(o::OpaqueNonnumeric) = getfield(o, :ref)[]
+
+nonnumeric_count(::OpaqueNonnumeric{K}) where {K} = K
+nonnumeric_count(::Type{OpaqueNonnumeric{K}}) where {K} = K
+
 struct MTKParameters{T, I, D, C, N, H}
     tunable::T
     initials::I
@@ -13,8 +55,7 @@ struct MTKParameters{T, I, D, C, N, H}
 
     function MTKParameters{T, I, D, C, N, H}(
             tunables::T, initials::I, discrete::D,
-            constant::C, nonnumeric::N,
-            caches::H
+            constant::C, nonnumeric, caches::H
         ) where {T, I, D, C, N, H}
         if tunables isa StaticVector{0}
             tunables = SVector{0, eltype(tunables)}()
@@ -22,22 +63,32 @@ struct MTKParameters{T, I, D, C, N, H}
         if initials isa StaticVector{0}
             initials = SVector{0, eltype(initials)}()
         end
-        return new{typeof(tunables), typeof(initials), D, C, N, H}(
+        nn = OpaqueNonnumeric(nonnumeric)
+        return new{typeof(tunables), typeof(initials), D, C, typeof(nn), H}(
             tunables, initials,
             discrete, constant,
-            nonnumeric, caches
+            nn, caches
         )
     end
     function MTKParameters(
             tunables::T, initials::I, discrete::D,
-            constant::C, nonnumeric::N,
+            constant::C, nonnumeric,
             caches::H
-        ) where {T, I, D, C, N, H}
-        return MTKParameters{T, I, D, C, N, H}(
+        ) where {T, I, D, C, H}
+        nn = OpaqueNonnumeric(nonnumeric)
+        return MTKParameters{T, I, D, C, typeof(nn), H}(
             tunables, initials, discrete, constant,
-            nonnumeric, caches
+            nn, caches
         )
     end
+end
+
+# `p.nonnumeric` yields the concrete buffers so the existing call sites (indexing,
+# copying, remake, SciMLStructures) are unchanged; `getfield(p, :nonnumeric)`
+# reaches the opaque wrapper itself.
+function Base.getproperty(p::MTKParameters, s::Symbol)
+    s === :nonnumeric && return nonnumeric_payload(getfield(p, :nonnumeric))
+    return getfield(p, s)
 end
 
 """
@@ -849,14 +900,12 @@ end
         end
         bufT
     end
-    nonnumericT = ntuple(Val(fieldcount(N))) do i
-        bufT = eltype(fieldtype(N, i))
-        for (j, idxT) in enumerate(idxtypes)
-            idxT <: ParameterIndex{Nonnumeric, i} || continue
-            bufT = promote_valtype(i, bufT)
-        end
-        bufT
-    end
+    # The nonnumeric buffers' element types are erased from `N` (see
+    # `OpaqueNonnumeric`), so they cannot be promoted at the type level. They are
+    # rebuilt dynamically below with an `Any` eltype, which is invisible to the
+    # `MTKParameters` type and matches what the other rebuild paths
+    # (`as_any_buffer`, `__remake_buffer`) already do for these buffers.
+    nonnumeric_n = nonnumeric_count(N)
 
     expr = quote
         tunables = $similar(oldbuf.tunable, $tunablesT)
@@ -897,16 +946,10 @@ end
             Expr(
                 :tuple,
                 (
-                    :($similar(oldbuf.nonnumeric[$i], $(nonnumericT[i])))
-                        for i in 1:length(nonnumericT)
+                    :($copyto!($similar(oldbuf.nonnumeric[$i], Any), oldbuf.nonnumeric[$i]))
+                        for i in 1:nonnumeric_n
                 )...
             )
-        )
-        $(
-            (
-                :($copyto!(nonnumerics[$i], oldbuf.nonnumeric[$i]))
-                    for i in 1:length(nonnumericT)
-            )...
         )
         caches = copy.(oldbuf.caches)
         newbuf = MTKParameters(
@@ -960,15 +1003,7 @@ end
         push!(
             expr.args,
             :(
-                nonnumerics = $(
-                    Expr(
-                        :tuple,
-                        (
-                            :($similar_type($(fieldtype(C, i)), $(nonnumericT[i]))(nonnumerics[$i]))
-                                for i in 1:length(nonnumericT)
-                        )...
-                    )
-                )
+                # nonnumeric buffers keep their dynamic form (types erased from `N`)
             )
         )
         push!(
@@ -1096,7 +1131,7 @@ end
     for i in 1:fieldcount(C)
         push!(paths, :(ps.constant[$i]))
     end
-    for i in 1:fieldcount(N)
+    for i in 1:nonnumeric_count(N)
         push!(paths, :(ps.nonnumeric[$i]))
     end
     for i in 1:fieldcount(H)
@@ -1123,7 +1158,7 @@ end
     if !(I <: SVector{0})
         len += 1
     end
-    len += fieldcount(D) + fieldcount(C) + fieldcount(N) + fieldcount(H)
+    len += fieldcount(D) + fieldcount(C) + nonnumeric_count(N) + fieldcount(H)
     return len
 end
 

--- a/lib/ModelingToolkitBase/test/opaque_nonnumeric.jl
+++ b/lib/ModelingToolkitBase/test/opaque_nonnumeric.jl
@@ -1,0 +1,76 @@
+using ModelingToolkitBase, Test
+using ModelingToolkitBase: t_nounits as t, D_nounits as D, as_any_buffer
+using SymbolicIndexingInterface: getp, setp, remake_buffer
+import SciMLStructures
+
+# Two distinct nonnumeric parameter types. Under the opaque nonnumeric buffer they
+# must share one `MTKParameters` type while every read/write path keeps seeing the
+# concrete payload.
+
+struct FA
+    c::Vector{Float64}
+end
+(f::FA)(τ) = f.c[1] * τ
+
+struct FB
+    c::Vector{Float64}
+end
+(f::FB)(τ) = f.c[1] * τ^2
+
+@parameters (f::FA)(..) d
+@variables z(t)
+sys = complete(System([D(z) ~ -d * z + f(t)], t; name = :R))
+prob = ODEProblem(sys, Dict(z => 0.0, d => 1.0, f => FA([2.0])), (0.0, 1.0))
+p = prob.p
+
+@testset "opaque nonnumeric buffer" begin
+    @testset "reads" begin
+        @test p.nonnumeric isa Tuple
+        @test p.nonnumeric[1][1] isa FA
+        @test getp(sys, d)(p) == 1.0
+        @test getp(sys, f)(p) isa FA
+    end
+
+    @testset "setp" begin
+        setp(sys, f)(p, FA([7.0]))
+        @test getp(sys, f)(p).c == [7.0]
+        setp(sys, d)(p, 3.0)
+        @test getp(sys, d)(p) == 3.0
+    end
+
+    # `remake_buffer` computes promoted buffer element types from the
+    # `MTKParameters` type parameters. The nonnumeric element types are no longer
+    # in the type, so that buffer is rebuilt dynamically — cover both a numeric
+    # and a nonnumeric edit.
+    @testset "remake_buffer" begin
+        p2 = remake_buffer(sys, p, (d,), (9.0,))
+        @test getp(sys, d)(p2) == 9.0
+        @test getp(sys, f)(p2).c == [7.0]
+
+        p3 = remake_buffer(sys, p, (f,), (FA([1.5]),))
+        @test getp(sys, f)(p3).c == [1.5]
+    end
+
+    @testset "copy / equality / as_any_buffer" begin
+        pc = copy(p)
+        @test pc == p
+        @test pc.nonnumeric[1][1].c == p.nonnumeric[1][1].c
+        @test as_any_buffer(p).nonnumeric isa Tuple
+    end
+
+    @testset "SciMLStructures" begin
+        buf, _, _ = SciMLStructures.canonicalize(SciMLStructures.Tunable(), p)
+        @test buf isa AbstractVector
+        p4 = SciMLStructures.replace(SciMLStructures.Tunable(), p, buf .* 2)
+        @test getp(sys, d)(p4) == 2 * getp(sys, d)(p)
+        @test getp(sys, f)(p4) isa FA
+    end
+
+    @testset "type is uniform across nonnumeric types" begin
+        @parameters (g::FB)(..) e
+        @variables w(t)
+        sys2 = complete(System([D(w) ~ -e * w + g(t)], t; name = :S))
+        p2 = ODEProblem(sys2, Dict(w => 0.0, e => 1.0, g => FB([3.0])), (0.0, 1.0)).p
+        @test typeof(p2) === typeof(p)
+    end
+end


### PR DESCRIPTION
**Do not merge. Do not review.** Opened purely to preserve an investigation in a reviewable form, and closed immediately. Context and full analysis: #4831.

This prototype delivers a large first-solve win and carries a **disqualifying runtime regression** that cannot be fixed without also changing parameter codegen. It is archived so the measurements and the design constraint are not lost.

### The problem

Models with a nonnumeric parameter (a DataInterpolations spline, a callable, any struct) put that declared type into the `MTKParameters` type. Solver specializations are keyed on the parameter object, so two models differing only in `CubicSpline` vs `LinearInterpolation` share no compiled code and each pays a full first-solve compilation (~16s with the default algorithm; see #4831 for that measurement).

### What this does

Wraps the nonnumeric buffers in an `OpaqueNonnumeric{K}` — a `Ref{Any}`, with `K` (buffer count) kept in the type because the generated parameter-path dispatch needs it, and element types erased. The field stays *named* `nonnumeric` and `getproperty` unwraps, so the ~45 existing `p.nonnumeric[i][j]` sites are untouched. One file plus tests.

### Compile time (two models, different nonnumeric parameter types, Tsit5)

| | baseline | erased |
|---|---|---|
| `MTKParameters` type uniform | false | **true** |
| solve A (cold) | 4.917s | 4.782s |
| **solve B (different nonnumeric type)** | **3.870s** | **0.015s** |
| results | identical | identical |

### Runtime (same model; nonnumeric parameter read on every RHS evaluation)

| | baseline | erased |
|---|---|---|
| RHS ns/call | **1.37** | **666.33** |
| RHS allocations/call | **0** | **112 B** |
| warm solve | 0.108 ms | 0.188 ms |

So it trades ~3.9s of one-time compilation for a 486x slower RHS on exactly the models it targets. Net loss for any non-trivial integration — hence not mergeable.

### Why, and what would be needed

Parameters are destructured via Symbolics `DestructuredArgs` over an argument typed `Vector{Vector{Any}}`, so the RHS reads buffers as `p[i][j]`. Baseline gets type stability *for free* from the concrete `Vector{FA}`; erasing the element type makes that read `Any`, so every nonnumeric access inside the time loop dispatches dynamically and boxes. This is inherent to erasing at the buffer level — storing `Vector{Any}` directly costs the same.

The only fix is for codegen to emit a **typed** access for nonnumeric buffers, e.g. `(p[i]::Vector{FA})[j]`. `BufferTemplate` already carries `type::TypeT`, so the index cache knows the concrete element types at codegen time. That is a change to the parameter destructuring in `codegen_utils.jl` (possibly needing Symbolics support for typed destructuring) and is **not attempted here**.

### Tests

Adds `test/opaque_nonnumeric.jl` covering symbolic read/write of a nonnumeric parameter, the rewritten `remake_buffer` path (numeric and nonnumeric edits), `copy`/`==`/`as_any_buffer`, `SciMLStructures` canonicalize/replace, and the type-uniformity property. These passed 16/16 as a standalone script; the committed file swaps in the non-deprecated `Dict` problem constructor, and I am re-running it against the committed form — if that surfaces anything I will push a correction to the branch even though the PR is closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UuAbA8hSnrirMrJjFqxwn5