### PR TITLE
Fix collect_vars! after late invalidation on Julia 1.10

### DIFF
--- a/lib/ModelingToolkitBase/src/utils.jl
+++ b/lib/ModelingToolkitBase/src/utils.jl
@@ -936,16 +936,14 @@ function collect_vars!(
     return nothing
 end
 
-# Break the inference cycle between the mutually recursive collectors. Julia 1.10
-# can otherwise miscompile the cycle after unrelated method additions. The
-# abstractly typed cell keeps downstream `collect_vars!` dispatch dynamic, while
-# the explicit keyword preserves metadata recursion's depth-zero semantics.
-const _COLLECT_VARS_DISPATCH = Ref{Function}(collect_vars!)
-
-@noinline Base.@constprop :none function _call_collect_vars!(
-        unknowns, parameters, expr, iv
-    )
-    return _COLLECT_VARS_DISPATCH[](unknowns, parameters, expr, iv; depth = 0)
+# Break the inference cycle between the mutually recursive collectors, which Julia
+# 1.10 can otherwise miscompile after unrelated method additions. Dispatching in the
+# latest world age also means a downstream `collect_vars!` method defined while this
+# call is already running is still found; because the four-argument fallback returns
+# `nothing`, missing it would silently drop parameters rather than error. The explicit
+# keyword preserves metadata recursion's depth-zero semantics.
+function _call_collect_vars!(unknowns, parameters, expr, iv)
+    return @invokelatest collect_vars!(unknowns, parameters, expr, iv; depth = 0)
 end
 
 """

--- a/lib/ModelingToolkitBase/src/utils.jl
+++ b/lib/ModelingToolkitBase/src/utils.jl
@@ -936,6 +936,18 @@ function collect_vars!(
     return nothing
 end
 
+# Break the inference cycle between the mutually recursive collectors. Julia 1.10
+# can otherwise miscompile the cycle after unrelated method additions. The
+# abstractly typed cell keeps downstream `collect_vars!` dispatch dynamic, while
+# the explicit keyword preserves metadata recursion's depth-zero semantics.
+const _COLLECT_VARS_DISPATCH = Ref{Function}(collect_vars!)
+
+@noinline Base.@constprop :none function _call_collect_vars!(
+        unknowns, parameters, expr, iv
+    )
+    return _COLLECT_VARS_DISPATCH[](unknowns, parameters, expr, iv; depth = 0)
+end
+
 """
     $(TYPEDSIGNATURES)
 
@@ -966,7 +978,7 @@ function collect_var!(unknowns::OrderedSet{SymbolicT}, parameters::OrderedSet{Sy
                 any(!SU.isconst, Iterators.drop(arguments(var), 1))
         )
         for arg in Iterators.drop(arguments(var), 1)
-            collect_vars!(unknowns, parameters, arg, iv)
+            _call_collect_vars!(unknowns, parameters, arg, iv)
         end
         var = arr
     end
@@ -975,7 +987,7 @@ function collect_var!(unknowns::OrderedSet{SymbolicT}, parameters::OrderedSet{Sy
     if iscalledparameter(var)
         callable = getcalledparameter(var)
         push!(parameters, callable)
-        collect_vars!(unknowns, parameters, arguments(var), iv)
+        _call_collect_vars!(unknowns, parameters, arguments(var), iv)
     elseif isparameter(var) || (iscall(var) && isparameter(operation(var)))
         push!(parameters, var)
     else
@@ -984,55 +996,55 @@ function collect_var!(unknowns::OrderedSet{SymbolicT}, parameters::OrderedSet{Sy
     # Add also any parameters that appear only as defaults in the var
     if hasdefault(var) && (def = getdefault(var)) !== missing
         if def isa SymbolicT
-            collect_vars!(unknowns, parameters, def, iv)
+            _call_collect_vars!(unknowns, parameters, def, iv)
         elseif def isa Num
-            collect_vars!(unknowns, parameters, def, iv)
+            _call_collect_vars!(unknowns, parameters, def, iv)
         elseif def isa Arr{Num, 1}
-            collect_vars!(unknowns, parameters, def, iv)
+            _call_collect_vars!(unknowns, parameters, def, iv)
         elseif def isa Arr{Num, 2}
-            collect_vars!(unknowns, parameters, def, iv)
+            _call_collect_vars!(unknowns, parameters, def, iv)
         elseif def isa CallAndWrap{Num}
-            collect_vars!(unknowns, parameters, def, iv)
+            _call_collect_vars!(unknowns, parameters, def, iv)
         elseif def isa CallAndWrap{Arr{Num, 1}}
-            collect_vars!(unknowns, parameters, def, iv)
+            _call_collect_vars!(unknowns, parameters, def, iv)
         elseif def isa CallAndWrap{Arr{Num, 2}}
-            collect_vars!(unknowns, parameters, def, iv)
+            _call_collect_vars!(unknowns, parameters, def, iv)
         elseif def isa Arr
-            collect_vars!(unknowns, parameters, def, iv)
+            _call_collect_vars!(unknowns, parameters, def, iv)
         elseif def isa CallAndWrap
-            collect_vars!(unknowns, parameters, def, iv)
+            _call_collect_vars!(unknowns, parameters, def, iv)
         else
-            collect_vars!(unknowns, parameters, def, iv)
+            _call_collect_vars!(unknowns, parameters, def, iv)
         end
     end
     # Add also any parameters that appear only in the bounds of the var
     if hasbounds(var)
         (lo, hi) = getbounds(var)
         if lo isa SymbolicT
-            collect_vars!(unknowns, parameters, lo, iv)
+            _call_collect_vars!(unknowns, parameters, lo, iv)
         elseif lo isa Num
-            collect_vars!(unknowns, parameters, lo, iv)
+            _call_collect_vars!(unknowns, parameters, lo, iv)
         elseif lo isa Arr{Num, 1}
-            collect_vars!(unknowns, parameters, lo, iv)
+            _call_collect_vars!(unknowns, parameters, lo, iv)
         elseif lo isa Arr{Num, 2}
-            collect_vars!(unknowns, parameters, lo, iv)
+            _call_collect_vars!(unknowns, parameters, lo, iv)
         elseif lo isa Arr
-            collect_vars!(unknowns, parameters, lo, iv)
+            _call_collect_vars!(unknowns, parameters, lo, iv)
         else
-            collect_vars!(unknowns, parameters, lo, iv)
+            _call_collect_vars!(unknowns, parameters, lo, iv)
         end
         if hi isa SymbolicT
-            collect_vars!(unknowns, parameters, hi, iv)
+            _call_collect_vars!(unknowns, parameters, hi, iv)
         elseif hi isa Num
-            collect_vars!(unknowns, parameters, hi, iv)
+            _call_collect_vars!(unknowns, parameters, hi, iv)
         elseif hi isa Arr{Num, 1}
-            collect_vars!(unknowns, parameters, hi, iv)
+            _call_collect_vars!(unknowns, parameters, hi, iv)
         elseif hi isa Arr{Num, 2}
-            collect_vars!(unknowns, parameters, hi, iv)
+            _call_collect_vars!(unknowns, parameters, hi, iv)
         elseif hi isa Arr
-            collect_vars!(unknowns, parameters, hi, iv)
+            _call_collect_vars!(unknowns, parameters, hi, iv)
         else
-            collect_vars!(unknowns, parameters, hi, iv)
+            _call_collect_vars!(unknowns, parameters, hi, iv)
         end
     end
     return nothing

--- a/lib/ModelingToolkitBase/test/dq_units.jl
+++ b/lib/ModelingToolkitBase/test/dq_units.jl
@@ -282,6 +282,10 @@ struct CollectorInvalidationExpression
     parameter::Symbolics.SymbolicT
 end
 
+struct CollectorSameWorldExpression
+    parameter::Symbolics.SymbolicT
+end
+
 function collect_default_parameters(var)
     unknowns = OrderedSet{Symbolics.SymbolicT}()
     parameters = OrderedSet{Symbolics.SymbolicT}()
@@ -326,4 +330,34 @@ end
 
     @test Symbolics.unwrap(scale_test) in collect_default_parameters(custom_default)
     @test Symbolics.unwrap(x0_test) in collect_default_parameters(x_test)
+end
+
+# Defines the downstream method from inside a running call, so the enclosing frame
+# keeps its old world age while collecting.
+function define_then_collect(var)
+    @eval function MT.collect_vars!(
+            unknowns::OrderedSet{Symbolics.SymbolicT},
+            parameters::OrderedSet{Symbolics.SymbolicT},
+            expr::CollectorSameWorldExpression,
+            ::Union{Symbolics.SymbolicT, Nothing};
+            depth = 0
+        )
+        push!(parameters, expr.parameter)
+        return nothing
+    end
+    return collect_default_parameters(var)
+end
+
+@testset "collect_vars! dispatches to same-world-age downstream methods" begin
+    @parameters same_world_test
+    @variables same_world_var(t)
+
+    target = MT.setdefault(
+        same_world_var, CollectorSameWorldExpression(Symbolics.unwrap(same_world_test))
+    )
+
+    # The four-argument fallback returns `nothing`, so failing to see the method here
+    # would drop the parameter silently instead of raising a `MethodError`.
+    @test Symbolics.unwrap(same_world_test) in define_then_collect(target)
+    @test Symbolics.unwrap(same_world_test) in collect_default_parameters(target)
 end

--- a/lib/ModelingToolkitBase/test/dq_units.jl
+++ b/lib/ModelingToolkitBase/test/dq_units.jl
@@ -2,6 +2,7 @@ using ModelingToolkitBase, OrdinaryDiffEq, JumpProcesses, DynamicQuantities
 using Symbolics
 import SymbolicUtils as SU
 using Test
+using DataStructures: OrderedSet
 MT = ModelingToolkitBase
 using ModelingToolkitBase: t, D
 @parameters τ [unit = u"s"] γ
@@ -273,30 +274,56 @@ let
     @test MT.get_unit(x_mat) == u"1"
 end
 
-# Issue #4211: collect_vars! must discover parameters in defaults with DynamicQuantities loaded
-# On Julia 1.10, loading DynamicQuantities could cause collect_vars! to fail to discover
-# parameters used in variable defaults due to a method invalidation bug.
-@testset "Issue #4211: collect_vars! discovers parameters in defaults" begin
-    using DataStructures: OrderedSet
+struct CollectorInvalidationString
+    value::String
+end
 
-    @parameters X0_test
-    @variables X_test(t) = X0_test
+struct CollectorInvalidationExpression
+    parameter::Symbolics.SymbolicT
+end
 
-    us = OrderedSet{Symbolics.SymbolicT}()
-    ps = OrderedSet{Symbolics.SymbolicT}()
-    MT.collect_vars!(us, ps, Symbolics.unwrap(X_test), Symbolics.unwrap(t), Symbolics.Operator; depth = 0)
+function collect_default_parameters(var)
+    unknowns = OrderedSet{Symbolics.SymbolicT}()
+    parameters = OrderedSet{Symbolics.SymbolicT}()
+    MT.collect_vars!(
+        unknowns, parameters, Symbolics.unwrap(var), Symbolics.unwrap(t),
+        Symbolics.Operator; depth = 0
+    )
+    return parameters
+end
 
-    # X0_test should be discovered in X_test's default value
-    @test Symbolics.unwrap(X0_test) in ps
+@testset "collect_vars! survives late method invalidation" begin
+    @parameters x0_test y0_test scale_test
+    @variables x_test(t) = x0_test y_test(t) = scale_test * y0_test
 
-    # Test with expression in default
-    @parameters a_test b_test
-    @variables Y_test(t) = a_test + 2 * b_test
+    @test Symbolics.unwrap(x0_test) in collect_default_parameters(x_test)
 
-    empty!(us)
-    empty!(ps)
-    MT.collect_vars!(us, ps, Symbolics.unwrap(Y_test), Symbolics.unwrap(t), Symbolics.Operator; depth = 0)
+    # This late definition exercises the Julia 1.10 invalidation that caused
+    # parameters in defaults to disappear after loading unrelated packages.
+    @eval Base.convert(::Type{Symbol}, value::CollectorInvalidationString) =
+        Symbol(value.value)
 
-    @test Symbolics.unwrap(a_test) in ps
-    @test Symbolics.unwrap(b_test) in ps
+    x_parameters = collect_default_parameters(x_test)
+    y_parameters = collect_default_parameters(y_test)
+
+    @test Symbolics.unwrap(x0_test) in x_parameters
+    @test Symbolics.unwrap(y0_test) in y_parameters
+    @test Symbolics.unwrap(scale_test) in y_parameters
+
+    custom_default = MT.setdefault(
+        x_test, CollectorInvalidationExpression(Symbolics.unwrap(scale_test))
+    )
+    @eval function MT.collect_vars!(
+            unknowns::OrderedSet{Symbolics.SymbolicT},
+            parameters::OrderedSet{Symbolics.SymbolicT},
+            expr::CollectorInvalidationExpression,
+            ::Union{Symbolics.SymbolicT, Nothing};
+            depth = 0
+        )
+        push!(parameters, expr.parameter)
+        return nothing
+    end
+
+    @test Symbolics.unwrap(scale_test) in collect_default_parameters(custom_default)
+    @test Symbolics.unwrap(x0_test) in collect_default_parameters(x_test)
 end


### PR DESCRIPTION
Please ignore this PR until reviewed by @ChrisRackauckas.

## Summary

- route recursive four-argument `collect_vars!` calls from metadata collection through a non-inlined `Ref{Function}` dispatch barrier
- preserve the public downstream extension point: methods added to four-argument `collect_vars!` after package load are still dispatched dynamically
- add a regression that first compiles default collection, adds an unrelated method that triggers the Julia 1.10 invalidation, checks scalar and expression defaults, and then checks a late downstream `collect_vars!` method

## Why

Loading DynamicQuantities and then unrelated packages can invalidate the mutually recursive `collect_vars!` / `collect_var!` inference cycle on Julia 1.10. After that invalidation, parameters used only in defaults can disappear. In downstream initialization this manifested as a missing `Initial(x0)` parameter and as `y0` no longer being recognized as an unknown.

The first bad ModelingToolkit commit is `22000aa03d317353500c3c73ca01744d069530be` (`refactor: change collect_vars! for type-stability`); its parent `ca6eb0a92` is good. A package-load warmup is not durable because later method additions can invalidate the warmed specialization again.

The barrier is deliberately restricted to the recursive four-argument calls inside `collect_var!`. The explicit `depth = 0` preserves their previous default-keyword semantics, while the abstract function cell prevents inference from rebuilding the problematic mutual cycle. It also avoids reaching into dependency internals or changing public API.

## Performance

Fresh-process construction microbenchmarks, baseline -> patch:

| case | allocations | time |
| --- | --- | --- |
| plain variable | 1240.01 B -> 1240.01 B | 4228.6 ns -> 4214.2 ns |
| parameter default | 3056.01 B -> 3088.01 B | 11029.7 ns -> 11288.1 ns (+2.34%) |
| bounded metadata | 1896.01 B -> 1992.01 B | 10347.1 ns -> 10502.4 ns (+1.50%) |

This is system-construction work, not the nonlinear `solve!` path. The warmed ImplicitDiscreteSolve homotopy solve remains 0 B per solve in the separate cache benchmark.

## Local verification

- Julia 1.10 targeted `dq_units.jl`: initialization 1/1; invalidation regression 6/6
- Julia 1.12 targeted `dq_units.jl`: initialization 1/1; invalidation regression 6/6
- Julia 1.10 real late-JSON reproduction: `[json_p]` is collected both before and after the late method addition; late custom dispatch collects `[custom_p]`
- Julia 1.10 official `GROUP=InterfaceI Pkg.test("ModelingToolkitBase")`: 1498 passed, 5 existing broken, 0 failed/errored
- Julia 1.10 official `GROUP=Initialization`: the two collector errors are gone; 583 passed, 9 unrelated DelayDiffEq `DEOptions` errors, 14 existing broken. The nine resolver errors are tracked by JuliaRegistries/General#162781.
- Julia 1.12 official `GROUP=QA`: JET 54/54 passed. Aqua reports 45 ambiguities and 14 piracy methods; an exact clean-master `d39174937` run reproduces the same Aqua 9 passed / 2 failed result, so that baseline failure is being handled separately rather than hidden here.
- Runic 1.7.0 whole-repository `--check .`: exit 0
- `git diff --check`: clean

No tests were skipped, disabled, silenced, or loosened.

## Investigation/process notes

The work started from the downstream LinearSolve/ModelingToolkit initialization failures discovered while validating the ImplicitDiscreteSolve homotopy cache path. I reproduced the failure with frozen dependencies on Julia 1.10, separated the two collector errors from nine independent DelayDiffEq resolver errors, bisected the collector regression, minimized the invalidation trigger, compared direct calls, `invoke`, function wrappers, and a dynamic function cell, verified late downstream dispatch, benchmarked construction overhead, then ran the package groups and formatting checks above. The unrelated clean-master QA failures are being bisected in a separate worktree so this remains one focused fix.