### PR TITLE
Make `varmap_to_vars` public

### DIFF
--- a/lib/ModelingToolkitBase/src/ModelingToolkitBase.jl
+++ b/lib/ModelingToolkitBase/src/ModelingToolkitBase.jl
@@ -401,6 +401,7 @@ const set_scalar_metadata = setmetadata
 @public collect_var_to_name!, collect_vars!, eqtype_supports_collect_vars, hasdefault
 @public getdefault, setdefault, setguess, iscomplete, isparameter, modified_unknowns!
 @public renamespace, namespace_equations
+@public varmap_to_vars
 @public check_mutable_cache, store_to_mutable_cache!, should_invalidate_mutable_cache_entry
 @public convert_bindings_for_time_independent_system, get_w
 @public Both


### PR DESCRIPTION
This function is [documented](https://github.com/SciML/ModelingToolkit.jl/blob/9717d6fcd6a89e60db4a3216718c710d45671599/docs/src/API/problems.md?plain=1#L81) and [explicitely recommended in the FAQ](https://github.com/SciML/ModelingToolkit.jl/blob/9717d6fcd6a89e60db4a3216718c710d45671599/docs/src/basics/FAQ.md?plain=1#L103). In order to properly work with ExplicitImports etc. it should be made public.

