### PR TITLE
[RFC] Add functional guesses

### DIFF
--- a/docs/src/tutorials/dynamic_optimization.md
+++ b/docs/src/tutorials/dynamic_optimization.md
@@ -68,6 +68,33 @@ axislegend(ax2)
 fig
 ```
 
+### Providing an initial trajectory
+
+By default every state variable is seeded with its constant value from `u0map` at
+each collocation point. When that starting point is a poor one, the solver can be
+given a guess of the whole trajectory instead. The `initial_trajectory` keyword
+takes a map from states to functions of time:
+
+```@example dynamic_opt
+jprob_guess = JuMPDynamicOptProblem(rocket, [u0map; pmap], (ts, te); dt = 0.001,
+    initial_trajectory = Dict(h(t) => τ -> 1 + τ, v(t) => τ -> 1.0))
+jsol_guess = solve(jprob_guess, JuMPCollocation(Ipopt.Optimizer));
+```
+
+Each function is evaluated at the collocation points to produce the start values
+handed to the optimizer. Only the states listed are affected — the rest keep their
+constant seed. This changes where the solve starts from, not the optimum it
+converges to.
+
+`initial_trajectory` is supported by the JuMP, InfiniteOpt, and CasADi backends.
+Passing a non-empty map to Pyomo raises an `ArgumentError`.
+
+!!! note
+
+    For free final time problems (see below) the collocation grid is normalized to
+    `[0, 1]`, so the trajectory functions receive normalized time rather than
+    physical time.
+
 ### Free final time problems
 
 There are additionally a class of dynamic optimization problems where we would like to know how to control our system to achieve something in the least time. Such problems are called free final time problems, since the final time is unknown. To model these problems in ModelingToolkit, we declare the final time as a parameter.

--- a/docs/src/tutorials/dynamic_optimization.md
+++ b/docs/src/tutorials/dynamic_optimization.md
@@ -73,18 +73,34 @@ fig
 By default every state variable is seeded with its constant value from `u0map` at
 each collocation point. When that starting point is a poor one, the solver can be
 given a guess of the whole trajectory instead. The `initial_trajectory` keyword
-takes a map from states to functions of time:
+takes a map from states to symbolic expressions in the independent variable:
 
 ```@example dynamic_opt
 jprob_guess = JuMPDynamicOptProblem(rocket, [u0map; pmap], (ts, te); dt = 0.001,
-    initial_trajectory = Dict(h(t) => τ -> 1 + τ, v(t) => τ -> 1.0))
+    initial_trajectory = Dict(h(t) => 1 + t, v(t) => 1.0))
 jsol_guess = solve(jprob_guess, JuMPCollocation(Ipopt.Optimizer));
 ```
 
-Each function is evaluated at the collocation points to produce the start values
-handed to the optimizer. Only the states listed are affected — the rest keep their
-constant seed. This changes where the solve starts from, not the optimum it
-converges to.
+Each expression is compiled to a function and evaluated at the collocation points to
+produce the start values handed to the optimizer. Only the states listed are affected
+— the rest keep their constant seed. This changes where the solve starts from, not the
+optimum it converges to.
+
+Expressions may reference parameters, which are resolved from the operating point, so
+the guess can be written in terms of the same quantities as the model:
+
+```@example dynamic_opt
+jprob_guess2 = JuMPDynamicOptProblem(rocket, [u0map; pmap], (ts, te); dt = 0.001,
+    initial_trajectory = Dict(h(t) => h₀ + t, v(t) => t))
+jsol_guess2 = solve(jprob_guess2, JuMPCollocation(Ipopt.Optimizer));
+```
+
+Only parameters of the compiled system can be resolved this way. Referencing something
+that `mtkcompile` has eliminated — or another state — raises an `ArgumentError` naming
+the unresolved quantity.
+
+A guess that cannot be written symbolically — an interpolation of measured data, for
+instance — can be passed as a function of time instead, and is used as-is.
 
 `initial_trajectory` is supported by the JuMP, InfiniteOpt, and CasADi backends.
 Passing a non-empty map to Pyomo raises an `ArgumentError`.
@@ -92,8 +108,8 @@ Passing a non-empty map to Pyomo raises an `ArgumentError`.
 !!! note
 
     For free final time problems (see below) the collocation grid is normalized to
-    `[0, 1]`, so the trajectory functions receive normalized time rather than
-    physical time.
+    `[0, 1]`, so the trajectory expressions are evaluated at normalized time rather
+    than physical time.
 
 ### Free final time problems
 

--- a/docs/src/tutorials/dynamic_optimization.md
+++ b/docs/src/tutorials/dynamic_optimization.md
@@ -95,12 +95,9 @@ jprob_guess2 = JuMPDynamicOptProblem(rocket, [u0map; pmap], (ts, te); dt = 0.001
 jsol_guess2 = solve(jprob_guess2, JuMPCollocation(Ipopt.Optimizer));
 ```
 
