### PR TITLE
fix: pin the unassigned type parameter of the observed dependency graph

### DIFF
--- a/lib/ModelingToolkitBase/src/utils.jl
+++ b/lib/ModelingToolkitBase/src/utils.jl
@@ -1202,13 +1202,26 @@ function is_numeric_symtype(T::Type)
 end
 
 """
+The concrete type of the graph returned by [`observed_dependency_graph`](@ref).
+"""
+const ObservedDependencyGraphT = DiCMOBiGraph{
+    false, Int, BipartiteGraph{Int, Nothing},
+    Matching{Unassigned, Vector{Union{Unassigned, Int}}},
+}
+
+"""
     $(TYPEDSIGNATURES)
 
 Return the `DiCMOBiGraph` denoting the dependencies between observed equations `eqs`.
 """
-function observed_dependency_graph(sys::AbstractSystem, eqs::Vector{Equation})
+function observed_dependency_graph(
+        sys::AbstractSystem, eqs::Vector{Equation}
+    )::ObservedDependencyGraphT
     graph, assigns = observed2graph(sys, eqs, getproperty.(eqs, (:lhs,)))
-    matching = complete(Matching(Vector{Union{Unassigned, Int}}(assigns)))
+    # The unassigned type parameter is given explicitly instead of letting `Matching`
+    # infer it from the eltype, since that inference is not part of a stable contract
+    # and has differed between `BipartiteGraphs` versions.
+    matching = complete(Matching{Unassigned}(Vector{Union{Unassigned, Int}}(assigns)))
     return DiCMOBiGraph{false}(graph, matching)
 end
 
@@ -1219,10 +1232,7 @@ function should_invalidate_mutable_cache_entry(::Type{ObservedGraphCacheKey}, pa
 end
 
 struct ObservedGraphCache
-    graph::DiCMOBiGraph{
-        false, Int, BipartiteGraph{Int, Nothing},
-        Matching{Unassigned, Vector{Union{Unassigned, Int}}},
-    }
+    graph::ObservedDependencyGraphT
     obsvar_to_idx::Dict{Any, Int}
 end
 

--- a/lib/ModelingToolkitBase/test/code_generation.jl
+++ b/lib/ModelingToolkitBase/test/code_generation.jl
@@ -158,3 +158,14 @@ end
     @mtkcomplete sys = System([D(y) ~ 2y + sum(x)], t, [y], []; observed = [x ~ [y, y + 1, y + 2]])
     @test ModelingToolkitBase.observed_equations_used_by(sys, [x[1]]) == [1]
 end
+
+@testset "`observed_dependency_graph` result is cacheable" begin
+    @variables x(t) y(t) z(t)
+    @mtkcompile sys = System([D(x) ~ z, y ~ 2x + 1, z ~ 3y], t)
+    obs = ModelingToolkitBase.observed(sys)
+    graph = ModelingToolkitBase.observed_dependency_graph(sys, obs)
+    @test graph isa fieldtype(ModelingToolkitBase.ObservedGraphCache, :graph)
+    # this populates the observed graph cache, which requires the above type to match
+    @test ModelingToolkitBase.observed_equations_used_by(sys, [equations(sys)[1].rhs]) ==
+        [1, 2]
+end


### PR DESCRIPTION
**This PR should be ignored until reviewed by @ChrisRackauckas.**

## The failure

On unmodified `master`, `GROUP=InterfaceI` errors:

```
Non-`Real` symtype parameters in callback with unknown: Error During Test at
  lib/ModelingToolkitBase/test/symbolic_events.jl:1643
  Got exception outside of a @test
  MethodError: Cannot `convert` an object of type
    DiCMOBiGraph{false,Int64,BipartiteGraph{Int64,Nothing},Matching{Union{Unassigned, Int64},Array{Union{Unassigned, Int64},1}}}
  to an object of type
    DiCMOBiGraph{false,Int64,BipartiteGraph{Int64,Nothing},Matching{Unassigned,Array{Union{Unassigned, Int64},1}}}
  Stacktrace:
   [1] ModelingToolkitBase.ObservedGraphCache(...)
     @ ModelingToolkitBase lib/ModelingToolkitBase/src/utils.jl:1222
   [2] observed_equations_used_by(...)
     @ ModelingToolkitBase lib/ModelingToolkitBase/src/utils.jl:1268
   [3] generate_rhs(...)
     @ ModelingToolkitBase lib/ModelingToolkitBase/src/systems/codegen.jl:73
```

## Root cause

`observed_dependency_graph` builds its matching as

```julia
matching = complete(Matching(Vector{Union{Unassigned, Int}}(assigns)))
```

and relies on `Matching(v)` inferring `Unassigned` as the unassigned type parameter, because `ObservedGraphCache` declares its `graph` field with the fully concrete type `DiCMOBiGraph{false, Int, BipartiteGraph{Int, Nothing}, Matching{Unassigned, Vector{Union{Unassigned, Int}}}}`.

BipartiteGraphs v0.1.11 (registered 2026-08-04) changed that inference. Verified locally on two pinned environments:

```julia
complete(Matching(Vector{Union{Unassigned, Int}}([1, 2, 3]))) |> typeof
# v0.1.10 -> Matching{Unassigned, Vector{Union{Unassigned, Int64}}}
# v0.1.11 -> Matching{Union{Unassigned, Int64}, Vector{Union{Unassigned, Int64}}}
```

The change comes from https://github.com/SciML/BipartiteGraphs.jl/commit/e5bc59169ccfa7316ab6bb0aafce36544ae0567f, which replaced

```julia
function Matching(v::V) where {U, V <: AbstractVector{Union{U, Int}}}
    return Matching{@isdefined(U) ? U : Unassigned, V}(v, nothing)
end
```

with a version that uses the whole eltype as `U`. There is no `convert` between the two `DiCMOBiGraph` types, so populating `ObservedGraphCache` throws. Nothing in ModelingToolkit changed — the repo's `Manifest.toml` is untracked, so the regression appeared purely from the dependency resolving to v0.1.11. Tracked upstream as https://github.com/SciML/BipartiteGraphs.jl/issues/54.

## The fix

Construct `Matching{Unassigned}` explicitly instead of depending on inference that is not part of a stable contract, and share the concrete graph type between `observed_dependency_graph` and the `ObservedGraphCache` field so the two cannot drift apart again. This works against both v0.1.10 and v0.1.11, so no compat bound change is needed.

## Reproduction and verification

Minimal reproduction of the underlying bug (fails on `master`, passes here):

```julia
using ModelingToolkit
using ModelingToolkit: t_nounits as t, D_nounits as D
import ModelingToolkitBase as MTKB
@variables x(t) y(t)
@parameters p
@mtkcompile sys = System([D(x) ~ -x + y, y ~ 2x + p], t)
MTKB.observed_equations_used_by(sys, [equations(sys)[1].rhs])
```

Runs performed locally (Julia 1.11.9, BipartiteGraphs v0.1.11):

* `lib/ModelingToolkitBase/test/symbolic_events.jl` without this patch — errors at the `Non-`Real` symtype parameters in callback with unknown` testset, exactly as CI does.
* `lib/ModelingToolkitBase/test/symbolic_events.jl` with this patch — whole file passes, including that testset.
* `lib/ModelingToolkitBase/test/code_generation.jl` with this patch — passes, including the new regression testset.

Note that `code_generation.jl` (group `InterfaceII`) hits the same code path, so that group is affected too.

## Regression test

`code_generation.jl` gets a testset asserting that `observed_dependency_graph`'s result is assignable to the `ObservedGraphCache` graph field and that populating the cache via `observed_equations_used_by` does not throw.
