### PR TITLE
fix: make the JET QA lane pass (include paths + 9 uncovered findings)

### DIFF
--- a/src/ModelingToolkit.jl
+++ b/src/ModelingToolkit.jl
@@ -130,28 +130,29 @@ using ModelingToolkitBase: COMMON_SENTINEL, COMMON_NOTHING, COMMON_MISSING,
 using ModelingToolkitBase: build_function_wrapper, BuildFunctionWrapperOptions,
     GeneratedFunctionOptions
 
-@recompile_invalidations begin
-    include("linearization.jl")
-    include("systems/analysis_points.jl")
-    include("systems/solver_nlprob.jl")
+# `@recompile_invalidations` evaluates its body through `Core.eval` at run time, which
+# hides these files from static analyzers and resolves the relative paths against the
+# caller's source directory rather than `src/`. Keep the includes at real top level.
+include("linearization.jl")
+include("systems/analysis_points.jl")
+include("systems/solver_nlprob.jl")
 
-    include("problems/docs.jl")
-    include("systems/codegen.jl")
-    include("systems/codegen_compat.jl")
-    include("problems/semilinearodeproblem.jl")
-    include("problems/sccnonlinearproblem.jl")
+include("problems/docs.jl")
+include("systems/codegen.jl")
+include("systems/codegen_compat.jl")
+include("problems/semilinearodeproblem.jl")
+include("problems/sccnonlinearproblem.jl")
 
-    include("discretedomain.jl")
-    include("systems/systemstructure.jl")
-    include("initialization.jl")
-    include("systems/systems.jl")
-    include("systems/clock_inference.jl")
-    include("systems/if_lifting.jl")
-    include("systems/substitute_component.jl")
+include("discretedomain.jl")
+include("systems/systemstructure.jl")
+include("initialization.jl")
+include("systems/systems.jl")
+include("systems/clock_inference.jl")
+include("systems/if_lifting.jl")
+include("systems/substitute_component.jl")
 
-    include("systems/alias_elimination.jl")
-    include("structural_transformation/StructuralTransformations.jl")
-end
+include("systems/alias_elimination.jl")
+include("structural_transformation/StructuralTransformations.jl")
 
 @reexport using .StructuralTransformations
 

--- a/src/linearization.jl
+++ b/src/linearization.jl
@@ -747,7 +747,7 @@ function linearize_symbolic(
     h = build_explicit_observed_function(
         sys, outputs,
         GeneratedFunctionOptions(; expression = Val{false}, eval_expression, eval_module)
-    )
+    )::GeneratedFunctionWrapper
     if split
         dx = fun(sts, p, t)
         y = h(sts, p, t)

