### PR TITLE
Fix verbose flag propagation in the InfiniteOpt backend

### DIFF
--- a/lib/ModelingToolkitBase/ext/MTKInfiniteOptExt.jl
+++ b/lib/ModelingToolkitBase/ext/MTKInfiniteOptExt.jl
@@ -322,7 +322,6 @@ function MTK.prepare_and_optimize!(
         prob::JuMPDynamicOptProblem, solver::JuMPCollocation; verbose = false, kwargs...
     )
     model = prob.wrapped_model.model
-    verbose || set_silent(model)
     # Unregister current solver constraints
     for con in all_constraints(model)
         if occursin("solve", JuMP.name(con))
@@ -339,6 +338,11 @@ function MTK.prepare_and_optimize!(
     end
     add_solve_constraints!(prob, solver.tableau)
     set_optimizer(model, solver.solver)
+    # `set_optimizer` resets the backend, so the silent flag must be applied
+    # afterwards or it is discarded. `unset_silent` (rather than an
+    # optimizer-specific option such as Ipopt's `print_level`) keeps this
+    # working with any optimizer.
+    verbose ? unset_silent(model) : set_silent(model)
     optimize!(model)
     return model
 end
@@ -348,9 +352,13 @@ function MTK.prepare_and_optimize!(
         solver::InfiniteOptCollocation; verbose = false, kwargs...
     )
     model = prob.wrapped_model.model
-    verbose || set_silent(model)
     set_derivative_method(model[:t], solver.derivative_method)
     set_optimizer(model, solver.solver)
+    # `set_optimizer` resets the backend, so the silent flag must be applied
+    # afterwards or it is discarded. `unset_silent` (rather than an
+    # optimizer-specific option such as Ipopt's `print_level`) keeps this
+    # working with any optimizer.
+    verbose ? unset_silent(model) : set_silent(model)
     optimize!(model)
     return model
 end

--- a/lib/ModelingToolkitBase/test/optimization/dynamic_optimization.jl
+++ b/lib/ModelingToolkitBase/test/optimization/dynamic_optimization.jl
@@ -962,7 +962,7 @@ end
     isol = solve(iprob, InfiniteOptCollocation(Ipopt.Optimizer))
     @test isol.sol[x][end] > isol.sol[x][begin]
 end
-                                                      
+
 @testset "Residual scaling of dynamics constraints" begin
     # Double integrator with nominal_values - should converge to same answer
     @variables x(..) v(..)
@@ -1034,4 +1034,26 @@ end
     changed = [(a, b) for (a, b) in zip(unscaled, rescaled) if a != b]
     @test length(changed) == 1
     @test occursin("0.1", last(only(changed)))
+end
+
+@testset "Verbose flag propagation" begin
+    @variables x(..)
+    @variables u(..) [bounds = (-1.0, 1.0), input = true]
+    @named vsys = System([D(x(t)) ~ u(t)], t; costs = [EvalAt(1.0)(x(t))^2])
+    vsys = mtkcompile(vsys; inputs = [u(t)])
+    op = [x(t) => 1.0, u(t) => 0.0]
+
+    # The silent flag used to be applied before `set_optimizer`, which resets it:
+    # `verbose = false` solves still printed the full solver log. Assert the flag
+    # survives on the model that `optimize!` actually saw.
+    silent_flag(m) = InfiniteOpt.get_attribute(m, InfiniteOpt.MOI.Silent())
+    for (verbose, silent) in ((false, true), (true, false))
+        jprob = JuMPDynamicOptProblem(vsys, op, (0.0, 1.0); dt = 0.25)
+        solve(jprob, JuMPCollocation(Ipopt.Optimizer, ExplicitTableaus.Verner8()); verbose)
+        @test silent_flag(jprob.wrapped_model.model) == silent
+
+        iprob = InfiniteOptDynamicOptProblem(vsys, op, (0.0, 1.0); dt = 0.25)
+        solve(iprob, InfiniteOptCollocation(Ipopt.Optimizer); verbose)
+        @test silent_flag(iprob.wrapped_model.model) == silent
+    end
 end


### PR DESCRIPTION
## Problem

Both `prepare_and_optimize!` methods in MTKInfiniteOptExt applied the silent flag (`verbose || set_silent(model)`) *before* `set_optimizer`. `set_optimizer` resets the model backend, discarding the attribute — so `verbose = false` (the default) solves still print the full solver log, which is also why the optimization test logs are full of Ipopt iteration tables.

## Fix

Apply the flag after `set_optimizer`, using `verbose ? unset_silent(model) : set_silent(model)`. `unset_silent` is deliberately preferred over an optimizer-specific option such as Ipopt's `"print_level" => 5`: it works with any MOI optimizer (MadNLP, for one, expects a `MadNLP.LogLevels` enum and errors on an `Int` print level).

## Tests

New "Verbose flag propagation" testset asserts `MOI.Silent` on the model that `optimize!` actually saw, for both `verbose = false` and `verbose = true`, on both the JuMP and InfiniteOpt problem types. Also strips a trailing-whitespace line in the test file that fails the whole-file Runic check.

## Note on SciMLLogging

Verbosity across SciML is moving to SciMLLogging.jl, but MTKBase hasn't adopted it yet (`utils.jl` notes the migration as future work), and the sibling backends handle `verbose` the same way (e.g. CasADi's `verbose || solver_options["print_level"] = 0`). This PR keeps the existing plain-Bool contract and just fixes the ordering bug; happy to route it through SciMLLogging instead if that migration should start here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