-Only parameters of the compiled system can be resolved this way. Referencing something
-that `mtkcompile` has eliminated — or another state — raises an `ArgumentError` naming
-the unresolved quantity.
-
-A guess that cannot be written symbolically — an interpolation of measured data, for
-instance — can be passed as a function of time instead, and is used as-is.
+Only parameters of the compiled system can be referenced this way; anything else —
+another state, or a quantity `mtkcompile` has eliminated that does not reduce to time
+and parameters — raises an `ArgumentError` naming the unresolved quantity.
 
 `initial_trajectory` is supported by the JuMP, InfiniteOpt, and CasADi backends.
 Passing a non-empty map to Pyomo raises an `ArgumentError`.

--- a/lib/ModelingToolkitBase/ext/MTKCasADiDynamicOptExt.jl
+++ b/lib/ModelingToolkitBase/ext/MTKCasADiDynamicOptExt.jl
@@ -121,6 +121,14 @@ function MTK.generate_state_variable!(model::Opti, u0, ns, tsteps)
     return MXLinearInterpolation(U, tsteps, tsteps[2] - tsteps[1])
 end
 
+function MTK.set_initial_trajectory!(m::Opti, U, idx, traj)
+    # The collocation grid is fixed when the variables are created, so the
+    # trajectory is sampled onto it. This overrides the constant `u0` seed set
+    # in `generate_state_variable!` for the entries of state `idx`.
+    t_samples = traj.(U.t)
+    return set_initial!(m, U[idx], DM(t_samples))
+end
+
 function MTK.generate_input_variable!(model::Opti, c0, nc, tsteps)
     nt = length(tsteps)
     V = CasADi.variable!(model, nc, nt)

--- a/lib/ModelingToolkitBase/ext/MTKCasADiDynamicOptExt.jl
+++ b/lib/ModelingToolkitBase/ext/MTKCasADiDynamicOptExt.jl
@@ -101,12 +101,12 @@ function MTK.CasADiDynamicOptProblem(
         dt = nothing,
         steps = nothing,
         tune_parameters = false,
-        guesses = Dict(),
+        guesses = Dict(), initial_trajectory = Dict(),
         bounds = Dict(), kwargs...
     )
     prob,
         _ = MTK.process_DynamicOptProblem(
-        CasADiDynamicOptProblem, CasADiModel, sys, op, tspan; dt, steps, tune_parameters, guesses, bounds, kwargs...
+        CasADiDynamicOptProblem, CasADiModel, sys, op, tspan; dt, steps, tune_parameters, guesses, initial_trajectory, bounds, kwargs...
     )
     return prob
 end

--- a/lib/ModelingToolkitBase/ext/MTKInfiniteOptExt.jl
+++ b/lib/ModelingToolkitBase/ext/MTKInfiniteOptExt.jl
@@ -101,6 +101,10 @@ function MTK.generate_tunable_params!(m::InfiniteModel, p0, np)
     return @variable(m, P[i = 1:np], start = p0[i])
 end
 
