### PR TITLE
Avoid piracy in jump dependency traversal

### DIFF
--- a/lib/ModelingToolkitBase/src/problems/jumpproblem.jl
+++ b/lib/ModelingToolkitBase/src/problems/jumpproblem.jl
@@ -254,19 +254,21 @@ function collect_vars!(
 end
 
 ### Functions to determine which unknowns a jump depends on
-function SU.search_variables!(dep, jump::Union{ConstantRateJump, VariableRateJump}; kw...)
+_get_variables!(dep, expr, variables) = get_variables!(dep, expr, variables)
+
+function _get_variables!(dep, jump::Union{ConstantRateJump, VariableRateJump}, variables)
     jr = unwrap(jump.rate)
-    (jr isa SymbolicT) && SU.search_variables!(dep, jr; kw...)
+    (jr isa SymbolicT) && get_variables!(dep, jr, variables)
     return dep
 end
 
-function SU.search_variables!(dep, jump::MassActionJump; is_atomic = SU.default_is_atomic, kw...)
+function _get_variables!(dep, jump::MassActionJump, variables)
     sr = unwrap(jump.scaled_rates)
-    (sr isa SymbolicT) && SU.search_variables!(dep, sr; is_atomic, kw...)
+    (sr isa SymbolicT) && get_variables!(dep, sr, variables)
     for varasop in jump.reactant_stoch
         var = unwrap(varasop[1])
         var isa SymbolicT || continue
-        is_atomic(var) && push!(dep, var)
+        get_variables!(dep, var, variables)
     end
     return dep
 end

--- a/lib/ModelingToolkitBase/src/systems/dependency_graphs.jl
+++ b/lib/ModelingToolkitBase/src/systems/dependency_graphs.jl
@@ -45,9 +45,9 @@ function equation_dependencies(
 
     for (i, eq) in enumerate(eqs)
         # For Equations, only examine RHS (dependencies, not what's modified).
-        # For jumps, use the whole object (specialized search_variables! handles it).
+        # For jumps, use the whole object so the local traversal handles their rate fields.
         target = eq isa Equation ? eq.rhs : eq
-        get_variables!(deps, target, variables)
+        _get_variables!(deps, target, variables)
         depeqs_to_vars[i] = [value(v) for v in deps]
         empty!(deps)
     end

--- a/lib/ModelingToolkitBase/test/dep_graphs.jl
+++ b/lib/ModelingToolkitBase/test/dep_graphs.jl
@@ -2,7 +2,20 @@ using Test
 using ModelingToolkitBase, Graphs, JumpProcesses, RecursiveArrayTools
 using ModelingToolkitBase: t_nounits as t, D_nounits as D
 import ModelingToolkitBase: value
+import SymbolicUtils
 using Symbolics: SymbolicT
+
+@testset "Jump dependency search does not pirate SymbolicUtils" begin
+    jump_types = (ConstantRateJump, VariableRateJump, MassActionJump)
+    @test all(methods(SymbolicUtils.search_variables!)) do method
+        method.module !== ModelingToolkitBase || all(jump_types) do jump_type
+            typeintersect(
+                method.sig,
+                Tuple{typeof(SymbolicUtils.search_variables!), Any, jump_type}
+            ) === Union{}
+        end
+    end
+end
 
 #################################
 #  testing for Jumps / all dgs


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## Summary

- keep jump-specific dependency traversal behind a ModelingToolkitBase-owned helper
- stop defining `SymbolicUtils.search_variables!` methods on JumpProcesses-owned jump types
- add a regression test that rejects those cross-package methods

## Context

A clean `origin/master` QA reproduction at `731eff66b596fbc6bc36aff45b21bb2e81e1bddb` reports 14 Aqua piracy methods: four `search_variables!` methods and ten older `toexpr` methods. This focused change removes the four jump-related methods. The remaining `toexpr` ownership work is tracked in #4670.

The existing narrow `SimpleNonlinearSolve` stale-dependency allowance is unchanged. That dependency is used only by `MTKBifurcationKitExt` and must remain hard so loading BifurcationKit activates the extension.

## Local verification

- Runic `--check --diff` on all three changed files: pass
- `git diff --check`: pass
- focused `lib/ModelingToolkitBase/test/dep_graphs.jl`: all testsets pass (`1/1`, `22/22`, `3/3`, `1/1`)
- full `GROUP=InterfaceI` package test: 1,502 pass, 5 pre-existing broken, 1,507 total; package test passed in 48m04s
- `Aqua.test_piracies(ModelingToolkitBase)`: expected nonzero result containing exactly the ten pre-existing `toexpr` methods and no `search_variables!` methods

## CI baseline

The repository-wide Runic check fails on unchanged clean-master `lib/ModelingToolkitBase/src/problems/initializationproblem.jl`. Exact local reproduction and the introducing commit are tracked in #4908. This PR does not mix that unrelated one-word formatting fix into the jump-piracy change.
