### PR TITLE
docs: repair dependency graph owner links

### DIFF
--- a/docs/src/basics/DependencyGraphs.md
+++ b/docs/src/basics/DependencyGraphs.md
@@ -1,18 +1,26 @@
 # Dependency Graphs
 
-# Functions for calculating dependency graphs
+# Dependency Graph API
+
+The dependency graph constructors return a
+[`BipartiteGraph`](https://docs.sciml.ai/BipartiteGraphs/dev/api/) from
+[`BipartiteGraphs.jl`](https://github.com/SciML/BipartiteGraphs.jl). The graph type and
+its primitive operations are documented and versioned by BipartiteGraphs; use that API
+when working with the returned graph.
+
+## Constructing Dependency Graphs
 
 ```@docs
-equation_dependencies
-asgraph
-variable_dependencies
-asdigraph
-eqeq_dependencies
-varvar_dependencies
+ModelingToolkitBase.equation_dependencies
+ModelingToolkitBase.asgraph
+ModelingToolkitBase.variable_dependencies
+ModelingToolkitBase.asdigraph
+ModelingToolkitBase.eqeq_dependencies
+ModelingToolkitBase.varvar_dependencies
 ```
 
-# Miscellaneous
+## Variable-to-Equation Mapping
 
 ```@docs
-map_variables_to_equations
+ModelingToolkit.map_variables_to_equations
 ```

--- a/lib/ModelingToolkitBase/src/systems/dependency_graphs.jl
+++ b/lib/ModelingToolkitBase/src/systems/dependency_graphs.jl
@@ -61,7 +61,8 @@ asgraph(eqdeps, vtois)
 ```
 
 Convert a collection of equation dependencies, for example as returned by
-`equation_dependencies`, to a [`BipartiteGraph`](@ref).
+`equation_dependencies`, to a
+[`BipartiteGraphs.BipartiteGraph`](https://docs.sciml.ai/BipartiteGraphs/dev/api/).
 
 Notes:
 
@@ -99,8 +100,9 @@ asgraph(sys::AbstractSystem; variables = unknowns(sys),
         variablestoids = Dict(convert(Variable, v) => i for (i, v) in enumerate(variables)))
 ```
 
-Convert an `AbstractSystem` to a [`BipartiteGraph`](@ref) mapping the index of equations
-to the indices of variables they depend on.
+Convert an `AbstractSystem` to a
+[`BipartiteGraphs.BipartiteGraph`](https://docs.sciml.ai/BipartiteGraphs/dev/api/)
+mapping the index of equations to the indices of variables they depend on.
 
 Notes:
 
@@ -132,12 +134,14 @@ variable_dependencies(sys::AbstractSystem; variables = unknowns(sys),
                       variablestoids = nothing)
 ```
 
-For each variable, determine the equations that modify it and return as a [`BipartiteGraph`](@ref).
+For each variable, determine the equations that modify it and return a
+[`BipartiteGraphs.BipartiteGraph`](https://docs.sciml.ai/BipartiteGraphs/dev/api/).
 
 Notes:
 
-  - Dependencies are returned as a [`BipartiteGraph`](@ref) mapping variable
-    indices to the indices of equations that modify them.
+  - Dependencies are returned as a
+    [`BipartiteGraphs.BipartiteGraph`](https://docs.sciml.ai/BipartiteGraphs/dev/api/)
+    mapping variable indices to the indices of equations that modify them.
   - `variables` denotes the list of variables to determine dependencies for.
   - `variablestoids` denotes a `Dict` mapping `Variable`s to their `Int` index in `variables`.
 
@@ -179,7 +183,9 @@ asdigraph(g::BipartiteGraph, sys::AbstractSystem; variables = unknowns(sys),
           equationsfirst = true)
 ```
 
-Convert a [`BipartiteGraph`](@ref) to a `LightGraph.SimpleDiGraph`.
+Convert a
+[`BipartiteGraphs.BipartiteGraph`](https://docs.sciml.ai/BipartiteGraphs/dev/api/)
+to a `LightGraph.SimpleDiGraph`.
 
 Notes:
 
@@ -189,7 +195,8 @@ Notes:
     collections of vertices, so they must be merged).
   - `variables` gives the variables that `g` are associated with (usually the
     `unknowns` of a system).
-  - `equationsfirst` (default is `true`) gives whether the [`BipartiteGraph`](@ref)
+  - `equationsfirst` (default is `true`) gives whether the
+    [`BipartiteGraphs.BipartiteGraph`](https://docs.sciml.ai/BipartiteGraphs/dev/api/)
     gives a mapping from equations to variables they depend on (`true`), as calculated
     by [`asgraph`](@ref), or whether it gives a mapping from variables to the equations
     that modify them, as calculated by [`variable_dependencies`](@ref).


### PR DESCRIPTION
## Summary
- link dependency-graph return types to the BipartiteGraphs-owned API documentation
- qualify the ModelingToolkit and ModelingToolkitBase documentation targets

## Validation
- focused Documenter target assertion: all seven documented ModelingToolkit/ModelingToolkitBase targets resolved and parsed
- static cross-reference assertion: six owner links, no local `BipartiteGraph` `@ref` links
- `Runic --check lib/ModelingToolkitBase/src/systems/dependency_graphs.jl`
- `git diff --check`

Ignore until reviewed by @ChrisRackauckas.