### PR TITLE
Enforce bounds on observed variables, with a selectable transformation

### DIFF
--- a/docs/src/tutorials/dynamic_optimization.md
+++ b/docs/src/tutorials/dynamic_optimization.md
@@ -130,6 +130,49 @@ move the optimum, only how the solver converges towards it.
 directly as derivative constraints. The JuMP and CasADi backends discretize through an
 ODE solver tableau instead and currently ignore it.
 
+### Bounds on observed variables
+
+Bounds declared on an observed variable are enforced too, not just bounds on states and
+inputs. Here the observed `power` is capped, which limits how hard the input may drive
+the state:
+
+```@example dynamic_opt
+@variables begin
+    z(..)
+    power(..), [bounds = (0.0, 1.0)]
+    w(..), [input = true, bounds = (-1.0, 1.0)]
+end
+
+@named limited = System(
+    [D(z(t)) ~ w(t), power(t) ~ 2z(t)], t; costs = [-z(1.0)])
+limited = mtkcompile(limited; inputs = [w(t)])
+
+lprob = JuMPDynamicOptProblem(
+    limited, [[z(t) => 0.0]; [w(t) => 0.0]], (0.0, 1.0); dt = 0.01)
+lsol = solve(lprob, JuMPCollocation(Ipopt.Optimizer));
+lsol.sol[z(t)][end]  # 0.5, not 1.0: power = 2z ≤ 1 binds
+```
+
+There are two ways to impose such a bound, selected with `observed_bounds_method`:
+
+  - `:lift` introduces an auxiliary decision variable bounded by `[lo, hi]` and ties it to
+    the observed expression with an equality constraint. Interior-point solvers such as
+    Ipopt handle variable bounds considerably better than the equivalent nonlinear
+    inequalities, so this is usually faster. Not every backend can do it.
+  - `:constraint` emits the bound directly as a nonlinear inequality. Every backend
+    supports this.
+  - `:auto`, the default, uses `:lift` where the backend supports it and `:constraint`
+    everywhere else.
+
+Currently only the JuMP and InfiniteOpt backends can lift; CasADi and Pyomo use
+`:constraint`. Asking a backend for `:lift` when it cannot raises an `ArgumentError`
+rather than silently doing something else.
+
+`:constraint` is worth choosing explicitly when the solver is not interior-point (active
+set and SQP methods handle inequalities natively), when there are many bounded observed
+variables and the extra equality constraints make finding an initial feasible point
+harder, or when comparing against a reference formulation.
+
 ### Free final time problems
 
 There are additionally a class of dynamic optimization problems where we would like to know how to control our system to achieve something in the least time. Such problems are called free final time problems, since the final time is unknown. To model these problems in ModelingToolkit, we declare the final time as a parameter.

--- a/lib/ModelingToolkitBase/ext/MTKCasADiDynamicOptExt.jl
+++ b/lib/ModelingToolkitBase/ext/MTKCasADiDynamicOptExt.jl
@@ -168,8 +168,8 @@ end
 
 MTK.set_objective!(m::CasADiModel, expr) = minimize!(m.model, MX(expr))
 
-function MTK.set_variable_bounds!(m::CasADiModel, sys, pmap, tf, tunable_params, user_bounds = Dict())
-    (; state_bounds, input_bounds, param_bounds, tf_bounds) = MTK.extract_variable_bounds(sys, pmap, tf, tunable_params, user_bounds)
+function MTK.set_variable_bounds!(m::CasADiModel, sys, pmap, tspan, tunable_params, user_bounds = Dict())
+    (; state_bounds, input_bounds, param_bounds, tf_bounds) = MTK.extract_variable_bounds(sys, pmap, tspan, tunable_params, user_bounds)
     for (i, (lo, hi)) in state_bounds
         subject_to!(m.model, m.U.u[i, :] >= lo)
         subject_to!(m.model, m.U.u[i, :] <= hi)

--- a/lib/ModelingToolkitBase/ext/MTKInfiniteOptExt.jl
+++ b/lib/ModelingToolkitBase/ext/MTKInfiniteOptExt.jl
@@ -251,7 +251,7 @@ end
 
 function MTK.add_initial_constraints!(m::InfiniteOptModel, u0, u0_idxs, ts)
     for i in u0_idxs
