### PR TITLE
Scale dynamics constraints as residuals for optimal control

### DIFF
--- a/docs/src/tutorials/dynamic_optimization.md
+++ b/docs/src/tutorials/dynamic_optimization.md
@@ -108,6 +108,28 @@ Passing a non-empty map to Pyomo raises an `ArgumentError`.
     `[0, 1]`, so the trajectory expressions are evaluated at normalized time rather
     than physical time.
 
+### Scaling the dynamics constraints
+
+When the states of a system span very different magnitudes, the residuals of the
+dynamics constraints do too, which can make the optimizer favor the large states and
+converge poorly. The `nominal_values` keyword takes a map from states to their typical
+magnitudes, and each dynamics constraint is divided by the corresponding value so that
+all residuals are comparable in size:
+
+```@example dynamic_opt
+iprob_scaled = InfiniteOptDynamicOptProblem(rocket, [u0map; pmap], (ts, te); dt = 0.001,
+    nominal_values = Dict(h(t) => 1.25, m(t) => 0.6))
+isol_scaled = solve(iprob_scaled, InfiniteOptCollocation(Ipopt.Optimizer));
+```
+
+States not listed default to their [`nominal` metadata](@ref getnominal) if set, and to
+`1.0` otherwise, in which case the constraint is unchanged. Scaling a residual does not
+move the optimum, only how the solver converges towards it.
+
+`nominal_values` affects the InfiniteOpt and Pyomo backends, which emit the dynamics
+directly as derivative constraints. The JuMP and CasADi backends discretize through an
+ODE solver tableau instead and currently ignore it.
+
 ### Free final time problems
 
 There are additionally a class of dynamic optimization problems where we would like to know how to control our system to achieve something in the least time. Such problems are called free final time problems, since the final time is unknown. To model these problems in ModelingToolkit, we declare the final time as a parameter.

--- a/lib/ModelingToolkitBase/ext/MTKCasADiDynamicOptExt.jl
+++ b/lib/ModelingToolkitBase/ext/MTKCasADiDynamicOptExt.jl
@@ -102,11 +102,12 @@ function MTK.CasADiDynamicOptProblem(
         steps = nothing,
         tune_parameters = false,
         guesses = Dict(), initial_trajectory = Dict(),
+        nominal_values = Dict(),
         bounds = Dict(), kwargs...
     )
     prob,