+function MTK.set_initial_trajectory!(m::InfiniteModel, U, idx, traj)
+    return set_start_value(U[idx], traj)
+end
+
 function MTK.generate_timescale!(m::InfiniteModel, guess, is_free_t)
     @variable(m, tₛ ≥ 0, start = guess)
     if !is_free_t
@@ -146,13 +150,13 @@ function MTK.JuMPDynamicOptProblem(
         dt = nothing,
         steps = nothing,
         tune_parameters = false,
-        guesses = Dict(),
+        guesses = Dict(), initial_trajectory = Dict(),
         bounds = Dict(), kwargs...
     )
     prob,
         _ = MTK.process_DynamicOptProblem(
         JuMPDynamicOptProblem, InfiniteOptModel, sys,
-        op, tspan; dt, steps, tune_parameters, guesses, bounds, kwargs...
+        op, tspan; dt, steps, tune_parameters, guesses, initial_trajectory, bounds, kwargs...
     )
     return prob
 end
@@ -162,13 +166,13 @@ function MTK.InfiniteOptDynamicOptProblem(
         dt = nothing,
         steps = nothing,
         tune_parameters = false,
-        guesses = Dict(),
+        guesses = Dict(), initial_trajectory = Dict(),
         bounds = Dict(), kwargs...
     )
     prob,
         pmap = MTK.process_DynamicOptProblem(
         InfiniteOptDynamicOptProblem, InfiniteOptModel,
-        sys, op, tspan; dt, steps, tune_parameters, guesses, bounds, kwargs...
+        sys, op, tspan; dt, steps, tune_parameters, guesses, initial_trajectory, bounds, kwargs...
     )
     MTK.add_equational_constraints!(prob.wrapped_model, sys, pmap, tspan)
     return prob

--- a/lib/ModelingToolkitBase/ext/MTKPyomoDynamicOptExt.jl
+++ b/lib/ModelingToolkitBase/ext/MTKPyomoDynamicOptExt.jl
@@ -97,13 +97,13 @@ end
 function MTK.PyomoDynamicOptProblem(
         sys::System, op, tspan;
         dt = nothing, steps = nothing, tune_parameters = false,
-        guesses = Dict(),
+        guesses = Dict(), initial_trajectory = Dict(),
         bounds = Dict(), kwargs...
     )
     prob,
         pmap = MTK.process_DynamicOptProblem(
         PyomoDynamicOptProblem, PyomoDynamicOptModel,
-        sys, op, tspan; dt, steps, tune_parameters, guesses, bounds, kwargs...
+        sys, op, tspan; dt, steps, tune_parameters, guesses, initial_trajectory, bounds, kwargs...
     )
     conc_model = prob.wrapped_model.model
     MTK.add_equational_constraints!(prob.wrapped_model, sys, pmap, tspan)

--- a/lib/ModelingToolkitBase/src/ModelingToolkitBase.jl
+++ b/lib/ModelingToolkitBase/src/ModelingToolkitBase.jl
@@ -339,6 +339,7 @@ export calculate_jacobian, generate_jacobian, generate_rhs, generate_custom_func
 export calculate_control_jacobian, generate_control_jacobian
 export calculate_tgrad, generate_tgrad
 export generate_cost, calculate_cost_gradient, generate_cost_gradient
+export generate_trajectory
 export calculate_cost_hessian, generate_cost_hessian
 export calculate_massmatrix, generate_diffusion_function
 export stochastic_integral_transform

