### PR TITLE
fix: consider `affect_neg` when figuring out when to save discretes

### DIFF
--- a/lib/ModelingToolkitBase/src/systems/index_cache.jl
+++ b/lib/ModelingToolkitBase/src/systems/index_cache.jl
@@ -431,11 +431,19 @@ end
 function parse_callbacks_for_discretes!(sys::AbstractSystem, events::Vector, disc_param_callbacks::Dict{SymbolicT, BitSet}, constant_buffers::Dict{TypeT, Set{SymbolicT}}, nonnumeric_buffers::Dict{TypeT, Set{SymbolicT}}, offset::Int)
     for (i, event) in enumerate(events)
         discs = Set{SymbolicParam}()
-        affect = event.affect::Union{AffectSystem, ImperativeAffect, Nothing}
-        if affect isa AffectSystem || affect isa ImperativeAffect
-            union!(discs, discretes(affect))
-        elseif affect === nothing
-            continue
+        affects = Union{AffectSystem, ImperativeAffect, Nothing}[]
+        if event isa SymbolicContinuousCallback
+            push!(affects, event.affect)
+            push!(affects, event.affect_neg)
+        else
+            push!(affects, event.affect)
+        end
+        for affect in affects
+            if affect isa AffectSystem || affect isa ImperativeAffect
+                union!(discs, discretes(affect))
+            elseif affect === nothing
+                continue
+            end
         end
 
         for sym in discs

--- a/lib/ModelingToolkitBase/test/symbolic_events.jl
+++ b/lib/ModelingToolkitBase/test/symbolic_events.jl
@@ -7,6 +7,7 @@ using ModelingToolkitBase: SymbolicContinuousCallback,
     D_nounits as D,
     affects, affect_negs, system, observed, AffectSystem
 import DiffEqNoiseProcess
+using Symbolics
 
 using StableRNGs
 import SciMLBase
@@ -1939,5 +1940,27 @@ if !@isdefined(ModelingToolkit)
             @test sol.discretes[1].t ≈ 0.05:0.1:1.0
             @test sol[d] ≈ 1:10
         end
+    end
+
+    vlk(v, i) = v[clamp(round(Int, i), 1, length(v))]
+    @register_symbolic vlk(v::AbstractVector, i::Real)
+
+    @testset "Issue#4870: Negative-edge affects are properly saved" begin
+        # Case 1 of the issue
+        gi = only(@discretes gi(t) = 1.0)
+        ps = @parameters begin
+            (up[1:3] = [1.0, 2.0, 1.0e6])
+            (dn[1:3] = [-1.0e6, 0.5, 1.5])
+        end
+        upv, dnv = ps
+        @variables y(t) = 0.0
+        eqs = [D(y) ~ ifelse(t < 6, 0.5, -0.5)]   # triangle: 0 -> 3 -> 0
+
+        cbu = SymbolicContinuousCallback([y ~ vlk(upv, gi)], [gi => min(gi + 1, 3)]; affect_neg = nothing)
+        cbd = SymbolicContinuousCallback([y ~ vlk(dnv, gi)], nothing; affect_neg = [gi => max(gi - 1, 1)])
+        @named sys = System(eqs, t, [y], [collect(Iterators.flatten(ps)); gi]; continuous_events = [cbu, cbd])
+        s = mtkcompile(sys)
+        sol = solve(ODEProblem(s, [], (0.0, 12.0)), Tsit5())
+        @test sol[gi] ≈ [1, 2, 3, 2, 1]
     end
 end


### PR DESCRIPTION
We don't consider `affect_neg` when building `IndexCache`, leading to negative-edge affects being ignored when it comes to saving.