### PR TITLE
fix: add `input_timedomain` and `output_timedomain` for `::SampleTime`

### DIFF
--- a/src/systems/clock_inference.jl
+++ b/src/systems/clock_inference.jl
@@ -15,6 +15,13 @@ function MTKTearing.input_timedomain(::Hold, args::MTKTearing.IOTimeDomainArgsT 
     return MTKTearing.InputTimeDomainElT[MTKTearing.InferredDiscrete()] # the Hold accepts any discrete
 end
 
+function MTKTearing.input_timedomain(::SampleTime, arg = nothing)
+    return ModelingToolkit.MTKTearing.InputTimeDomainElT[]
+end
+function MTKTearing.output_timedomain(::SampleTime, arg = nothing)
+    ModelingToolkit.MTKTearing.InferredDiscrete(1)
+end
+
 function MTKTearing.output_timedomain(::Hold, _::MTKTearing.IOTimeDomainArgsT = nothing)
     return ContinuousClock()
 end


### PR DESCRIPTION
After changing `SampleTime` [here](https://github.com/SciML/ModelingToolkit.jl/pull/4806), I got `ERROR: MethodError: no method matching input_timedomain(::SampleTime, ::SymbolicUtils.SmallVec{…})`. This fixes it.

## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
