### PR TITLE
test: use processed parameters for trajectories

### DIFF
--- a/lib/ModelingToolkitBase/test/optimization/dynamic_optimization.jl
+++ b/lib/ModelingToolkitBase/test/optimization/dynamic_optimization.jl
@@ -900,7 +900,7 @@ struct UnsupportedTrajectoryBackend end
     )
 
     # Expressions are compiled to callables of the independent variable
-    p_test = MTKParameters(block, parammap)
+    p_test = iprob.p
     fx = M.build_trajectory_function(block, x(t), 0.125 * t^2, p_test)
     @test fx isa Function
     @test fx(2.0) ≈ 0.5
@@ -919,7 +919,8 @@ struct UnsupportedTrajectoryBackend end
     @parameters a
     @named psys = System([D(x(t)) ~ a * v(t), D(v(t)) ~ 0.0], t)
     psys = mtkcompile(psys)
-    fp = M.build_trajectory_function(psys, x(t), a * t, MTKParameters(psys, [a => 4.0]))
+    oprob = ODEProblem(psys, [x(t) => 0.0, v(t) => 0.0, a => 4.0], tspan)
+    fp = M.build_trajectory_function(psys, x(t), a * t, oprob.p)
     @test fp(2.0) ≈ 8.0
 
     # Anything that does not reduce to time and parameters is reported


### PR DESCRIPTION
Ignore until reviewed by @ChrisRackauckas.

## What changed and why

Use parameter objects produced by the public problem-construction paths in the expression-valued trajectory tests. Direct `MTKParameters` construction omitted generated parameters such as `var"v#0"(t)`, so the Optimization group errored before exercising the trajectory function on Julia 1.10 and 1.12.

The existing `InfiniteOptDynamicOptProblem` now supplies `iprob.p`; the independent parameterized system obtains `p` from an `ODEProblem` constructed with its initial values and parameter. This tests the same `build_trajectory_function` behavior without duplicating problem processing or naming generated parameters.

## Regression evidence

Failing before on clean `d7f3ad523c00b4150281f259d1e97618fba79982` with Julia 1.10.11:

```sh
GROUP=Optimization timeout 3600 /home/crackauc/.juliaup/bin/julia +lts --project -e 'using Pkg; Pkg.test(coverage=false)'
```

```text
Some parameters are missing from the variable map.
Please provide a value or default for the following variables:

var"v#0"(t)

Test Summary: | Pass  Error  Broken  Total
Optimization  |  158      1       1    160
```

Passing after with the same command:

```text
Test Summary: | Pass  Broken  Total      Time
Optimization  |  160       1    161  14m46.3s
Testing ModelingToolkit tests passed
```

## Verification

```sh
GROUP=Optimization timeout 3600 /home/crackauc/.juliaup/bin/julia +lts --project -e 'using Pkg; Pkg.test(coverage=false)'
```

```text
Optimization | 160 passed, 1 broken, 161 total | 14m46.3s
```

```sh
GROUP=Optimization timeout 3600 /home/crackauc/.juliaup/bin/julia +release --project -e 'using Pkg; Pkg.test(coverage=false)'
```

```text
Optimization | 186 passed, 1 broken, 187 total | 23m36.5s
```

```sh
/home/crackauc/.juliaup/bin/julia +release -m Runic --check lib/ModelingToolkitBase/test/optimization/dynamic_optimization.jl
typos lib/ModelingToolkitBase/test/optimization/dynamic_optimization.jl
git diff --check upstream/master...HEAD
```

All three checks exited 0 with no output.

The required QA group was also run on this exact branch. A first isolated-depot run reached its 3600-second shell limit after spending about 31 minutes precompiling, before it emitted a test summary. The warm rerun completed:

```sh
JULIA_DEPOT_PATH=.opt-qa-depot:/home/crackauc/.julia GROUP=QA timeout 7200 /home/crackauc/.juliaup/bin/julia +release --project -e 'using Pkg; Pkg.test(coverage=false)'
```

```text
QA | 19 passed, 3 failed, 3 errored, 25 total | 39m30.7s
```

It reproduced the clean-base ExplicitImports errors, missing `StructuralTransformations` docstring, unapproved `generate_trajectory` reexport, and existing JET reports tracked in issue 4670. The isolated two-depot setup added an Aqua `Persistent tasks` error from a Pkg manifest assertion; the clean-base run without that setup reported 20 passed, 3 failed, and 2 errored. Aqua Piracy passed in the branch run. This test-only diff is not loaded by the QA group.

## Not verified

- Documentation was not built because this changes only an internal test and no public API or docstring.
- GPU and downstream package paths were not run.

## Review note

The deliberate choice is to reuse processed problem parameters instead of manufacturing values for `parameters(sys; initial_parameters=true)`: generated parameter identities are transformation details, while `prob.p` is the public processed result callers actually use.

## Links

- Tracking issue: https://github.com/SciML/ModelingToolkit.jl/issues/4925
- Failing Julia LTS job: https://github.com/SciML/ModelingToolkit.jl/actions/runs/31361117175/job/93370103717
- Existing clean-base QA failures: https://github.com/SciML/ModelingToolkit.jl/issues/4670
- Test-introducing pull request: https://github.com/SciML/ModelingToolkit.jl/pull/4839
