### PR TITLE
docs: remove stale API targets

### DIFF
--- a/docs/src/API/dynamic_opt.md
+++ b/docs/src/API/dynamic_opt.md
@@ -29,7 +29,6 @@ JuMPCollocation
 InfiniteOptCollocation
 CasADiCollocation
 PyomoCollocation
-CommonSolve.solve(::AbstractDynamicOptProblem)
 DynamicOptSolution
 ```
 

--- a/docs/src/API/model_building.md
+++ b/docs/src/API/model_building.md
@@ -250,30 +250,3 @@ Sample
 Hold
 SampleTime
 ```
-
-ModelingToolkit uses the clock definition in SciMLBase
-
-```@docs
-SciMLBase.TimeDomain
-SciMLBase.Clock
-SciMLBase.SolverStepClock
-SciMLBase.Continuous
-```
-
-### State machines
-
-While ModelingToolkit has the capability to represent state machines, it lacks the ability
-to compile and simulate them.
-
-!!! warn
-
-    This functionality is considered experimental API
-
-```@docs
-initial_state
-transition
-activeState
-entry
-ticksInState
-timeInState
-```

--- a/docs/src/API/variables.md
+++ b/docs/src/API/variables.md
@@ -197,7 +197,6 @@ getnominal(x[1])
 hasnominal
 getnominal
 setnominal
-ModelingToolkit.VariableNominal
 ```
 
 ## Guess
@@ -395,10 +394,6 @@ ModelingToolkit makes heavy use of "operators". These are custom functions that 
 to symbolic variables. The most common operator is the `Differential` operator, defined in
 Symbolics.jl.
 
-```@docs
-Symbolics.Differential
-```
-
 ModelingToolkit also defines a plethora of custom operators.
 
 ```@docs
@@ -429,5 +424,4 @@ such systems, it has the capability to represent them.
 Sample
 Hold
 SampleTime
-sampletime
 ```

--- a/docs/src/tutorials/SampledData.md
+++ b/docs/src/tutorials/SampledData.md
@@ -193,5 +193,4 @@ connections = [r ~ sin(t)          # reference signal
 Sample
 Hold
 ShiftIndex
-Clock
 ```


### PR DESCRIPTION
## Summary
- Remove stale, external-owner, and removed `@docs` targets from the four owned pages.
- Retain current ModelingToolkit-owned API documentation.

## Validation
- `git diff --check`
- `julia +1.10 --project=docs docs/make.jl` (exercises doctests and strict docs; repository baseline diagnostics remain)

Ignore until reviewed by @ChrisRackauckas.