### PR TITLE
Seed the rational homotopy extension test

### DIFF
--- a/lib/ModelingToolkitBase/test/extensions/homotopy_continuation.jl
+++ b/lib/ModelingToolkitBase/test/extensions/homotopy_continuation.jl
@@ -23,7 +23,7 @@ function test_all_roots(sol; atol = 1.0e-10)
 end
 
 function solve_allroots_closest(prob)
-    sol = solve(prob, allrootsalg)
+    sol = solve(prob, allrootsalg; seed = 0x00012345)
     return argmin(sol.u) do nlsol
         return norm(nlsol.u - prob.u0)
     end


### PR DESCRIPTION
> Please ignore this draft until it has been reviewed by @ChrisRackauckas.

## What changed

Seed the `HomotopyContinuationJL` solve used by the rational-functions extension test. HomotopyContinuation uses a random γ-trick by default; on an unlucky draw it can report no accepted real roots, after which NonlinearSolveHomotopyContinuation returns its failure sentinel at `prob.u0`. That makes the existing assertion observe `x == 2.0` instead of the expected root `x == 1.0`.

The fixed seed keeps the test deterministic without changing package behavior or weakening the assertion. This follows the same stabilization used in https://github.com/SciML/NonlinearSolve.jl/pull/914.

## Failing before / passing after

A deterministic injected bad γ draw (`seed = UInt32(26)`) reproduced the reported failure in the existing test file:

```
Rational functions: Test Failed at .../homotopy_continuation.jl:198
  Expression: sol[x] ≈ 1.0
   Evaluated: 2.0 ≈ 1.0

Test Summary:      | Pass  Fail  Total
Rational functions |   29     1     30
```

With the committed `seed = 0x00012345`, the same file passed:

```
Test Summary:      | Pass  Total   Time
Rational functions |   30     30  23.7s
```

The exact released dependency graph on unmodified current master also passed once (96/96), confirming that the original failure is stochastic rather than caused by the AutoDespecialize changes.

## Verification

```sh
env JULIA_DEPOT_PATH=.baseline-depot:../.registry-depot:/home/crackauc/.julia JULIA_NUM_PRECOMPILE_TASKS=1 CI=true GROUP=Extensions timeout 7200 /home/crackauc/.juliaup/bin/julia +release --startup-file=no --project=. -e 'using Pkg; Pkg.test(coverage=false)'
```

```
Test Summary: | Pass  Total      Time
Extensions    |   96     96  14m10.5s
     Testing ModelingToolkit tests passed
```

`Runic 1.7.0 --check lib/ModelingToolkitBase/test/extensions/homotopy_continuation.jl`, `typos` over the diff, and `git diff --check` all exited 0.

`GROUP=QA` was run, but the existing unrelated QA checks did not pass: 19 passed, 4 failed, and 2 errored (persistent tasks, ExplicitImports analysis, missing `StructuralTransformations` docstring, and unapproved `generate_trajectory` reexport). A separate clean-master investigation is in progress. No docs build was run because this changes only a private test helper.

## Links

- Reported failing job: https://github.com/SciML/ModelingToolkit.jl/actions/runs/31534476032/job/93922272634
- Original NonlinearSolve homotopy migration: https://github.com/SciML/ModelingToolkit.jl/pull/3385
- Existing seeded HomotopyContinuation precedent: https://github.com/SciML/NonlinearSolve.jl/pull/914
