### PR TITLE
Register callable parameters as solver nonlinear operators

### DIFF
--- a/lib/ModelingToolkitBase/ext/MTKInfiniteOptExt.jl
+++ b/lib/ModelingToolkitBase/ext/MTKInfiniteOptExt.jl
@@ -11,6 +11,7 @@ using UnPack
 using Symbolics: unwrap
 import SymbolicUtils
 import NaNMath
+import FunctionWrappers
 const MTK = ModelingToolkitBase
 
 function __init__()
@@ -114,6 +115,43 @@ function MTK.generate_timescale!(m::InfiniteModel, guess, is_free_t)
     return tₛ
 end
 
+# Register a callable parameter as a JuMP nonlinear operator. `val` is the callable used for
+# values; `underlying` is what we look up a symbolic first-derivative rule for — the same object
+# for a bare callable, or the wrapped function for a `FunctionWrapper`. The rule is resolved
+# through Symbolics' registry, so any derivative registered for the callable's type (e.g. by a
+# DataInterpolations→Symbolics extension) is used without MTK depending on that package. When no
+# rule exists we register value-only and JuMP differentiates numerically.
+function _register_callable_operator!(m::InfiniteOptModel, dim, underlying, val, name)
+    # InfiniteOpt wants a ::Function; wrap non-Function callables (interpolators, wrappers).
+    f = val isa Function ? val : (x_args...) -> val(x_args...)
+    syms = ntuple(i -> Symbolics.variable(Symbol(:_arg, i)), dim)
+    d1 = Symbolics._derivative_rule_proxy(underlying, syms, Val(1))
+    isnothing(d1) && return add_nonlinear_operator(m.model, dim, f; name)
+
+    d1_unwrapped = unwrap(d1)
+    op = operation(d1_unwrapped)
+    args = arguments(d1_unwrapped)
+    # Identify which args are our symbolic variables vs constants
+    sym_positions = Dict(unwrap(s) => i for (i, s) in enumerate(syms))
+    arg_specs = map(args) do a
+        a_uw = unwrap(a)
+        idx = get(sym_positions, a_uw, nothing)
+        !isnothing(idx) ? (:var, idx) : (:const, SymbolicUtils.unwrap_const(a_uw))
+    end
+    ∇f = function (x_args...)
+        realized = map(arg_specs) do (kind, v)
+            kind === :var ? x_args[v] : v
+        end
+        return op(realized...)
+    end
+    return add_nonlinear_operator(m.model, dim, f, ∇f; name)
+end
+
+MTK.register_operator!(m::InfiniteOptModel, dim, val, name) =
+    _register_callable_operator!(m, dim, val, val, name)
+MTK.register_operator!(m::InfiniteOptModel, dim, val::FunctionWrappers.FunctionWrapper, name) =
+    _register_callable_operator!(m, dim, val.obj[], val, name)
+
 function MTK.add_constraint!(m::InfiniteOptModel, expr::Union{Equation, Inequality})
     return if expr isa Equation
         @constraint(m.model, SymbolicUtils.unwrap_const(expr.lhs) - SymbolicUtils.unwrap_const(expr.rhs) == 0)
@@ -182,6 +220,7 @@ function MTK.lowered_integral(model::InfiniteOptModel, expr, lo, hi)
     return model.tₛ * InfiniteOpt.∫(SymbolicUtils.unwrap_const(expr), model.model[:t], lo, hi)
 end
 MTK.lowered_derivative(model::InfiniteOptModel, i) = ∂(model.U[i], model.model[:t])
+MTK.lowered_time_variable(model::InfiniteOptModel) = model.model[:t]
 
 function MTK.process_integral_bounds(model::InfiniteOptModel, integral_span, tspan)
     return if MTK.is_free_final(model) && isequal(integral_span, tspan)

--- a/lib/ModelingToolkitBase/src/systems/optimal_control_interface.jl
+++ b/lib/ModelingToolkitBase/src/systems/optimal_control_interface.jl
@@ -318,6 +318,44 @@ end
 ##########################
 ### MODEL CONSTRUCTION ###
 ##########################
