### PR TITLE
Bump 2 package versions for release

### DIFF
--- a/lib/ModelingToolkitBase/Project.toml
+++ b/lib/ModelingToolkitBase/Project.toml
@@ -1,7 +1,7 @@
 name = "ModelingToolkitBase"
 uuid = "7771a370-6774-4173-bd38-47e70ca0b839"
 authors = ["Yingbo Ma <mayingbo5@gmail.com>", "Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
-version = "1.59.0"
+version = "1.60.0"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/lib/SciCompDSL/Project.toml
+++ b/lib/SciCompDSL/Project.toml
@@ -1,7 +1,7 @@
 name = "SciCompDSL"
 uuid = "91a8cdf1-4ca6-467b-a780-87fda3fff15e"
 authors = ["Aayush Sabharwal <aayush.sabharwal@gmail.com>"]
-version = "1.0.1"
+version = "1.0.2"
 
 [deps]
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"


### PR DESCRIPTION
        These packages have unreleased changes to `src`, `ext`, or `Project.toml` relative to the
        tree recorded in the General registry for their current version, but the version was never
        bumped — so the changes cannot be released.

        | package | from | to | kind | why |
        |---|---|---|---|---|
        | `ModelingToolkitBase` | 1.59.0 | **1.60.0** | minor | makes varmap_to_vars public API |
| `SciCompDSL` | 1.0.1 | **1.0.2** | patch | unreleased changes to `src`/`ext`/`Project.toml` since the registered tree |

        ### How the versions were chosen

        Patch by default. A package was promoted to a **minor** bump only where it gained public API
        or a user-facing capability. For `0.y.z` packages the non-breaking slot is `z`, so those stay
        in the patch position regardless of what they added.

        No package in this PR needs a major bump: comparing the exported/`@public` name sets between
        each package's released commit and master, **no name that the package itself defines was
        removed**. The removals that do appear are blanket reexports of names owned by other packages
        (e.g. `BVPJacobianAlgorithm` and `integral`, which belong to `BoundaryValueDiffEqCore`), which
        SciML does not treat as documented public API.

        Registration follows once this merges.

        ---

        Found by a `/sciml-release-sweep` pass over the org. **Please ignore until reviewed by @ChrisRackauckas.**
