### PR TITLE
style: fix the Runic format check that is red on master

### DIFF
--- a/lib/ModelingToolkitBase/src/problems/initializationproblem.jl
+++ b/lib/ModelingToolkitBase/src/problems/initializationproblem.jl
@@ -169,7 +169,7 @@ function InitializationProblem{iip, specialize}(
     # Only forward `check_length` when the caller explicitly set it; otherwise let the
     # underlying problem type apply its own default (see the keyword's definition above).
     check_length_kw = check_length === nothing ? (;) : (; check_length)
-    TProb{_iip}(
+    return TProb{_iip}(
         isys, op; kwargs..., check_length_kw...,
         u0_constructor, p_constructor, missing_guess_value,
         eval_expression, eval_module, warn_cyclic_dependency,


### PR DESCRIPTION
**Please ignore this PR until it has been reviewed by @ChrisRackauckas.**

## What changed and why

`master` is red on the Runic format check, so *every* open PR fails it too. Runic v1.7.0 wants an explicit `return` on the final expression of the `InitializationProblem{iip, specialize}` constructor in `lib/ModelingToolkitBase/src/problems/initializationproblem.jl`. This adds it. That is the whole diff — one line, no version bump (matching #4884, #4824, #4801).

The expression was already the last one in the function body, so adding `return` is semantically a no-op.

## Where it came from

Not a Runic version bump: Runic v1.7.0 was registered 2026-04-22, months before this code landed, and CI has been resolving `runic-version: "1"` to it the whole time. The regression is a merge with a red check:

- 21f3163f99..b77c4757f5 ("Make the opts-accepting InitializationProblem method primary") landed on master as part of #4893, merged 2026-08-07T17:01:22Z at 79b19d7efc.
- #4893's own `Runic / Runic Format Check` was **FAILURE** at merge time: https://github.com/SciML/ModelingToolkit.jl/actions/runs/31200346113/job/92938575650
- The push build of the merge commit is correspondingly red: https://github.com/SciML/ModelingToolkit.jl/actions/runs/31200352099/job/92938595855
- Every PR merged after it inherited the failure (#4900, #4905, #4883 all FAILURE), and every open PR sampled (#4912, #4909, #4907, #4881, #4841, #4840) fails on this one file and nothing else.

## Verification

Reproduced CI exactly on a clean `origin/master` checkout at 731eff66b5: Runic v1.7.0 (same version CI installs — see the job log, `+ Runic v1.7.0`), invoked the way `fredrikekre/runic-action@v1` does, `Runic.main(["--check", "--diff", "--verbose", git ls-files -- '*.jl'...])`.

**Before (on unmodified master), exit code 1:**

```
[ 46/223] Checking `lib/ModelingToolkitBase/src/problems/initializationproblem.jl`  ✖
diff --git a/initializationproblem.jl b/initializationproblem.jl
--- a/initializationproblem.jl
+++ b/initializationproblem.jl
@@ -169,7 +169,7 @@ function InitializationProblem{iip, specialize}(
-    TProb{_iip}(
+    return TProb{_iip}(
...
n files = 223
EXIT_CODE=1
```

That is the only `✖` in the run — all 223 tracked `.jl` files were checked and no other file fails.

**After this commit, exit code 0:**

```
[ 46/223] Checking `lib/ModelingToolkitBase/src/problems/initializationproblem.jl`  ✔
...
[223/223] Checking `test/substitute_component.jl` ............................ ✔
n files = 223
EXIT_CODE=0
```

Zero `✖` lines in the whole run.

## What I did not verify

I did not run the ModelingToolkit test suite. The change adds `return` to an expression that was already the function's last, so it cannot change behavior; the test suites, docs build, and downstream jobs are left to CI.
