### PR TITLE
Fix SampleTime clock inference formatting

### DIFF
--- a/src/systems/clock_inference.jl
+++ b/src/systems/clock_inference.jl
@@ -19,7 +19,7 @@ function MTKTearing.input_timedomain(::SampleTime, arg = nothing)
     return ModelingToolkit.MTKTearing.InputTimeDomainElT[]
 end
 function MTKTearing.output_timedomain(::SampleTime, arg = nothing)
-    ModelingToolkit.MTKTearing.InferredDiscrete(1)
+    return ModelingToolkit.MTKTearing.InferredDiscrete(1)
 end
 
 function MTKTearing.output_timedomain(::Hold, _::MTKTearing.IOTimeDomainArgsT = nothing)


### PR DESCRIPTION
This PR should be ignored until reviewed by @ChrisRackauckas.

## Summary

- Add the Runic-required explicit `return` to `MTKTearing.output_timedomain(::SampleTime, ...)`.
- This is a formatting-only change with no behavioral effect.

## Root cause

Runic 1.7 fails on clean `master` in `src/systems/clock_inference.jl`. An independent `git bisect run` identified `9b46cd0eaf79ea41edf1ac7482830bfdea53bda4` (`Add input_timedomain and output_timedomain for SampleTime`) as the first bad commit. It introduced this method without Runic's explicit final `return` form.

The failure was reproduced on current clean upstream `master` at `59cea9e83079fcf1aa5b7d7395c121c509f91c48`; the exact whole-repository check failed only this file among 223 tracked Julia files.

## Validation

Validated rebased head `8fbb42ae8cd5fb8bb8d7eb09d502195cca9ebd58`:

- Exact whole-repository Runic 1.7 check: 223/223 tracked Julia files passed.
- Official `GROUP=InterfaceI` package test in an isolated workspace-local depot: 1,475 passed, 3 pre-existing broken, 1,478 total in 73m13.4s; `Testing ModelingToolkit tests passed`.
- The relevant `Clock Test` executed without errors.
- `git diff --check` passed.