### PR TITLE
test: import SciMLBase in discrete system tests

### DIFF
--- a/lib/ModelingToolkitBase/test/discrete_system.jl
+++ b/lib/ModelingToolkitBase/test/discrete_system.jl
@@ -3,7 +3,7 @@
 - https://github.com/epirecipes/sir-julia/blob/master/markdown/function_map/function_map.md
 - https://en.wikipedia.org/wiki/Compartmental_models_in_epidemiology#Deterministic_versus_stochastic_epidemic_models
 =#
-using ModelingToolkitBase, SymbolicIndexingInterface, Test
+using ModelingToolkitBase, SciMLBase, SymbolicIndexingInterface, Test
 using ModelingToolkitBase: t_nounits as t
 using Setfield: @set!
 


### PR DESCRIPTION
## Summary
- Import `SciMLBase` explicitly in the discrete-system test module.
- The missing binding was introduced by 635c12aacfdde130422a62ef74c9c2dba3202083 (`test: update tests to SciMLBase@3`), which changed `OrdinaryDiffEq` to `OrdinaryDiffEqFunctionMap` while retaining the qualified assertions.

## Validation
- Julia 1.12.6 focused `discrete_system.jl` execution in the Pkg.test dependency environment: passed (2/2, 2/2, and 1/1 test sets).
- Julia 1.12.6 `timeout 3600 env GROUP=InterfaceII ... Pkg.test()`: the affected cases passed; the broader group reached the one-hour timeout while running unrelated `test/semilinearodeproblem.jl`, with no test failure reported.
- `Runic --check lib/ModelingToolkitBase/test/discrete_system.jl`: passed.

Ignore this PR until reviewed by @ChrisRackauckas.