### PR TITLE
Expose field roles on PDESystem

### DIFF
--- a/docs/src/API/PDESystem.md
+++ b/docs/src/API/PDESystem.md
@@ -35,6 +35,12 @@ block symbolic functions like Jacobians.
 PDESystem
 ```
 
+Dependent variables may use the standard ModelingToolkit input and output metadata.
+The declarations are available through `inputs(sys)` and `outputs(sys)` in dependent-variable
+declaration order. If a variable is marked as both an input and an output, it is reported as an
+input. These roles describe the symbolic PDE interface; support for discretizing them depends on
+the selected PDE discretizer.
+
 ### Domains (WIP)
 
 Domains are specifying by saying `indepvar in domain`, where `indepvar` is a

--- a/lib/ModelingToolkitBase/src/systems/pde/pdesystem.jl
+++ b/lib/ModelingToolkitBase/src/systems/pde/pdesystem.jl
@@ -188,6 +188,19 @@ end
 get_unknowns(sys::PDESystem) = getfield(sys, :dvs)
 has_unknowns(::PDESystem) = true
 
+# PDESystem stores field roles as variable metadata instead of dedicated fields.
+# Return unwrapped variables to match the AbstractSystem input/output interface.
+function get_inputs(sys::PDESystem)
+    return filter(isinput, unwrap.(get_dvs(sys)))
+end
+
+function get_outputs(sys::PDESystem)
+    return filter(x -> !isinput(x) && isoutput(x), unwrap.(get_dvs(sys)))
+end
+
+has_inputs(::PDESystem) = true
+has_outputs(::PDESystem) = true
+
 function Base.propertynames(sys::PDESystem; private = false)
     if private
         return fieldnames(PDESystem)

--- a/lib/ModelingToolkitBase/test/pdesystem.jl
+++ b/lib/ModelingToolkitBase/test/pdesystem.jl
@@ -92,6 +92,59 @@ using ModelingToolkitBase: renamespace, does_namespacing
     @test pdesys2.bcs isa Vector
 end
 
+@testset "PDESystem input and output roles" begin
+    @variables state(..) ordinary(..)
+    @variables input_field(..) [input = true]
+    @variables output_field(..) [output = true]
+    @variables input_output_field(..) [input = true, output = true]
+    @variables disabled_field(..) [input = false, output = false]
+    @variables array_input(..)[1:2] [input = true]
+
+    role_eq = Dt(state(t, x)) ~ input_field(t, x)
+    role_dvs = [
+        state, output_field, ordinary, input_field, input_output_field,
+        disabled_field, array_input,
+    ]
+    @named role_sys = PDESystem(role_eq, [], domains, [t, x], role_dvs)
+
+    @test isequal(
+        ModelingToolkitBase.inputs(role_sys),
+        [input_field, input_output_field, array_input]
+    )
+    @test isequal(ModelingToolkitBase.outputs(role_sys), [output_field])
+    @test ModelingToolkitBase.has_inputs(role_sys)
+    @test ModelingToolkitBase.has_outputs(role_sys)
+    @test isequal(ModelingToolkitBase.unknowns(role_sys), role_dvs)
+
+    called_dvs = [
+        state(t, x), input_field(t, x), output_field(t, x), array_input(t, x),
+    ]
+    @named called_role_sys = PDESystem(role_eq, [], domains, [t, x], called_dvs)
+    @test isequal(
+        ModelingToolkitBase.inputs(called_role_sys), [input_field(t, x), array_input(t, x)]
+    )
+    @test isequal(ModelingToolkitBase.outputs(called_role_sys), [output_field(t, x)])
+
+    unwrapped_dvs = ModelingToolkitBase.unwrap.(
+        [
+            state, input_field, output_field, array_input,
+        ]
+    )
+    @named unwrapped_role_sys = PDESystem(role_eq, [], domains, [t, x], unwrapped_dvs)
+    @test isequal(ModelingToolkitBase.inputs(unwrapped_role_sys), unwrapped_dvs[[2, 4]])
+    @test isequal(ModelingToolkitBase.outputs(unwrapped_role_sys), unwrapped_dvs[[3]])
+    @test isequal(ModelingToolkitBase.unknowns(unwrapped_role_sys), unwrapped_dvs)
+
+    @named no_role_sys = PDESystem(
+        Dt(state(t, x)) ~ 0, [], domains, [t, x], [state, ordinary]
+    )
+    @test isempty(ModelingToolkitBase.inputs(no_role_sys))
+    @test isempty(ModelingToolkitBase.outputs(no_role_sys))
+    # `has_*` reports accessor availability, as it does for an empty `System` field.
+    @test ModelingToolkitBase.has_inputs(no_role_sys)
+    @test ModelingToolkitBase.has_outputs(no_role_sys)
+end
+
 @testset "PDESystem property accessor without parameters" begin
     @parameters z
     @variables f(..)


### PR DESCRIPTION
## Summary

- expose `PDESystem` input and output field metadata through the standard system accessors
- preserve dependent-variable declaration order and give input metadata precedence over output metadata
- document that numerical support remains discretizer-specific

## Motivation

`PDESystem` fields can already carry `input` and `output` metadata, but `inputs(pdesys)` and `outputs(pdesys)` currently fall through to fields that do not exist on `PDESystem`. Downstream PDE discretizers therefore cannot discover field roles through the public ModelingToolkit system interface.

The accessors are derived from existing dependent-variable metadata. This does not change the `PDESystem` layout, constructor, serialization, or unknown ordering.

## Tests

- focused `ModelingToolkitBase` `pdesystem.jl` test: existing tests plus 14 new role assertions
- wrapped, called, explicitly unwrapped, and array-valued field declarations
- mixed, empty, disabled, ordered, and dual-role metadata
- `Runic --check` on both changed Julia files

## Downstream work

- SciML/PDEBase.jl#104 will preserve active field roles during PDE lowering
- SciML/MethodOfLines.jl#627 will add bounded external-field discretization support

Closes #4914
