### PR TITLE
Make the QA group scan the package extensions

### DIFF
--- a/ext/MTKFMIExt.jl
+++ b/ext/MTKFMIExt.jl
@@ -1,12 +1,19 @@
 module MTKFMIExt
 
 using ModelingToolkit
-using SymbolicIndexingInterface
-using ModelingToolkit: t_nounits as t, D_nounits as D
-using DocStringExtensions
+using SymbolicIndexingInterface: NotSymbolic, symbolic_type
+using ModelingToolkitBase: t_nounits, D_nounits
+using DocStringExtensions: TYPEDEF, TYPEDFIELDS, TYPEDSIGNATURES
 import ModelingToolkit as MTK
+import ModelingToolkitBase as MTKBase
 import SciMLBase
+import SymbolicUtils
 import FMIImport as FMI
+
+# Spelled as `const` rather than `t_nounits as t`, because ExplicitImports reports a
+# renaming import as stale (it tracks the pre-rename name, which never appears in use).
+const t = t_nounits
+const D = D_nounits
 
 """
     $(TYPEDSIGNATURES)
@@ -173,7 +180,7 @@ function MTK.FMIComponent(
     inputs = []
     fmi_variables_to_mtk_variables!(
         fmu, FMI.getInputValueReferencesAndNames(fmu),
-        value_references, inputs, states, observed; postprocess_variable = v -> MTK.setinput(
+        value_references, inputs, states, observed; postprocess_variable = v -> MTKBase.setinput(
             v, true
         )
     )
@@ -187,7 +194,7 @@ function MTK.FMIComponent(
     outputs = []
     fmi_variables_to_mtk_variables!(
         fmu, FMI.getOutputValueReferencesAndNames(fmu),
-        value_references, outputs, states, observed; postprocess_variable = v -> MTK.setoutput(
+        value_references, outputs, states, observed; postprocess_variable = v -> MTKBase.setoutput(
             v, true
         )
     )
@@ -361,22 +368,22 @@ function fmi_variables_to_mtk_variables!(
         end
         if parameters
             vars = [
-                postprocess_variable(MTK.unwrap(only(@parameters $sname::stateT)))
+                postprocess_variable(SymbolicUtils.unwrap(only(@parameters $sname::stateT)))
                     for sname in snames
             ]
         else
             vars = [
-                postprocess_variable(MTK.unwrap(only(@variables $sname(t)::stateT)))
+                postprocess_variable(SymbolicUtils.unwrap(only(@variables $sname(t)::stateT)))
                     for sname in snames
             ]
         end
         for i in eachindex(vars)
             der = ders[i]
-            vars[i] = MTK.unwrap(vars[i])
+            vars[i] = SymbolicUtils.unwrap(vars[i])
             for j in 1:der
                 vars[i] = D(vars[i])
             end
-            vars[i] = MTK.default_toterm(vars[i])
+            vars[i] = MTKBase.default_toterm(vars[i])
         end
         for i in eachindex(vars)
             if i == 1

--- a/ext/MTKOrdinaryDiffEqBDFExt.jl
+++ b/ext/MTKOrdinaryDiffEqBDFExt.jl
@@ -1,8 +1,8 @@
 module MTKOrdinaryDiffEqBDFExt
 
 using ModelingToolkit
-using OrdinaryDiffEqBDF
-using PrecompileTools
+using OrdinaryDiffEqBDF: FBDF
+using PrecompileTools: @compile_workload, @setup_workload
 using ModelingToolkit: t_nounits, D_nounits
 
 @setup_workload begin

--- a/ext/MTKOrdinaryDiffEqDefaultExt.jl
+++ b/ext/MTKOrdinaryDiffEqDefaultExt.jl
@@ -1,8 +1,8 @@
 module MTKOrdinaryDiffEqDefaultExt
 
 using ModelingToolkit
-using OrdinaryDiffEqDefault
-using PrecompileTools
+using OrdinaryDiffEqDefault: OrdinaryDiffEqDefault
+using PrecompileTools: @compile_workload, @setup_workload
 using ModelingToolkit: t_nounits, D_nounits
 
 @setup_workload begin

--- a/ext/MTKOrdinaryDiffEqRosenbrockExt.jl
+++ b/ext/MTKOrdinaryDiffEqRosenbrockExt.jl
@@ -1,8 +1,8 @@
 module MTKOrdinaryDiffEqRosenbrockExt
 
 using ModelingToolkit
-using OrdinaryDiffEqRosenbrock
-using PrecompileTools
+using OrdinaryDiffEqRosenbrock: Rodas5P
+using PrecompileTools: @compile_workload, @setup_workload
 using ModelingToolkit: t_nounits, D_nounits
 
 @setup_workload begin

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -1,7 +1,11 @@
 [deps]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+FMIImport = "9fcbc62e-52a0-44e9-a616-1359a0008194"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 ModelingToolkit = "961ee093-0014-501f-94e3-6117800e7a78"
+OrdinaryDiffEqBDF = "6ad6398a-0878-4a85-9266-38940aa047c8"
+OrdinaryDiffEqDefault = "50262376-6c5a-4cf5-baba-aaf4f84d72d7"
+OrdinaryDiffEqRosenbrock = "43230ef6-c299-4910-a778-202eb28ce4ce"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
@@ -11,7 +15,11 @@ ModelingToolkit = {path = "../.."}
 
 [compat]
 Aqua = "0.8"
+FMIImport = "1"
 JET = "0.9,0.10,0.11"
+OrdinaryDiffEqBDF = "1, 2"
+OrdinaryDiffEqDefault = "1.2, 2"
+OrdinaryDiffEqRosenbrock = "1, 2"
 SafeTestsets = "0.1, 1"
 SciMLTesting = "1, 2.1"
 Test = "1"

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -2,6 +2,29 @@ using ModelingToolkit
 using Aqua
 using JET
 using SciMLTesting
+using Test
+
+# ExplicitImports only sees an extension module once its trigger package is loaded, so
+# every weakdep is loaded here to bring the extensions into the checked module set.
+using FMIImport
+using OrdinaryDiffEqBDF
+using OrdinaryDiffEqDefault
+using OrdinaryDiffEqRosenbrock
+
+const MTK_EXTENSIONS = (
+    :MTKFMIExt,
+    :MTKOrdinaryDiffEqBDFExt,
+    :MTKOrdinaryDiffEqDefaultExt,
+    :MTKOrdinaryDiffEqRosenbrockExt,
+)
+
+# ExplicitImports silently skips an extension that fails to load, so assert the
+# extension modules actually exist rather than trusting a green run_qa.
+@testset "Extensions loaded" begin
+    for ext in MTK_EXTENSIONS
+        @test Base.get_extension(ModelingToolkit, ext) !== nothing
+    end
+end
 
 # Public names that reach ModelingToolkit's API surface only through
 # `@reexport using Symbolics` in ModelingToolkitBase. They are owned (and undocumented) by
@@ -18,11 +41,27 @@ const SYMBOLICS_OWNED_REEXPORTS = (
     :supremum,
 )
 
+# Names the extensions must reach for which no public spelling exists.
+const NONPUBLIC_QUALIFIED_ACCESSES = (
+    # ModelingToolkitBase: the FMI extension's variable metadata helpers.
+    :default_toterm,
+    :setinput,
+    :setoutput,
+    # ModelingToolkit's own stub that MTKFMIExt implements; it is documented API but has
+    # not been declared `public`, and an extension has no way to add a method unqualified.
+    :FMIComponent,
+    # Base: `Base.RefValue` has no public spelling.
+    :RefValue,
+)
+
 run_qa(
     ModelingToolkit;
     Aqua = Aqua,
     JET = JET,
     jet = true,
     jet_kwargs = (; target_defined_modules = true),
+    ei_kwargs = (;
+        all_qualified_accesses_are_public = (; ignore = NONPUBLIC_QUALIFIED_ACCESSES),
+    ),
     api_docs_kwargs = (; ignore = SYMBOLICS_OWNED_REEXPORTS),
 )


### PR DESCRIPTION
**This PR should be ignored until reviewed by @ChrisRackauckas.**

## Why

`SciMLTesting.run_qa` runs ExplicitImports' checks on the package module. ExplicitImports *does* know about extensions — it reads the `[extensions]` table out of `Project.toml` and adds each one to the checked module set — but only if the extension module actually exists:

```julia
ext_mod = Base.get_extension(mod, Symbol(ext))
ext_mod === nothing && continue
```

An extension module only exists once its trigger weakdep is loaded, and the QA environment loaded none of them. Verified on `master` before the change:

```
MTKFMIExt => nothing
MTKOrdinaryDiffEqBDFExt => nothing
MTKOrdinaryDiffEqDefaultExt => nothing
MTKOrdinaryDiffEqRosenbrockExt => nothing
SCANNED: ModelingToolkit
SCANNED: ModelingToolkit.StructuralTransformations
```

So **no ModelingToolkit extension was checked at all**. This was a real gap, not an incidental one — none of the four weakdeps is pulled in transitively by another QA dep.

## What changed

* `test/qa/Project.toml` gains `FMIImport`, `OrdinaryDiffEqBDF`, `OrdinaryDiffEqDefault`, `OrdinaryDiffEqRosenbrock` under `[deps]`, with `[compat]` entries mirroring the root `Project.toml`.
* `test/qa/qa.jl` loads them before `run_qa`, and asserts the four extension modules exist. That assertion is load-bearing: ExplicitImports *silently skips* an extension that fails to load, so without it a future change that breaks an extension's precompilation would make QA go green while coverage silently dropped back to zero.

After the change, all four are scanned:

```
MTKFMIExt => MTKFMIExt
MTKOrdinaryDiffEqBDFExt => MTKOrdinaryDiffEqBDFExt
MTKOrdinaryDiffEqDefaultExt => MTKOrdinaryDiffEqDefaultExt
MTKOrdinaryDiffEqRosenbrockExt => MTKOrdinaryDiffEqRosenbrockExt

SCANNED: MTKOrdinaryDiffEqDefaultExt
SCANNED: ModelingToolkit
SCANNED: MTKOrdinaryDiffEqBDFExt
SCANNED: ModelingToolkit.StructuralTransformations
SCANNED: MTKOrdinaryDiffEqRosenbrockExt
SCANNED: MTKFMIExt
```

## Extension coverage

All four extensions are now scanned; none is left out.

## Findings fixed in extension source (not ignored)

**`no_implicit_imports`**

* `ext/MTKOrdinaryDiffEqBDFExt.jl`: `using OrdinaryDiffEqBDF` → `using OrdinaryDiffEqBDF: FBDF`; `using PrecompileTools` → `using PrecompileTools: @compile_workload, @setup_workload`.
* `ext/MTKOrdinaryDiffEqRosenbrockExt.jl`: same, with `Rodas5P`.
* `ext/MTKOrdinaryDiffEqDefaultExt.jl`: `using PrecompileTools: @compile_workload, @setup_workload`, and `using OrdinaryDiffEqDefault: OrdinaryDiffEqDefault`. The workload calls `solve(prob)` and so uses no name from the package, but the `using` is load-bearing — dropping it entirely makes the workload fail to precompile with `Default algorithm choices require DifferentialEquations.jl`. The explicit form keeps the package loaded without an implicit import, and ExplicitImports does not report it as stale.
* `ext/MTKFMIExt.jl`: `using SymbolicIndexingInterface` → `using SymbolicIndexingInterface: NotSymbolic, symbolic_type`; `using DocStringExtensions` → `using DocStringExtensions: TYPEDEF, TYPEDFIELDS, TYPEDSIGNATURES`.

**`all_qualified_accesses_via_owners`** — `ext/MTKFMIExt.jl` reached four names through `ModelingToolkit` rather than their owners:

* `MTK.setinput`, `MTK.setoutput`, `MTK.default_toterm` → `MTKBase.*` (owner `ModelingToolkitBase`).
* `MTK.unwrap` → `SymbolicUtils.unwrap` (owner `SymbolicUtils`, where the name *is* public).

**`no_stale_explicit_imports`** — `using ModelingToolkit: t_nounits as t, D_nounits as D` was reported stale. This is an ExplicitImports limitation with renaming imports: it records the pre-rename name (`t_nounits`), which never appears in use, and flags it (reproduced standalone with `using Base: sqrt as mysqrt`). Replaced with an import from the owner plus `const` aliases, which is also what the three sibling extensions already do:

```julia
using ModelingToolkitBase: t_nounits, D_nounits
const t = t_nounits
const D = D_nounits
```

## Ignore entries added

One new `ei_kwargs` entry, `all_qualified_accesses_are_public`:

| name | owner | why it cannot be fixed in source |
| --- | --- | --- |
| `default_toterm` | `ModelingToolkitBase` | non-public at its owner; the FMI extension needs it to canonicalise derivative variables |
| `setinput` | `ModelingToolkitBase` | non-public at its owner; used to mark FMU inputs |
| `setoutput` | `ModelingToolkitBase` | non-public at its owner; used to mark FMU outputs |
| `FMIComponent` | `ModelingToolkit` | ModelingToolkit's own stub that `MTKFMIExt` implements. It is documented API (`docs/src/API/model_building.md`, `docs/src/tutorials/fmi.md`) but has never been declared `public`, and an extension has no way to add a method to it unqualified. Declaring it `public` would be the better fix but is a public-API change; left for a follow-up. |
| `RefValue` | `Base` | `Base.RefValue` has no public spelling |

No check was disabled, no `@test_broken` was added.

## Local test results

**`GROUP=QA julia --project=. -e 'using Pkg; Pkg.test()'` on this branch (Julia 1.12.4) — FAILS, exactly as it already fails on `master`:**

```
Test Summary:                                  | Pass  Fail  Error  Total      Time
QA                                             |   16     3      6     25  18m07.2s
  Extensions loaded                            |    4                   4      0.0s
  Quality Assurance                            |   12     3      6     21  17m42.7s
    ...
    Piracy                                     |          1             1      3.3s
    ExplicitImports                            |                 6      6     46.9s
      no_implicit_imports                      |                 1      1     25.3s
      no_stale_explicit_imports                |                 1      1      3.8s
      all_explicit_imports_via_owners          |                 1      1      2.5s
      all_qualified_accesses_via_owners        |                 1      1      4.4s
      all_qualified_accesses_are_public        |                 1      1      5.9s
      all_explicit_imports_are_public          |                 1      1      4.9s
    Public API documentation                   |    2                   2     23.2s
    No unapproved public reexports             |          1             1      0.1s
```

**The same `qa.jl` body on `master` (no weakdeps loaded) — the identical failure profile, minus the new testset:**

```
Test Summary:                                | Pass  Fail  Error  Total      Time
Quality Assurance                            |   12     3      6     21  15m50.5s
```

`master` QA is already red (this matches the `tests / QA (julia 1, ubuntu-latest)` failure on the latest master run, https://github.com/SciML/ModelingToolkit.jl/actions/runs/30691045549): Aqua piracy, JET (29 reports), all six ExplicitImports checks, and the reexport audit fail on `ModelingToolkit` itself. **This PR does not fix any of that, and does not make it worse.** The six ExplicitImports errors carry an *identical* set of 153 findings before and after this change, and no `ext/MTK*` path appears anywhere in the new QA output — i.e. the newly-scanned extensions contribute zero findings.

Also verified directly against the non-throwing ExplicitImports API (the `check_*` functions throw on the first offending module, so the extensions' results are invisible behind ModelingToolkit's own failures): implicit imports, stale imports, non-owner imports/accesses and non-public imports/accesses across all four extension modules come back empty apart from the five ignored names.

**`GROUP=FMI julia --project=. -e 'using Pkg; Pkg.test()'` — passes**, exercising the rewritten `MTKFMIExt`:

```
Testing ModelingToolkit tests passed
EXIT=0
```

Runic was run on every touched file.