--- a/src/problems/sccnonlinearproblem.jl
+++ b/src/problems/sccnonlinearproblem.jl
@@ -752,10 +752,11 @@ function SciMLBase.SCCNonlinearProblem{iip}(
 
     new_dvs = dvs[reduce(vcat, decomposition.var_sccs)]
     new_eqs = eqs[reduce(vcat, decomposition.eq_sccs)]
+    ic = get_index_cache(sys)
+    new_ic = ic === nothing ? nothing :
+        subset_unknowns_observed(ic, sys, new_dvs, SymbolicT[])
     sys = ConstructionBase.setproperties(
-        sys; unknowns = new_dvs, eqs = new_eqs, index_cache = subset_unknowns_observed(
-            get_index_cache(sys), sys, new_dvs, SymbolicT[]
-        )
+        sys; unknowns = new_dvs, eqs = new_eqs, index_cache = new_ic
     )
 
     if length(subprobs) <= 5
@@ -777,7 +778,8 @@ function calculate_op_from_u0_p(sys::System, u0::Union{Nothing, AbstractVector},
     @assert length(rps) == length(p)
 
     for (i, pvars) in enumerate(rps)
-        for (var, val) in zip(pvars, p[i])
+        # `reorder_parameters` flattens by default, so every buffer is a flat variable list.
+        for (var, val) in zip(pvars::Vector{SymbolicT}, p[i])
             write_possibly_indexed_array!(op, var, Symbolics.SConst(val), COMMON_NOTHING)
         end
     end

--- a/src/structural_transformation/pantelides.jl
+++ b/src/structural_transformation/pantelides.jl
@@ -23,7 +23,7 @@ function pantelides_reassemble(state::TearingState, var_eq_matching)
     fill!(out_vars, ModelingToolkit.COMMON_NOTHING)
     out_vars[1:length(fullvars)] .= fullvars
 
-    iv = get_iv(sys)
+    iv = get_iv(sys)::SymbolicT
     D = Differential(iv)
 
     for (varidx, diff) in edges(var_to_diff)

--- a/src/systems/alias_elimination.jl
+++ b/src/systems/alias_elimination.jl
@@ -706,7 +706,9 @@ function eliminate_zero_variables!(state::TearingState, mm::CLIL.SparseMatrixCLI
         all_int_vars, resid = StateSelection.find_eq_solvables!(state, e, to_rm, coeffs; allow_symbolic, allow_parameter)
         if all_int_vars && SU._iszero(resid)
             push!(mm.nzrows, e)
-            push!(mm.row_cols, copy(𝑠neighbors(state.structure.solvable_graph, e)))
+            # `find_eq_solvables!` writes into `solvable_graph`, so it is populated here.
+            solvable_graph = state.structure.solvable_graph::BipartiteGraph
+            push!(mm.row_cols, copy(𝑠neighbors(solvable_graph, e)))
             push!(mm.row_vals, copy(coeffs))
         end
     end

--- a/src/systems/if_lifting.jl
+++ b/src/systems/if_lifting.jl
@@ -336,7 +336,9 @@ function generate_condition(cw::CondRewriter, sym)
     # the solvers don't treat the transition from a number to NaN or back as a zero-crossing,
     # so it can be used to effectively disable the affect when the condition is not meant to
     # be evaluated.
-    return ifelse(dep, zero_crossing, NaN) ~ 0
+    # `Equation` rather than `~`: the zero-crossing is always a scalar, and `~` widens to
+    # `Union{Equation, Vector{Equation}}` because of its complex-valued methods.
+    return Equation(ifelse(dep, zero_crossing, NaN), 0)
 end
 
 """

--- a/src/systems/systemstructure.jl
+++ b/src/systems/systemstructure.jl
@@ -309,6 +309,17 @@ struct DifferentiatedVariableNotUnknownError <: Exception
     undifferentiated::Any
 end
 
+"""
+    $TYPEDSIGNATURES
+
+Return how many levels above the current system a variable with the given `scope` becomes
+an unknown. `GlobalScope` returns `-1`, matching the sentinel used by
+[`ModelingToolkitBase.check_scope_depth`](@ref).
+"""
+expected_scope_depth(::LocalScope) = 0
+expected_scope_depth(::GlobalScope) = -1
+expected_scope_depth(scope::ParentScope) = expected_scope_depth(scope.parent)::Int + 1
+
 function Base.showerror(io::IO, err::DifferentiatedVariableNotUnknownError)
     undiff = err.undifferentiated
     diff = err.differentiated
@@ -316,7 +327,7 @@ function Base.showerror(io::IO, err::DifferentiatedVariableNotUnknownError)
         io,
         "Variable $undiff occurs differentiated as $diff but is not an unknown of the system."
     )
-    scope = getmetadata(undiff, SymScope, LocalScope())
+    scope = getmetadata(undiff, SymScope, LocalScope())::AllScopes
     depth = expected_scope_depth(scope)
     return if depth > 0
         print(

--- a/test/structural_transformation/utils.jl
+++ b/test/structural_transformation/utils.jl
@@ -431,3 +431,21 @@ end
     @named sys = System([D(x) ~ x], t)
     @test_deprecated structural_simplify(sys)
 end
+
+@testset "`DifferentiatedVariableNotUnknownError` message" begin
+    @variables q(t)
+    uq = unwrap(q)
+    err = ModelingToolkit.DifferentiatedVariableNotUnknownError(unwrap(D(q)), uq)
+    @test sprint(showerror, err) ==
+        "Variable $uq occurs differentiated as $(unwrap(D(q))) but is not an unknown of the system."
+
+    scoped = unwrap(ModelingToolkit.ParentScope(ModelingToolkit.ParentScope(q)))
+    err = ModelingToolkit.DifferentiatedVariableNotUnknownError(unwrap(D(scoped)), scoped)
+    @test occursin("expects 2 more levels in the hierarchy", sprint(showerror, err))
+
+    @test ModelingToolkit.expected_scope_depth(ModelingToolkit.LocalScope()) == 0
+    @test ModelingToolkit.expected_scope_depth(ModelingToolkit.GlobalScope()) == -1
+    @test ModelingToolkit.expected_scope_depth(
+        ModelingToolkit.ParentScope(ModelingToolkit.LocalScope())
+    ) == 1
+end


### PR DESCRIPTION
> **Ignore until reviewed by @ChrisRackauckas.** Opened as a draft; do not merge on the strength of the description alone.

## What was broken

`GROUP=QA` fails in the JET check, and it failed with *toplevel load errors* rather than type errors:

```
Quality Assurance: JET-test failed at .../JET/src/JETBase.jl:1046
  Expression: (JET.report_package)(ModelingToolkit; toplevel_logger = nothing, target_defined_modules = true)
  ═════ 3 toplevel errors found ═════
  ┌ @ src/ModelingToolkit.jl:133
  │ SystemError: opening file ".../test/qa/linearization.jl": No such file or directory
  │  [1] include(mod::Module, _path::String)
  │  [5] recompile_invalidations(__module__::Module, expr::Any) @ PrecompileTools
  ┌ @ src/ModelingToolkit.jl:156
  │ UndefVarError: `StructuralTransformations` not defined in `ModelingToolkit`     (x2)
```

## Root cause

`PrecompileTools.@recompile_invalidations` does **not** splice its body into the enclosing
scope. It expands to

```julia
:(recompile_invalidations($__module__, $(QuoteNode(expr))))
```

i.e. an ordinary *runtime* function call whose body runs through `Core.eval(__module__, expr)`.
So everything inside the block stops being lexically top level:

* `Base.include(mod, "linearization.jl")` resolves the relative path against the *caller's*
  `SOURCE_PATH` (there is no active include stack), not against `src/`. Under `Pkg.test()`
  that is `test/qa/`, hence the `SystemError`.
* Static analyzers cannot see through `Core.eval`, so JET's `handle_include` (which resolves
  includes against `dirname` of the analyzed file) is never reached.
* The failed include leaves the `StructuralTransformations` submodule undefined, so the
  `@reexport using .StructuralTransformations` on the next line throws too.

Minimal reproduction, no ModelingToolkit involved — a 6-line package:

```julia
module JetMini
using PrecompileTools
@recompile_invalidations begin
    include("helper.jl")
end
end
```

```
julia> JET.report_package(JetMini; target_defined_modules=true)
═════ 1 toplevel error found ═════
┌ @ .../JetMini/src/JetMini.jl:3
│ SystemError: opening file ".../<cwd>/helper.jl": No such file or directory
│  [5] recompile_invalidations(__module__::Module, expr::Any) @ PrecompileTools
```

Removing the `@recompile_invalidations` wrapper makes it report `No errors detected`.

A package's own `include` paths must not depend on who loads it, so the first commit hoists
the include block back out of the macro. The three `@recompile_invalidations` blocks that
wrap `using`/`import` statements are untouched — only the block wrapping `include`s is
moved, and `lib/ModelingToolkitBase` already only wraps `using`/`import`.

## What that uncovered

With the module body analyzable again, `JET.test_package(ModelingToolkit; target_defined_modules = true)`
reports 9 errors that the load failure had been masking. The second commit fixes all of them:

1. **Genuine bug.** `Base.showerror(::IO, ::DifferentiatedVariableNotUnknownError)` calls
   `expected_scope_depth`, which has never been defined anywhere (introduced undefined in
   811196b16). Printing the error threw `UndefVarError`. Now defined next to the error type,
   mirroring `check_scope_depth`'s `-1` sentinel for `GlobalScope`, with a unit test.
2. `src/systems/alias_elimination.jl` — `𝑠neighbors(state.structure.solvable_graph, e)` on a
   `Union{Nothing, BipartiteGraph}`. `find_eq_solvables!` on the previous line writes into that
   graph, so it is populated; assert it.
3. `src/structural_transformation/pantelides.jl` — `Differential(get_iv(sys))` where `get_iv`
   is `Union{Nothing, SymbolicT}`. Same `::SymbolicT` assertion `alias_elimination.jl` already uses.
4. `src/linearization.jl` — `build_explicit_observed_function(...)` is
   `Union{Expr, GeneratedFunctionWrapper}`; with `expression = Val{false}` it is always the
   wrapper.
5. `src/problems/sccnonlinearproblem.jl` — `subset_unknowns_observed(get_index_cache(sys), ...)`
   with a possibly-`nothing` cache. Handled the way the sibling code at line 123 already does.
6. `src/problems/sccnonlinearproblem.jl` — `pvars` from `reorder_parameters(sys)` is
   `Union{Vector{SymbolicT}, Vector{Vector{SymbolicT}}}`; the nested form only occurs with
   `flatten = false`, which this call does not use.
7. `src/systems/if_lifting.jl` — `x ~ 0` is `Union{Equation, Vector{Equation}}` because of
   `Base.:~`'s complex-valued methods; the zero-crossing is always scalar, so build the
   `Equation` directly.

Nothing was disabled or narrowed: `jet = true`, `jet_broken` stays `false`, and `jet_kwargs`
is unchanged (`target_defined_modules = true`, i.e. JET's default `mode = :basic`).

## Verified locally

Julia 1.11.9, reproducing the QA lane's environment stacking (`test/qa` env with
`lib/ModelingToolkitBase` and the repo root as parent environments):

| | `report_package` result |
|---|---|
| `origin/master` (32a955af2) | `═════ 3 toplevel errors found ═════` (exactly the CI failure) |
| after commit 1 | `═════ 9 possible errors found ═════` |
| after commit 2 | `No errors detected` |

## Upstream

The underlying macro behaviour is a PrecompileTools issue: `@recompile_invalidations` cannot
be used around `include`/`using` in a package without breaking every static analyzer, and it
silently changes relative-include resolution. Worth reporting to
JuliaLang/PrecompileTools.jl — the macro could emit an `Expr(:toplevel, ...)` so its body
stays lexically top level (JET already handles macros that expand to `:toplevel`). Not filed
here; flagging for @ChrisRackauckas to decide.

Note: `@recompile_invalidations` around the include block was added in 49115cbf6
("refactor: improve precompilation of MTKBase, MTK"). Dropping it means invalidations caused
by ModelingToolkit's own method definitions are no longer force-recompiled during
precompilation. The invalidation-heavy part — loading `Symbolics`, `DiffEqBase`,
`SciMLBase`, `StateSelection` — is still wrapped. I did not measure the TTFX delta (the
machine was too loaded for a meaningful timing), so that is worth a look before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ywCW8vbGoc9X3dUbmXyme