-        _ = MTK.process_DynamicOptProblem(
-        CasADiDynamicOptProblem, CasADiModel, sys, op, tspan; dt, steps, tune_parameters, guesses, initial_trajectory, bounds, kwargs...
+        _, _ = MTK.process_DynamicOptProblem(
+        CasADiDynamicOptProblem, CasADiModel, sys, op, tspan; dt, steps, tune_parameters, guesses, initial_trajectory, nominal_values, bounds, kwargs...
     )
     return prob
 end

--- a/lib/ModelingToolkitBase/ext/MTKInfiniteOptExt.jl
+++ b/lib/ModelingToolkitBase/ext/MTKInfiniteOptExt.jl
@@ -151,12 +151,13 @@ function MTK.JuMPDynamicOptProblem(
         steps = nothing,
         tune_parameters = false,
         guesses = Dict(), initial_trajectory = Dict(),
+        nominal_values = Dict(),
         bounds = Dict(), kwargs...
     )
     prob,
-        _ = MTK.process_DynamicOptProblem(
+        _, _ = MTK.process_DynamicOptProblem(
         JuMPDynamicOptProblem, InfiniteOptModel, sys,
-        op, tspan; dt, steps, tune_parameters, guesses, initial_trajectory, bounds, kwargs...
+        op, tspan; dt, steps, tune_parameters, guesses, initial_trajectory, nominal_values, bounds, kwargs...
     )
     return prob
 end
@@ -167,14 +168,15 @@ function MTK.InfiniteOptDynamicOptProblem(
         steps = nothing,
         tune_parameters = false,
         guesses = Dict(), initial_trajectory = Dict(),
+        nominal_values = Dict(),
         bounds = Dict(), kwargs...
     )
     prob,
-        pmap = MTK.process_DynamicOptProblem(
+        pmap, nominal_values = MTK.process_DynamicOptProblem(
         InfiniteOptDynamicOptProblem, InfiniteOptModel,
-        sys, op, tspan; dt, steps, tune_parameters, guesses, initial_trajectory, bounds, kwargs...
+        sys, op, tspan; dt, steps, tune_parameters, guesses, initial_trajectory, nominal_values, bounds, kwargs...
     )
-    MTK.add_equational_constraints!(prob.wrapped_model, sys, pmap, tspan)
+    MTK.add_equational_constraints!(prob.wrapped_model, sys, pmap, tspan, nominal_values)
     return prob
 end
 

--- a/lib/ModelingToolkitBase/ext/MTKPyomoDynamicOptExt.jl
+++ b/lib/ModelingToolkitBase/ext/MTKPyomoDynamicOptExt.jl
@@ -98,15 +98,16 @@ function MTK.PyomoDynamicOptProblem(
         sys::System, op, tspan;
         dt = nothing, steps = nothing, tune_parameters = false,
         guesses = Dict(), initial_trajectory = Dict(),
+        nominal_values = Dict(),
         bounds = Dict(), kwargs...
     )
     prob,
-        pmap = MTK.process_DynamicOptProblem(
+        pmap, nominal_values = MTK.process_DynamicOptProblem(
         PyomoDynamicOptProblem, PyomoDynamicOptModel,
-        sys, op, tspan; dt, steps, tune_parameters, guesses, initial_trajectory, bounds, kwargs...
+        sys, op, tspan; dt, steps, tune_parameters, guesses, initial_trajectory, nominal_values, bounds, kwargs...
     )
     conc_model = prob.wrapped_model.model
-    MTK.add_equational_constraints!(prob.wrapped_model, sys, pmap, tspan)
+    MTK.add_equational_constraints!(prob.wrapped_model, sys, pmap, tspan, nominal_values)
     return prob
 end
 

--- a/lib/ModelingToolkitBase/src/systems/optimal_control_interface.jl
+++ b/lib/ModelingToolkitBase/src/systems/optimal_control_interface.jl
@@ -47,6 +47,13 @@ of the interpolation arrays.
 Related to `JuMPDynamicOptProblem`, but directly adds the differential equations
 of the system as derivative constraints, rather than using a solver tableau.
 
+Each dynamics constraint is emitted as a residual scaled by the state's nominal
+value, `(∂x - tₛ*f(x)) / nominal ~ 0`, so that states of different magnitudes
+produce comparable residuals. The nominal value is taken from the variable's
+`nominal` metadata (see `getnominal`; `1.0` if unset) and can be overridden per
+state with the `nominal_values` keyword, a map from states to their typical
+magnitudes.
+
 To construct the problem, please load InfiniteOpt along with ModelingToolkitBase.
 """
 function InfiniteOptDynamicOptProblem end
@@ -68,6 +75,13 @@ Convert a System representing an optimal control system into a Pyomo model
 for solving using optimization. Must provide either `dt`, the timestep between collocation
 points (which, along with the timespan, determines the number of points), or directly
 provide the number of points as `steps`.
+
+Each dynamics constraint is emitted as a residual scaled by the state's nominal
+value, `(∂x - tₛ*f(x)) / nominal ~ 0`, so that states of different magnitudes
+produce comparable residuals. The nominal value is taken from the variable's
+`nominal` metadata (see `getnominal`; `1.0` if unset) and can be overridden per
+state with the `nominal_values` keyword, a map from states to their typical
+magnitudes.
 
 To construct the problem, please load Pyomo along with ModelingToolkitBase.
 """

--- a/lib/ModelingToolkitBase/src/systems/optimal_control_interface.jl
+++ b/lib/ModelingToolkitBase/src/systems/optimal_control_interface.jl
@@ -324,6 +324,7 @@ function process_DynamicOptProblem(
         steps = nothing,
         tune_parameters = false,
         guesses = Dict(), initial_trajectory = Dict(),
+        nominal_values = Dict(),
         bounds = Dict(),
         eval_expression = false, eval_module = @__MODULE__,
         kwargs...
@@ -336,6 +337,7 @@ function process_DynamicOptProblem(
     stidxmap = Dict([v => i for (i, v) in enumerate(states)])
     op = Dict([default_toterm(value(k)) => v for (k, v) in op])
     initial_trajectory = Dict([default_toterm(value(k)) => v for (k, v) in initial_trajectory])
+    nominal_values = Dict([default_toterm(value(k)) => v for (k, v) in nominal_values])
     bounds = Dict([default_toterm(value(k)) => v for (k, v) in bounds])
     u0_idxs = has_alg_eqs(sys) ? collect(1:length(states)) :
         [stidxmap[default_toterm(k)] for (k, v) in op if haskey(stidxmap, k)]
@@ -399,7 +401,7 @@ function process_DynamicOptProblem(
     add_user_constraints!(fullmodel, sys, tspan, pmap)
     add_initial_constraints!(fullmodel, u0, u0_idxs, model_tspan[1])
 
-    return prob_type(f, u0, tspan, p, fullmodel; kwargs...), pmap
+    return prob_type(f, u0, tspan, p, fullmodel; kwargs...), pmap, nominal_values
 end
 
 """
@@ -696,15 +698,20 @@ function add_user_constraints!(model, sys, tspan, pmap)
     return
 end
 
-function add_equational_constraints!(model, sys, pmap, tspan)
+function add_equational_constraints!(model, sys, pmap, tspan, nominal_values = Dict())
     rules = Dict{Any, Any}()
     get_observed_substitution_rules!(rules, sys)
     get_model_vars_substitution_rules!(rules, model, sys, tspan)
     get_param_substitution_rules!(rules, pmap)
     get_differential_substitution_rules!(rules, model, sys)
+    dvs = unknowns(sys)
     diff_eqs = fixpoint_sub(diff_equations(sys), rules; fold = Val(true), filterer = Returns(true))
-    for eq in diff_eqs
-        add_constraint!(model, eq.lhs ~ unwrap_const(eq.rhs) * model.tₛ)
+    for (i, eq) in enumerate(diff_eqs)
+        # User-provided nominal values override the variable's nominal metadata.
+        # Scale the entire residual, not each side independently.
+        # (∂x - tₛ*f(x)) / scale == 0 prevents degenerate tₛ → 0 solutions.
+        s = get(nominal_values, dvs[i], getnominal(dvs[i]))
+        add_constraint!(model, (unwrap_const(eq.lhs) - unwrap_const(eq.rhs) * model.tₛ) / s ~ 0)
     end
 
     alg_eqs = fixpoint_sub(alg_equations(sys), rules; fold = Val(true), filterer = Returns(true))

--- a/lib/ModelingToolkitBase/test/optimization/dynamic_optimization.jl
+++ b/lib/ModelingToolkitBase/test/optimization/dynamic_optimization.jl
@@ -973,4 +973,29 @@ end
         csol = solve(cprob, CasADiCollocation("ipopt", ExplicitTableaus.Verner8()))
         @test ≈(csol.sol[x(t)][end], 0.25, rtol = 1.0e-3)
     end
+
+    # Scaling a residual does not move the optimum, so the solves above pass with or
+    # without `nominal_values` and cannot tell whether the scale was applied at all. Assert
+    # directly that it reaches the dynamics constraint.
+    function dynamics_constraint_strings(nominal_values)
+        prob = InfiniteOptDynamicOptProblem(
+            block, [u0map; parammap], tspan; dt = 0.5, nominal_values = nominal_values
+        )
+        m = prob.wrapped_model.model
+        strs = String[]
+        for (F, S) in InfiniteOpt.list_of_constraint_types(m)
+            for c in InfiniteOpt.all_constraints(m, F, S)
+                push!(strs, string(InfiniteOpt.constraint_object(c).func))
+            end
+        end
+        return strs
+    end
+
+    unscaled = dynamics_constraint_strings(Dict())
+    rescaled = dynamics_constraint_strings(Dict(x(t) => 10.0))
+    @test length(unscaled) == length(rescaled)
+    # Only the constraint for `x` changes, and it picks up the 1/10 factor.
+    changed = [(a, b) for (a, b) in zip(unscaled, rescaled) if a != b]
+    @test length(changed) == 1
+    @test occursin("0.1", last(only(changed)))
 end

--- a/lib/ModelingToolkitBase/test/optimization/dynamic_optimization.jl
+++ b/lib/ModelingToolkitBase/test/optimization/dynamic_optimization.jl
@@ -926,3 +926,51 @@ struct UnsupportedTrajectoryBackend end
     @parameters b
     @test_throws ArgumentError M.build_trajectory_function(block, x(t), b * t, p_test)
 end
+
+@testset "Residual scaling of dynamics constraints" begin
+    # Double integrator with nominal_values - should converge to same answer
+    @variables x(..) v(..)
+    @variables u(..) [bounds = (-1.0, 1.0), input = true]
+    constr = [v(1.0) ~ 0.0]
+    cost = [-x(1.0)]
+
+    @named block = System(
+        [D(x(t)) ~ v(t), D(v(t)) ~ u(t)], t; costs = cost, constraints = constr
+    )
+    block = mtkcompile(block; inputs = [u(t)])
+
+    u0map = [x(t) => 0.0, v(t) => 0.0]
+    tspan = (0.0, 1.0)
+    parammap = [u(t) => 0.0]
+
+    # With scaling
+    nominal_values = Dict(x(t) => 10.0, v(t) => 1.0)
+    iprob = InfiniteOptDynamicOptProblem(
+        block, [u0map; parammap], tspan; dt = 0.01,
+        nominal_values = nominal_values
+    )
+    isol = solve(iprob, InfiniteOptCollocation(Ipopt.Optimizer))
+    @test ≈(isol.sol[x(t)][end], 0.25, rtol = 1.0e-3)
+
+    # Without scaling - should also work
+    iprob2 = InfiniteOptDynamicOptProblem(block, [u0map; parammap], tspan; dt = 0.01)
+    isol2 = solve(iprob2, InfiniteOptCollocation(Ipopt.Optimizer))
+    @test ≈(isol2.sol[x(t)][end], 0.25, rtol = 1.0e-3)
+
+    # Nominal values kwarg passes through JuMP without error
+    jprob = JuMPDynamicOptProblem(
+        block, [u0map; parammap], tspan; dt = 0.01,
+        nominal_values = nominal_values
+    )
+    jsol = solve(jprob, JuMPCollocation(Ipopt.Optimizer, ExplicitTableaus.Verner8()))
+    @test ≈(jsol.sol[x(t)][end], 0.25, rtol = 1.0e-3)
+
+    if ENABLE_CASADI
+        cprob = CasADiDynamicOptProblem(
+            block, [u0map; parammap], tspan; dt = 0.01,
+            nominal_values = nominal_values
+        )
+        csol = solve(cprob, CasADiCollocation("ipopt", ExplicitTableaus.Verner8()))
+        @test ≈(csol.sol[x(t)][end], 0.25, rtol = 1.0e-3)
+    end
+end


### PR DESCRIPTION
Split out of #4394.

## What this does

Dynamics constraints are currently emitted as `∂x ~ tₛ*f(x)`, scaling each side
independently. For problems with multi-scale state variables this admits degenerate
`tₛ → 0` solutions and converges poorly in Ipopt. This reformulates them as a single
scaled residual:

```
(∂x - tₛ*f(x)) / scale ~ 0
```

The scale defaults to `getnominal(dvs[i])`, which is `1.0` unless the variable carries
nominal-value metadata (#4425) — so with no metadata and no user-supplied nominal values,
the formulation reduces exactly to the original. A `nominal_values` keyword overrides it
per variable.

`process_DynamicOptProblem` now returns the resolved `nominal_values` alongside `pmap` so
the backends can apply them in `add_equational_constraints!`.

## Backend coverage

`nominal_values` reaches the dynamics constraints on the backends that build them
directly — **InfiniteOpt and Pyomo**. JuMP and CasADi discretise through an ODE tableau
instead and never call `add_equational_constraints!`, so `nominal_values` currently has no
effect there. They accept the keyword without complaint. Worth deciding whether that
should warn, error, or just be documented; I left the behaviour as-is rather than guess.

## Relationship to #4840

Both PRs touch scaling, but they do not block each other:

- Here, a dynamics **equality** is divided by the scale so its residual is comparable to
  the others.
- In #4840, the `:lift` mode divides its auxiliary equality by `getnominal(var)` — the
  same convention. Its `:constraint` mode emits a plain inequality, which has no residual
  to normalise and so is unscaled.

Once both land, #4840's lift can take a user-supplied `nominal_values` entry as an
override the way this PR does, which is a one-line follow-up.

## Testing

Scaling a residual does not move the optimum, so a solve-and-compare test passes whether
or not the scale is applied. The tests therefore also inspect the generated InfiniteOpt
constraints: with `nominal_values = Dict(x => 10.0)`, exactly one constraint changes and
it picks up the `1/10` factor. Plus the existing coverage that the keyword is accepted on
the tableau backends and that results are unchanged.

## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
