### PR TITLE
Fix ModelingToolkitBase method ambiguities

### DIFF
--- a/lib/ModelingToolkitBase/Project.toml
+++ b/lib/ModelingToolkitBase/Project.toml
@@ -1,7 +1,7 @@
 name = "ModelingToolkitBase"
 uuid = "7771a370-6774-4173-bd38-47e70ca0b839"
 authors = ["Yingbo Ma <mayingbo5@gmail.com>", "Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
-version = "1.58.1"
+version = "1.58.2"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/lib/ModelingToolkitBase/src/deprecations.jl
+++ b/lib/ModelingToolkitBase/src/deprecations.jl
@@ -113,6 +113,24 @@ for T in [
             """
             return $T{iip, spec}(sys, merge($uCanonical, $pCanonical), tspan; kw...)
         end
+        if T === :ODEProblem
+            @eval function SciMLBase.ODEProblem{
+                    iip, SciMLBase.FunctionWrapperSpecialize,
+                }(
+                    sys::System, u0::$uType, tspan, p::$pType; kw...
+                ) where {iip}
+                ctor = string(ODEProblem{iip, SciMLBase.FunctionWrapperSpecialize})
+                uCan = string($(QuoteNode(uCanonical)))
+                pCan = string($(QuoteNode(pCanonical)))
+                @warn """
+                `$ctor(sys, u0, tspan, p; kw...)` is deprecated. Use
+                `$ctor(sys, merge($uCan, $pCan), tspan)` instead.
+                """
+                return ODEProblem{iip, SciMLBase.FunctionWrapperSpecialize}(
+                    sys, merge($uCanonical, $pCanonical), tspan; kw...
+                )
+            end
+        end
     end
 
     for pType in [SciMLBase.NullParameters, Nothing], uType in [Any, Nothing]
@@ -147,6 +165,23 @@ for T in [
             `$ctor(sys, u0, tspan)` instead.
             """
             return $T{iip, spec}(sys, u0, tspan; kw...)
+        end
+        if T === :ODEProblem
+            @eval function SciMLBase.ODEProblem{
+                    iip, SciMLBase.FunctionWrapperSpecialize,
+                }(
+                    sys::System, u0::$uType, tspan, p::$pType; kw...
+                ) where {iip}
+                ctor = string(ODEProblem{iip, SciMLBase.FunctionWrapperSpecialize})
+                pT = string($(QuoteNode(pType)))
+                @warn """
+                `$ctor(sys, u0, tspan, p::$pT; kw...)` is deprecated. Use
+                `$ctor(sys, u0, tspan)` instead.
+                """
+                return ODEProblem{iip, SciMLBase.FunctionWrapperSpecialize}(
+                    sys, u0, tspan; kw...
+                )
+            end
         end
     end
 end

--- a/lib/ModelingToolkitBase/src/problems/odeproblem.jl
+++ b/lib/ModelingToolkitBase/src/problems/odeproblem.jl
@@ -116,8 +116,8 @@ function SciMLBase.ODEFunction{iip, spec}(
     return odefn
 end
 
-Base.@nospecializeinfer @fallback_iip_specialize function SciMLBase.ODEProblem{iip, spec}(
-        sys::System, @nospecialize(op), tspan;
+Base.@nospecializeinfer function _ode_problem(
+        ::Type{ODEProblem{iip, spec}}, sys::System, @nospecialize(op), tspan;
         @nospecialize(callback = nothing), check_length = true, eval_expression = false,
         expression = Val{false}, eval_module = @__MODULE__, check_compatibility = true,
         _skip_events = false, kwargs...
@@ -146,7 +146,36 @@ Base.@nospecializeinfer @fallback_iip_specialize function SciMLBase.ODEProblem{i
 
     ptype = getmetadata(sys, ProblemTypeCtx, StandardODEProblem())
     args = (; f, u0, tspan, p, ptype)
-    maybe_codegen_scimlproblem(expression, ODEProblem{_iip}, args; kwargs...)
+    return maybe_codegen_scimlproblem(expression, ODEProblem{_iip}, args; kwargs...)
+end
+
+Base.@nospecializeinfer @fallback_iip_specialize function SciMLBase.ODEProblem{iip, spec}(
+        sys::System, @nospecialize(op), tspan;
+        @nospecialize(callback = nothing), check_length = true, eval_expression = false,
+        expression = Val{false}, eval_module = @__MODULE__, check_compatibility = true,
+        _skip_events = false, kwargs...
+    ) where {iip, spec}
+    return _ode_problem(
+        ODEProblem{iip, spec}, sys, op, tspan;
+        callback, check_length, eval_expression, expression, eval_module, check_compatibility,
+        _skip_events, kwargs...
+    )
+end
+
+# SciMLBase also defines this fixed-specialization constructor for arbitrary functions.
+Base.@nospecializeinfer function SciMLBase.ODEProblem{
+        iip, SciMLBase.FunctionWrapperSpecialize,
+    }(
+        sys::System, @nospecialize(op), tspan;
+        @nospecialize(callback = nothing), check_length = true, eval_expression = false,
+        expression = Val{false}, eval_module = @__MODULE__, check_compatibility = true,
+        _skip_events = false, kwargs...
+    ) where {iip}
+    return _ode_problem(
+        ODEProblem{iip, SciMLBase.FunctionWrapperSpecialize}, sys, op, tspan;
+        callback, check_length, eval_expression, expression, eval_module, check_compatibility,
+        _skip_events, kwargs...
+    )
 end
 
 @fallback_iip_specialize function DiffEqBase.SteadyStateProblem{iip, spec}(

--- a/lib/ModelingToolkitBase/src/systems/abstractsystem.jl
+++ b/lib/ModelingToolkitBase/src/systems/abstractsystem.jl
@@ -1270,16 +1270,31 @@ end
 
 const AllScopes = Union{LocalScope, ParentScope, GlobalScope}
 
-renamespace(sys, eq::Equation) = namespace_equation(eq, sys)
+_renamespace(names::AbstractVector, x) = foldr(renamespace, names, init = x)
 
-renamespace(names::AbstractVector, x) = foldr(renamespace, names, init = x)
+renamespace(sys, eq::Equation) = namespace_equation(eq, sys)
+renamespace(names::AbstractVector, eq::Equation) = _renamespace(names, eq)
+
+renamespace(names::AbstractVector, x) = _renamespace(names, x)
 
 renamespace(sys, tgt::AbstractSystem) = rename(tgt, renamespace(sys, nameof(tgt)))
+renamespace(names::AbstractVector, tgt::AbstractSystem) = _renamespace(names, tgt)
 renamespace(sys, tgt::Symbol) = Symbol(getname(sys), NAMESPACE_SEPARATOR_SYMBOL, tgt)
+renamespace(names::AbstractVector, tgt::Symbol) = _renamespace(names, tgt)
 renamespace(sys, x::Num) = Num(renamespace(sys, unwrap(x)))
+renamespace(names::AbstractVector, x::Num) = _renamespace(names, x)
 renamespace(sys, x::Arr{T, N}) where {T, N} = Arr{T, N}(renamespace(sys, unwrap(x)))
+function renamespace(names::AbstractVector, x::Arr{T, N}) where {T, N}
+    return _renamespace(names, x)
+end
 renamespace(sys, x::CallAndWrap{T}) where {T} = CallAndWrap{T}(renamespace(sys, unwrap(x)))
+function renamespace(names::AbstractVector, x::CallAndWrap{T}) where {T}
+    return _renamespace(names, x)
+end
 renamespace(sys, x::AbstractArray{SymbolicT}) = map(Base.Fix1(renamespace, sys), x)
+function renamespace(names::AbstractVector, x::AbstractArray{SymbolicT})
+    return _renamespace(names, x)
+end
 
 """
     $(TYPEDSIGNATURES)
@@ -1326,6 +1341,8 @@ function renamespace(sys, x::SymbolicT)
         end
     end
 end
+
+renamespace(names::AbstractVector, x::SymbolicT) = _renamespace(names, x)
 
 namespace_variables(sys::AbstractSystem) = unknowns(sys, unknowns(sys))
 namespace_parameters(sys::AbstractSystem) = parameters(sys, parameters(sys))

--- a/lib/ModelingToolkitBase/src/systems/analysis_points.jl
+++ b/lib/ModelingToolkitBase/src/systems/analysis_points.jl
@@ -177,6 +177,8 @@ function renamespace(sys, ap::AnalysisPoint)
     )
 end
 
+renamespace(names::AbstractVector, ap::AnalysisPoint) = _renamespace(names, ap)
+
 # create analysis points via `connect`
 function connect(in, ap::AnalysisPoint, outs...; verbose = true)
     return AnalysisPoint() ~ AnalysisPoint(unwrap(in), ap.name, collect(unwrap.(outs)); verbose)

--- a/lib/ModelingToolkitBase/src/systems/parameter_buffer.jl
+++ b/lib/ModelingToolkitBase/src/systems/parameter_buffer.jl
@@ -305,12 +305,14 @@ function _split_helper(buf_v::T, recurse, raw, idx) where {T}
 end
 
 function _split_helper(::Type{<:AbstractArray}, buf_v, ::Val{N}, raw, idx) where {N}
+    iszero(N) && return _split_helper((), buf_v, (), raw, idx)
     return map(b -> _split_helper(eltype(b), b, Val(N - 1), raw, idx), buf_v)
 end
 
 function _split_helper(
         ::Type{<:AbstractArray}, buf_v::BlockedArray, ::Val{N}, raw, idx
     ) where {N}
+    iszero(N) && return _split_helper((), buf_v, (), raw, idx)
     return BlockedArray(
         map(b -> _split_helper(eltype(b), b, Val(N - 1), raw, idx), buf_v),
         blocksizes(buf_v, 1)
@@ -318,14 +320,11 @@ function _split_helper(
 end
 
 function _split_helper(::Type{<:AbstractArray}, buf_v::Tuple, ::Val{N}, raw, idx) where {N}
+    iszero(N) && return _split_helper((), buf_v, (), raw, idx)
     return ntuple(
         i -> _split_helper(eltype(buf_v[i]), buf_v[i], Val(N - 1), raw, idx),
         Val(length(buf_v))
     )
-end
-
-function _split_helper(::Type{<:AbstractArray}, buf_v, ::Val{0}, raw, idx)
-    return _split_helper((), buf_v, (), raw, idx)
 end
 
 function _split_helper(_, buf_v, _, raw, idx)

--- a/lib/ModelingToolkitBase/test/namespacing.jl
+++ b/lib/ModelingToolkitBase/test/namespacing.jl
@@ -28,6 +28,15 @@ nsys = toggle_namespacing(sys, false)
     Equation[], t; systems = [nsys], name = :a
 )
 
+@testset "Vector namespaces" begin
+    outer = System(Equation[], t; name = :outer)
+    names = [outer, sys]
+    for value in (:value, x, D(x) ~ x, [ModelingToolkitBase.unwrap(x)])
+        expected = renamespace(outer, renamespace(sys, value))
+        @test isequal(renamespace(names, value), expected)
+    end
+end
+
 @testset "Variables of variables" begin
     @variables x(t) y(x)
     @named inner = System([D(x) ~ x, y ~ 2x + 1], t)

--- a/lib/ModelingToolkitBase/test/sciml_problem_inputs.jl
+++ b/lib/ModelingToolkitBase/test/sciml_problem_inputs.jl
@@ -196,7 +196,9 @@ end
     @testset "$ctor" for (sys, ctor) in [
             (odesys, ODEProblem),
             (odesys, ODEProblem{true}),
-            (odesys, ODEProblem{true, SciMLBase.FullSpecialize}), (odesys, BVProblem),
+            (odesys, ODEProblem{true, SciMLBase.FullSpecialize}),
+            (odesys, ODEProblem{true, SciMLBase.FunctionWrapperSpecialize}),
+            (odesys, BVProblem),
             (odesys, BVProblem{true}),
             (odesys, BVProblem{true, SciMLBase.FullSpecialize}), (sdesys, SDEProblem),
             (sdesys, SDEProblem{true}),


### PR DESCRIPTION
## Summary

- resolve the `ODEProblem` constructor intersections with SciMLBase's fixed `FunctionWrapperSpecialize` constructor, including deprecated input forms
- resolve vector `renamespace` intersections by routing exact overlapping signatures through one implementation
- resolve `_split_helper` intersections at zero recursion depth without adding ambiguity-only fallback methods
- add constructor and vector-namespacing regressions and bump ModelingToolkitBase to 1.58.2

Closes the ambiguity portion of #4670. The 14 Aqua piracy findings documented there are intentionally separate and are not changed here.

## Root cause

Current clean master has 45 ambiguities:

- 34 intersections between ModelingToolkitBase's `ODEProblem{iip,spec}(::System, ...)` methods and SciMLBase's fixed `ODEProblem{iip,FunctionWrapperSpecialize}(f, ...)` constructor
- 2 local `_split_helper` intersections between the `Val{0}` fallback and the tuple/`BlockedArray` methods
- 9 intersections between `renamespace(::AbstractVector, x)` and more-specific second-argument methods

The `ODEProblem` issue is not caused by the currently registered SciMLBase 3.39.1. Repeating the clean-master Aqua scan against local SciMLBase 3.40.1 produces the same 45-method set.

## Validation

- `GROUP=SymbolicIndexingInterface JULIA_NUM_THREADS=2 timeout 3600 julia +1.12 --startup-file=no --project=lib/ModelingToolkitBase -e 'using Pkg; Pkg.test(; coverage=false)'`: **exit 0**; 64 + 1,824 + 118 assertions passed
- `timeout 3600 julia +1.12 --startup-file=no --project=lib/ModelingToolkitBase/test/qa -e 'using ModelingToolkitBase, Aqua; Aqua.test_ambiguities(ModelingToolkitBase); println("AQUA_AMBIGUITIES_PASS")'`: **exit 0**, `AQUA_AMBIGUITIES_PASS` (45 → 0 ambiguities)
- wrapped `lib/ModelingToolkitBase/test/namespacing.jl`: **21/21 passed**
- repository-wide Runic `--check`: **exit 0**
- `git diff --check`: **exit 0**

The clean-master official `GROUP=QA` reproduction on Julia 1.12.6 exits 1 with JET **54/54 passing** and Aqua reporting exactly the two independently tracked classes: **45 ambiguities** and **14 piracy methods**. Prior CI on this change likewise showed the ambiguity check passing and only the separate piracy finding remaining in Aqua.

## Historical and dependency audit

Using one locked historical Manifest (Aqua 0.8.16, SciMLBase 2.153.1), the first standalone ModelingToolkitBase commit `fb2450ea82` already reports 44 ambiguities: 34 `ODEProblem`, 2 `_split_helper`, and 8 `renamespace`. Its parent has no `lib/ModelingToolkitBase` package. The ninth current `renamespace` ambiguity entered later with symbolic-array namespacing at `f5761ee695`.

Source-history boundaries for the intersecting methods are documented in #4670. In particular, the SciMLBase fixed-specialization constructor dates to `37715146e3`, while the ModelingToolkit deprecated problem-constructor family dates to `018e2d631d`.

## Process

I reproduced the failure from an exact clean `origin/master`, separated the ambiguity and piracy classes, checked the dependency-version hypothesis, rebased this focused branch onto current master, reran the affected package tests and formatting check, then re-fetched both remotes and verified that the remote PR branch still contained only its original author-owned commit before the lease-protected update.

**Please ignore this draft until it has been reviewed by @ChrisRackauckas.**
