### PR TITLE
Separate full_equations timeout from subprocess setup

### DIFF
--- a/lib/ModelingToolkitBase/test/odesystem.jl
+++ b/lib/ModelingToolkitBase/test/odesystem.jl
@@ -1666,32 +1666,55 @@ end
 end
 
 @testset "`full_equations` doesn't recurse infinitely" begin
-    code = """
-    using ModelingToolkitBase
-    using ModelingToolkitBase: t_nounits as t, D_nounits as D
-    @variables x(t)[1:3]=[0,0,1]
-    @variables u1(t)=0 u2(t)=0
-    y₁, y₂, y₃ = x
-    k₁, k₂, k₃ = 1,1,1
-    eqs = [
-        D(y₁) ~ -k₁*y₁ + k₃*y₂*y₃ + u1
-        D(y₂) ~ k₁*y₁ - k₃*y₂*y₃ - k₂*y₂^2 + u2
-        y₁ + y₂ + y₃ ~ 1
-    ]
+    mktempdir(pwd()) do tempdir
+        ready_file = joinpath(tempdir, "ready")
+        code = """
+        using ModelingToolkitBase
+        using ModelingToolkitBase: t_nounits as t, D_nounits as D
+        @variables x(t)[1:3]=[0,0,1]
+        @variables u1(t)=0 u2(t)=0
+        y₁, y₂, y₃ = x
+        k₁, k₂, k₃ = 1,1,1
+        eqs = [
+            D(y₁) ~ -k₁*y₁ + k₃*y₂*y₃ + u1
+            D(y₂) ~ k₁*y₁ - k₃*y₂*y₃ - k₂*y₂^2 + u2
+            y₁ + y₂ + y₃ ~ 1
+        ]
 
-    @named sys = System(eqs, t)
+        @named sys = System(eqs, t)
 
-    inputs = [u1, u2]
-    outputs = [y₁, y₂, y₃]
-    ss = mtkcompile(sys; inputs)
-    full_equations(ss)
-    """
+        inputs = [u1, u2]
+        outputs = [y₁, y₂, y₃]
+        ss = mtkcompile(sys; inputs)
+        touch($(repr(ready_file)))
+        full_equations(ss)
+        """
 
-    cmd = `$(Base.julia_cmd()) --project=$(pwd()) -e $code`
-    proc = run(cmd, stdin, stdout, stderr; wait = false)
-    sleep(180)
-    @test !process_running(proc)
-    kill(proc, Base.SIGKILL)
+        cmd = `$(Base.julia_cmd()) --project=$(pwd()) -e $code`
+        proc = run(cmd, stdin, stdout, stderr; wait = false)
+
+        # Package loading can wait on a shared precompile cache.
+        setup_status = timedwait(
+            () -> isfile(ready_file) || !process_running(proc), 3600
+        )
+        @test setup_status == :ok
+
+        run_status = :not_started
+        if setup_status == :ok
+            setup_ready = isfile(ready_file)
+            @test setup_ready
+            if setup_ready
+                run_status = timedwait(() -> !process_running(proc), 180)
+                @test run_status == :ok
+            end
+        end
+
+        process_running(proc) && kill(proc, Base.SIGKILL)
+        wait(proc)
+        if run_status == :ok
+            @test success(proc)
+        end
+    end
 end
 
 @testset "`ProblemTypeCtx`" begin

--- a/src/systems/clock_inference.jl
+++ b/src/systems/clock_inference.jl
@@ -19,7 +19,7 @@ function MTKTearing.input_timedomain(::SampleTime, arg = nothing)
     return ModelingToolkit.MTKTearing.InputTimeDomainElT[]
 end
 function MTKTearing.output_timedomain(::SampleTime, arg = nothing)
-    ModelingToolkit.MTKTearing.InferredDiscrete(1)
+    return ModelingToolkit.MTKTearing.InferredDiscrete(1)
 end
 
 function MTKTearing.output_timedomain(::Hold, _::MTKTearing.IOTimeDomainArgsT = nothing)


### PR DESCRIPTION
Depends on #4844. This branch is based directly on its head commit, `9d7b22a35bc107a880baa10b54b90cb41f561b3e`; the only commit added here is `10949fa3552a3cd13aeb7f303d879b12f1a497ee`.

Ignore this PR until it has been reviewed by @ChrisRackauckas.

## Problem

The `full_equations` recursion regression test slept for 180 seconds before checking its child process. That combined package loading, cache-lock waits, precompilation, model setup, and the call being tested into one timeout.

On clean master, the child needed 265.37 seconds to finish after compiling `ModelingToolkitBase`. A contention-focused run spent 293 seconds precompiling before the tested call and then passed. The old assertion could therefore fail without `full_equations` hanging.

The subprocess itself is necessary: running the model against the parent of the original fix entered `full_equations` and was still running when an external 3600-second timeout terminated it.

## Change

- Touch a readiness marker after package loading, model construction, and `mtkcompile`.
- Allow setup/cache work up to 3600 seconds.
- Preserve the 180-second timeout specifically around `full_equations`.
- Reap the child and require a successful exit, so a crash no longer satisfies the test.

## Investigation

- `f215ec083a439be63603b83bc42178db24ce685e` introduced the subprocess regression test with a 120-second combined timeout.
- `9ed9aa758c759c8d49155679a915e8db0a88fcf1` increased that timeout to 180 seconds.
- Clean-master `GROUP=InterfaceI` passed 1475 tests with 3 pre-existing broken tests in 49m03s, confirming that the reported failure is contention-dependent rather than deterministic.

## Validation

- Focused test, Julia 1.12: 4/4 passed in 10.8 seconds.
- Focused test, Julia 1.10 LTS: 4/4 passed in 1m53.7s.
- Cold/contention-focused test: 4/4 passed in 5m05.6s, including 293 seconds of child precompilation.
- `GROUP=InterfaceI julia +1.12 --project=lib/ModelingToolkitBase -e 'using Pkg; Pkg.test(; coverage = false)'`: 1498 passed, 5 pre-existing broken, 1503 total, in 38m16.8s.
- Whole-repository Runic 1.5.1 check passed.