+
+# Collect the arity (number of call arguments) of every callable parameter that
+# appears in `expr`, e.g. `curvature(s)` or `forcing(t)`. Keyed by the bare
+# callable-parameter symbol (`default_toterm`ed to match `pmap` keys).
+function _collect_called_param_arities!(arities, expr)
+    expr = value(expr)
+    iscall(expr) || return arities
+    if iscalledparameter(expr)
+        arities[default_toterm(getcalledparameter(expr))] = length(arguments(expr))
+    end
+    for arg in arguments(expr)
+        _collect_called_param_arities!(arities, arg)
+    end
+    return arities
+end
+
+function callable_parameter_arities(sys)
+    arities = Dict{Any, Int}()
+    for eq in equations(sys)
+        _collect_called_param_arities!(arities, eq.lhs)
+        _collect_called_param_arities!(arities, eq.rhs)
+    end
+    for eq in observed(unhack_system(sys))
+        _collect_called_param_arities!(arities, eq.rhs)
+    end
+    cons = get_constraints(sys)
+    if cons !== nothing
+        for c in cons
+            _collect_called_param_arities!(arities, c.lhs)
+            _collect_called_param_arities!(arities, c.rhs)
+        end
+    end
+    for cost in get_costs(sys)
+        _collect_called_param_arities!(arities, cost)
+    end
+    return arities
+end
+
 function process_DynamicOptProblem(
         prob_type::Type{<:SciMLBase.AbstractDynamicOptProblem}, model_type, sys::System, op, tspan;
         dt = nothing,
@@ -394,6 +432,27 @@ function process_DynamicOptProblem(
 
     merge!(pmap, Dict(tunable_params .=> P_syms))
 
+    # Register callable parameters and update MTKParameters for numerical tracing (e.g. JuMP).
+    # Any parameter called in the equations (`curvature(s)`, `forcing(t)`, ...) must become a
+    # solver operator so the backend can trace it symbolically; this covers both `FunctionWrapper`
+    # values and bare callables (e.g. a `DataInterpolations` object stored unwrapped).
+    arities = callable_parameter_arities(sys)
+    new_nonnumeric = Tuple(convert(Vector{Any}, copy(v)) for v in p.nonnumeric)
+    p = MTKParameters(p.tunable, p.initials, p.discrete, p.constant, new_nonnumeric, p.caches)
+    for (sym, val) in pmap
+        # Prefer the arity recorded from the call site; fall back to a `FunctionWrapper`'s own
+        # argument-tuple type. A parameter that is never called is left untouched.
+        dim = get(arities, sym) do
+            val isa FunctionWrapper ? fieldcount(typeof(val).parameters[2]) : nothing
+        end
+        dim === nothing && continue
+        reg_op = register_operator!(fullmodel, dim, val, nameof(sym))
+        pmap[sym] = reg_op
+        setp(sys, sym)(p, reg_op)
+    end
+    narrow_nn = Tuple(map(identity, v) for v in p.nonnumeric)
+    @set! p.nonnumeric = narrow_nn
+
     set_variable_bounds!(fullmodel, sys, pmap, tspan[2], tunable_params, bounds)
     add_cost_function!(fullmodel, sys, tspan, pmap)
     add_user_constraints!(fullmodel, sys, tspan, pmap)
@@ -456,6 +515,7 @@ end
 function set_initial_trajectory!(model, U, idx, traj)
     throw(ArgumentError("The `initial_trajectory` keyword argument is not supported by the $(nameof(typeof(model))) backend."))
 end
+function register_operator! end
 function generate_time_variable! end
 function generate_internal_model end
 function generate_state_variable! end
@@ -468,6 +528,9 @@ function add_constraint! end
 get_param_for_pmap(model, P, i) = P isa AbstractArray ? P[i] : P
 # Some backends need symbolic accessors instead of raw variables (CasADi in particular)
 needs_individual_tunables(model) = false
+# Backend representation of the independent variable, used to lower a bare `t` (e.g. inside a
+# callable parameter). Backends without an explicit time decision variable return `nothing`.
+lowered_time_variable(model) = nothing
 
 function f_wrapper(f, Uₙ, Vₙ, p, P, t)
     if isempty(P)
@@ -599,6 +662,11 @@ function get_model_vars_substitution_rules!(rules::Dict{Any, Any}, model, sys, t
         rules[tf] = _tf
     end
     merge!(rules, fixed_t_map(model, x_ops, c_ops))
+    # Lower a bare independent variable (e.g. inside `forcing(t)`) onto the backend's time
+    # variable. State/input calls `x(t)` are replaced as whole subtrees before the traversal
+    # reaches their inner `t`, so this rule only fires on genuinely-bare occurrences.
+    tvar = lowered_time_variable(model)
+    tvar === nothing || (rules[unwrap(t)] = tvar)
     return nothing
 end
 

--- a/lib/ModelingToolkitBase/test/optimization/dynamic_optimization.jl
+++ b/lib/ModelingToolkitBase/test/optimization/dynamic_optimization.jl
@@ -926,3 +926,39 @@ struct UnsupportedTrajectoryBackend end
     @parameters b
     @test_throws ArgumentError M.build_trajectory_function(block, x(t), b * t, p_test)
 end
+
+@testset "Callable parameter registration" begin
+    # A parameter that is called in the equations (here an interpolator) must be
+    # registered as a solver nonlinear operator; without it the collocation
+    # backends cannot trace the RHS symbolically.
+    @parameters (forcing::LinearInterpolation)(..)
+    @variables x(t)
+
+    eqs = [D(x) ~ -x + forcing(t)]
+    @named sys = System(eqs, t)
+    sys = mtkcompile(sys)
+
+    # Constant extrapolation is required for the InfiniteOpt backend: MOI builds the
+    # Lagrangian Hessian by running ForwardDiff over the operator's gradient, which
+    # perturbs `t` past the last knot at the boundary collocation point.
+    interp = LinearInterpolation(
+        [1.0, 2.0, 1.5], [0.0, 0.5, 1.0];
+        extrapolation = ExtrapolationType.Constant
+    )
+
+    u0map = [x => 0.5]
+    pmap = [forcing => interp]
+    tspan = (0.0, 1.0)
+
+    # JuMP backend: direct collocation evaluates the callable at numeric time points.
+    jprob = JuMPDynamicOptProblem(sys, [u0map; pmap], tspan; dt = 0.05)
+    jsol = solve(jprob, JuMPCollocation(Ipopt.Optimizer, ImplicitTableaus.ImplicitEuler()))
+    @test all(isfinite, jsol.sol[x])
+    @test length(jsol.sol[x]) > 1
+
+    # InfiniteOpt backend: the callable is registered as a JuMP nonlinear operator and
+    # the equational constraints substitute it in symbolically (see register_operator!).
+    iprob = InfiniteOptDynamicOptProblem(sys, [u0map; pmap], tspan; dt = 0.05)
+    isol = solve(iprob, InfiniteOptCollocation(Ipopt.Optimizer))
+    @test isol.sol[x][end] > isol.sol[x][begin]
+end


### PR DESCRIPTION
Splits the callable-parameter support out of #4394, rebuilt on current master.

Parameters that are *called* in the equations — `FunctionWrapper`-wrapped interpolators or bare callables such as `DataInterpolations` objects — previously broke the dynamic-optimization backends: `fixpoint_sub` with `fold = Val(true)` calls them with JuMP/InfiniteOpt decision-variable types they cannot accept, surfacing as e.g. `MethodError: no method matching *(::Symbolic, ::GeneralVariableRef)`.

This PR registers every called parameter as a JuMP nonlinear operator:

- arities are collected from the call sites (equations, observed, constraints, costs) via `callable_parameter_arities`, falling back to a `FunctionWrapper`'s argument-tuple type; parameters that are never called are untouched
- a symbolic first-derivative rule is resolved through Symbolics' registry when one exists (e.g. registered by a DataInterpolations extension) and used as the operator gradient; otherwise the operator is registered value-only and JuMP differentiates numerically
- the parameter's `pmap` entry and its `MTKParameters` nonnumeric storage are replaced with the registered operator, so both the symbolic path (InfiniteOpt equational constraints) and the numeric tracing path (JuMP `f_wrapper`) see the operator
- a bare independent variable inside a callable-parameter call (`forcing(t)`) is lowered onto the backend's time variable via the new `lowered_time_variable` hook

Tests cover the JuMP and InfiniteOpt backends with a `LinearInterpolation` parameter (constant extrapolation, since MOI's Hessian-by-ForwardDiff perturbs past the last knot at the boundary collocation point).

Known gap, unchanged from before: `register_operator!` has methods only for the InfiniteOpt model type (which the JuMP backend routes through); CasADi and Pyomo error when a callable parameter is present, as they previously did during substitution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MSmps1uroq5XBeStMsStG4