### PR TITLE
Fix typos in documentation

### DIFF
--- a/docs/src/basics/MTKLanguage.md
+++ b/docs/src/basics/MTKLanguage.md
@@ -332,7 +332,7 @@ MTK provides 3 distinct connectors:
 
   - `DomainConnector`: A connector which has only one unknown which is of `Flow` type,
     specified by `[connect = Flow]`.
-  - `StreamConnector`: A connector which has atleast one stream variable, specified by
+  - `StreamConnector`: A connector which has at least one stream variable, specified by
     `[connect = Stream]`. A `StreamConnector` must have exactly one flow variable.
   - `RegularConnector`: Connectors that don't fall under above categories.
 

--- a/docs/src/tutorials/disturbance_modeling.md
+++ b/docs/src/tutorials/disturbance_modeling.md
@@ -1,4 +1,4 @@
-# Disturbance and input modeling modeling
+# Disturbance and input modeling
 
 Disturbances are often seen as external factors that influence a system. Modeling and simulation of such external influences is common in order to ensure that the plant and or control system can adequately handle or suppress these disturbances. Disturbance modeling is also integral to the problem of state estimation, indeed, modeling how disturbances affect the evolution of the state of the system is crucial in order to accurately estimate this state.
 


### PR DESCRIPTION
Two small typos in the docs:

- `docs/src/tutorials/disturbance_modeling.md`: title "Disturbance and input modeling modeling" -> "Disturbance and input modeling".
- `docs/src/basics/MTKLanguage.md`: "has atleast one stream variable" -> "at least".

Documentation only.
