### PR TITLE
Let user nominal values override the metadata in observed-bound lifting

### DIFF
--- a/lib/ModelingToolkitBase/src/systems/optimal_control_interface.jl
+++ b/lib/ModelingToolkitBase/src/systems/optimal_control_interface.jl
@@ -481,7 +481,8 @@ function process_DynamicOptProblem(
 
     set_variable_bounds!(fullmodel, sys, pmap, tspan, tunable_params, bounds)
     add_observed_bounds!(
-        fullmodel, sys, pmap, tspan, tunable_params, bounds, observed_bounds_method
+        fullmodel, sys, pmap, tspan, tunable_params, bounds, observed_bounds_method,
+        nominal_values
     )
     add_cost_function!(fullmodel, sys, tspan, pmap)
     add_user_constraints!(fullmodel, sys, tspan, pmap)
@@ -721,7 +722,8 @@ Enforce bounds declared on observed variables.
     everywhere else.
 """
 function add_observed_bounds!(
-        model, sys, pmap, tspan, tunable_params, user_bounds, method = :auto
+        model, sys, pmap, tspan, tunable_params, user_bounds, method = :auto,
+        nominal_values = Dict()
     )
     (; observed_bounds) = extract_variable_bounds(
         sys, pmap, tspan, tunable_params, user_bounds
@@ -743,9 +745,10 @@ function add_observed_bounds!(
         hi = value(Symbolics.fixpoint_sub(hi, pmap))
         if method === :lift
             expr = fixpoint_sub(var, rules; fold = Val(true), filterer = Returns(true))
-            lift_observed_bound!(
-                model, expr, lo, hi, getnominal(var), aux_start_value(lo, hi)
-            )
+            # A user-supplied nominal value overrides the metadata, mirroring the
+            # residual scaling of the dynamics constraints.
+            scale = get(nominal_values, var, getnominal(var))
+            lift_observed_bound!(model, expr, lo, hi, scale, aux_start_value(lo, hi))
         else
             cons = Any[]
             isfinite(lo) && push!(cons, var ≳ lo)


### PR DESCRIPTION
Follow-up to #4840, now that #4841's `nominal_values` keyword is available.

The lifted equality `(expr - aux) / scale == 0` introduced in #4840 scales only by `getnominal(var)`, which defaults to 1. An observed quantity whose magnitude is far from 1 then contributes a badly scaled equality row to the NLP, which can push interior-point solvers into the restoration phase. This lets the user-supplied `nominal_values` dict override the metadata for lifted observed bounds, exactly mirroring what #4841 does for the dynamics residuals.

Validated end-to-end on the dynamic-optimization benchmark used to validate the #4394 split PRs. The existing observed-bounds testsets cover the default (`getnominal`) path, which is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)