### PR TITLE
Generate `nlstep_data` for the fully implicit DAE path

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ModelingToolkit"
 uuid = "961ee093-0014-501f-94e3-6117800e7a78"
-version = "11.38.2"
+version = "11.39.0"
 authors = ["Yingbo Ma <mayingbo5@gmail.com>", "Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
 
 [deps]
@@ -87,7 +87,7 @@ Libdl = "1"
 LinearAlgebra = "1"
 LinearSolve = "3.66, 4, 5"
 Logging = "1"
-ModelingToolkitBase = "1.57"
+ModelingToolkitBase = "1.62"
 ModelingToolkitStandardLibrary = "2.20"
 ModelingToolkitTearing = "1.19.2"
 Moshi = "0.3.6"

--- a/lib/ModelingToolkitBase/Project.toml
+++ b/lib/ModelingToolkitBase/Project.toml
@@ -1,7 +1,7 @@
 name = "ModelingToolkitBase"
 uuid = "7771a370-6774-4173-bd38-47e70ca0b839"
 authors = ["Yingbo Ma <mayingbo5@gmail.com>", "Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
-version = "1.61.0"
+version = "1.62.0"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
@@ -174,7 +174,7 @@ ReferenceTests = "0.10"
 RuntimeGeneratedFunctions = "0.5.12"
 SCCNonlinearSolve = "1.13"
 SafeTestsets = "0.1"
-SciMLBase = "3.38"
+SciMLBase = "3.44"
 SciMLPublic = "1.0.0"
 SciMLStructures = "1.7"
 Serialization = "1"

--- a/lib/ModelingToolkitBase/src/problems/daeproblem.jl
+++ b/lib/ModelingToolkitBase/src/problems/daeproblem.jl
@@ -1,3 +1,29 @@
+"""
+    generate_DAENLStepData(sys, u0, p, mm, nlstep_compile, nlstep_scc; jac = false)
+
+Generate the NLStep data for fully implicit DAE solvers. This is a stub that throws an
+error if called without ModelingToolkit loaded. The actual implementation is provided by
+ModelingToolkit when it is loaded.
+
+The result is the same `SciMLBase.ODENLStepData` the mass-matrix path produces, since for
+`0 = F(du, u, p, t)` both arguments of `F` are affine in the stage unknown and the six
+hooks parametrize the stage system as
+`g(z, p') = F(γ₁ z + outer_tmp, γ₂ z + inner_tmp, p, c)`. `γ₃` is unused and is fixed to
+`1`; it is kept in the tuple only so that the setter arity matches the mass-matrix path.
+
+When `jac = true`, the analytic Jacobian of the teared inner nonlinear system is
+generated symbolically and attached to `nlprob.f.jac`, so NonlinearSolve does not
+have to recompute it via AD/FD on every Newton iteration.
+"""
+function generate_DAENLStepData(sys, u0, p, mm, nlstep_compile, nlstep_scc; jac = false)
+    error(
+        """
+        `nlstep=true` requires ModelingToolkit.jl to be loaded.
+        Please add `using ModelingToolkit` to your code before creating a DAEProblem with `nlstep=true`.
+        """
+    )
+end
+
 @fallback_iip_specialize function SciMLBase.DAEFunction{iip, spec}(
         sys::System; u0 = nothing, p = nothing, tgrad = false, jac = false,
         t = nothing, eval_expression = false, eval_module = @__MODULE__,
@@ -5,7 +31,8 @@
         steady_state = false, checkbounds = false, sparsity = false,
         analytic = nothing,
         simplify = false, initialization_data = nothing,
-        expression = Val{false}, check_compatibility = true, optimize = nothing,
+        expression = Val{false}, check_compatibility = true, nlstep = false,
+        nlstep_compile = true, nlstep_scc = false, optimize = nothing,
         compiler_options::CompilerOptions = CompilerOptions(), kwargs...
     ) where {iip, spec}
     opts = SciMLFunctionOptions(;
@@ -13,7 +40,9 @@
         expression, check_compatibility, eval_expression, eval_module, compiler_options,
         checkbounds, optimize, kwargs...,
     )
-    return DAEFunction{iip, spec}(sys, opts; steady_state)
+    return DAEFunction{iip, spec}(
+        sys, opts; steady_state, nlstep, nlstep_compile, nlstep_scc
+    )
 end
 
 """
@@ -24,7 +53,8 @@ Public entry point that builds a `DAEFunction` directly from a pre-assembled
 """
 function SciMLBase.DAEFunction{iip, spec}(
         sys::System, opts::SciMLFunctionOptions{E};
-        steady_state::Bool = false
+        steady_state::Bool = false, nlstep::Bool = false, nlstep_compile::Bool = true,
+        nlstep_scc::Bool = false
     ) where {iip, spec, E}
     check_complete(sys, DAEFunction)
     opts.check_compatibility && check_compatible_system(DAEFunction, sys)
@@ -51,6 +81,14 @@ function SciMLBase.DAEFunction{iip, spec}(
         _jac = nothing
     end
 
+    if nlstep
+        dae_nlstep = generate_DAENLStepData(
+            sys, u0, p, calculate_massmatrix(sys), nlstep_compile, nlstep_scc; jac
+        )
+    else
+        dae_nlstep = nothing
+    end
+
     observedfun = ObservedFunctionCache(sys, codegen_opts; steady_state)
 
     jac_prototype = if sparse
@@ -74,6 +112,7 @@ function SciMLBase.DAEFunction{iip, spec}(
         observed = observedfun,
         analytic = analytic,
         initialization_data,
+        nlstep_data = dae_nlstep,
     )
     args = (; f)
 

--- a/src/systems/solver_nlprob.jl
+++ b/src/systems/solver_nlprob.jl
@@ -4,6 +4,22 @@ function MTKBase.generate_ODENLStepData(
         jac::Bool = false
     )
     nlsys, outer_tmp, inner_tmp = inner_nlsystem(sys, mm, nlstep_compile)
+    return assemble_nlstep_data(sys, nlsys, outer_tmp, inner_tmp, u0, p, nlstep_scc, jac)
+end
+
+function MTKBase.generate_DAENLStepData(
+        sys::System, u0, p, mm = calculate_massmatrix(sys),
+        nlstep_compile::Bool = true, nlstep_scc::Bool = false;
+        jac::Bool = false
+    )
+    nlsys, outer_tmp, inner_tmp = inner_dae_nlsystem(sys, mm, nlstep_compile)
+    return assemble_nlstep_data(sys, nlsys, outer_tmp, inner_tmp, u0, p, nlstep_scc, jac)
+end
+
+function assemble_nlstep_data(
+        sys::System, nlsys::System, outer_tmp, inner_tmp, u0, p,
+        nlstep_scc::Bool, jac::Bool
+    )
     state = ProblemState(; u = u0, p)
     op = Dict()
     op[ODE_GAMMA[1]] = one(eltype(u0))
@@ -16,7 +32,7 @@ function MTKBase.generate_ODENLStepData(
         haskey(op, v) && continue
         op[v] = getsym(sys, v)(state)
     end
-    # Forward the outer ODEFunction's `jac` flag so the inner teared nonlinear
+    # Forward the outer function's `jac` flag so the inner teared nonlinear
     # problem also carries an analytic Jacobian. This lets NonlinearSolve.jl
     # skip the per-iteration AD/FD Jacobian computation on the inner Newton.
     nlprob = if nlstep_scc
@@ -64,6 +80,53 @@ function inner_nlsystem(sys::System, mm, nlstep_compile::Bool)
     subrules[t] = unwrap(c)
     new_rhss = map(Base.Fix2(substitute, subrules), rhss)
     new_rhss = collect(outer_tmp) .+ gamma1 .* new_rhss .- gamma3 * mm * dvs
+    new_eqs = [0 ~ rhs for rhs in new_rhss]
+
+    new_dvs = unknowns(sys)
+    new_ps = [parameters(sys); [gamma1, gamma2, gamma3, c, inner_tmp, outer_tmp]]
+    nlsys = System(new_eqs, new_dvs, new_ps; name = :nlsys)
+    nlsys = if nlstep_compile
+        mtkcompile(nlsys; split = is_split(sys))
+    else
+        complete(nlsys; split = is_split(sys))
+    end
+    return nlsys, outer_tmp, inner_tmp
+end
+
+"""
+    $(TYPEDSIGNATURES)
+
+Build the stage system of the fully implicit form `0 = F(du, u, p, t)`, i.e.
+`g(z, p') = F(γ₁ z + outer_tmp, γ₂ z + inner_tmp, p, c)`.
+
+`full_equations` leaves a compiled system's differential equations as `D(x) ~ rhs` and its
+algebraic ones as `0 ~ rhs`, so the residual `rhs - lhs` that `DAEFunction` generates is
+`rhs - mm * du`: row `i` of `mm` picks out the `du` component that equation differentiates,
+if any. Substituting the derivative argument is therefore subtracting `mm * (γ₁ z +
+outer_tmp)`. An algebraic component has an all-zero `mm` column, so its `outer_tmp` entry
+drops out — correct, since `F` does not depend on that component's derivative.
+
+`γ₃` scales the `M z` term of the mass-matrix stage system; the fully implicit form has no
+such term, so it is absent here and consumers must leave it at `1`. It stays in the
+parameter list only so that `set_γ_c` takes the same four values on both paths.
+"""
+function inner_dae_nlsystem(sys::System, mm, nlstep_compile::Bool)
+    dvs = unknowns(sys)
+    eqs = full_equations(sys)
+    t = get_iv(sys)
+    N = length(dvs)
+    @assert length(eqs) == N
+    @assert mm isa UniformScaling || size(mm) == (N, N)
+    rhss = [eq.rhs for eq in eqs]
+    gamma1, gamma2, gamma3 = ODE_GAMMA
+    c = ODE_C
+    outer_tmp = get_outer_tmp(N)
+    inner_tmp = get_inner_tmp(N)
+
+    subrules = Dict([v => unwrap(gamma2 * v + inner_tmp[i]) for (i, v) in enumerate(dvs)])
+    subrules[t] = unwrap(c)
+    new_rhss = map(Base.Fix2(substitute, subrules), rhss)
+    new_rhss = new_rhss .- mm * (gamma1 .* dvs .+ collect(outer_tmp))
     new_eqs = [0 ~ rhs for rhs in new_rhss]
 
     new_dvs = unknowns(sys)

--- a/test/dae_nlstep.jl
+++ b/test/dae_nlstep.jl
@@ -97,7 +97,11 @@ end
         deepcopy(nd.nlprob), nd, inv(dt), 1.0, dt, -uprev ./ dt, zeros(N)
     )
 
-    sol = solve(nlp, NewtonRaphson(); abstol = 1.0e-14, reltol = 1.0e-14)
+    # `γ₁ z + outer_tmp` is `(z - uprev) / dt`, so the stage residual is a cancellation of
+    # two `O(1/dt)` quantities and cannot be resolved below an absolute `eps() / dt`
+    # (`2.2e-12` at `dt = 1e-4`). A tolerance under that floor makes Newton report
+    # `Stalled` at a fully converged iterate, so keep it above.
+    sol = solve(nlp, NewtonRaphson(); abstol = 1.0e-10, reltol = 1.0e-10)
     @test SciMLBase.successful_retcode(sol)
 
     z = nd.nlprobmap(sol)

--- a/test/dae_nlstep.jl
+++ b/test/dae_nlstep.jl
@@ -1,0 +1,150 @@
+using ModelingToolkit, Test, LinearAlgebra
+using ModelingToolkit: t_nounits as t, D_nounits as D
+using NonlinearSolve
+using OrdinaryDiffEqBDF
+using SciMLBase
+
+# Robertson in index-1 DAE form: the canonical fully implicit test case.
+@parameters k1 = 0.04 k2 = 3.0e7 k3 = 1.0e4
+@variables y1(t) = 1.0 y2(t) = 0.0 y3(t) = 0.0
+@named rob = System(
+    [
+        D(y1) ~ -k1 * y1 + k3 * y2 * y3,
+        D(y2) ~ k1 * y1 - k2 * y2^2 - k3 * y2 * y3,
+        0 ~ y1 + y2 + y3 - 1,
+    ], t
+)
+robsys = mtkcompile(rob)
+rob_du0 = [D(y1) => -0.04, D(y2) => 0.04]
+rob_tspan = (0.0, 1.0e4)
+
+# `w` cannot be solved for symbolically, so the algebraic equation survives `mtkcompile`
+# and the compiled system keeps a singular mass matrix: the semi-explicit DAE case.
+@variables x(t) = 1.0 w(t) = 0.5
+@named semi = System([D(x) ~ -x + w, 0 ~ w^3 + w - x], t)
+semisys = mtkcompile(semi)
+semi_du0 = [D(x) => -0.5, D(w) => 0.0]
+
+# `nlstep_data` is a stage-system template, so a stage residual has to be evaluated at
+# hand-chosen `γ`/`tmp` values rather than at whatever the problem was built with.
+function set_stage!(nlp, nd, γ₁, γ₂, c, outer, inner)
+    nd.set_γ_c(nlp, (γ₁, γ₂, 1.0, c))
+    nd.set_outer_tmp(nlp, outer)
+    nd.set_inner_tmp(nlp, inner)
+    return nlp
+end
+
+@testset "`nlstep_data` is attached to the `DAEFunction`" begin
+    prob = DAEProblem(robsys, rob_du0, rob_tspan; nlstep = true)
+    nd = prob.f.nlstep_data
+    @test nd isa SciMLBase.ODENLStepData
+
+    # the stage unknowns are a subset of the ODE unknowns: tearing introduced nothing new
+    @test all(!isnothing, nd.u0perm)
+    @test allunique(nd.u0perm)
+    @test issubset(nd.u0perm, eachindex(unknowns(robsys)))
+    @test length(nd.nlprob.u0) == length(nd.u0perm)
+
+    # γ₃ is unused by the fully implicit stage system but must stay settable, so that
+    # `set_γ_c` takes the same four values as it does on the mass-matrix path
+    nlp = deepcopy(nd.nlprob)
+    nd.set_γ_c(nlp, (2.0, 3.0, 1.0, 0.5))
+
+    @test DAEProblem(robsys, rob_du0, rob_tspan).f.nlstep_data === nothing
+end
+
+# `g(z, p') = F(γ₁ z + outer_tmp, γ₂ z + inner_tmp, p, c)`. With `nlstep_compile = false`
+# the stage system is not teared, so its residual is comparable to `F` componentwise.
+@testset "stage residual is the fully implicit residual: $name" for (name, sys, du0) in (
+        ("Robertson", robsys, rob_du0), ("semi-explicit", semisys, semi_du0),
+    )
+    prob = DAEProblem(sys, du0, (0.0, 1.0); nlstep = true, nlstep_compile = false)
+    nd = prob.f.nlstep_data
+    N = length(unknowns(sys))
+    @test nd.u0perm == 1:N
+
+    γ₁, γ₂, c = 7.0, 3.0, 0.3
+    outer = [0.11, -0.22]
+    inner = [0.05, 0.07]
+    nlp = set_stage!(deepcopy(nd.nlprob), nd, γ₁, γ₂, c, outer, inner)
+
+    for z in ([0.9, 0.01], [0.4, -0.3])
+        resid = zeros(N)
+        nlp.f(resid, z, nlp.p)
+        expected = zeros(N)
+        prob.f(expected, γ₁ .* z .+ outer, γ₂ .* z .+ inner, prob.p, c)
+        @test resid ≈ expected
+    end
+end
+
+# The teared stage system drops `x`, so this also covers the case where `u0perm` is a
+# strict subset of the ODE unknowns and `nlprobmap` has to rebuild the rest.
+@testset "compiled stage solution solves the fully implicit residual: $name" for (
+        name, sys, du0, dt, perm,
+    ) in (
+        ("Robertson", robsys, rob_du0, 1.0e-4, [1, 2]),
+        ("semi-explicit", semisys, semi_du0, 1.0e-2, [2]),
+    )
+    prob = DAEProblem(sys, du0, (0.0, 1.0); nlstep = true)
+    nd = prob.f.nlstep_data
+    N = length(unknowns(sys))
+    @test nd.u0perm == perm
+
+    # a backward Euler step of size `dt` from `uprev`: `du ≈ (u - uprev) / dt`, i.e.
+    # `γ₁ = inv(dt)`, `outer_tmp = -uprev / dt`, `γ₂ = 1`, `inner_tmp = 0`
+    uprev = prob.u0
+    nlp = set_stage!(
+        deepcopy(nd.nlprob), nd, inv(dt), 1.0, dt, -uprev ./ dt, zeros(N)
+    )
+
+    sol = solve(nlp, NewtonRaphson(); abstol = 1.0e-14, reltol = 1.0e-14)
+    @test SciMLBase.successful_retcode(sol)
+
+    z = nd.nlprobmap(sol)
+    @test length(z) == N
+    resid = zeros(N)
+    prob.f(resid, (z .- uprev) ./ dt, z, prob.p, dt)
+    @test maximum(abs, resid) < 1.0e-8
+end
+
+# `γ₁` is the `gamma` of the `DAEFunction` Jacobian signature `jac(J, du, u, p, gamma, t)`:
+# the stage residual's Jacobian in `z` is `γ₁ * dF/d(du) + dF/du`.
+@testset "`γ₁` matches the `DAEFunction` Jacobian's `gamma`" begin
+    prob = DAEProblem(
+        semisys, semi_du0, (0.0, 1.0); jac = true, nlstep = true, nlstep_compile = false
+    )
+    nd = prob.f.nlstep_data
+    N = length(unknowns(semisys))
+    @test nd.nlprob.f.jac !== nothing
+
+    γ₁, γ₂, c = 5.0, 1.0, 0.25
+    outer = [0.3, 0.0]
+    nlp = set_stage!(deepcopy(nd.nlprob), nd, γ₁, γ₂, c, outer, zeros(N))
+
+    z = [0.8, 0.6]
+    Jstage = zeros(N, N)
+    nlp.f.jac(Jstage, z, nlp.p)
+    Jdae = zeros(N, N)
+    prob.f.jac(Jdae, γ₁ .* z .+ outer, γ₂ .* z, prob.p, γ₁, c)
+    @test Jstage ≈ Jdae
+end
+
+@testset "attaching `nlstep_data` does not change the solve" begin
+    ref = solve(
+        DAEProblem(robsys, rob_du0, rob_tspan), DFBDF(); abstol = 1.0e-10, reltol = 1.0e-10
+    )
+    withnl = solve(
+        DAEProblem(robsys, rob_du0, rob_tspan; nlstep = true), DFBDF();
+        abstol = 1.0e-10, reltol = 1.0e-10
+    )
+    @test SciMLBase.successful_retcode(withnl)
+    @test withnl.t ≈ ref.t
+    @test withnl.u ≈ ref.u
+end
+
+@testset "`nlstep_scc` builds an SCC stage problem" begin
+    prob = DAEProblem(robsys, rob_du0, rob_tspan; nlstep = true, nlstep_scc = true)
+    nd = prob.f.nlstep_data
+    @test nd.nlprob isa SciMLBase.AbstractNonlinearProblem
+    @test all(!isnothing, nd.u0perm)
+end

--- a/test/dae_nlstep.jl
+++ b/test/dae_nlstep.jl
@@ -80,15 +80,21 @@ end
 # The teared stage system drops `x`, so this also covers the case where `u0perm` is a
 # strict subset of the ODE unknowns and `nlprobmap` has to rebuild the rest.
 @testset "compiled stage solution solves the fully implicit residual: $name" for (
-        name, sys, du0, dt, perm,
+        name, sys, du0, dt, n_stage,
     ) in (
-        ("Robertson", robsys, rob_du0, 1.0e-4, [1, 2]),
-        ("semi-explicit", semisys, semi_du0, 1.0e-2, [2]),
+        ("Robertson", robsys, rob_du0, 1.0e-4, 2),
+        ("semi-explicit", semisys, semi_du0, 1.0e-2, 1),
     )
     prob = DAEProblem(sys, du0, (0.0, 1.0); nlstep = true)
     nd = prob.f.nlstep_data
     N = length(unknowns(sys))
-    @test nd.u0perm == perm
+    # Which unknowns tearing retains is the contract; the order it returns them in is not,
+    # and does vary by Julia version (Robertson gives `[1, 2]` on 1.11/1.12 and `[2, 1]` on
+    # 1.10). `nlprobmap` undoes the permutation either way, which the residual check below
+    # verifies, so pin the count rather than the arrangement.
+    @test length(nd.u0perm) == n_stage
+    @test allunique(nd.u0perm)
+    @test issubset(nd.u0perm, eachindex(unknowns(sys)))
 
     # a backward Euler step of size `dt` from `uprev`: `du ≈ (u - uprev) / dt`, i.e.
     # `γ₁ = inv(dt)`, `outer_tmp = -uprev / dt`, `γ₂ = 1`, `inner_tmp = 0`

--- a/test/group_interfaceii.jl
+++ b/test/group_interfaceii.jl
@@ -15,4 +15,5 @@ include("shared/mtktestset.jl")
     @safetestset "Linearization Tests" include("linearize.jl")
     @safetestset "Fractional Differential Equations Tests" include("fractional_to_ordinary.jl")
     @safetestset "SemilinearODEProblem tests" include("semilinearodeproblem.jl")
+    @safetestset "DAE NLStep tests" include("dae_nlstep.jl")
 end

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -278,7 +278,8 @@ const NONPUBLIC_QUALIFIED_ACCESSES = (
     # `ModelingToolkitBase.StructuralHint`; `Base.Type` is public and is not affected.
     :AnalysisVariable, :check_compatible_system, :compute_array_variable_buffer_idxs,
     :default_missing_guess_value, :discover_maybe_zeros, :EXPERIMENTAL_WARNING,
-    :function_docstring, :generate_homotopy_residual, :generate_ODENLStepData,
+    :function_docstring, :generate_DAENLStepData, :generate_homotopy_residual,
+    :generate_ODENLStepData,
     :GENERATE_X_KWARGS, :get_initialization_problem_type, :get_nonlinear_problem_type,
     :has_any_homotopy, :indp_to_system, :invalidate_cache!, :lower_homotopy, :__mtkcompile,
     :ParameterArrayAssignments, :problem_docstring, :ReorderedDefaultParameters,


### PR DESCRIPTION
**Please ignore this PR until it has been reviewed by @ChrisRackauckas.** It is a draft and should not be merged before then.

**Dependency: requires SciMLBase ≥ 3.44**, which adds the `nlstep_data` field to `DAEFunction` (SciML/SciMLBase.jl#1509, merged as `2b711f36b`). `lib/ModelingToolkitBase/Project.toml` raises the floor to `SciMLBase = "3.44"`. **SciMLBase 3.44.0 is now in the General registry**, so CI resolves normally; the earlier note that it could not is obsolete. Local verification below was run against a `Pkg.develop`'d SciMLBase master at that same version.

Note that the `Runic Format Check` failure on this PR is **not from this PR**: it is `lib/ModelingToolkitBase/src/problems/initializationproblem.jl`, which this branch does not touch, and it reproduces on unmodified master. Tracked and fixed separately.

## What this does

`ODEProblem(sys, ...; nlstep = true)` hands an implicit stage solve a pre-built `NonlinearProblem` instead of a stage-equation closure. `DAEProblem` had no equivalent, so the fully implicit `0 = F(du, u, p, t)` form could not reach that path. This adds `generate_DAENLStepData` and plumbs `nlstep` / `nlstep_compile` / `nlstep_scc` through `DAEFunction`, mirroring `generate_ODENLStepData` and `odeproblem.jl`.

`SciMLBase.ODENLStepData` is reused unchanged — no new type, no `DENLStepData` alias.

## The stage system

For `0 = F(du, u, p, t)` both arguments of `F` are affine in the stage unknown, so the existing six hooks parametrize the stage system as

```
g(z, p') = F(γ₁ z + outer_tmp,  γ₂ z + inner_tmp,  p, c)
             └─ derivative arg ┘ └─── state arg ──┘
```

`generate_DAENLStepData` builds that from `full_equations(sys)`, which leaves a compiled system's differential equations as `D(x) ~ rhs` and its algebraic ones as `0 ~ rhs`. That is exactly the `rhs - mm * du` residual `generate_rhs(..., implicit_dae = true)` emits, so substituting the derivative argument is subtracting `mm * (γ₁ z + outer_tmp)`:

```julia
new_rhss = map(Base.Fix2(substitute, subrules), rhss)          # state arg + t → c
new_rhss = new_rhss .- mm * (gamma1 .* dvs .+ collect(outer_tmp))   # derivative arg
```

Compare the mass-matrix path, which multiplies the whole rhs by `γ₁` and subtracts a separate `γ₃ M z` term:

```julia
new_rhss = collect(outer_tmp) .+ gamma1 .* new_rhss .- gamma3 * mm * dvs
```

The fully implicit form has one term where the ODE form has two, and `γ₁` lands on the `du` slot rather than on `f`. That makes `γ₁` exactly the `gamma` of `DAEFunction`'s Jacobian signature `jac(J, du, u, p, gamma, t)` — the stage residual's Jacobian in `z` is `γ₁ dF/d(du) + dF/du`. There is a test asserting precisely that against the generated `f.jac`.

### `γ₃`

Kept in the tuple, fixed at `1`, absent from the equations. The fully implicit form has no `M z` term for it to scale, but `ODE_GAMMA` is a 3-tuple and `set_γ_c = setsym(nlsys, (ODE_GAMMA..., ODE_C))` sets four values; keeping the arity identical means a consumer does not branch on tuple length between the ODE and DAE paths. It is declared in `new_ps` and verified to survive `mtkcompile` of the stage system despite being unused.

## `differential_vars` and the index map

Neither needs special handling, and here is why.

`DAEProblem` computes `differential_vars[j] = unknowns(sys)[j] ∈ collect_differential_variables(sys)`, i.e. "variable `j` appears differentiated". For a compiled system that is the same predicate as "column `j` of `calculate_massmatrix(sys)` is nonzero", since `calculate_massmatrix` sets `M[i, variable_index(sys, x)] = 1` for each `D(x) ~ rhs` and errors on anything else. So `differential_vars` is already carried by `mm`, and the stage system gets it for free: an algebraic component `k` has an all-zero `mm` column, so `outer_tmp[k]` drops out of every equation — correct, since `F` genuinely does not depend on `du[k]`. Whatever the integrator writes into that slot is ignored rather than wrong.

It does not touch the index map either. `subsetidxs` maps `unknowns(nlsys)` into `unknowns(sys)`; the differential/algebraic split lives in the outer problem's state vector, not in the stage system, where every retained unknown is just an unknown of one nonlinear algebraic system.

**The `subsetidxs` index-subset requirement holds** — this was the flagged risk and it checks out. The DAE stage system has the same sparsity structure as the mass-matrix one (both are `substitute(rhs)` minus an affine term in `z`), so tearing behaves the same way and introduces no auxiliary unknowns. Verified on a system where tearing actually bites: for `D(x) ~ -x + w`, `0 ~ w³ + w - x` the stage system tears down to a single unknown, and `nlprobmap` rebuilds the dropped component such that `F` at the reconstructed stage state is `4.6e-15`. (Which index that single unknown carries is version-dependent — see the permutation note under Tests — so the test asserts the count, not the index.)

Also worth noting: MTK's existing `implicit_dae` codegen path gives a directly usable `F`. It is `rhs - lhs` over `equations(sys)` with `D(x)` replaced by `du[j]`, which is the same information `calculate_massmatrix` extracts, so the stage residual matches the generated `f` by construction rather than by coincidence.

## Tests

New `test/dae_nlstep.jl`, registered in the `InterfaceII` group. Two systems: Robertson in index-1 DAE form (compiles to `M = I` after `y3` is torn to an observed) and a semi-explicit DAE whose algebraic equation `0 ~ w³ + w - x` survives `mtkcompile` (`M = Diagonal([1, 0])`).

Run as `julia --project=env test/dae_nlstep.jl > log 2>&1; echo "EXIT=$?"` against `SciMLBase` 3.44.0, on **both Julia versions CI uses** — `1.12.4` (the `1` entry) and `1.10.11` (the `lts` entry). 31 tests over 8 testsets, exit status `0`, zero failures on each. Below is 1.12.4; 1.10.11 is identical in counts:

```
Test Summary:                                  | Pass  Total   Time
`nlstep_data` is attached to the `DAEFunction` |    6      6  47.2s
Test Summary:                                            | Pass  Total  Time
stage residual is the fully implicit residual: Robertson |    3      3   5.5s
Test Summary:                                                | Pass  Total  Time
stage residual is the fully implicit residual: semi-explicit |    3      3   2.7s
Test Summary:                                                         | Pass  Total  Time
compiled stage solution solves the fully implicit residual: Robertson |    6      6   4.5s
Test Summary:                                                             | Pass  Total  Time
compiled stage solution solves the fully implicit residual: semi-explicit |    6      6   1.7s
Test Summary:                                     | Pass  Total  Time
`γ₁` matches the `DAEFunction` Jacobian's `gamma` |    2      2   7.8s
Test Summary:                                     | Pass  Total   Time
attaching `nlstep_data` does not change the solve |    3      3  19.2s
Test Summary:                            | Pass  Total  Time
`nlstep_scc` builds an SCC stage problem |    2      2   4.1s
```

Two assertions in the first revision were pinned to values that are not stable across Julia versions, and both are fixed below. Neither was a defect in the generated code — in both cases the independent accuracy checks passed throughout. They are written up because a reviewer should know a test changed and why.

### A tolerance the first revision got wrong

Worth flagging for a reviewer, since it changed a test rather than the code. The Robertson stage solve originally asked for `abstol = reltol = 1e-14` and failed `successful_retcode` with `Stalled`, which aborted the file before the last four testsets ran.

That tolerance is unachievable, and not because of a bug: `γ₁ z + outer_tmp` is `(z - uprev) / dt`, a cancellation of two `O(1/dt)` quantities, so the residual has an absolute roundoff floor of `eps() / dt ≈ 2.2e-12` at `dt = 1e-4` — the request was 222× below it. Newton reached a converged iterate and correctly reported that it could not improve:

```
retcode  = Stalled
|resid|  = 1.9479409837430552e-13
outer |F| at the reconstructed stage state = 1.0419989956468595e-13
tol=1e-12 -> Success  |resid|=1.9479410310557182e-13
tol=1e-10 -> Success  |resid|=1.9479410310557182e-13
tol=1e-8  -> Success  |resid|=1.9479410310557182e-13
```

Identical residual at every tolerance, which is what distinguishes a floor from a convergence failure. Now `1e-10` — 45× above the floor, still far tighter than the `< 1e-8` assertion on the fully implicit residual that independently checks the same solve. The accuracy assertions were never the thing failing.

Measured across all three versions, `1e-10` converges on every one:

| | 1.10.11 (`lts`) | 1.11.9 | 1.12.4 (`1`) |
|---|---|---|---|
| `retcode` at the old `1e-14` | `Stalled` | `Success` | `Stalled` |
| `retcode` at the new `1e-10` | `Success` | `Success` | `Success` |

### A hardcoded permutation, which only `lts` catches

The same testset asserted `nd.u0perm == [1, 2]` for Robertson and `== [2]` for the semi-explicit system. Tearing's retained-unknown **ordering** is not stable across Julia versions — Robertson gives `[1, 2]` on 1.11 and 1.12 but `[2, 1]` on 1.10 — so the file failed on `lts` at that assertion, before reaching the later testsets. It is a distinct failure from the tolerance one and neither masks the other.

The ordering is internal bookkeeping rather than the contract, and `nlprobmap` demonstrably undoes it: on 1.10 and 1.12 the reconstructed stage state is the identical `[3.953102750667083e-6, 0.9999960000161853]` despite the differing `u0perm`, and the fully implicit residual check passes on both. What the two cases are actually there to distinguish is that the semi-explicit system tears down to one unknown while Robertson keeps both, so the assertion is now on the count plus `allunique`/`issubset` rather than on the arrangement.

What each covers:

- **attached** — `f.nlstep_data isa ODENLStepData`, `u0perm` is a subset of `eachindex(unknowns(sys))` with no `nothing`, `set_γ_c` accepts four values, and `nlstep = false` still gives `nothing`.
- **stage residual** — with `nlstep_compile = false` the stage system is not teared, so its residual is comparable to `F` componentwise. At two `z` values with `γ₁ = 7`, `γ₂ = 3`, `c = 0.3`, nonzero `outer_tmp` and `inner_tmp`, `nlp.f(z)` equals `prob.f(γ₁ z + outer, γ₂ z + inner, p, c)`.
- **compiled stage solution** — a backward Euler step (`γ₁ = 1/dt`, `outer_tmp = -uprev/dt`) solved with `NewtonRaphson`, then `F` evaluated at the `nlprobmap`-reconstructed stage state: `1.0e-13` (Robertson, untorn) and `4.6e-15` (semi-explicit, torn to one unknown).
- **`γ₁` is the Jacobian's `gamma`** — `nlp.f.jac(z)` vs `prob.f.jac(du, u, p, γ₁, c)`, exact match.
- **does not change the solve** — `DFBDF` on Robertson with and without `nlstep = true` produce identical `t` and `u`. (No DAE integrator consumes `nlstep_data` yet; this pins that attaching it is inert until one does.)
- **`nlstep_scc`** — the SCC path builds without error and keeps a valid `u0perm`.

## Other verification

The shared tail of `generate_ODENLStepData` moved into `assemble_nlstep_data`, so the ODE path was re-checked separately. Both bullets were originally reported from a `julia … 2>&1 | tail -N` pipeline, which reports `tail`'s status rather than julia's, and from a `println` script with no assertions at all — so neither had a meaningful pass/fail. Both have been rewritten as real `@test`s and re-run as `julia --project=env ode_regression_test.jl > log 2>&1; echo $?`, **exit status `0`**, zero `Test Failed`/`ERROR` occurrences:

```
  z=[0.9, 0.01]  maxdiff=0.0
  z=[0.4, -0.3]  maxdiff=1.1102230246251565e-16
Test Summary:                               | Pass  Total   Time
ODE mass-matrix stage residual is unchanged |    4      4  11.5s
  nlstep final=[0.9941080276301338, 0.9858877066923856]  ref final=[0.9941077880185154, 0.9858871209643493]  maxdiff=5.857280362953077e-7
Test Summary:                              | Pass  Total   Time
NonlinearSolveAlg consumes ODE nlstep_data |    2      2  40.0s
```

- mass-matrix stage residual still equals `outer + γ₁ f(γ₂ z + inner, p, c) - γ₃ M z`, checked with `γ₃ = 1.1 ≠ 1` so the term cannot be silently dropped;
- `ImplicitEuler(nlsolve = NonlinearSolveAlg())` — the one stepper that actually consumes `ODEFunction.nlstep_data` — matches plain `ImplicitEuler` to `5.9e-7` at `dt = 1e-3`.

`lib/ModelingToolkitBase/test/odesystem.jl`, which carries the existing `DAEProblem` coverage, re-run the same way: **exit status `0`**, 45 testsets, zero `Test Failed`/`Error During Test`/`Some tests did not pass` occurrences, and no test-summary line carrying a `Fail`, `Error` or `Broken` column.

### Correction on how the `1e-14` tolerance escaped

Not exit-code masking. That run was `julia … > log 2>&1; echo $?` — unpiped — and genuinely exited `0`. Re-running the pre-fix file today confirms it: exit `0` on Julia 1.11.9, exit `1` on Julia 1.12.4 with exactly the reported `Stalled` failure. The real cause is that it was only ever run on **one Julia version, and not one CI uses**, against a tolerance whose margin was never measured:

| | Julia 1.11.9 | Julia 1.12.4 |
|---|---|---|
| Robertson stage residual (`dt = 1e-4`, floor `eps()/dt = 2.2e-12`) | `1.235e-15` | `1.948e-13` |
| margin vs. the old `abstol = 1e-14` | 8× under (passes) | 19× over (**fails**) |
| margin vs. the new `abstol = 1e-10` | 81000× | 513× |

A 158× swing in the residual across Julia versions, against an 8× margin — the pass on 1.11.9 was luck, not evidence. Exit-code masking was a real defect in the *ODE-regression* command above, and is fixed there, but it is not what hid this.

Margins on every other numeric assertion, measured on both versions, for a reviewer deciding whether any of these are similarly brittle:

| assertion | 1.11.9 | 1.12.4 |
|---|---|---|
| stage residual `resid ≈ expected` (rtol floor `1.49e-8`) | ~5e7× | ~6.7e7× |
| semi-explicit stage residual vs `abstol = 1e-10` | 134× | 134× (identical) |
| outer `\|F\| < 1e-8` | 96000× / 13400× | 96000× / 13400× |
| `Jstage ≈ Jdae` | bitwise identical | bitwise identical |
| `DFBDF` with/without `nlstep`, `t` and `u` | bitwise identical | bitwise identical |

The tightest remaining margin is the semi-explicit stage solve at 134×, but unlike the Robertson case it is *bit-identical across both versions*, so it is not exhibiting the cross-version drift that broke the other one. Flagging it rather than tightening anything further.

## A hazard this PR creates downstream, which a reviewer should weigh

Merging this makes a currently-unreachable wrong-answer path reachable, and the fix belongs in OrdinaryDiffEq rather than here — but it should not be discovered later.

`OrdinaryDiffEqNonlinearSolve`'s `initialize!(nlsolver::NLSolver{<:NonlinearSolveAlg, true}, integrator)` reads `f.nlstep_data` and, when it is non-`nothing`, sets the stage parameters with mass-matrix ODE conventions in both arms:

```julia
if method === COEFFICIENT_MULTISTEP
    set_γ_c(nlprob, (one(t), one(t), α * invγdt, tstep))   # γ₃ carries the M z term
else
    set_γ_c(nlprob, (dt, γ, one(t), tstep))
end
```

There is no fully implicit arm. Before SciMLBase 3.44 a `DAEFunction` had no `nlstep_data` field at all, so that read threw — SciML/OrdinaryDiffEq.jl#4127. With 3.44 the field exists, and once this PR can populate it, `DFBDF(nlsolve = NonlinearSolveAlg())` on an `nlstep = true` problem would take that branch and solve the stage system with the wrong `γ` assignment — silently, not as an error.

It is not reachable today: the branch dispatches on `NonlinearSolveAlg`, and default `DFBDF()` uses NLNewton, which is why the `DFBDF` test above passes bitwise-identically and does so legitimately. The OrdinaryDiffEq-side PR should add the fully implicit arm, and the #4127 guard should throw rather than fall through in the interim.

## Not verified

- No DAE integrator consumes `nlstep_data` yet, so there is no end-to-end stiff-DAE-through-NLStep result to show. The `DFBDF` test only pins that attaching the field is inert; the real acceptance test — a `DFBDF` solve routed *through* NLStep matching the non-NLStep solve — cannot exist until the OrdinaryDiffEq side lands.
- Julia `1.11.9` was used for the margin table, but CI runs only `1` (1.12.4) and `lts` (1.10.11); the suite is verified green on both of those.
- `Runic Format Check` is red on this PR for a file it does not touch (see the note at the top). Every other check should be judged on its own.

Runic verified clean on all changed files, including `test/dae_nlstep.jl` after both test fixes. Minor version bumps: ModelingToolkit `11.38.2 → 11.39.0`, ModelingToolkitBase `1.61.0 → 1.62.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B9GHoo4pFa3DU9yhyTkevL