--- a/lib/ModelingToolkitBase/src/systems/codegen.jl
+++ b/lib/ModelingToolkitBase/src/systems/codegen.jl
@@ -500,6 +500,39 @@ end
 """
     $(TYPEDSIGNATURES)
 
+Generate a function `f(p, t)` which evaluates the symbolic expression `expr` at time `t`
+with the parameter object `p`. `expr` may involve the independent variable, parameters,
+observed variables and bound parameters of `sys` (the latter two are inlined
+symbolically), but not its unknowns. The `f(p, t)` signature matches the initial guess
+function convention used across the SciML ecosystem, e.g. by `BVProblem`.
+
+# Keyword Arguments
+
+$GENERATE_X_KWARGS
+"""
+function generate_trajectory(sys::System, expr, opts::GeneratedFunctionOptions)
+    (; eval_expression, eval_module, compiler_options) = opts
+    expression = expression_val(opts)
+    wrap_gfw = wrap_gfw_val(opts)
+    p = reorder_parameters(sys)
+    res = build_function_wrapper(
+        sys, expr, [p; Any[get_iv(sys)]], BuildFunctionWrapperOptions(;
+            p_start = 1, p_end = length(p), wrap_delays = false,
+            codegen_function_options = opts.codegen
+        )
+    )
+    if !(expr isa AbstractArray || symbolic_type(expr) == ArraySymbolic())
+        res = res[1]
+    end
+    return maybe_compile_function(
+        expression, wrap_gfw, (1, 2, is_split(sys)), res;
+        compiler_options, eval_expression, eval_module
+    )
+end
+
+"""
+    $(TYPEDSIGNATURES)
+
 Calculate the mass matrix of `sys`. `simplify` controls whether `Symbolics.simplify` is
 applied to the symbolic mass matrix. Returns a `Diagonal` or `LinearAlgebra.I` wherever
 possible.

--- a/lib/ModelingToolkitBase/src/systems/optimal_control_interface.jl
+++ b/lib/ModelingToolkitBase/src/systems/optimal_control_interface.jl
@@ -324,7 +324,9 @@ function process_DynamicOptProblem(
         steps = nothing,
         tune_parameters = false,
         guesses = Dict(), initial_trajectory = Dict(),
-        bounds = Dict(), kwargs...
+        bounds = Dict(),
+        eval_expression = false, eval_module = @__MODULE__,
+        kwargs...
     )
     warn_overdetermined(sys, op)
     ctrls = inputs(sys)
@@ -342,7 +344,7 @@ function process_DynamicOptProblem(
     f, u0,
         p = process_SciMLProblem(
         ODEInputFunction, sys, _op;
-        t = tspan !== nothing ? tspan[1] : tspan, kwargs...
+        t = tspan !== nothing ? tspan[1] : tspan, eval_expression, eval_module, kwargs...
     )
     model_tspan, steps, is_free_t = process_tspan(tspan, dt, steps)
     warn_overdetermined(sys, op)
@@ -375,7 +377,7 @@ function process_DynamicOptProblem(
     for (var, traj) in initial_trajectory
         idx = get(stidxmap, var, nothing)
         idx === nothing && continue
-        set_initial_trajectory!(model, U, idx, build_trajectory_function(sys, var, traj, pmap))
+        set_initial_trajectory!(model, U, idx, build_trajectory_function(sys, var, traj, p; eval_expression, eval_module))
     end
     V = generate_input_variable!(model, c0, length(ctrls), tsteps)
     P = generate_tunable_params!(model, p0, length(tunable_params))
@@ -401,39 +403,52 @@ function process_DynamicOptProblem(
 end
 
 """
-    build_trajectory_function(sys, var, traj, pmap)
+    build_trajectory_function(sys, var, traj, p; eval_expression = false, eval_module = @__MODULE__)
 
 Compile an `initial_trajectory` entry for `var` into a callable of the independent
-variable of `sys`.
+variable of `sys`, closing over the parameter object `p`.
 
