### PR TITLE
docs: remove duplicate System API entries

### DIFF
--- a/docs/src/API/System.md
+++ b/docs/src/API/System.md
@@ -264,12 +264,3 @@ isolated, input_vars, output_vars =
     isolate_subsystem(closed_loop, :plant_input, :plant_output)
 isequal(only(input_vars), plant.input.u), isequal(only(output_vars), plant.output.u)
 ```
-
-## Additional Equation Classification
-
-```@docs
-alg_equations
-diff_equations
-has_alg_equations
-has_diff_equations
-```


### PR DESCRIPTION
Remove the duplicate noncanonical System API documentation block. The four canonical entries remain in the earlier equation-querying section.

Validation:
- git diff --check passed.
- Direct Julia 1.10 API documentation check passed for alg_equations, diff_equations, has_alg_equations, and has_diff_equations; each appears exactly once in docs/src/API/System.md.
- Configured docs build was attempted with julia +1.10 --project=docs --startup-file=no docs/make.jl; it exits 1 on pre-existing dependency doctests.

Baseline failures, reproduced on detached origin/master at 3061ef5b1d with the identical command:
- ModelingToolkitBase/src/discretedomain.jl:15-20: Shift is undefined.
- ModelingToolkitBase/src/discretedomain.jl:222-229: ModelingToolkit is undefined.
- ModelingToolkitBase/src/discretedomain.jl:222-229: Sample is undefined.

Ignore until reviewed by @ChrisRackauckas.