### PR TITLE
Generate control-aware dynamics for BVProblems on compiled systems

### DIFF
--- a/lib/ModelingToolkitBase/src/problems/bvproblem.jl
+++ b/lib/ModelingToolkitBase/src/problems/bvproblem.jl
@@ -28,9 +28,15 @@ end
     dvs = unknowns(sys)
     ctrls = inputs(sys)
     op = to_varmap(op, dvs)
+    # Optimal-control BVPs (systems carrying a cost) deliberately pin only the
+    # operating-point initial conditions — the remaining degrees of freedom are
+    # what the cost selects — and their algebraic equations (e.g. lifted output
+    # bounds) do not imply a fully determined initial state. Only plain algebraic
+    # BVPs skip the guess merge and pin every state.
+    is_full_ic = has_alg_eqs(sys) && isempty(get_costs(sys))
     # Systems without algebraic equations should use both fixed values + guesses
     # for initialization.
-    _op = has_alg_eqs(sys) ? op : merge(Dict(op), Dict(guesses))
+    _op = is_full_ic ? op : merge(Dict(op), Dict(guesses))
 
     if isempty(ctrls)
         fode, u0,
@@ -56,6 +62,10 @@ end
         )
         fode = BVPStackedControlRHS(fin, length(dvs))
         f_prototype = zeros(eltype(u0), length(dvs))
+        # The bare wrapper hides the generated function's mass matrix from
+        # BVPFunction's `__has_mass_matrix` probe; forward it explicitly so
+        # algebraic (lifted-output) rows keep their zero mass rows.
+        mass_matrix = fin.mass_matrix
     end
 
     fcost = generate_bvp_cost(
@@ -67,7 +77,7 @@ end
     )
 
     stidxmap = Dict([v => i for (i, v) in enumerate(dvs)])
-    u0_idxs = has_alg_eqs(sys) ? collect(1:length(dvs)) :
+    u0_idxs = is_full_ic ? collect(1:length(dvs)) :
         [stidxmap[k] for (k, v) in op if haskey(stidxmap, k)]
     # The boundary-condition residual is generated from the state-length `u0`;
     # the controls are appended to the problem's decision vector afterwards.
@@ -86,7 +96,13 @@ end
         u0 = vcat(u0, c0)
     end
 
-    bvpfn = BVPFunction{_iip}(fode, fbc; cost = fcost, f_prototype, bcresid_prototype)
+    bvpfn = if isempty(ctrls)
+        BVPFunction{_iip}(fode, fbc; cost = fcost, f_prototype, bcresid_prototype)
+    else
+        BVPFunction{_iip}(
+            fode, fbc; cost = fcost, f_prototype, bcresid_prototype, mass_matrix
+        )
+    end
 
     if (length(constraints(sys)) + length(op) > length(dvs))
         @warn "The BVProblem is overdetermined. The total number of conditions (# constraints + # fixed initial values given by op) exceeds the total number of states. The BVP solvers will default to doing a nonlinear least-squares optimization."

