### PR TITLE
Fix the BVP parameter estimation OOM in MTKBase tests

### DIFF
--- a/lib/ModelingToolkitBase/test/bvproblem.jl
+++ b/lib/ModelingToolkitBase/test/bvproblem.jl
@@ -394,12 +394,10 @@ end
     sys′ = subset_tunables(sys, [γ, α])
 
     bprob = BVProblem(sys′, u0map, tspan; tune_parameters = true)
-    if @isdefined(ModelingToolkit)
-        bsol = solve(bprob, MIRK4(; optimize = IpoptOptimizer()), dt = 1.0e-3)
+    # `dt` here sets the collocation mesh, which drives the size of the Ipopt problem.
+    # 1e-3 gives 1001 mesh points (4004 variables) for no gain in accuracy over 1e-2.
+    bsol = solve(bprob, MIRK4(; optimize = IpoptOptimizer()), dt = 1.0e-2)
 
-        @test bsol.ps[α] ≈ 1.8 rtol = 1.0e-2
-        @test bsol.ps[γ] ≈ 6.5 rtol = 1.0e-2
-    else
-        @test_broken solve(bprob, MIRK4(; optimize = IpoptOptimizer()), dt = 1.0e-3)
-    end
+    @test bsol.ps[α] ≈ 1.8 rtol = 1.0e-2
+    @test bsol.ps[γ] ≈ 6.5 rtol = 1.0e-2
 end


### PR DESCRIPTION
Fixes the `MTKBase/InterfaceII` CI runner OOM that @AayushSabharwal has been hitting,
and un-gates a test that currently errors.

## The OOM is one testset, not "BVPs"

Measured in isolation, peak RSS:

| | peak RSS | wall |
|---|---|---|
| `Parameter estimation` alone | **7.20 GiB** | 3m34 |
| `ODE with constraints` alone | 1.68 GiB | 48s |
| whole `bvproblem.jl` | 7.4–8.0 GiB | ~5m40 |

The parameter-estimation testset accounts for essentially the entire peak of the file.
`dt = 1e-3` over `tspan = (0, 1)` builds a 1001-point collocation mesh — 4004 Ipopt
variables and 26010 Lagrangian-Hessian nonzeros — and it is differentiated by a fallback
sparse `SecondOrder` AD that the stack itself warns is suboptimal.

That mesh dates from when the test was added (`b003e955f0`, 2026-02-26), while the MIRK
interpolation bug fixed by [BoundaryValueDiffEq.jl #452](https://github.com/SciML/BoundaryValueDiffEq.jl/pull/452)
was still present — a fine mesh limits interpolation error at the 51 `EvalAt` cost
points. #452 merged 2026-03-30 and the `dt` was never revisited.

It now buys nothing:

```
dt = 1e-3    7.20 GiB   3m34   α = 1.8000275184   γ = 6.4998637712
dt = 1e-2    2.15 GiB   1m02   α = 1.8000278445   γ = 6.4998629391
```

Same answer to six significant figures, for 70% less memory and 71% less time. Given
that, sectioning this group off may not be necessary.

## The gate makes CI error, and its premise no longer holds

```julia
else
    @test_broken solve(bprob, MIRK4(; optimize = IpoptOptimizer()), dt = 1.0e-3)
end
```

`@test_broken` needs a Boolean. The solve now succeeds and returns an `ODESolution`, so
Test reports a hard **error**, not a broken test. This is the same failure mode #4843
fixed — its body describes it exactly — at a fifth site that PR missed.

#4843 chose to "leave the genuinely broken parameter-estimation cases marked broken",
but they are not broken. Running the gated-off path with only ModelingToolkitBase loaded:

```
retcode: Success
bsol.ps[α] = 1.8000275184250567   target 1.8   ✓
bsol.ps[γ] = 6.499863771223533    target 6.5   ✓
```

So the gate is removed and the assertions run unconditionally.

## Not addressed here

Passing an explicit `SecondOrder` ADType to `IpoptOptimizer` would fix the underlying AD
suboptimality rather than just shrinking the problem. Worth doing if 2.15 GiB is still
too much for the runner, but it is a separate change.

## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API