### PR TITLE
docs: remove stale API targets

### DIFF
--- a/docs/src/API/dynamic_opt.md
+++ b/docs/src/API/dynamic_opt.md
@@ -29,7 +29,6 @@ JuMPCollocation
 InfiniteOptCollocation
 CasADiCollocation
 PyomoCollocation
-CommonSolve.solve(::AbstractDynamicOptProblem)
 DynamicOptSolution
 ```
 

--- a/docs/src/API/model_building.md
+++ b/docs/src/API/model_building.md
@@ -250,30 +250,3 @@ Sample
 Hold
 SampleTime
 ```
-
-ModelingToolkit uses the clock definition in SciMLBase
-
-```@docs
-SciMLBase.TimeDomain
-SciMLBase.Clock
-SciMLBase.SolverStepClock
-SciMLBase.Continuous
-```
-
-### State machines
-
-While ModelingToolkit has the capability to represent state machines, it lacks the ability
-to compile and simulate them.
-
-!!! warn
-
-    This functionality is considered experimental API
-
-```@docs
-initial_state
-transition
-activeState
-entry
-ticksInState
-timeInState
-```

--- a/docs/src/API/variables.md
+++ b/docs/src/API/variables.md
@@ -392,12 +392,8 @@ ModelingToolkit.dump_parameters
 ## Symbolic operators
 
 ModelingToolkit makes heavy use of "operators". These are custom functions that are applied
-to symbolic variables. The most common operator is the `Differential` operator, defined in
+to symbolic variables. The most common operator is the Differential operator, defined in
 Symbolics.jl.
-
-```@docs
-Symbolics.Differential
-```
 
 ModelingToolkit also defines a plethora of custom operators.
 
@@ -429,5 +425,4 @@ such systems, it has the capability to represent them.
 Sample
 Hold
 SampleTime
-sampletime
 ```

--- a/docs/src/tutorials/SampledData.md
+++ b/docs/src/tutorials/SampledData.md
@@ -193,5 +193,4 @@ connections = [r ~ sin(t)          # reference signal
 Sample
 Hold
 ShiftIndex
-Clock
 ```


### PR DESCRIPTION
Removes stale or externally owned API documentation targets from the dynamic optimization, model-building, variables, and sampled-data documentation.

Validation:
- `git diff --check`
- Full strict docs build; it still fails on pre-existing repository-wide documentation and linkcheck errors, while the removed `@docs` target errors are absent.

Ignore until reviewed by @ChrisRackauckas.