--- a/lib/ModelingToolkitBase/src/problems/bvproblem.jl
+++ b/lib/ModelingToolkitBase/src/problems/bvproblem.jl
@@ -1,3 +1,18 @@
+# Adapts dynamics generated with an explicit control argument, `f(du, x, u, p, t)`,
+# to the stacked decision vector the BVP solvers hand out: each mesh-node vector is
+# `[states; controls]`, the controls being extra per-node decision variables with no
+# differential equations of their own (`f_prototype` tells the solver how many
+# defect rows exist).
+struct BVPStackedControlRHS{F} <: Function
+    f::F
+    nx::Int
+end
+function (w::BVPStackedControlRHS)(du, xu, p, t)
+    w.f(du, @view(xu[1:(w.nx)]), @view(xu[(w.nx + 1):end]), p, t)
+    return nothing
+end
+(w::BVPStackedControlRHS)(xu, p, t) = w.f(@view(xu[1:(w.nx)]), @view(xu[(w.nx + 1):end]), p, t)
+
 @fallback_iip_specialize function SciMLBase.BVProblem{iip, spec}(
         sys::System, op, tspan;
         check_compatibility = true,
@@ -11,17 +26,37 @@
 
     _iip = resolve_iip(iip, op)
     dvs = unknowns(sys)
+    ctrls = inputs(sys)
     op = to_varmap(op, dvs)
     # Systems without algebraic equations should use both fixed values + guesses
     # for initialization.
     _op = has_alg_eqs(sys) ? op : merge(Dict(op), Dict(guesses))
 
-    fode, u0,
-        p = process_SciMLProblem(
-        ODEFunction{_iip, spec}, sys, _op; guesses,
-        t = tspan !== nothing ? tspan[1] : tspan, check_compatibility = false,
-        checkbounds, time_dependent_init = false, expression, kwargs...
-    )
+    if isempty(ctrls)
+        fode, u0,
+            p = process_SciMLProblem(
+            ODEFunction{_iip, spec}, sys, _op; guesses,
+            t = tspan !== nothing ? tspan[1] : tspan, check_compatibility = false,
+            checkbounds, time_dependent_init = false, expression, kwargs...
+        )
+        f_prototype = nothing
+    else
+        # Like `process_DynamicOptProblem`: a plain `ODEFunction` on a compiled
+        # system would freeze the inputs at their operating-point parameter values
+        # and silently generate control-free dynamics. Generate with an explicit
+        # control argument instead and stack the controls onto each node's decision
+        # vector; their initial values come from the processed parameter object.
+        expression == Val{false} ||
+            error("`expression = Val{true}` is not supported for BVProblems with control inputs.")
+        fin, u0,
+            p = process_SciMLProblem(
+            ODEInputFunction{_iip, spec}, sys, _op; guesses, inputs = ctrls,
+            t = tspan !== nothing ? tspan[1] : tspan, check_compatibility = false,
+            checkbounds, time_dependent_init = false, expression, kwargs...
+        )
+        fode = BVPStackedControlRHS(fin, length(dvs))
+        f_prototype = zeros(eltype(u0), length(dvs))
+    end
 
     fcost = generate_bvp_cost(
         sys,
@@ -34,6 +69,8 @@
     stidxmap = Dict([v => i for (i, v) in enumerate(dvs)])
     u0_idxs = has_alg_eqs(sys) ? collect(1:length(dvs)) :
         [stidxmap[k] for (k, v) in op if haskey(stidxmap, k)]
+    # The boundary-condition residual is generated from the state-length `u0`;
+    # the controls are appended to the problem's decision vector afterwards.
     fbc = generate_boundary_conditions(
         sys, u0, u0_idxs, tspan[1],
         GeneratedFunctionOptions(;
@@ -42,9 +79,12 @@
         )
     )
 
-    n_controls = length(default_codegen_inputs(sys))
-    f_prototype = n_controls > 0 ? zeros(eltype(u0), length(dvs) - n_controls) : nothing
     bcresid_prototype = zeros(eltype(u0), length(u0_idxs) + length(constraints(sys)))
+
+    if !isempty(ctrls)
+        c0 = collect(eltype(u0), SymbolicIndexingInterface.getp(sys, ctrls)(p))
+        u0 = vcat(u0, c0)
+    end
 
     bvpfn = BVPFunction{_iip}(fode, fbc; cost = fcost, f_prototype, bcresid_prototype)
 

--- a/lib/ModelingToolkitBase/test/bvproblem.jl
+++ b/lib/ModelingToolkitBase/test/bvproblem.jl
@@ -390,3 +390,42 @@ end
     @test bsol.ps[α] ≈ 1.8 rtol = 1.0e-2
     @test bsol.ps[γ] ≈ 6.5 rtol = 1.0e-2
 end
+
+@testset "Control-aware dynamics on compiled systems" begin
+    # A compiled system with a bound input used to generate control-free dynamics:
+    # `ODEFunction` froze the input at its operating-point value, and
+    # `f_prototype = length(dvs) - n_controls` miscounted the defect rows.
+    @variables x(t) u(t) [input = true, bounds = (-1.0, 1.0)]
+    costs = [ModelingToolkitBase.EvalAt(2.0)(x)^2]
+    cons = [ModelingToolkitBase.EvalAt(0.0)(x) ~ 1.0]
+    @named plant = System([D(x) ~ u], t; costs, constraints = cons)
+    @variables y(t) [output = true] v(t) [input = true, bounds = (-1.0, 1.0)]
+    @named gain = System([y ~ v], t)
+    @named composed = System([connect(gain.y, plant.u)], t; systems = [plant, gain])
+    sys = mtkcompile(composed; inputs = [gain.v])
+
+    prob = BVProblem(sys, [plant.x => 1.0, gain.v => 0.25], (0.0, 2.0))
+
+    nx = length(unknowns(sys))
+    nc = length(ModelingToolkitBase.inputs(sys))
+    @test nc == 1
+    # The controls are appended to the per-node decision vector, seeded from op
+    @test length(prob.u0) == nx + nc
+    @test prob.u0[(nx + 1):end] == [0.25]
+    # Defect rows are sized by the true state count, not states + controls
+    @test length(prob.f.f_prototype) == nx
+
+    # The dynamics respond to the stacked control input; D(x) ~ u exactly here
+    du1 = zeros(nx)
+    du2 = zeros(nx)
+    xu = copy(prob.u0)
+    xu[nx + 1] = 0.7
+    prob.f.f(du1, xu, prob.p, 0.0)
+    xu[nx + 1] = -0.3
+    prob.f.f(du2, xu, prob.p, 0.0)
+    @test du1[1] ≈ 0.7
+    @test du2[1] ≈ -0.3
+
+    # Out-of-place evaluation goes through the same stacked wrapper
+    @test prob.f.f(xu, prob.p, 0.0)[1] ≈ -0.3
+end


### PR DESCRIPTION
## Problem

`BVProblem` construction generated dynamics through `ODEFunction`, which on compiled systems freezes bound inputs at their operating-point parameter values — the same control-free-dynamics trap `process_DynamicOptProblem` documents. At the same time, `f_prototype = length(dvs) - n_controls` miscounted the defect rows (inputs are no longer part of `unknowns` after compilation), so the generated `f!` wrote past the solver's `f_prototype`-sized stage buffers.

## Fix

When the compiled system has inputs, generate through `ODEInputFunction` with `inputs = inputs(sys)` and adapt the result to the BVP solvers' stacked per-node decision vector `[states; controls]` via a small `BVPStackedControlRHS` wrapper. Control initial values are read from the processed parameter object and appended to `u0`, and `f_prototype` is sized by the true state count.

Two optimal-control refinements ride along:

- Cost-carrying systems pin only the operating-point initial conditions and keep the guess merge even when algebraic equations are present: their remaining degrees of freedom are what the cost selects, and lifted output bounds introduce algebraic rows without implying a fully determined initial state. Plain algebraic BVPs keep the previous full-IC behavior.
- The generated function's mass matrix is forwarded through the stacked-control wrapper (`BVPFunction`'s `__has_mass_matrix` probe cannot see through a bare wrapper), so algebraic (lifted-output) rows keep their zero mass rows.

With this, output path constraints can be expressed by lifting the bounded outputs into irreducible algebraic unknowns before compilation: the lifted variables become plain per-node decision variables of a semi-explicit index-1 DAE-BVP, and ordinary lb/ub bounds enforce the limits at the mesh nodes.

## Tests

A construction-level regression testset asserts the control is appended to the decision vector and seeded from `op`, `f_prototype` matches the state count, and the generated dynamics respond to the stacked control input (in-place and out-of-place). Solving these problems requires the optimize seat on the BVP solvers (BoundaryValueDiffEq.jl side), so end-to-end solves are exercised downstream; this path has been validated against a racing optimal-control benchmark (lifted DAE-BVP converging to the reference lap time).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