-`traj` is a symbolic expression in the independent variable; any parameters it
-references are resolved numerically from `pmap`. Expressions that reduce to a constant
-become constant functions. A `Function` is passed through unchanged, which lets guesses
-that cannot be written symbolically (an interpolation of measured data, say) still be
-used.
+`traj` is a symbolic expression in the independent variable and parameters; observed
+variables and parameter bindings it references are inlined symbolically, and parameter
+values are read from `p` when the trajectory is evaluated. A constant is a valid
+trajectory; callables are not supported and raise an `ArgumentError`.
 
 The result is a `Function`, which is what backends such as InfiniteOpt require of
 `JuMP.set_start_value`.
 """
-function build_trajectory_function(sys, var, traj, pmap)
-    traj isa Function && return traj
+function build_trajectory_function(
+        sys, var, traj, p; eval_expression = false, eval_module = @__MODULE__
+    )
+    if symbolic_type(traj) === NotSymbolic()
+        # A guess that does not vary in time is still a valid trajectory.
+        traj isa Number && return Returns(traj)
+        throw(
+            ArgumentError(
+                "Only symbolic trajectories are supported for `initial_trajectory`, " *
+                    "got a $(nameof(typeof(traj))) for $var."
+            )
+        )
+    end
 
     iv = get_iv(sys)
-    expr = SymbolicUtils.unwrap_const(unwrap(Symbolics.fixpoint_sub(unwrap(traj), pmap)))
-    # A guess that does not vary in time is still a valid trajectory.
-    symbolic_type(expr) === NotSymbolic() && return Returns(expr)
+    expr = get_ir_info(sys).obs_subber(unwrap(traj))
 
-    unresolved = setdiff(Symbolics.get_variables(expr), [unwrap(iv)])
+    unresolved = filter(
+        v -> !isequal(v, unwrap(iv)) && !is_parameter(sys, v),
+        Symbolics.get_variables(expr)
+    )
     isempty(unresolved) || throw(
         ArgumentError(
             "The `initial_trajectory` for $var may only depend on the independent " *
-                "variable $iv and on parameters, but it also depends on " *
-                "$(join(unresolved, ", ")). Parameters are resolved from the operating " *
-                "point, so anything left over cannot be evaluated."
+                "variable $iv and on parameters, but after inlining observed variables " *
+                "and parameter bindings it also depends on $(join(unresolved, ", "))."
         )
     )
 
-    return Symbolics.build_function(expr, iv; expression = Val(false))
+    opts = GeneratedFunctionOptions(; expression = Val{false}, eval_expression, eval_module)
+    rgf = generate_trajectory(sys, expr, opts)
+
+    return Base.Fix1(rgf, p)
 end
 
 # Set the start values of state `idx` from a trajectory callable.

--- a/lib/ModelingToolkitBase/src/systems/optimal_control_interface.jl
+++ b/lib/ModelingToolkitBase/src/systems/optimal_control_interface.jl
@@ -400,7 +400,11 @@ function process_DynamicOptProblem(
     return prob_type(f, u0, tspan, p, fullmodel; kwargs...), pmap
 end
 
-function set_initial_trajectory! end
+# Set the start values of state `idx` from a function-valued trajectory.
+# Backends without a method for their model type do not support this.
+function set_initial_trajectory!(model, U, idx, traj)
+    throw(ArgumentError("The `initial_trajectory` keyword argument is not supported by the $(nameof(typeof(model))) backend."))
+end
 function generate_time_variable! end
 function generate_internal_model end
 function generate_state_variable! end

--- a/lib/ModelingToolkitBase/src/systems/optimal_control_interface.jl
+++ b/lib/ModelingToolkitBase/src/systems/optimal_control_interface.jl
@@ -323,7 +323,7 @@ function process_DynamicOptProblem(
         dt = nothing,
         steps = nothing,
         tune_parameters = false,
-        guesses = Dict(),
+        guesses = Dict(), initial_trajectory = Dict(),
         bounds = Dict(), kwargs...
     )
     warn_overdetermined(sys, op)
@@ -333,6 +333,7 @@ function process_DynamicOptProblem(
 
     stidxmap = Dict([v => i for (i, v) in enumerate(states)])
     op = Dict([default_toterm(value(k)) => v for (k, v) in op])
+    initial_trajectory = Dict([default_toterm(value(k)) => v for (k, v) in initial_trajectory])
     bounds = Dict([default_toterm(value(k)) => v for (k, v) in bounds])
     u0_idxs = has_alg_eqs(sys) ? collect(1:length(states)) :
         [stidxmap[default_toterm(k)] for (k, v) in op if haskey(stidxmap, k)]
@@ -370,6 +371,12 @@ function process_DynamicOptProblem(
     model = generate_internal_model(model_type)
     generate_time_variable!(model, model_tspan, tsteps)
     U = generate_state_variable!(model, u0, length(states), tsteps)
+    # Apply function-valued start trajectories
+    for (var, traj) in initial_trajectory
+        idx = get(stidxmap, var, nothing)
+        idx === nothing && continue
+        set_initial_trajectory!(model, U, idx, traj)
+    end
     V = generate_input_variable!(model, c0, length(ctrls), tsteps)
     P = generate_tunable_params!(model, p0, length(tunable_params))
     # Add the symbolic representation of the tunable parameters to the map
@@ -393,6 +400,7 @@ function process_DynamicOptProblem(
     return prob_type(f, u0, tspan, p, fullmodel; kwargs...), pmap
 end
 
+function set_initial_trajectory! end
 function generate_time_variable! end
 function generate_internal_model end
 function generate_state_variable! end

--- a/lib/ModelingToolkitBase/src/systems/optimal_control_interface.jl
+++ b/lib/ModelingToolkitBase/src/systems/optimal_control_interface.jl
@@ -371,11 +371,11 @@ function process_DynamicOptProblem(
     model = generate_internal_model(model_type)
     generate_time_variable!(model, model_tspan, tsteps)
     U = generate_state_variable!(model, u0, length(states), tsteps)
-    # Apply function-valued start trajectories
+    # Apply start trajectories, compiling the symbolic expressions to callables
     for (var, traj) in initial_trajectory
         idx = get(stidxmap, var, nothing)
         idx === nothing && continue
-        set_initial_trajectory!(model, U, idx, traj)
+        set_initial_trajectory!(model, U, idx, build_trajectory_function(sys, var, traj, pmap))
     end
     V = generate_input_variable!(model, c0, length(ctrls), tsteps)
     P = generate_tunable_params!(model, p0, length(tunable_params))
@@ -400,7 +400,43 @@ function process_DynamicOptProblem(
     return prob_type(f, u0, tspan, p, fullmodel; kwargs...), pmap
 end
 
-# Set the start values of state `idx` from a function-valued trajectory.
+"""
+    build_trajectory_function(sys, var, traj, pmap)
+
+Compile an `initial_trajectory` entry for `var` into a callable of the independent
+variable of `sys`.
+
+`traj` is a symbolic expression in the independent variable; any parameters it
+references are resolved numerically from `pmap`. Expressions that reduce to a constant
+become constant functions. A `Function` is passed through unchanged, which lets guesses
+that cannot be written symbolically (an interpolation of measured data, say) still be
+used.
+
+The result is a `Function`, which is what backends such as InfiniteOpt require of
+`JuMP.set_start_value`.
+"""
+function build_trajectory_function(sys, var, traj, pmap)
+    traj isa Function && return traj
+
+    iv = get_iv(sys)
+    expr = SymbolicUtils.unwrap_const(unwrap(Symbolics.fixpoint_sub(unwrap(traj), pmap)))
+    # A guess that does not vary in time is still a valid trajectory.
+    symbolic_type(expr) === NotSymbolic() && return Returns(expr)
+
+    unresolved = setdiff(Symbolics.get_variables(expr), [unwrap(iv)])
+    isempty(unresolved) || throw(
+        ArgumentError(
+            "The `initial_trajectory` for $var may only depend on the independent " *
+                "variable $iv and on parameters, but it also depends on " *
+                "$(join(unresolved, ", ")). Parameters are resolved from the operating " *
+                "point, so anything left over cannot be evaluated."
+        )
+    )
+
+    return Symbolics.build_function(expr, iv; expression = Val(false))
+end
+
+# Set the start values of state `idx` from a trajectory callable.
 # Backends without a method for their model type do not support this.
 function set_initial_trajectory!(model, U, idx, traj)
     throw(ArgumentError("The `initial_trajectory` keyword argument is not supported by the $(nameof(typeof(model))) backend."))

--- a/lib/ModelingToolkitBase/test/optimization/dynamic_optimization.jl
+++ b/lib/ModelingToolkitBase/test/optimization/dynamic_optimization.jl
@@ -900,26 +900,29 @@ struct UnsupportedTrajectoryBackend end
     )
 
     # Expressions are compiled to callables of the independent variable
-    pmap_test = Dict()
-    fx = M.build_trajectory_function(block, x(t), 0.125 * t^2, pmap_test)
+    p_test = MTKParameters(block, parammap)
+    fx = M.build_trajectory_function(block, x(t), 0.125 * t^2, p_test)
     @test fx isa Function
     @test fx(2.0) ≈ 0.5
 
     # A constant expression is still a valid trajectory
-    fc = M.build_trajectory_function(block, x(t), 3.0, pmap_test)
+    fc = M.build_trajectory_function(block, x(t), 3.0, p_test)
     @test fc isa Function
     @test fc(2.0) == 3.0
 
-    # Callables pass through unchanged, for guesses that aren't expressible symbolically
+    # Callables are rejected: trajectories are symbolic-only for now
     g = τ -> 7.0
-    @test M.build_trajectory_function(block, x(t), g, pmap_test) === g
+    @test_throws ArgumentError M.build_trajectory_function(block, x(t), g, p_test)
 
-    # Parameters are resolved from the operating point
+    # Parameters stay symbolic and are read from the parameter object when the
+    # trajectory is evaluated
     @parameters a
-    fp = M.build_trajectory_function(block, x(t), a * t, Dict(a => 4.0))
+    @named psys = System([D(x(t)) ~ a * v(t), D(v(t)) ~ 0.0], t)
+    psys = mtkcompile(psys)
+    fp = M.build_trajectory_function(psys, x(t), a * t, MTKParameters(psys, [a => 4.0]))
     @test fp(2.0) ≈ 8.0
 
-    # Anything left unresolved after substitution is reported
+    # Anything that does not reduce to time and parameters is reported
     @parameters b
-    @test_throws ArgumentError M.build_trajectory_function(block, x(t), b * t, pmap_test)
+    @test_throws ArgumentError M.build_trajectory_function(block, x(t), b * t, p_test)
 end

--- a/lib/ModelingToolkitBase/test/optimization/dynamic_optimization.jl
+++ b/lib/ModelingToolkitBase/test/optimization/dynamic_optimization.jl
@@ -852,3 +852,50 @@ end
     jsol_tf = solve(jprob_tf, JuMPCollocation(Ipopt.Optimizer, ExplicitTableaus.RK4()))
     @test 2 * jsol_tf.sol[x][end] ≤ 0.8
 end
+
+struct UnsupportedTrajectoryBackend end
+
+@testset "Function-valued initial trajectories" begin
+    @variables x(..) v(..)
+    @variables u(..) [bounds = (-1.0, 1.0), input = true]
+    constr = [v(1.0) ~ 0.0]
+    cost = [-x(1.0)]
+
+    @named block = System(
+        [D(x(t)) ~ v(t), D(v(t)) ~ u(t)], t; costs = cost, constraints = constr
+    )
+    block = mtkcompile(block; inputs = [u(t)])
+
+    u0map = [x(t) => 0.0, v(t) => 0.0]
+    tspan = (0.0, 1.0)
+    parammap = [u(t) => 0.0]
+
+    # Provide function-valued trajectories
+    traj = Dict(x(t) => t -> 0.125 * t^2, v(t) => t -> 0.25 * t)
+
+    iprob = InfiniteOptDynamicOptProblem(
+        block, [u0map; parammap], tspan; dt = 0.01,
+        initial_trajectory = traj
+    )
+    isol = solve(iprob, InfiniteOptCollocation(Ipopt.Optimizer))
+    @test ≈(isol.sol[x(t)][end], 0.25, rtol = 1.0e-3)
+
+    # Without trajectory should also work
+    iprob2 = InfiniteOptDynamicOptProblem(block, [u0map; parammap], tspan; dt = 0.01)
+    isol2 = solve(iprob2, InfiniteOptCollocation(Ipopt.Optimizer))
+    @test ≈(isol2.sol[x(t)][end], 0.25, rtol = 1.0e-3)
+
+    if ENABLE_CASADI
+        cprob = CasADiDynamicOptProblem(
+            block, [u0map; parammap], tspan; dt = 0.01,
+            initial_trajectory = traj
+        )
+        csol = solve(cprob, CasADiCollocation("ipopt"))
+        @test ≈(csol.sol[x(t)][end], 0.25, rtol = 1.0e-3)
+    end
+
+    # Backends without a `set_initial_trajectory!` method report it clearly
+    @test_throws ArgumentError M.set_initial_trajectory!(
+        UnsupportedTrajectoryBackend(), nothing, 1, identity
+    )
+end

--- a/lib/ModelingToolkitBase/test/optimization/dynamic_optimization.jl
+++ b/lib/ModelingToolkitBase/test/optimization/dynamic_optimization.jl
@@ -855,7 +855,7 @@ end
 
 struct UnsupportedTrajectoryBackend end
 
-@testset "Function-valued initial trajectories" begin
+@testset "Expression-valued initial trajectories" begin
     @variables x(..) v(..)
     @variables u(..) [bounds = (-1.0, 1.0), input = true]
     constr = [v(1.0) ~ 0.0]
@@ -870,8 +870,8 @@ struct UnsupportedTrajectoryBackend end
     tspan = (0.0, 1.0)
     parammap = [u(t) => 0.0]
 
-    # Provide function-valued trajectories
-    traj = Dict(x(t) => t -> 0.125 * t^2, v(t) => t -> 0.25 * t)
+    # Trajectories are symbolic expressions in the independent variable
+    traj = Dict(x(t) => 0.125 * t^2, v(t) => 0.25 * t)
 
     iprob = InfiniteOptDynamicOptProblem(
         block, [u0map; parammap], tspan; dt = 0.01,
@@ -898,4 +898,28 @@ struct UnsupportedTrajectoryBackend end
     @test_throws ArgumentError M.set_initial_trajectory!(
         UnsupportedTrajectoryBackend(), nothing, 1, identity
     )
+
+    # Expressions are compiled to callables of the independent variable
+    pmap_test = Dict()
+    fx = M.build_trajectory_function(block, x(t), 0.125 * t^2, pmap_test)
+    @test fx isa Function
+    @test fx(2.0) ≈ 0.5
+
+    # A constant expression is still a valid trajectory
+    fc = M.build_trajectory_function(block, x(t), 3.0, pmap_test)
+    @test fc isa Function
+    @test fc(2.0) == 3.0
+
+    # Callables pass through unchanged, for guesses that aren't expressible symbolically
+    g = τ -> 7.0
+    @test M.build_trajectory_function(block, x(t), g, pmap_test) === g
+
+    # Parameters are resolved from the operating point
+    @parameters a
+    fp = M.build_trajectory_function(block, x(t), a * t, Dict(a => 4.0))
+    @test fp(2.0) ≈ 8.0
+
+    # Anything left unresolved after substitution is reported
+    @parameters b
+    @test_throws ArgumentError M.build_trajectory_function(block, x(t), b * t, pmap_test)
 end


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

For dynamic optimization problems it is not enough to provide constant guesses for the initial conditions and in some cases a functional form of the guess is needed. This also has a precedent in BoundaryValueDiffEq with continuation: https://docs.sciml.ai/BoundaryValueDiffEq/dev/tutorials/continuation/#On-providing-initial-guess

How do we want the interface for this to look like? The proposal here is `initial_trajectory` as a `Dict` mapping the variables to the function, but we can adapt this to be closer to BVP.

Another question is how should the free final time problems be handled. We could internally scale the time if the simpler approach in this PR is not good enough.