### PR TITLE
Variable Bounds in OrdinaryDiffEq and Logging updates

### DIFF
--- a/lib/ModelingToolkitBase/src/debugging.jl
+++ b/lib/ModelingToolkitBase/src/debugging.jl
@@ -129,6 +129,29 @@ function SciMLBase.diagnose_symbolic_instability(sys::AbstractSystem, u, uprev)
         append!(diagnosis, singularities)
     end
 
+    #check for declared variable-bound violations in the current state
+    bound_violations = String[]
+    for (i, v) in enumerate(unks)
+        hasbounds(v) || continue
+        i <= length(u) || continue
+        val = unwrap(u[i])
+        val isa Number || continue
+        lo, hi = getbounds(v)
+        lo_v, hi_v = unwrap(lo), unwrap(hi)
+        (lo_v isa Number && hi_v isa Number) || continue
+        if val > hi_v
+            push!(bound_violations,
+                "   $v exceeded its upper bound $hi_v by $(@sprintf("%.4g", val - hi_v))")
+        elseif val < lo_v
+            push!(bound_violations,
+                "   $v fell below its lower bound $lo_v by $(@sprintf("%.4g", lo_v - val))")
+        end
+    end
+    if !isempty(bound_violations)
+        push!(diagnosis, "\nDeclared variable bounds violated:")
+        append!(diagnosis, bound_violations)
+    end
+
     return isempty(diagnosis) ? "" : join(diagnosis, "\n")
 end
 

--- a/lib/ModelingToolkitBase/src/systems/problem_utils.jl
+++ b/lib/ModelingToolkitBase/src/systems/problem_utils.jl
@@ -2176,10 +2176,62 @@ function SciMLBase.detect_cycles(sys::AbstractSystem, varmap::Dict{Any, Any}, va
     return !isempty(cycles)
 end
 
+"""
+    build_bounds_isoutofdomain(sys)
+
+Compile the `bounds` metadata of `sys`'s unknowns into an `isoutofdomain`-style
+predicate `(u, p, t) -> Bool` that returns `true` when any bounded unknown leaves
+its `[lo, hi]` range in the proposed state `u`. Returns `nothing` if no enforceable
+bounds are found.
+
+A variable's bound is enforceable here only if the variable is an actual unknown in
+the state vector (so it has an index in `u`) and its bounds are concrete numbers.
+Bounds on eliminated (observed) variables, and symbolic bounds that reference
+parameters, are skipped with a warning.
+
+This is used to enforce `@variables x [bounds = (lo, hi)]` during ODE integration by
+injecting the predicate as the problem's `isoutofdomain`; see `process_kwargs`.
+"""
+function build_bounds_isoutofdomain(sys)
+    idxs = Int[]
+    los = Any[]
+    his = Any[]
+    for v in unknowns(sys)
+        hasbounds(v) || continue
+        idx = variable_index(sys, v)
+        if idx === nothing
+            @warn "Variable $v declares `bounds` but was eliminated (observed) during simplification, so it is not in the state vector and its bounds cannot be enforced via isoutofdomain. Skipping."
+            continue
+        end
+        lo, hi = getbounds(v)
+        lo_v, hi_v = unwrap(lo), unwrap(hi)
+        if !(lo_v isa Number && hi_v isa Number)
+            @warn "Variable $v has symbolic bounds ($lo, $hi); enforcing symbolic bounds directly in integration is not yet supported. Skipping."
+            continue
+        end
+        push!(idxs, idx)
+        push!(los, lo_v)
+        push!(his, hi_v)
+    end
+    isempty(idxs) && return nothing
+    # freeze into tuples so the returned closure is type-stable.
+    idxs_t = Tuple(idxs)
+    los_t = Tuple(los)
+    his_t = Tuple(his)
+    return function (u, p, t)
+        for k in eachindex(idxs_t)
+            i = idxs_t[k]
+            (u[i] < los_t[k] || u[i] > his_t[k]) && return true
+        end
+        return false
+    end
+end
+
 function process_kwargs(
         sys::System; expression = Val{false}, callback = nothing,
         eval_expression = false, eval_module = @__MODULE__,
-        _skip_events = false, _skip_tstops = false, tspan = nothing, kwargs...
+        _skip_events = false, _skip_tstops = false, tspan = nothing,
+        enforce_bounds = false, kwargs...
     )
     kwargs = filter_kwargs(kwargs)
     kwargs1 = (;)
@@ -2200,6 +2252,14 @@ function process_kwargs(
             )
             if tstops !== nothing
                 kwargs1 = merge(kwargs1, (; tstops))
+            end
+        end
+
+        # opt-in: compile variable `bounds` metadata into an isoutofdomain predicate.
+        if enforce_bounds && expression == Val{false}
+            iood = build_bounds_isoutofdomain(sys)
+            if iood !== nothing
+                kwargs1 = merge(kwargs1, (isoutofdomain = iood,))
             end
         end
     end


### PR DESCRIPTION
Hooks MTK's variable bounds into OrdinaryDiffEq's isoutofdomain and reports any variable bound failures in the logging messages.

Example result:
```julia
@variables x(t) [bounds = (0.0, 10.0)]
@variables y(t) [bounds = (-1.0, 5.0)]
@mtkbuild sys = ODESystem([D(x) ~ 1.0, D(y) ~ -1.0], t)
prob = ODEProblem(sys, [x => 0.0, y => 0.0], (0.0, 3.0); enforce_bounds = true) #new kwarg
sol = solve(prob, Tsit5())

┌ Warning: Verbosity toggle: dt_epsilon 
│  At t=1.0, dt was forced below floating point epsilon 2.220446049250313e-16. Aborting. There is either an error in your model specification or the true solution is unstable (or it cannot be represented in Float64 precision).
│ 
│ Diagnostics:
│ 
│ Is Out of Domain: Gates results of integrator steps:
│   isoutofdomain predicate returned true for the proposed state, causing failure of the step
│ 
│ Declared variable bounds violated:
│    y(t) fell below its lower bound -1.0 by 2.22e-16
└ @ SciMLBase ~/Documents/GitHub/SciMLBase.jl/src/integrator_interface.jl:1015

```