### PR TITLE
Route every `MTKParameters` buffer's cotangent back to its own argument

### DIFF
--- a/lib/ModelingToolkitBase/ext/MTKChainRulesCoreExt.jl
+++ b/lib/ModelingToolkitBase/ext/MTKChainRulesCoreExt.jl
@@ -9,14 +9,34 @@ import SciMLStructures
 import SymbolicIndexingInterface: remake_buffer, parameter_index
 import SciMLBase: AbstractNonlinearProblem, remake
 
+# Positional arguments of `MTKParameters` after `tunables`, in order. `setproperties`
+# (and hence every `@set!`/`SciMLStructures.replace` rebuild) lowers to this
+# constructor, so the pullback has to route each buffer's cotangent back to its own
+# argument — otherwise a rebuild silently zeroes every non-tunable portion.
+const MTP_NONTUNABLE_FIELDS = (:initials, :discrete, :constant, :nonnumeric, :caches)
+
+_mtp_tangent(::Nothing) = NoTangent()
+_mtp_tangent(x) = x
+
 function ChainRulesCore.rrule(::Type{MTKParameters}, tunables, args...)
     function mtp_pullback(dt)
         dt = unthunk(dt)
-        dtunables = dt isa AbstractArray ? dt : dt.tunable
-        return (
-            NoTangent(), dtunables[1:length(tunables)],
-            ntuple(_ -> NoTangent(), length(args))...,
-        )
+        # A flat cotangent carries the tunable portion only.
+        if dt isa AbstractArray
+            return (
+                NoTangent(), dt[1:length(tunables)],
+                ntuple(_ -> NoTangent(), length(args))...,
+            )
+        end
+        dtunables = hasproperty(dt, :tunable) ? _mtp_tangent(dt.tunable) : NoTangent()
+        if dtunables isa AbstractArray
+            dtunables = dtunables[1:length(tunables)]
+        end
+        dargs = ntuple(length(args)) do i
+            field = MTP_NONTUNABLE_FIELDS[i]
+            hasproperty(dt, field) ? _mtp_tangent(getproperty(dt, field)) : NoTangent()
+        end
+        return (NoTangent(), dtunables, dargs...)
     end
     return MTKParameters(tunables, args...), mtp_pullback
 end

--- a/lib/ModelingToolkitBase/test/extensions/ad.jl
+++ b/lib/ModelingToolkitBase/test/extensions/ad.jl
@@ -203,3 +203,29 @@ end
 
     @test fd ≈ zg[1] atol = 1.0e-6
 end
+
+# https://github.com/SciML/SciMLSensitivity.jl/issues/1582
+@testset "`Initials` cotangent survives an `MTKParameters` rebuild" begin
+    @parameters m = 1.5 d = 9.0
+    @variables s(t) = 1.0 v(t) = 1.0
+    sys = mtkcompile(System([D(s) ~ v, m * D(v) ~ 1 - d * v], t; name = :model))
+    prob = ODEProblem(sys, [], (0.0, 1.0))
+    p0 = parameter_values(prob)
+
+    # `setproperties`/`@set!` on an `MTKParameters` goes through its positional
+    # constructor. `promote_u0_p` does exactly this inside `remake`, so a rebuild
+    # that drops the non-tunable cotangents silently zeroes every `Initial(x)`
+    # gradient downstream.
+    for portion in (SciMLStructures.Tunable(), SciMLStructures.Initials())
+        buf = SciMLStructures.canonicalize(portion, p0)[1]
+        g = Zygote.gradient(
+            p -> sum(SciMLStructures.replace(portion, p, buf).initials), p0
+        )[1]
+        @test g.initials == ones(length(p0.initials))
+    end
+
+    # End-to-end: `u0` is a derived quantity here, so `Initial(v)` must reach it.
+    set_v0 = setp_oop(prob, [Initial(sys.v)])
+    f = x -> sum(state_values(remake(prob; p = set_v0(prob, x))))
+    @test Zygote.gradient(f, [1.1])[1] ≈ ForwardDiff.gradient(f, [1.1])
+end


### PR DESCRIPTION
> **Ignore until reviewed by @ChrisRackauckas.** Opened as a draft.

## What changed and why

`ChainRulesCore.rrule(::Type{MTKParameters}, tunables, args...)` returned `NoTangent()` for every constructor argument after `tunables`. `MTKParameters` defines no custom `ConstructionBase.constructorof`, so `setproperties` — and therefore every `@set!` and `SciMLStructures.replace` — lowers to that positional constructor. `promote_with_nothing(::Type{T}, ::MTKParameters)` (`initializesystem.jl:731`) rebuilds the object that way twice, and `promote_u0_p` calls it from `late_binding_update_u0_p` **inside `remake`**.

Net effect: an *identity* rebuild of a parameter object silently zeroed the `Initials` cotangent while passing `Tunable` through untouched. Since MTK derives `u0` from the `Initial(x)` parameters, reverse-mode AD reported zero gradients w.r.t. any `Initial(x)`.

The pullback now routes each buffer's cotangent back to its own argument. A flat (`AbstractArray`) cotangent still means "tunable portion only" and is unchanged.

## Verification

The asymmetry, measured on `mtkcompile(System([D(s) ~ v, m*D(v) ~ 1 - d*v], t))`, before and after:

```
                                                     before      after
d/dp sum(p.initials)            [no rebuild]         [1,1,1,1]   [1,1,1,1]
d/dp sum(replace(Tunable,p,p.tunable).initials)      nothing     [1,1,1,1]
d/dp sum(replace(Initials,p,p.initials).initials)    nothing     [1,1,1,1]
d/dp sum(promote_with_nothing(Float64,p).initials)   nothing     [1,1,1,1]
d/dp sum(promote_u0_p(u0,p,0.0)[2].initials)         nothing     [1,1,1,1]
d/dp sum(replace(Tunable,p,p.tunable).tunable)       [1,1]       [1,1]
```

End-to-end, the reporter's MRE from SciML/SciMLSensitivity.jl#1582 (with the matching SciMLSensitivity change):

```
                before                after
ForwardDiff     [17.042409339235398]  [17.042409339235398]
Zygote          nothing               [17.04241152270429]
Enzyme          [0.0]                 [17.04241152270429]
```

Julia 1.12.6, MTK 11.38.2, MTKBase 1.61.0, SciMLBase 3.43.0, Zygote 0.7.12, Enzyme 0.13.198.

## What I did NOT verify

- I did not run `lib/ModelingToolkitBase/test/extensions/ad.jl` as a whole, nor any other MTK test group — the box was under load ~120–280 for the duration and a single 4-minute testset was taking 15+ minutes of wall clock. The added testset's assertions are exactly the before/after measurements above, taken with the same package versions, but I have not seen the file run start-to-finish. **Please let CI do that.**
- No docs build, no QA/Aqua/JET group, no downstream packages, no GPU paths.

## For a reviewer to push back on

- The `hasproperty(dt, field)` guards accept both `Tangent` and Zygote's plain `NamedTuple` cotangents. If there is a canonical tangent type here I have missed, this is the place to say so.
- `MTP_NONTUNABLE_FIELDS` hard-codes the positional field order after `tunables`. It will silently mis-route if `MTKParameters`' field order ever changes. A `fieldnames`-derived constant would be safer; I kept it explicit for clarity.
- The flat-`AbstractArray` early return preserves existing behaviour, but it means a flat cotangent can never carry non-tunable information. That was already true; worth confirming it's intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fs33bFwCYG5u4XvMHXJxCm
