### PR TITLE
Mark ModelingToolkit's ModelingToolkitBase piracies as allowed

### DIFF
--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -3,24 +3,31 @@ Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 FMIImport = "9fcbc62e-52a0-44e9-a616-1359a0008194"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 ModelingToolkit = "961ee093-0014-501f-94e3-6117800e7a78"
+ModelingToolkitBase = "7771a370-6774-4173-bd38-47e70ca0b839"
+ModelingToolkitTearing = "6bb917b9-1269-42b9-9f7c-b0dca72083ab"
 OrdinaryDiffEqBDF = "6ad6398a-0878-4a85-9266-38940aa047c8"
 OrdinaryDiffEqDefault = "50262376-6c5a-4cf5-baba-aaf4f84d72d7"
 OrdinaryDiffEqRosenbrock = "43230ef6-c299-4910-a778-202eb28ce4ce"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
+StateSelection = "64909d44-ed92-46a8-bbd9-f047dfbdc84b"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [sources]
 ModelingToolkit = {path = "../.."}
+ModelingToolkitBase = {path = "../../lib/ModelingToolkitBase"}
 
 [compat]
 Aqua = "0.8"
 FMIImport = "1"
 JET = "0.9,0.10,0.11"
+ModelingToolkitBase = "1.57"
+ModelingToolkitTearing = "1.19.2"
 OrdinaryDiffEqBDF = "1, 2"
 OrdinaryDiffEqDefault = "1.2, 2"
 OrdinaryDiffEqRosenbrock = "1, 2"
 SafeTestsets = "0.1, 1"
 SciMLTesting = "1, 2.1"
+StateSelection = "1.10.5"
 Test = "1"
 julia = "1.10"

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,4 +1,7 @@
 using ModelingToolkit
+using ModelingToolkitBase
+using ModelingToolkitTearing
+using StateSelection
 using Aqua
 using JET
 using SciMLTesting
@@ -54,12 +57,36 @@ const NONPUBLIC_QUALIFIED_ACCESSES = (
     :RefValue,
 )
 
+# ModelingToolkit is the upper half of ModelingToolkitBase: the two are one library split
+# across a monorepo boundary, with the compilation and problem-construction layer living
+# here and dispatching on the system and operator types defined below it. Methods added to
+# those types are extensions of the pair's own API, so Aqua should not count them as piracy.
+const MTKBASE_OWNED_TYPES = (
+    ModelingToolkitBase.Hold,
+    ModelingToolkitBase.Sample,
+    ModelingToolkitBase.SampleTime,
+    ModelingToolkitBase.ShiftIndex,
+    ModelingToolkitBase.System,
+)
+
+# ModelingToolkit is also where the structural-transformation stack is wired to
+# ModelingToolkitBase's hooks, which means forwarding a handful of MTKBase functions to the
+# StateSelection/ModelingToolkitTearing implementations on their own types. `TearingState`
+# is not yet public in ModelingToolkitTearing, so it has to be reached by qualified access.
+const STRUCTURAL_TYPES = (
+    ModelingToolkitTearing.TearingState,
+    StateSelection.DiffGraph,
+)
+
 run_qa(
     ModelingToolkit;
     Aqua = Aqua,
     JET = JET,
     jet = true,
     jet_kwargs = (; target_defined_modules = true),
+    aqua_kwargs = (;
+        piracies = (; treat_as_own = (MTKBASE_OWNED_TYPES..., STRUCTURAL_TYPES...)),
+    ),
     ei_kwargs = (;
         all_qualified_accesses_are_public = (; ignore = NONPUBLIC_QUALIFIED_ACCESSES),
     ),


### PR DESCRIPTION
## Summary

Marks the methods ModelingToolkit defines on ModelingToolkitBase's types as allowed in Aqua's piracy check, taking `Aqua.test_piracies(ModelingToolkit)` from **35 reported methods to zero**.

ModelingToolkit is the upper half of ModelingToolkitBase: the two are one library split across a monorepo boundary, with the compilation and problem-construction layer here dispatching on the system and operator types defined below it. Those methods are extensions of the pair's own API, not piracy.

Passed to Aqua via `treat_as_own`:

- **ModelingToolkitBase types** — `System`, `Sample`, `SampleTime`, `Hold`, `ShiftIndex` (all exported by ModelingToolkitBase). These account for 33 of the 35.
- **Structural types** — `ModelingToolkitTearing.TearingState` and `StateSelection.DiffGraph`, covering the two one-line forwarding shims that wire the structural-transformation stack to ModelingToolkitBase's hooks (`MTKBase.complete(::DiffGraph)` in `src/ModelingToolkit.jl` and `MTKBase.singular_check(::TearingState)` in `src/initialization.jl`).

The change is purely additive: 34 lines across `test/qa/qa.jl` and `test/qa/Project.toml`, no deletions, no existing check weakened or skipped.

## Verification

Run locally on Julia 1.11 in an isolated depot, comparing this branch against its merge base (`b3ff68bf3`):

| Check | master | this branch |
|---|---|---|
| **Aqua: Piracy** | **Fail — 35 methods** | **Pass** |
| Aqua: ambiguity / unbound / exports / extras / stale / compat / persistent | pass | pass |
| ExplicitImports (6 sub-checks) | 6 errors | 6 errors |
| JET | fail | fail |
| Public API documentation | 2 pass | 2 pass |
| No unapproved public reexports | fail | fail |
| **Totals** | 12 Pass / 3 Fail / 6 Error | **13 Pass / 2 Fail / 6 Error** |

Exactly one check changes, in the right direction. Confirmed both by running `test/qa/qa.jl` directly and through the real harness (`GROUP=QA julia --project -e 'using Pkg; Pkg.test()'`), which also exercises the new `test/qa/Project.toml` deps and the `ModelingToolkitBase` `[sources]` entry via `activate_group_env`:

```
  Extensions loaded  |    4                   4
  Quality Assurance  |   13     2      6     21
    Piracy           |    1                   1
```

Runic reports both changed files already formatted.

## Notes

- **The QA job will still be red.** ModelingToolkit's QA lane is already failing on `master` — the 6 ExplicitImports errors, the JET failure and the public-reexports failure all reproduce on an unmodified `master` checkout. This PR does not address those; it only removes the piracy failure from the pile.
- `ModelingToolkitTearing.TearingState` is neither exported nor declared `public` in ModelingToolkitTearing, so it has to be reached by qualified access here. `src/ModelingToolkit.jl` already imports it that way, so this is not a new dependency on a non-public name, but promoting it to public API in ModelingToolkitTearing would be the cleaner fix.
- Split out of #4832, which additionally removes several QA waivers and is blocked on upstream Symbolics/SymbolicUtils public-API work. This piece stands alone.

Please ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ywCW8vbGoc9X3dUbmXyme
