### PR TITLE
Make ProblemTypeCtx public API

### DIFF
--- a/docs/src/API/problems.md
+++ b/docs/src/API/problems.md
@@ -48,6 +48,16 @@ SciMLBase.HomotopyNonlinearFunction
 SciMLBase.LinearProblem
 ```
 
+## Problem type metadata
+
+Systems can carry a `problem_type` that is forwarded to the constructed problem. This is
+how discretization packages attach their own metadata to a generated problem and recover
+it downstream, for example to wrap a solution in a richer solution type.
+
+```@docs
+ModelingToolkit.ProblemTypeCtx
+```
+
 ## Optimization and optimal control
 
 ```@docs

--- a/lib/ModelingToolkitBase/Project.toml
+++ b/lib/ModelingToolkitBase/Project.toml
@@ -1,7 +1,7 @@
 name = "ModelingToolkitBase"
 uuid = "7771a370-6774-4173-bd38-47e70ca0b839"
 authors = ["Yingbo Ma <mayingbo5@gmail.com>", "Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
-version = "1.57.0"
+version = "1.58.0"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/lib/ModelingToolkitBase/src/ModelingToolkitBase.jl
+++ b/lib/ModelingToolkitBase/src/ModelingToolkitBase.jl
@@ -406,6 +406,7 @@ const set_scalar_metadata = setmetadata
 @public Both
 @public SymbolicADDisallowed, check_symbolic_ad_allowed
 @public tobrownian, toparam
+@public ProblemTypeCtx
 
 for prop in [SYS_PROPS; [:continuous_events, :discrete_events]]
     getter = Symbol(:get_, prop)


### PR DESCRIPTION
## Summary

Marks `ModelingToolkitBase.ProblemTypeCtx` as `@public` and adds it to the rendered docs.

`ProblemTypeCtx` is already documented in `lib/ModelingToolkitBase/src/systems/system.jl` as the metadata key controlling `problem_type`:

> Metadata key for systems containing the `problem_type` to be passed to the problem constructor, where applicable. For example, if `getmetadata(sys, ProblemTypeCtx, nothing)` is `CustomType()` then `ODEProblem(sys, ...).problem_type` will be `CustomType()` instead of `StandardODEProblem`.

It is read at `lib/ModelingToolkitBase/src/problems/odeproblem.jl:133` and `problems/nonlinearproblem.jl:127`, and the resulting `prob.problem_type` is what `SciMLBase.wrap_sol` dispatches on (`SciMLBase/src/solutions/basic_solutions.jl:195` → `solutions/pde_solutions.jl:160`) to wrap a solve result in `PDETimeSeriesSolution` / `PDENoTimeSolution`.

So it is a cross-package protocol key: PDE discretization stacks have to write it for their solutions to be wrapped correctly. But it was neither exported nor `public`, so there was no non-internal way to reach it. `MTKVariableTypeCtx` is already `@public`, so this just gives the same treatment to the other metadata context type.

## Motivation

Found while reviewing https://github.com/SciML/PDEBase.jl/pull/98. A strict-QA pass there flagged `ProblemTypeCtx` as a non-public name and the workaround was to substitute a PDEBase-local key. That silently broke the MethodOfLines solution interface: `prob.problem_type` fell back to `StandardODEProblem`, `wrap_sol` stopped producing a `PDETimeSeriesSolution`, and `sol[u(t,x)]` failed with `ArgumentError: Symbol u(t, x) is not present in the system` — with no error at discretize or solve time. Making the key public removes the incentive to work around it.

## Validation

Verified locally on Julia 1.12.6:

```
ispublic(ProblemTypeCtx) = true
has docstring           = true
```

`Runic --check` clean on the changed source file. Version bumped `1.57.0` → `1.58.0` (additive public API).

Ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0117aJvytDT3y2jMi5Ng6Q5m