### PR TITLE
Import benchmark init from CommonSolve

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -23,5 +23,5 @@ jobs:
         with:
           julia-version: "${{ matrix.version }}"
           script: "benchmark/benchmarks.jl"
-          extra-pkgs: "${{ github.event.pull_request.head.repo.clone_url }}#${{ github.event.pull_request.head.sha }}:lib/ModelingToolkitBase,ModelingToolkitStandardLibrary,OrdinaryDiffEqDefault"
+          extra-pkgs: "${{ github.event.pull_request.head.repo.clone_url }}#${{ github.event.pull_request.head.sha }}:lib/ModelingToolkitBase,ModelingToolkitStandardLibrary,OrdinaryDiffEqDefault,CommonSolve"
           job-summary: "${{ github.event.pull_request.head.repo.fork }}"

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -4,6 +4,7 @@ using ModelingToolkitStandardLibrary.Electrical
 using ModelingToolkitStandardLibrary.Mechanical.Rotational
 using ModelingToolkitStandardLibrary.Blocks
 using OrdinaryDiffEqDefault
+using CommonSolve: init
 using ModelingToolkit: t_nounits as t, D_nounits as D
 
 const SUITE = BenchmarkGroup()


### PR DESCRIPTION
## What changed and why

Import `init` directly from its owner, CommonSolve, in the benchmark script. AirspeedVelocity runs the script in a temporary project, so the workflow adds CommonSolve as a direct benchmark dependency.

This restores the benchmark workflow after OrdinaryDiffEqDefault 2.4.3 stopped blanket-reexporting its dependencies. A transitive CommonSolve install is not loadable from an isolated benchmark project, so the workflow must declare it explicitly.

CommonSolve is already a ModelingToolkit dependency and uses the MIT license.

Closes https://github.com/SciML/ModelingToolkit.jl/issues/4910.

## Verification

Failing before, using Julia 1.12.6 and an isolated AirspeedVelocity-shaped local project (including CommonSolve as a direct dependency) while loading the unfixed script from `master`:

```console
$ env JULIA_LOAD_PATH=@:@stdlib julia +release --startup-file=no --project=.benchmark-repro -e 'source = read(`git show HEAD:benchmark/benchmarks.jl`, String); include_string(Main, source, "benchmark/benchmarks.jl")'
ERROR: LoadError: UndefVarError: `init` not defined
  @ benchmark/benchmarks.jl:60
```

The script change alone also discriminates the workflow change: with CommonSolve omitted from the isolated project, it fails immediately instead of reaching the benchmarks.

```console
$ env JULIA_LOAD_PATH=@:@stdlib julia +release --startup-file=no --project=.benchmark-repro -e 'include("benchmark/benchmarks.jl")'
ERROR: LoadError: ArgumentError: Package CommonSolve not found in current path.
```

Passing after both changes, with CommonSolve added as a direct dependency of the AirspeedVelocity-shaped project:

```console
$ env JULIA_LOAD_PATH=@:@stdlib julia +release --startup-file=no --project=.benchmark-repro -e 'include("benchmark/benchmarks.jl"); println("PASS benchmark suite definitions: ", length(SUITE))'
PASS benchmark suite definitions: 5
$ env JULIA_LOAD_PATH=@:@stdlib julia +lts --startup-file=no --project=.benchmark-repro-lts -e 'include("benchmark/benchmarks.jl"); println("PASS benchmark suite definitions: ", length(SUITE))'
PASS benchmark suite definitions: 5
```

Additional local checks:

```console
$ actionlint .github/workflows/benchmark.yml
$ julia +release --startup-file=no --project=../ModelingToolkit.jl/.runic-env -e 'using Runic; exit(Runic.main(["--check", "benchmark/benchmarks.jl"]))'
$ git diff -- .github/workflows/benchmark.yml benchmark/benchmarks.jl | typos -
$ git diff --check
```

All four commands exited successfully with no output.

The required root QA group was also run against this branch:

```console
$ GROUP=QA JULIA_DEPOT_PATH="$PWD/.registry-depot:/home/crackauc/.julia" julia +release --startup-file=no --project=. -e 'using Pkg; Pkg.test(coverage=false)'
Test Summary:                                  | Pass  Fail  Error  Total      Time
QA                                             |   20     3      2     25  66m15.2s
ERROR: Package ModelingToolkit errored during testing
```

The same failures reproduce on clean upstream `master` and are unrelated to the benchmark files changed here. They are existing JET/ExplicitImports/public-API QA debt tracked separately in https://github.com/SciML/ModelingToolkit.jl/issues/4670.

The full timed AirspeedVelocity benchmark matrix was not run locally. The benchmark suite was loaded through the failing `init(prob)` call on both supported Julia channels, but individual benchmark trials were not executed.

The draft PR's full AirspeedVelocity workflow subsequently passed on both supported channels:

- Julia LTS: success in 29m07s — https://github.com/SciML/ModelingToolkit.jl/actions/runs/31534720796/job/93922977895
- Julia 1: success in 56m14s — https://github.com/SciML/ModelingToolkit.jl/actions/runs/31534720796/job/93922977984

Please ignore this draft until it has been reviewed by @ChrisRackauckas.
