### PR TITLE
Fix observables tutorial reference

### DIFF
--- a/docs/src/tutorials/ode_modeling.md
+++ b/docs/src/tutorials/ode_modeling.md
@@ -137,7 +137,7 @@ You can check the observed equations via the `observed` function:
 observed(fol)
 ```
 
-For more information on this process, see [Observables and Variable Elimination](@ref).
+For more information on this process, see [`observables`](@ref observables).
 
 MTK still knows how to calculate them out of the information available
 in a simulation result. The intermediate variable `RHS` therefore can be plotted


### PR DESCRIPTION
> Ignore this PR until reviewed by @ChrisRackauckas.

Fixes the ODE tutorial reference so it resolves directly to the existing `observables` documentation section.

Local verification:
- `git diff --check` passed.
- `Runic --check docs/src/tutorials/ode_modeling.md` passed.

The broader developer-API documentation cleanup is being handled separately. This PR intentionally does not remove unresolved API targets, since public and developer-facing names must be documented rather than hidden.