### PR TITLE
fix: handle `t` in `observed_syms_to_timeseries` calculation

### DIFF
--- a/lib/ModelingToolkitBase/src/systems/index_cache.jl
+++ b/lib/ModelingToolkitBase/src/systems/index_cache.jl
@@ -378,7 +378,9 @@ function get_observed_and_dependent_to_timeseries(
         timeseries = TimeseriesSetType()
         for v in varsbuf
             arrv, _ = split_indexed_var(v)
-            if (idx = get(disc_idxs, v, nothing)) !== nothing
+            if isequal(v, get_iv(sys)::SymbolicT)
+                push!(timeseries, ContinuousTimeseries())
+            elseif (idx = get(disc_idxs, v, nothing)) !== nothing
                 push!(timeseries, idx.clock_idx)
             elseif (idx = get(disc_idxs, arrv, nothing)) !== nothing
                 push!(timeseries, idx.clock_idx)


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
