### PR TITLE
Document structural transformation developer API

### DIFF
--- a/docs/src/internals/structural_transformation.md
+++ b/docs/src/internals/structural_transformation.md
@@ -1,88 +1,43 @@
 # Structural Transformation
 
-!!! warning "Internal API"
-    The functions documented on this page are internal implementation details of ModelingToolkit. They are not part of the public API and may change or be removed without notice in non-breaking releases. This documentation is provided to help contributors understand the codebase.
+!!! warning "Developer API"
+    These APIs support ModelingToolkit's structural-transformation machinery and
+    extension packages. They are version-controlled for ModelingToolkit developers;
+    end-user applications should use the documented public simplification API instead.
 
 These functions are used for structural analysis and transformation of equation systems, including index reduction, tearing, and other algebraic manipulations used in the simplification process.
 
 ## Tearing and Algebraic Simplification
 
 ```@docs
-tearing
-tearing_reassemble
-tearing_substitution
-torn_system_jacobian_sparsity
-find_solvables!
-linear_subsys_adjmat!
+ModelingToolkit.tearing
+ModelingToolkit.tearing_substitution
+ModelingToolkit.dummy_derivative
 ```
 
 ## Index Reduction
 
 ```@docs
-dae_index_lowering
-pantelides!
-pantelides_reassemble
-dummy_derivative
-```
-
-## Consistency Checking
-
-```@docs
-check_consistency
+ModelingToolkit.dae_index_lowering
+ModelingToolkit.pantelides_reassemble
 ```
 
 ## Incidence Matrix Operations
 
 ```@docs
-sorted_incidence_matrix
-but_ordered_incidence
+ModelingToolkit.sorted_incidence_matrix
+ModelingToolkit.but_ordered_incidence
 ```
 
 ## Variable Ordering and Masks
 
 ```@docs
-lowest_order_variable_mask
-highest_order_variable_mask
-computed_highest_diff_variables
+ModelingToolkit.lowest_order_variable_mask
+ModelingToolkit.highest_order_variable_mask
 ```
 
-## Shift Operations
-
-These functions handle shift operations in discrete-time systems.
+## In-Place Compilation
 
 ```@docs
-shift2term
-lower_shift_varname
-simplify_shifts
-distribute_shift
-```
-
-## System Structure Types and Functions
-
-```@docs
-SystemStructure
-TearingState
-TransformationState
-mtkcompile!
-isdiffvar
-isdervar
-isalgvar
-isdiffeq
-algeqs
-is_only_discrete
-dervars_range
-diffvars_range
-algvars_range
-get_fullvars
-system_subset
-```
-
-## Graph Types
-
-```@docs
-Matching
-InducedCondensationGraph
-MatchedCondensationGraph
-Unassigned
-unassigned
+ModelingToolkit.mtkcompile!
 ```

--- a/src/structural_transformation/StructuralTransformations.jl
+++ b/src/structural_transformation/StructuralTransformations.jl
@@ -78,7 +78,7 @@ should usually call [`mtkcompile`](@ref).
 # Arguments
 
 - `sys`: system whose equations should be substituted.
-- `kwargs...`: keyword arguments forwarded to [`full_equations`](@ref).
+- `kwargs...`: keyword arguments forwarded to `full_equations`.
 
 # Returns
 

--- a/src/structural_transformation/pantelides.jl
+++ b/src/structural_transformation/pantelides.jl
@@ -97,8 +97,8 @@ end
     dae_index_lowering(sys::System; kwargs...) -> System
 
 Perform the Pantelides algorithm to transform a higher index DAE to an index 1
-DAE. `kwargs` are forwarded to [`pantelides!`](@ref). End users are encouraged to call [`mtkcompile`](@ref)
-instead, which calls this function internally.
+DAE. `kwargs` are forwarded to the internal Pantelides pass. End users are encouraged to
+call [`mtkcompile`](@ref) instead, which calls this function internally.
 """
 function dae_index_lowering(sys::System; kwargs...)
     state = TearingState(sys)


### PR DESCRIPTION
> Ignore this PR until reviewed by @ChrisRackauckas.

Documents only ModelingToolkit-owned structural-transformation developer APIs with canonical qualified targets. Dependency-owned and stale targets are removed from ModelingToolkit documentation; no API behavior changes.

Validation:
- Focused strict Documenter resolution and HTML rendering passed.
- Clean-master focused build fails on the legacy unresolved `@docs` targets and cross-references.
- Runic and `git diff --check` passed.