### PR TITLE
build: bump ModelingToolkitBase for DAE NLStep hook

### DIFF
--- a/lib/ModelingToolkitBase/Project.toml
+++ b/lib/ModelingToolkitBase/Project.toml
@@ -1,7 +1,7 @@
 name = "ModelingToolkitBase"
 uuid = "7771a370-6774-4173-bd38-47e70ca0b839"
 authors = ["Yingbo Ma <mayingbo5@gmail.com>", "Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
-version = "1.62.0"
+version = "1.63.0"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"


### PR DESCRIPTION
Ignore until reviewed by @ChrisRackauckas.

## What changed and why

Bump ModelingToolkitBase from 1.62.0 to 1.63.0 so the public `generate_DAENLStepData` hook added on master can be released. ModelingToolkit master currently permits and resolves registered ModelingToolkitBase 1.62.0 on Julia 1.10, but that release predates the hook and causes ModelingToolkit precompilation to fail.

This is a standalone SemVer-minor release bump. ModelingToolkit already accepts all 1.x ModelingToolkitBase releases through its existing 1.62 compat entry.

## Regression evidence

Failing before, from the working-folder parent with clean ModelingToolkit commit `d7f3ad523c00b4150281f259d1e97618fba79982`, clean LinearSolve commit `f5b63ee4ed69a7558d2133a27d73805556d37a16`, and Julia 1.10.11:

```sh
timeout 3600 julialauncher +1.10 --project=mtk-clean -e 'using Pkg; Pkg.develop(PackageSpec(path=abspath("mtk-ls-clean"))); Pkg.update(); using ModelingToolkit'
```

```text
ERROR: LoadError: UndefVarError: `generate_DAENLStepData` not defined
@ mtk-clean/src/systems/solver_nlprob.jl:10
```

Git bisect identified `4ae2e03f00957017e6a28e96196c338f3e944bfa` as the first bad commit.

Passing from the ModelingToolkit checkout with the bumped local ModelingToolkitBase release contents:

```sh
timeout 3600 julialauncher +1.10 --project=. -e 'using Pkg; Pkg.develop(PackageSpec(path=abspath("lib/ModelingToolkitBase"))); Pkg.develop(PackageSpec(path=abspath("../mtk-ls-clean"))); Pkg.update(); using ModelingToolkit; println("MODELINGTOOLKIT_LOAD_OK")'
```

```text
MODELINGTOOLKIT_LOAD_OK
```

## Verification

```sh
env GROUP=InterfaceI julialauncher +1.10 --project=. -e 'using Pkg; Pkg.test()'
```

```text
Test Summary: | Pass  Broken  Total      Time
InterfaceI    | 1501       5   1506  24m02.0s
Testing ModelingToolkitBase tests passed
```

```sh
env GROUP=QA julialauncher +1.10 --project=. -e 'using Pkg; Pkg.test()'
```

```text
JET Tests  | 54 passed, 54 total
Aqua Tests | 10 passed, 1 failed
```

The Aqua piracy failure reproduces on clean master. Its QA lane has been red since the lane was introduced by `9fadfdca1e0c119ce7d109ae7fa5416ca05ce200`. Draft PR 4907 fixes the four JumpProcesses-related methods; the ten historical `SymbolicUtils.Code.toexpr` methods are tracked by issue 4670. This version-only diff does not touch those methods.

Additional checks:

- `git diff --check upstream/master...HEAD`: clean.
- `typos lib/ModelingToolkitBase/Project.toml`: clean.
- Runic is not applicable to a TOML-only diff.

## CI status

CI completed with 76 passing, 14 failing, and 3 skipped checks. None of the failures exercise the changed version line:

- Five long jobs reached the two-hour job limit and ended only with `The operation was canceled`, without a test failure: root QA on Julia 1, root InterfaceII on Julia pre, root Optimization on Julia lts, and ModelingToolkitBase Optimization on Julia lts/pre.
- The two benchmark failures are tracked by issue 4910.
- The Catalyst unexpected passes are fixed on Catalyst master by PR 1512 and await a release.
- The ModelingToolkitBase downgrade, InterfaceI minimum-version, and ModelingToolkitStandardLibrary resolver failures have clean reproductions and focused tracking issues or fixes linked below.
- The remaining Optimization Julia 1/pre error reproduces on clean master and is tracked separately by issue 4925.

## Not verified

- The original downstream job cannot resolve 1.63.0 until this bump is merged, tagged, and registered; the explicit local-develop reproducer verifies the release contents in the meantime.
- Docs were not built because this PR only changes package version metadata. The hook documentation and tests landed with the feature commit.
- GPU paths were not run.

## Review note

The judgment call is a minor rather than patch bump because `generate_DAENLStepData` is new public API.

## Links

- First bad downstream commit: https://github.com/SciML/ModelingToolkit.jl/commit/4ae2e03f00957017e6a28e96196c338f3e944bfa
- Existing jump-piracy fix: https://github.com/SciML/ModelingToolkit.jl/pull/4907
- Existing piracy tracking issue: https://github.com/SciML/ModelingToolkit.jl/issues/4670
- Benchmark tracking issue: https://github.com/SciML/ModelingToolkit.jl/issues/4910
- Catalyst unexpected-pass fix: https://github.com/SciML/Catalyst.jl/pull/1512
- ModelingToolkitBase DiffEqBase floor issue: https://github.com/SciML/ModelingToolkit.jl/issues/4922
- BoundaryValueDiffEqMIRK floor issue: https://github.com/SciML/ModelingToolkit.jl/issues/4923
- LinearSolve floor issue: https://github.com/SciML/ModelingToolkit.jl/issues/4924
- ModelingToolkitStandardLibrary resolver issue: https://github.com/SciML/ModelingToolkitStandardLibrary.jl/issues/498
- ModelingToolkitStandardLibrary resolver fix: https://github.com/SciML/ModelingToolkitStandardLibrary.jl/pull/499
- Optimization generated-parameter tracking issue: https://github.com/SciML/ModelingToolkit.jl/issues/4925
- LinearSolve PR downstream failure: https://github.com/SciML/LinearSolve.jl/actions/runs/31363806735/job/93377835731
- Clean LinearSolve main downstream failure: https://github.com/SciML/LinearSolve.jl/actions/runs/31361291552/job/93370530272
