### PR TITLE
Avoid InfiniteOpt macro conflicts in dynamic optimization docs

### DIFF
--- a/docs/src/tutorials/dynamic_optimization.md
+++ b/docs/src/tutorials/dynamic_optimization.md
@@ -44,7 +44,7 @@ Now we can construct a problem and solve it. Let us use JuMP as our backend here
 The collocation solver uses a default ODE tableau. A custom tableau can still be supplied when needed.
 
 ```@example dynamic_opt
-using InfiniteOpt, Ipopt
+import InfiniteOpt, Ipopt
 jprob = JuMPDynamicOptProblem(rocket, [u0map; pmap], (ts, te); dt = 0.001)
 jsol = solve(jprob, JuMPCollocation(Ipopt.Optimizer));
 ```


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

Load `InfiniteOpt` and `Ipopt` with `import` in the dynamic optimization tutorial. `using InfiniteOpt` reexports JuMP's `@variables`, making the later ModelingToolkit `@variables` blocks ambiguous and causing every subsequent example in the shared Documenter namespace to fail.

All dependency-owned names in the tutorial are already module-qualified. A focused smoke test also confirms that `import InfiniteOpt` still loads the `MTKInfiniteOptExt` extension.

## Regression evidence

The same file-derived smoke test was run against clean `upstream/master` at `4ae2e03f00957017e6a28e96196c338f3e944bfa` and this branch. It reads the `using`/`import` line from the tutorial, evaluates it between two ModelingToolkit `@variables` declarations, and then evaluates `@parameters`.

Before this change:

```text
ERROR: LoadError: UndefVarError: `@variables` not defined in `Main.DynamicOptDocsImportSmoke`
Hint: It looks like two or more modules export different bindings with this name, resulting in ambiguity.
Hint: a global variable of this name also exists in JuMP.
    - Also exported by InfiniteOpt
Hint: a global variable of this name also exists in Symbolics.
    - Also exported by ModelingToolkitBase.
    - Also exported by ModelingToolkit.
```

After this change:

```text
dynamic optimization import smoke: pass
```

A `git bisect run` identified `e38a335df4904faaf064d9d2615058d7bdec184b`, which added the conflict-bearing tutorial to `docs/pages.jl`, as the first bad commit.

## Verification

```sh
/home/crackauc/.juliaup/bin/julia +release --project=docs --startup-file=no docs/make.jl
```

- Clean base: exited 1 with Documenter errors `[:linkcheck, :example_block]`. The first example error was the ambiguous `@variables`; seven later blocks then failed on undefined names.
- This branch: exited 1 with only `[:linkcheck]`. Every dynamic optimization example, including the formerly failing free-final-time and parameter-estimation blocks, executed without an `:example_block` error.
- The remaining link failures reproduce on clean base: a worktree-local `file://` source link and a transient GitHub 429 for `NEWS.md`. The deterministic local-link failure is being handled independently.

```sh
JULIA_NUM_PRECOMPILE_TASKS=1 GROUP=QA \
  /home/crackauc/.juliaup/bin/julia +release --project=. --startup-file=no \
  -e 'using Pkg; Pkg.test()'
```

Result: `20 passed, 3 failed, 2 errored` in 41m33s, exactly matching clean upstream. The pre-existing findings are JET/ExplicitImports, a missing `StructuralTransformations` docstring, and the unallowlisted `generate_trajectory` reexport; they are unrelated to this Markdown-only change and remain tracked separately.

Additional checks:

```text
git diff --check: pass
typos over the diff: pass
Runic: not applicable (no Julia source changed)
```

No dependencies were added. GPU, downstream, Julia pre-release, and other Julia-version jobs were not run locally.

## Links

- Introducing commit: https://github.com/SciML/ModelingToolkit.jl/commit/e38a335df4904faaf064d9d2615058d7bdec184b
- Existing QA tracking issue: https://github.com/SciML/ModelingToolkit.jl/issues/4670
- Existing JET context: https://github.com/SciML/ModelingToolkit.jl/pull/4879
