### PR TITLE
Configure canonical documentation source links

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -10,6 +10,10 @@ MTKFMIExt = Base.get_extension(ModelingToolkit, :MTKFMIExt)
 ENV["GKSwstype"] = "100"
 using Plots
 
+const REPO_ROOT = abspath(joinpath(@__DIR__, ".."))
+const REPO_REMOTE = Documenter.Remotes.GitHub("SciML", "ModelingToolkit.jl")
+const REPO_COMMIT = readchomp(`git -C $REPO_ROOT rev-parse HEAD`)
+
 cp("./docs/Manifest.toml", "./docs/src/assets/Manifest.toml", force = true)
 cp("./docs/Project.toml", "./docs/src/assets/Project.toml", force = true)
 
@@ -35,6 +39,7 @@ makedocs(
     sitename = "ModelingToolkit.jl",
     authors = "Chris Rackauckas",
     modules = [ModelingToolkitBase, ModelingToolkit, MTKFMIExt],
+    remotes = Dict(REPO_ROOT => (REPO_REMOTE, REPO_COMMIT)),
     clean = true, doctest = true, checkdocs = :exports, linkcheck = true,
     linkcheck_ignore = [
         "https://epubs.siam.org/doi/10.1137/0903023",


### PR DESCRIPTION
> Ignore this PR until reviewed by @ChrisRackauckas.

Adds an explicit Documenter remote mapping for the ModelingToolkit repository:
- repository root: `abspath(joinpath(@__DIR__, ".."))`
- remote: `Documenter.Remotes.GitHub("SciML", "ModelingToolkit.jl")`
- revision: the checked-out repository commit

This preserves canonical HTTPS GitHub source links when the documentation is built from a Git worktree. It does not remove source links, change docstrings, or alter runtime code.

## Local verification

The focused Documenter assertion passed with Julia 1.10.11 and produced:

```text
https://github.com/SciML/ModelingToolkit.jl/blob/458d1e05ee131666c5b0c241d787a0416eecf3d0/lib/ModelingToolkitBase/src/atomic_array_dict.jl#L202-L205
```

`Runic --check docs/make.jl` and `git diff --check` also passed. The broader docs cleanup is being handled separately; this PR is limited to making Documenter resolve repository source URLs correctly.