### PR TITLE
ci: revert the env: blocks that invalidated Tests.yml and SublibraryCI.yml

### DIFF
--- a/.github/workflows/SublibraryCI.yml
+++ b/.github/workflows/SublibraryCI.yml
@@ -24,6 +24,4 @@ jobs:
     uses: "SciML/.github/.github/workflows/sublibrary-project-tests.yml@v1"
     with:
       check-bounds: auto
-    env:
-      JULIA_PKG_PRECOMPILE_AUTO: "0"
     secrets: "inherit"

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -27,6 +27,4 @@ jobs:
     with:
       coverage-directories: "src,ext,lib/ModelingToolkitBase/src,lib/ModelingToolkitBase/ext"
       cache: false
-    env:
-      JULIA_PKG_PRECOMPILE_AUTO: "0"
     secrets: "inherit"


### PR DESCRIPTION
> [!NOTE]
> Draft — please ignore until reviewed by @ChrisRackauckas.

Targets `as/fix-ci` (#4867), not `master`. I don't have push access to that branch, hence a PR into it.

## Problem

`0d3a55fde` ("ci: disable eager precompilation in test jobs") adds an `env:` map to the two jobs that call reusable workflows with `uses:`. GitHub's schema doesn't allow that key there, and the failure mode is not "the env is ignored" — the entire workflow file becomes invalid and **no jobs are created**:

```
$ actionlint .github/workflows/Tests.yml .github/workflows/SublibraryCI.yml
.github/workflows/Tests.yml:30:5: when a reusable workflow is called with "uses", "env" is not available.
  only following keys are allowed: "name", "uses", "with", "secrets", "needs", "if", and "permissions" in job "tests" [syntax-check]
.github/workflows/SublibraryCI.yml:27:5: ... in job "sublibrary-ci" [syntax-check]
exit=1
```

That's why #4867 currently has no `Tests` and no `Sublibrary CI` checks. The runs exist but are listed by file path with zero jobs:

```
$ gh api "repos/SciML/ModelingToolkit.jl/actions/runs?head_sha=40379c7e3..."
.github/workflows/SublibraryCI.yml   failure   push
.github/workflows/Tests.yml          failure   push

$ gh run view 30901431064
X This run likely failed because of a workflow file issue.
```

Worth stating explicitly, since it came up as the suspected cause: **this is not a path-filtering problem.** Sublibrary test-only changes do select the sublibrary — `compute_affected_sublibraries.jl` puts any `lib/<pkg>/**` change into the `direct` set (only reverse-dep *propagation* is gated on `src/`/`Project.toml`), and the root `grouped-tests.yml` matrix isn't diff-filtered at all:

```
$ echo "lib/ModelingToolkitBase/test/symbolic_events.jl" | \
    julia .sciml-dotgithub/scripts/compute_affected_sublibraries.jl . --projects-matrix
```
→ 25 cells, the full `lib/ModelingToolkitBase` group × version expansion. And #4843, which touched only `lib/ModelingToolkitBase/test/bvproblem.jl`, ran both `Tests` and `Sublibrary CI`.

## Change

Revert the two `env:` blocks. Both files are byte-identical to `master` again and lint clean:

```
$ actionlint .github/workflows/*.yml
exit=0
```

The rest of #4867 (the BVP group split, the tolerance updates) is untouched.

## Getting the precompile setting back

It has to be an input on the reusable workflows. SciML/.github#125 adds `auto-precompile` to `tests.yml` (job-level, so it covers `julia-buildpkg` too) and forwards it from `grouped-tests.yml` and all four `sublibrary-project-tests.yml` shards. Once that merges and `v1` is retagged, these two callers become:

```yaml
    with:
      check-bounds: auto
      auto-precompile: false
```

Note `v1` only moves when a `vX.Y.Z` release tag is pushed, so that second step has to wait for a release cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0172My4BE5TgvJmuYxkBuvxU
