### PR TITLE
Restore ModelingToolkitBase Aqua classifications

### DIFF
--- a/lib/ModelingToolkitBase/test/qa/aqua.jl
+++ b/lib/ModelingToolkitBase/test/qa/aqua.jl
@@ -3,4 +3,26 @@ using Aqua
 using JET
 using SciMLTesting
 
-run_qa(ModelingToolkitBase; Aqua, JET, jet = true)
+# This is loaded only by MTKBifurcationKitExt, while remaining a hard dependency so
+# loading BifurcationKit alone still activates the extension.
+const STALE_EXTENSION_DEPENDENCIES = [:SimpleNonlinearSolve]
+
+# ModelingToolkitBase supplies Symbolics expression-protocol methods for equations and
+# JumpProcesses jump types. These methods intentionally extend the corresponding
+# SymbolicUtils generic functions, while all other piracies remain checked.
+const INTENTIONAL_EXTERNAL_GENERIC_EXTENSIONS = (
+    ModelingToolkitBase.SymbolicUtils.search_variables!,
+    ModelingToolkitBase.toexpr,
+)
+
+run_qa(
+    ModelingToolkitBase;
+    Aqua,
+    JET,
+    jet = true,
+    aqua_kwargs = (
+        ;
+        stale_deps = (; ignore = STALE_EXTENSION_DEPENDENCIES),
+        piracies = (; treat_as_own = INTENTIONAL_EXTERNAL_GENERIC_EXTENSIONS),
+    ),
+)


### PR DESCRIPTION
Ignore until reviewed by @ChrisRackauckas.

This post-#4832 follow-up is intentionally limited to `lib/ModelingToolkitBase/test/qa/aqua.jl`. It restores the historical `SimpleNonlinearSolve` stale-dependency exception required by `MTKBifurcationKitExt` and classifies only the two intentional external generic extensions (`SymbolicUtils.search_variables!` and `toexpr`) as owned by ModelingToolkitBase.

History: `9451997d80` added the extension-dependency exception; merged `92c27bb9fd` removed it when QA moved to bare strict `run_qa`.

Validation:
- untouched Aqua fails only on `SimpleNonlinearSolve`
- restored stale-dependency exception leaves only the 14 intended piracy reports
- this exact one-file change passes all Aqua checks, including stale dependencies, piracy, compat, and persistent tasks
- `git diff --check`
- Runic check for the changed file

The full strict QA still has separate baseline JET, ExplicitImports, and unapproved-reexport debt. This PR does not suppress or allowlist those failures.