### PR TITLE
test: restore working MTKBase BVP assertions

### DIFF
--- a/lib/ModelingToolkitBase/test/bvproblem.jl
+++ b/lib/ModelingToolkitBase/test/bvproblem.jl
@@ -32,16 +32,10 @@ daesolvers = [Ascher2, Ascher4, Ascher6]
         lotkavolterra, [u0map; parammap], tspan
     )
 
-    if @isdefined(ModelingToolkit)
-        for solver in solvers
-            sol = solve(bvp, solver(), dt = 0.01)
-            @test isapprox(sol.u[end], osol.u[end]; atol = 0.01)
-            @test sol[[x, y], 1] == [1.0, 2.0]
-        end
-    else
-        for solver in solvers
-            @test_broken solve(bvp, solver(), dt = 0.01)
-        end
+    for solver in solvers
+        sol = solve(bvp, solver(), dt = 0.01)
+        @test isapprox(sol.u[end], osol.u[end]; atol = 0.01)
+        @test sol[[x, y], 1] == [1.0, 2.0]
     end
 
     # Test out of place
@@ -49,16 +43,10 @@ daesolvers = [Ascher2, Ascher4, Ascher6]
         lotkavolterra, [u0map; parammap], tspan
     )
 
-    if @isdefined(ModelingToolkit)
-        for solver in solvers
-            sol = solve(bvp2, solver(), dt = 0.01)
-            @test isapprox(sol.u[end], osol.u[end]; atol = 0.01)
-            @test sol[[x, y], 1] == [1.0, 2.0]
-        end
-    else
-        for solver in solvers
-            @test_broken solve(bvp2, solver(), dt = 0.01)
-        end
+    for solver in solvers
+        sol = solve(bvp2, solver(), dt = 0.01)
+        @test isapprox(sol.u[end], osol.u[end]; atol = 0.01)
+        @test sol[[x, y], 1] == [1.0, 2.0]
     end
 end
 
@@ -346,17 +334,13 @@ end
     @test_broken costfn(sol, prob.p, _t) ≈ (sol(0.6; idxs = x(t)) + 3)^2 + sol(0.3; idxs = x(t))^2
 
     bvp = SciMLBase.BVProblem{true, SciMLBase.AutoSpecialize}(lksys, [u0map; parammap], tspan)
-    if @isdefined(ModelingToolkit)
-        sol = solve(bvp, MIRK4(), dt = 0.05)
-        @test SciMLBase.successful_retcode(sol)
+    sol = solve(bvp, MIRK4(), dt = 0.05)
+    @test SciMLBase.successful_retcode(sol)
 
-        costfn = ModelingToolkitBase.generate_bvp_cost(
-            lksys; expression = Val{false}, wrap_gfw = Val{true}
-        )
-        @test costfn(sol, bvp.p) ≈ (sol(0.6; idxs = x(t)) + 3)^2 + sol(0.3; idxs = x(t))^2
-    else
-        @test_broken solve(bvp, MIRK4(), dt = 0.05)
-    end
+    costfn = ModelingToolkitBase.generate_bvp_cost(
+        lksys; expression = Val{false}, wrap_gfw = Val{true}
+    )
+    @test costfn(sol, bvp.p) ≈ (sol(0.6; idxs = x(t)) + 3)^2 + sol(0.3; idxs = x(t))^2
 
     ### With a parameter
     @parameters t_c
@@ -374,17 +358,13 @@ end
         log(sol(0.56; idxs = y(t)) + sol(0.0; idxs = x(t))) - sol(0.4; idxs = x(t))^2
 
     bvp = SciMLBase.BVProblem{true, SciMLBase.AutoSpecialize}(lksys, [u0map; parammap], tspan)
-    if @isdefined(ModelingToolkit)
-        sol = solve(bvp, MIRK4(), dt = 0.05)
-        @test SciMLBase.successful_retcode(sol)
+    sol = solve(bvp, MIRK4(), dt = 0.05)
+    @test SciMLBase.successful_retcode(sol)
 
-        costfn = ModelingToolkitBase.generate_bvp_cost(
-            lksys; expression = Val{false}, wrap_gfw = Val{true}
-        )
-        @test costfn(sol, bvp.p) ≈ log(sol(0.56; idxs = y(t)) + sol(0.0; idxs = x(t))) - sol(0.4; idxs = x(t))^2
-    else
-        @test_broken solve(bvp, MIRK4(), dt = 0.05)
-    end
+    costfn = ModelingToolkitBase.generate_bvp_cost(
+        lksys; expression = Val{false}, wrap_gfw = Val{true}
+    )
+    @test costfn(sol, bvp.p) ≈ log(sol(0.56; idxs = y(t)) + sol(0.0; idxs = x(t))) - sol(0.4; idxs = x(t))^2
 end
 
 @testset "Parameter estimation" begin


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## Summary

- restore the four ModelingToolkitBase BVP solve paths that currently succeed
- assert their solution values and successful return codes instead of passing solution objects to Test.@test_broken
- leave the genuinely broken parameter-estimation cases marked broken

## Cause

Commit f71cc7d5ae805e9c57bf86a7867dfbc7e538d201 wrapped four successful BVP solves in Test.@test_broken. A successful solve returns a solution object, not a Boolean, so Test reports each case as an error rather than a broken test.

This is the same failure in BoundaryValueDiffEq clean master run https://github.com/SciML/BoundaryValueDiffEq.jl/actions/runs/30342212061 and PR #541. The PR #541 shooting changes are unrelated.

## Verification

Using Julia 1.11 and the official ModelingToolkitBase InterfaceII group with local BoundaryValueDiffEqCore, BoundaryValueDiffEqMIRK, and BoundaryValueDiffEqAscher:

- clean ModelingToolkit master at a35a814d: BVP tests report 14 passed, 4 errored, 6 broken; the group fails
- this branch: BVP tests report 22 passed, 6 broken; the complete InterfaceII group passes in 3707.7 seconds

A bisect from 3c2e4a752 to a35a814d identified f71cc7d5 as the first bad commit.

The changed file passes Runic and git diff --check. Whole-repository Runic currently fails on unchanged master in src/systems/clock_inference.jl; that independent FormatCheck regression is intentionally not mixed into this focused PR.