-        @constraint(m.model, m.U[i](ts) == u0[i])
+        fix(m.U[i](ts), u0[i], force = true)
     end
     return
 end

--- a/lib/ModelingToolkitBase/ext/MTKInfiniteOptExt.jl
+++ b/lib/ModelingToolkitBase/ext/MTKInfiniteOptExt.jl
@@ -164,7 +164,7 @@ end
 MTK.set_objective!(m::InfiniteOptModel, expr) = @objective(m.model, Min, SymbolicUtils.unwrap_const(expr))
 
 function MTK.set_variable_bounds!(m::InfiniteOptModel, sys, pmap, tspan, tunable_params, user_bounds = Dict())
-    (; state_bounds, input_bounds, param_bounds, tf_bounds, observed_bounds) = MTK.extract_variable_bounds(sys, pmap, tspan, tunable_params, user_bounds)
+    (; state_bounds, input_bounds, param_bounds, tf_bounds) = MTK.extract_variable_bounds(sys, pmap, tspan, tunable_params, user_bounds)
     for (i, (lo, hi)) in state_bounds
         set_lower_bound(m.U[i], lo)
         set_upper_bound(m.U[i], hi)
@@ -181,24 +181,21 @@ function MTK.set_variable_bounds!(m::InfiniteOptModel, sys, pmap, tspan, tunable
         set_lower_bound(m.tₛ, tf_bounds[1])
         set_upper_bound(m.tₛ, tf_bounds[2])
     end
+end
 
-    # Observed variable bounds: create auxiliary bounded variables + equality constraints.
-    # This "lifts" what would be nonlinear inequality constraints into variable bounds,
-    # which interior-point solvers (Ipopt) handle much more efficiently.
-    if !isempty(observed_bounds)
-        rules = Dict{Any, Any}()
-        MTK.get_model_vars_substitution_rules!(rules, m, sys, tspan)
-        MTK.get_observed_substitution_rules!(rules, sys)
-        MTK.get_param_substitution_rules!(rules, pmap)
+MTK.supports_bounds_lifting(::InfiniteOptModel) = true
 
-        for (var, (lo, hi)) in observed_bounds
-            expr = Symbolics.fixpoint_sub(var, rules; fold = Val(true), filterer = Returns(true))
-            aux = @variable(m.model, variable_type = Infinite(m.model[:t]))
-            isfinite(lo) && set_lower_bound(aux, lo)
-            isfinite(hi) && set_upper_bound(aux, hi)
-            @constraint(m.model, (SymbolicUtils.unwrap_const(Symbolics.value(expr)) - aux) / getnominal(var) == 0)
-        end
-    end
+# Lift a bounded observed expression into an auxiliary bounded decision variable. Ipopt
+# handles variable bounds far more efficiently than the equivalent nonlinear inequalities.
+function MTK.lift_observed_bound!(m::InfiniteOptModel, expr, lo, hi, scale, start)
+    aux = @variable(m.model, variable_type = Infinite(m.model[:t]))
+    isfinite(lo) && set_lower_bound(aux, lo)
+    isfinite(hi) && set_upper_bound(aux, hi)
+    set_start_value_function(aux, Returns(start))
+    return @constraint(
+        m.model,
+        (SymbolicUtils.unwrap_const(Symbolics.value(expr)) - aux) / scale == 0
+    )
 end
 
 function MTK.JuMPDynamicOptProblem(

--- a/lib/ModelingToolkitBase/ext/MTKInfiniteOptExt.jl
+++ b/lib/ModelingToolkitBase/ext/MTKInfiniteOptExt.jl
@@ -163,8 +163,8 @@ function MTK.add_constraint!(m::InfiniteOptModel, expr::Union{Equation, Inequali
 end
 MTK.set_objective!(m::InfiniteOptModel, expr) = @objective(m.model, Min, SymbolicUtils.unwrap_const(expr))
 
-function MTK.set_variable_bounds!(m::InfiniteOptModel, sys, pmap, tf, tunable_params, user_bounds = Dict())
-    (; state_bounds, input_bounds, param_bounds, tf_bounds) = MTK.extract_variable_bounds(sys, pmap, tf, tunable_params, user_bounds)
+function MTK.set_variable_bounds!(m::InfiniteOptModel, sys, pmap, tspan, tunable_params, user_bounds = Dict())
+    (; state_bounds, input_bounds, param_bounds, tf_bounds, observed_bounds) = MTK.extract_variable_bounds(sys, pmap, tspan, tunable_params, user_bounds)
     for (i, (lo, hi)) in state_bounds
         set_lower_bound(m.U[i], lo)
         set_upper_bound(m.U[i], hi)
@@ -180,6 +180,24 @@ function MTK.set_variable_bounds!(m::InfiniteOptModel, sys, pmap, tf, tunable_pa
     return if !isnothing(tf_bounds)
         set_lower_bound(m.tₛ, tf_bounds[1])
         set_upper_bound(m.tₛ, tf_bounds[2])
+    end
+
+    # Observed variable bounds: create auxiliary bounded variables + equality constraints.
+    # This "lifts" what would be nonlinear inequality constraints into variable bounds,
+    # which interior-point solvers (Ipopt) handle much more efficiently.
+    if !isempty(observed_bounds)
+        rules = Dict{Any, Any}()
+        MTK.get_model_vars_substitution_rules!(rules, m, sys, tspan)
+        MTK.get_observed_substitution_rules!(rules, sys)
+        MTK.get_param_substitution_rules!(rules, pmap)
+
+        for (var, (lo, hi)) in observed_bounds
+            expr = Symbolics.fixpoint_sub(var, rules; fold = Val(true), filterer = Returns(true))
+            aux = @variable(m.model, variable_type = Infinite(m.model[:t]))
+            isfinite(lo) && set_lower_bound(aux, lo)
+            isfinite(hi) && set_upper_bound(aux, hi)
+            @constraint(m.model, (SymbolicUtils.unwrap_const(Symbolics.value(expr)) - aux) / getnominal(var) == 0)
+        end
     end
 end
 
@@ -236,7 +254,7 @@ end
 
 function MTK.add_initial_constraints!(m::InfiniteOptModel, u0, u0_idxs, ts)
     for i in u0_idxs
-        fix(m.U[i](0), u0[i], force = true)
+        @constraint(m.model, m.U[i](ts) == u0[i])
     end
     return
 end

--- a/lib/ModelingToolkitBase/ext/MTKPyomoDynamicOptExt.jl
+++ b/lib/ModelingToolkitBase/ext/MTKPyomoDynamicOptExt.jl
@@ -170,8 +170,8 @@ function MTK.add_constraint!(pmodel::PyomoDynamicOptModel, cons; n_idxs = 1)
     end
 end
 
-function MTK.set_variable_bounds!(m::PyomoDynamicOptModel, sys, pmap, tf, tunable_params, user_bounds = Dict())
-    (; state_bounds, input_bounds, param_bounds, tf_bounds) = MTK.extract_variable_bounds(sys, pmap, tf, tunable_params, user_bounds)
+function MTK.set_variable_bounds!(m::PyomoDynamicOptModel, sys, pmap, tspan, tunable_params, user_bounds = Dict())
+    (; state_bounds, input_bounds, param_bounds, tf_bounds) = MTK.extract_variable_bounds(sys, pmap, tspan, tunable_params, user_bounds)
     t = MTK.get_iv(sys)
     for (i, (lo, hi)) in state_bounds
         var = MTK.lowered_var(m, :U, i, t)

--- a/lib/ModelingToolkitBase/src/systems/optimal_control_interface.jl
+++ b/lib/ModelingToolkitBase/src/systems/optimal_control_interface.jl
@@ -469,7 +469,7 @@ function process_DynamicOptProblem(
     narrow_nn = Tuple(map(identity, v) for v in p.nonnumeric)
     @set! p.nonnumeric = narrow_nn
 
-    set_variable_bounds!(fullmodel, sys, pmap, tspan[2], tunable_params, bounds)
+    set_variable_bounds!(fullmodel, sys, pmap, tspan, tunable_params, bounds)
     add_cost_function!(fullmodel, sys, tspan, pmap)
     add_user_constraints!(fullmodel, sys, tspan, pmap)
     add_initial_constraints!(fullmodel, u0, u0_idxs, model_tspan[1])
@@ -566,24 +566,30 @@ end
     extract_variable_bounds(sys, pmap, tf, tunable_params)
 
 Extract and parameter-substitute variable bounds from the system.
-Returns `(; state_bounds, input_bounds, param_bounds, tf_bounds)` where each
-`*_bounds` is a `Dict{Int, Tuple{Any, Any}}` mapping variable index to `(lo, hi)`,
-and `tf_bounds` is either `nothing` or a `(lo, hi)` tuple.
+Returns `(; state_bounds, input_bounds, param_bounds, tf_bounds, observed_bounds)` where
+`state_bounds`, `input_bounds`, `param_bounds` are `Dict{Int, Tuple{Any, Any}}` mapping
+variable index to `(lo, hi)`, `tf_bounds` is either `nothing` or a `(lo, hi)` tuple,
+and `observed_bounds` is a `Dict{Any, Tuple{Any, Any}}` mapping observed variable symbols
+to `(lo, hi)`. Observed bounds are sourced from variable metadata and the `user_bounds` dict
+(user bounds take priority). The backend is responsible for lifting observed bounds into
+auxiliary bounded decision variables with equality constraints.
 """
-function extract_variable_bounds(sys, pmap, tf, tunable_params, user_bounds = Dict())
+function extract_variable_bounds(sys, pmap, tspan, tunable_params, user_bounds = Dict())
+    tf = last(tspan)
     state_bounds = _extract_bounds(unknowns(sys), pmap)
     input_bounds = _extract_bounds(inputs(sys), pmap)
     param_bounds = _extract_bounds(tunable_params, pmap)
     # Merge user-provided bounds (override metadata bounds)
     dvs = unknowns(sys)
-    ctrls = inputs(sys)
+    dvs_set = Set(default_toterm.(dvs))
+    ctrls_set = Set(default_toterm.(inputs(sys)))
     for (var, (lo, hi)) in user_bounds
         idx = findfirst(v -> isequal(v, var), dvs)
         if !isnothing(idx)
             state_bounds[idx] = (lo, hi)
             continue
         end
-        idx = findfirst(v -> isequal(v, var), ctrls)
+        idx = findfirst(v -> isequal(v, var), inputs(sys))
         if !isnothing(idx)
             input_bounds[idx] = (lo, hi)
         end
@@ -597,7 +603,23 @@ function extract_variable_bounds(sys, pmap, tf, tunable_params, user_bounds = Di
     else
         nothing
     end
-    return (; state_bounds, input_bounds, param_bounds, tf_bounds)
+
+    # Collect bounds on observed variables: metadata first, user overrides
+    observed_bounds = Dict{Any, Tuple{Any, Any}}()
+    for eq in observed(unhack_system(sys))
+        v = default_toterm(unwrap(eq.lhs))
+        if hasbounds(v)
+            lo, hi = getbounds(v)
+            observed_bounds[v] = (Symbolics.fixpoint_sub(lo, pmap), Symbolics.fixpoint_sub(hi, pmap))
+        end
+    end
+    for (var, (lo, hi)) in user_bounds
+        var ∈ dvs_set && continue
+        var ∈ ctrls_set && continue
+        observed_bounds[var] = (lo, hi)
+    end
+
+    return (; state_bounds, input_bounds, param_bounds, tf_bounds, observed_bounds)
 end
 
 function _extract_bounds(vars, pmap)

--- a/lib/ModelingToolkitBase/src/systems/optimal_control_interface.jl
+++ b/lib/ModelingToolkitBase/src/systems/optimal_control_interface.jl
@@ -726,6 +726,11 @@ function add_observed_bounds!(
     get_param_substitution_rules!(rules, pmap)
 
     for (var, (lo, hi)) in observed_bounds
+        # `observed_bounds` stores its values symbolically: resolve parameter
+        # references and unwrap numeric constants so the backends receive plain
+        # numbers, as for the state and input bounds.
+        lo = value(Symbolics.fixpoint_sub(lo, pmap))
+        hi = value(Symbolics.fixpoint_sub(hi, pmap))
         if method === :lift
             expr = fixpoint_sub(var, rules; fold = Val(true), filterer = Returns(true))
             lift_observed_bound!(

--- a/lib/ModelingToolkitBase/src/systems/optimal_control_interface.jl
+++ b/lib/ModelingToolkitBase/src/systems/optimal_control_interface.jl
@@ -687,9 +687,11 @@ end
 # lifted equality from an infeasible point and defeats the purpose of lifting.
 function aux_start_value(lo, hi)
     isfinite(lo) && isfinite(hi) && return (lo + hi) / 2
-    isfinite(lo) && return lo
-    isfinite(hi) && return hi
-    return 0.0
+    # One-sided (or unbounded): keep the backend's natural 0 start when it is
+    # feasible — starting exactly on the finite bound is hostile to interior-point
+    # methods — and only fall back to the bound itself when 0 is outside.
+    lo <= 0 <= hi && return 0.0
+    return isfinite(lo) ? lo : hi
 end
 
 """

--- a/lib/ModelingToolkitBase/src/systems/optimal_control_interface.jl
+++ b/lib/ModelingToolkitBase/src/systems/optimal_control_interface.jl
@@ -377,7 +377,7 @@ function process_DynamicOptProblem(
         tune_parameters = false,
         guesses = Dict(), initial_trajectory = Dict(),
         nominal_values = Dict(),
-        bounds = Dict(),
+        bounds = Dict(), observed_bounds_method = :auto,
         eval_expression = false, eval_module = @__MODULE__,
         kwargs...
     )
@@ -470,6 +470,9 @@ function process_DynamicOptProblem(
     @set! p.nonnumeric = narrow_nn
 
     set_variable_bounds!(fullmodel, sys, pmap, tspan, tunable_params, bounds)
+    add_observed_bounds!(
+        fullmodel, sys, pmap, tspan, tunable_params, bounds, observed_bounds_method
+    )
     add_cost_function!(fullmodel, sys, tspan, pmap)
     add_user_constraints!(fullmodel, sys, tspan, pmap)
     add_initial_constraints!(fullmodel, u0, u0_idxs, model_tspan[1])
@@ -636,6 +639,108 @@ function _extract_bounds(vars, pmap)
 end
 
 function set_variable_bounds! end
+
+"""
+    supports_bounds_lifting(model)
+
+Whether `model`'s backend can lift a bounded observed expression into an auxiliary
+bounded decision variable. Backends that can should define this to return `true` and
+implement [`lift_observed_bound!`](@ref).
+"""
+supports_bounds_lifting(model) = false
+
+"""
+    lift_observed_bound!(model, expr, lo, hi, scale, start)
+
+Introduce an auxiliary decision variable bounded by `[lo, hi]` and tie it to `expr` with
+the scaled equality `(expr - aux) / scale == 0`. `start` is the auxiliary variable's start
+value. Only called for backends where `supports_bounds_lifting` is `true`.
+"""
+function lift_observed_bound! end
+
+function resolve_observed_bounds_method(model, method)
+    return if method === :auto
+        supports_bounds_lifting(model) ? :lift : :constraint
+    elseif method === :lift
+        supports_bounds_lifting(model) || throw(
+            ArgumentError(
+                "`observed_bounds_method = :lift` is not supported by the " *
+                    "$(nameof(typeof(model))) backend. Use `:constraint`, or `:auto` to " *
+                    "pick the best available method per backend."
+            )
+        )
+        :lift
+    elseif method === :constraint
+        :constraint
+    else
+        throw(
+            ArgumentError(
+                "`observed_bounds_method` must be one of `:auto`, `:lift` or " *
+                    "`:constraint`, got $(repr(method))."
+            )
+        )
+    end
+end
+
+# Pick a start value for the auxiliary variable that at least satisfies its own bounds.
+# Defaulting to 0 (the backend default) can sit outside `[lo, hi]`, which starts the
+# lifted equality from an infeasible point and defeats the purpose of lifting.
+function aux_start_value(lo, hi)
+    isfinite(lo) && isfinite(hi) && return (lo + hi) / 2
+    isfinite(lo) && return lo
+    isfinite(hi) && return hi
+    return 0.0
+end
+
+"""
+    add_observed_bounds!(model, sys, pmap, tspan, tunable_params, user_bounds, method)
+
+Enforce bounds declared on observed variables.
+
+`method` selects how:
+
+  - `:lift` introduces an auxiliary bounded decision variable per bounded observed
+    expression, tied to it by an equality constraint. Interior-point solvers handle
+    variable bounds much better than nonlinear inequalities, but not every backend can
+    do this.
+  - `:constraint` emits the bounds directly as nonlinear inequality constraints. Works
+    on every backend.
+  - `:auto` (the default) uses `:lift` where the backend supports it and `:constraint`
+    everywhere else.
+"""
+function add_observed_bounds!(
+        model, sys, pmap, tspan, tunable_params, user_bounds, method = :auto
+    )
+    (; observed_bounds) = extract_variable_bounds(
+        sys, pmap, tspan, tunable_params, user_bounds
+    )
+    isempty(observed_bounds) && return nothing
+
+    method = resolve_observed_bounds_method(model, method)
+
+    rules = Dict{Any, Any}()
+    get_model_vars_substitution_rules!(rules, model, sys, tspan)
+    get_observed_substitution_rules!(rules, sys)
+    get_param_substitution_rules!(rules, pmap)
+
+    for (var, (lo, hi)) in observed_bounds
+        if method === :lift
+            expr = fixpoint_sub(var, rules; fold = Val(true), filterer = Returns(true))
+            lift_observed_bound!(
+                model, expr, lo, hi, getnominal(var), aux_start_value(lo, hi)
+            )
+        else
+            cons = Any[]
+            isfinite(lo) && push!(cons, var ≳ lo)
+            isfinite(hi) && push!(cons, var ≲ hi)
+            cons = fixpoint_sub(cons, rules; fold = Val(true), filterer = Returns(true))
+            for c in cons
+                add_constraint!(model, c)
+            end
+        end
+    end
+    return nothing
+end
 
 is_free_final(model) = model.is_free_final
 

--- a/lib/ModelingToolkitBase/src/systems/optimal_control_interface.jl
+++ b/lib/ModelingToolkitBase/src/systems/optimal_control_interface.jl
@@ -608,7 +608,7 @@ function extract_variable_bounds(sys, pmap, tspan, tunable_params, user_bounds =
     end
 
     # Collect bounds on observed variables: metadata first, user overrides
-    observed_bounds = Dict{Any, Tuple{Any, Any}}()
+    observed_bounds = Dict{SymbolicT, Tuple{SymbolicT, SymbolicT}}()
     for eq in observed(unhack_system(sys))
         v = default_toterm(unwrap(eq.lhs))
         if hasbounds(v)

--- a/lib/ModelingToolkitBase/test/optimization/dynamic_optimization.jl
+++ b/lib/ModelingToolkitBase/test/optimization/dynamic_optimization.jl
@@ -1057,3 +1057,63 @@ end
         @test silent_flag(iprob.wrapped_model.model) == silent
     end
 end
+
+@testset "Observed variable bounds lifting" begin
+    # Test that bounds on observed variables are enforced via auxiliary variables
+    @variables x(t) = 1.0
+    @variables obs_val(t) [bounds = (0.0, 2.0)]  # observed variable with bounds
+    @variables u(t) [input = true, bounds = (-10.0, 10.0)]
+
+    te = 1.0
+    costs = [EvalAt(te)(x)^2]
+
+    eqs = [
+        D(x) ~ -x + u,
+        obs_val ~ 2x,  # observed: obs_val = 2x, so x should stay in [0, 1]
+    ]
+
+    @named sys = System(eqs, t; costs)
+    sys = mtkcompile(sys; inputs = [u])
+
+    u0map = [x => 1.0]
+    pmap = [u => 0.0]
+    tspan = (0.0, te)
+
+    # InfiniteOpt should lift the observed bounds into auxiliary variables
+    iprob = InfiniteOptDynamicOptProblem(sys, [u0map; pmap], tspan; dt = 0.05)
+    isol = solve(iprob, InfiniteOptCollocation(Ipopt.Optimizer))
+
+    # obs_val = 2x should respect bounds [0, 2], so x ∈ [0, 1]
+    obs_values = 2 .* isol.sol[x]
+    @test all(v -> v ≥ -0.01, obs_values)  # allow small numerical tolerance
+    @test all(v -> v ≤ 2.01, obs_values)
+
+    # Test with user-provided bounds dict for observed variables
+    @variables x2(t) = 1.0
+    @variables obs2(t)
+    @variables u2(t) [input = true, bounds = (-10.0, 10.0)]
+
+    eqs2 = [
+        D(x2) ~ -x2 + u2,
+        obs2 ~ 3x2,
+    ]
+
+    costs2 = [EvalAt(te)(x2)^2]
+    @named sys2 = System(eqs2, t; costs = costs2)
+    sys2 = mtkcompile(sys2; inputs = [u2])
+
+    u0map2 = [x2 => 1.0]
+    pmap2 = [u2 => 0.0]
+
+    # Provide bounds for observed variable via user dict
+    user_bounds = Dict(obs2 => (0.0, 3.0))
+    iprob2 = InfiniteOptDynamicOptProblem(
+        sys2, [u0map2; pmap2], tspan; dt = 0.05,
+        bounds = user_bounds
+    )
+    isol2 = solve(iprob2, InfiniteOptCollocation(Ipopt.Optimizer))
+
+    obs2_values = 3 .* isol2.sol[x2]
+    @test all(v -> v ≥ -0.01, obs2_values)
+    @test all(v -> v ≤ 3.01, obs2_values)
+end

--- a/lib/ModelingToolkitBase/test/optimization/dynamic_optimization.jl
+++ b/lib/ModelingToolkitBase/test/optimization/dynamic_optimization.jl
@@ -1058,7 +1058,7 @@ end
     end
 end
 
-@testset "Observed variable bounds lifting" begin
+@testset "Observed variable bounds" begin
     # Test that bounds on observed variables are enforced via auxiliary variables
     @variables x(t) = 1.0
     @variables obs_val(t) [bounds = (0.0, 2.0)]  # observed variable with bounds
@@ -1116,4 +1116,52 @@ end
     obs2_values = 3 .* isol2.sol[x2]
     @test all(v -> v ≥ -0.01, obs2_values)
     @test all(v -> v ≤ 3.01, obs2_values)
+
+    # The cases above stay inside their bounds on their own, so they cannot tell an
+    # enforced bound from a silently dropped one. Here the bound binds: maximizing
+    # x(1) subject to ẋ = u, u ∈ [-1, 1], x(0) = 0 gives x(1) = 1 unconstrained, but
+    # obs = 2x ≤ 1 forces x(1) = 0.5.
+    @variables xb(t) = 0.0
+    @variables obb(t) [bounds = (0.0, 1.0)]
+    @variables ub(t) [input = true, bounds = (-1.0, 1.0)]
+    @named bsys = System([D(xb) ~ ub, obb ~ 2xb], t; costs = [-EvalAt(1.0)(xb)])
+    bsys = mtkcompile(bsys; inputs = [ub])
+    bop = [[xb => 0.0]; [ub => 0.0]]
+    btspan = (0.0, 1.0)
+
+    # Reference without the bound, to confirm it is what moves the answer.
+    @variables xf(t) = 0.0
+    @variables obf(t)
+    @variables uf(t) [input = true, bounds = (-1.0, 1.0)]
+    @named fsys = System([D(xf) ~ uf, obf ~ 2xf], t; costs = [-EvalAt(1.0)(xf)])
+    fsys = mtkcompile(fsys; inputs = [uf])
+    fprob = InfiniteOptDynamicOptProblem(
+        fsys, [[xf => 0.0]; [uf => 0.0]], btspan; dt = 0.01
+    )
+    fsol = solve(fprob, InfiniteOptCollocation(Ipopt.Optimizer))
+    @test ≈(fsol.sol[xf][end], 1.0, rtol = 1.0e-4)
+
+    for meth in (:auto, :lift, :constraint)
+        prob = InfiniteOptDynamicOptProblem(
+            bsys, bop, btspan; dt = 0.01, observed_bounds_method = meth
+        )
+        sol = solve(prob, InfiniteOptCollocation(Ipopt.Optimizer))
+        @test ≈(sol.sol[xb][end], 0.5, rtol = 1.0e-4)
+    end
+
+    if ENABLE_CASADI
+        # `:auto` falls back to `:constraint`, which every backend can do. Before this
+        # was wired up, observed bounds were silently dropped outside InfiniteOpt.
+        cprob = CasADiDynamicOptProblem(bsys, bop, btspan; dt = 0.01)
+        csol = solve(cprob, CasADiCollocation("ipopt"))
+        @test ≈(csol.sol[xb][end], 0.5, rtol = 1.0e-4)
+
+        @test_throws ArgumentError CasADiDynamicOptProblem(
+            bsys, bop, btspan; dt = 0.01, observed_bounds_method = :lift
+        )
+    end
+
+    @test_throws ArgumentError InfiniteOptDynamicOptProblem(
+        bsys, bop, btspan; dt = 0.01, observed_bounds_method = :bogus
+    )
 end


### PR DESCRIPTION
Split out of #4394.

## What this fixes

Bounds declared on observed variables were **never applied**. `set_variable_bounds!` ends
in

```julia
return if !isnothing(tf_bounds)
    ...
end
```

and the observed-bounds block sat *after* that `return`, so it was unreachable. (Runic
rewrites a trailing `if` into `return if`; the block was appended later and nobody
noticed.) Confirmed empirically — building the same system with and without a bounded
observed variable produced models with an identical number of decision variables.

The existing tests passed because their bounds never actually bound: the state decayed
toward zero on its own, so the observed value stayed inside its range regardless.

## What changed

Handling moved out of the backend into `add_observed_bounds!`, called from
`process_DynamicOptProblem`, so it cannot be stranded behind a `return` again and the
portable path is shared by every backend. A new `observed_bounds_method` keyword selects
how a bound is imposed.

## The two modes

They are not the same formulation numerically, so the choice can matter:

**`:lift`** introduces an auxiliary decision variable `aux` bounded by `[lo, hi]` and ties
it to the observed expression with a scaled equality:

```
(expr - aux) / getnominal(var) == 0
```

The bound then lives on a variable rather than in a constraint. Interior-point solvers
(Ipopt) handle variable bounds considerably better than the equivalent nonlinear
inequalities, so this is usually faster. The cost is one extra decision variable and one
extra equality constraint per bounded observed variable, and the equality is scaled by the
variable's nominal value so its residual is comparable to the others.

**`:constraint`** emits the bound directly:

```
lo ≤ expr    and    expr ≤ hi
```

No auxiliary variable, no equality, and — since an inequality has no residual to
normalise — no scaling. Every backend supports it.

`:auto` (the default) lifts where the backend can and constrains everywhere else.

Prefer `:constraint` explicitly when the solver is not interior-point (active-set and SQP
methods take inequalities natively), when many bounded observed variables would add enough
equality constraints to make finding an initial feasible point harder, or when comparing
against a reference formulation.

Backends opt in via `supports_bounds_lifting` and `lift_observed_bound!`; only InfiniteOpt
(and therefore JuMP) does today. Requesting `:lift` from a backend that cannot lift raises
an `ArgumentError` rather than silently doing something else.

## Also fixed

- **Observed bounds were silently dropped on CasADi and Pyomo.** They received
  `observed_bounds` and ignored it, so a user's bound was enforced on JuMP/InfiniteOpt and
  quietly discarded elsewhere. `:auto` now gives them the `:constraint` path.
- **The auxiliary variable had no start value**, defaulting to 0, which can lie outside
  `[lo, hi]` — an infeasible starting point for the lifted equality, undercutting the
  reason to lift. It now starts inside its own bounds.

## Testing

The old cases could not distinguish an enforced bound from a dropped one, so the tests now
include one where the bound binds: maximising `x(1)` subject to `ẋ = u`, `u ∈ [-1, 1]`,
`x(0) = 0` gives `x(1) = 1` unconstrained, while `obs = 2x ≤ 1` forces `x(1) = 0.5`.

| | `x(1)` |
|---|---|
| no bound | 0.99999975 |
| InfiniteOpt `:auto` | 0.50000000 |
| InfiniteOpt `:lift` | 0.50000000 |
| InfiniteOpt `:constraint` | 0.50000000 |
| CasADi `:auto` | 0.50000000 |

Plus coverage for the `ArgumentError`s on an unsupported and an unknown method.

## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API