### PR TITLE
docs: define collocation API boundary

### DIFF
--- a/docs/src/API/dynamic_opt.md
+++ b/docs/src/API/dynamic_opt.md
@@ -9,12 +9,12 @@ JuMPCollocation(Ipopt.Optimizer, constructRK4())
 CasADiCollocation("ipopt", constructRK4())
 ```
 
-**JuMP** and **CasADi** collocation require an ODE tableau to be passed in. These can be constructed by calling the `constructX()` functions from DiffEqDevTools. The list of tableaus can be found [here](https://docs.sciml.ai/DiffEqDevDocs/dev/internals/tableaus/). If none is passed in, both solvers will default to using Radau second-order with five collocation points.
+**JuMP** and **CasADi** collocation accept an optional ODE tableau. These can be constructed by calling the `constructX()` functions from DiffEqDevTools. The list of tableaus can be found [here](https://docs.sciml.ai/DiffEqDevDocs/dev/internals/tableaus/). If none is passed in, both solvers use the fifth-order, three-stage Radau IIA tableau.
 
 **Pyomo** and **InfiniteOpt** each have their own built-in collocation methods.
 
  1. **InfiniteOpt**: The list of InfiniteOpt collocation methods can be found [in the table on this page](https://infiniteopt.github.io/InfiniteOpt.jl/stable/guide/derivative/). If none is passed in, the solver defaults to `FiniteDifference(Backward())`, which is effectively implicit Euler.
- 2. **Pyomo**: The list of Pyomo collocation methods can be found [at the bottom of this page](https://github.com/SciML/Pyomo.jl). If none is passed in, the solver defaults to a `LagrangeRadau(3)`.
+ 2. **Pyomo**: The list of Pyomo collocation methods can be found [at the bottom of this page](https://github.com/SciML/Pyomo.jl). If none is passed in, the solver defaults to a `LagrangeRadau(5)`.
 
 Some examples of the latter two collocations:
 

--- a/lib/ModelingToolkitBase/src/systems/optimal_control_interface.jl
+++ b/lib/ModelingToolkitBase/src/systems/optimal_control_interface.jl
@@ -1,10 +1,34 @@
 """
     AbstractCollocation
 
-Abstract supertype for dynamic-optimization collocation method descriptors.
+Opaque common base type for supported dynamic-optimization collocation descriptors.
 
-Concrete collocation types are provided by backend extensions such as JuMP, InfiniteOpt,
-CasADi, and Pyomo.
+# Public API Boundary
+
+`AbstractCollocation` is not a third-party extension interface. It is the common base for
+the concrete descriptors supported by ModelingToolkitBase's JuMP, InfiniteOpt, CasADi, and
+Pyomo backends. `solve(::AbstractDynamicOptProblem, ::AbstractCollocation)` dispatches to
+backend hooks that are implementation details and not public API.
+
+Do not subtype `AbstractCollocation`, implement collocation-solving hooks, or otherwise
+extend collocation solving from an external package. External subtyping and extension are
+unsupported unless a public interface is defined and documented in a future release.
+
+# Usage
+
+Select one of the documented concrete descriptors for the backend used to construct the
+dynamic-optimization problem:
+
+- [`JuMPCollocation`](@ref) for the JuMP backend.
+- [`InfiniteOptCollocation`](@ref) for the InfiniteOpt backend.
+- [`CasADiCollocation`](@ref) for the CasADi backend.
+- [`PyomoCollocation`](@ref) for the Pyomo backend.
+
+Pass that descriptor to `solve(prob, solver)`. The problem constructor and descriptor must
+use the same backend.
+
+See [`Dynamic Optimization Solvers`](@ref dynamic_opt_api) for constructor arguments and
+backend-specific options.
 """
 abstract type AbstractCollocation end
 
@@ -96,29 +120,107 @@ To construct the problem, please load Pyomo along with ModelingToolkitBase.
 """
 function PyomoDynamicOptProblem end
 
-### Collocations
 """
-JuMP Collocation solver. Takes two arguments:
-- `solver`: a optimization solver such as Ipopt
-- `tableau`: An ODE RK tableau. Load a tableau by calling a function like `constructRK4` and may be found at https://docs.sciml.ai/DiffEqDevDocs/stable/internals/tableaus/. If this argument is not passed in, the solver will default to Radau second order.
+    JuMPCollocation(solver, tableau = constructDefault()) -> AbstractCollocation
+
+Configure the collocation descriptor used to solve a [`JuMPDynamicOptProblem`](@ref).
+
+# Arguments
+
+- `solver`: a JuMP optimizer constructor, such as `Ipopt.Optimizer`.
+- `tableau`: an ODE Runge-Kutta tableau used to transcribe the dynamics. Defaults to
+  the built-in fifth-order Radau IIA tableau.
+
+# Returns
+
+- `AbstractCollocation`: a descriptor accepted by `solve` for a `JuMPDynamicOptProblem`.
+
+# Examples
+
+```julia
+using ModelingToolkitBase, InfiniteOpt, Ipopt
+
+JuMPCollocation(Ipopt.Optimizer)
+```
 """
 function JuMPCollocation end
+
 """
-InfiniteOpt Collocation solver.
-- `solver`: an optimization solver such as Ipopt
-- `derivative_method`: the method used by InfiniteOpt to compute derivatives. The list of possible options can be found at https://infiniteopt.github.io/InfiniteOpt.jl/stable/guide/derivative/. Defaults to FiniteDifference(Backward()).
+    InfiniteOptCollocation(solver, derivative_method = ...) -> AbstractCollocation
+
+Configure the collocation descriptor used to solve an
+[`InfiniteOptDynamicOptProblem`](@ref).
+
+# Arguments
+
+- `solver`: a JuMP optimizer constructor, such as `Ipopt.Optimizer`.
+- `derivative_method`: an `InfiniteOpt.AbstractDerivativeMethod` used to discretize the
+  independent variable. Defaults to backward finite differences.
+
+# Returns
+
+- `AbstractCollocation`: a descriptor accepted by `solve` for an
+  `InfiniteOptDynamicOptProblem`.
+
+# Examples
+
+```julia
+using ModelingToolkitBase, InfiniteOpt, Ipopt
+
+InfiniteOptCollocation(Ipopt.Optimizer)
+```
 """
 function InfiniteOptCollocation end
+
 """
-CasADi Collocation solver.
-- `solver`: an optimization solver such as Ipopt. Should be given as a string or symbol in all lowercase, e.g. "ipopt"
-- `tableau`: An ODE RK tableau. Load a tableau by calling a function like `constructRK4` and may be found at https://docs.sciml.ai/DiffEqDevDocs/stable/internals/tableaus/. If this argument is not passed in, the solver will default to Radau second order.
+    CasADiCollocation(solver, tableau = constructDefault()) -> AbstractCollocation
+
+Configure the collocation descriptor used to solve a [`CasADiDynamicOptProblem`](@ref).
+
+# Arguments
+
+- `solver`: the name of a CasADi solver plugin, supplied as a `String` or `Symbol`, such
+  as `"ipopt"`.
+- `tableau`: an ODE Runge-Kutta tableau used to transcribe the dynamics. Defaults to
+  the built-in fifth-order Radau IIA tableau.
+
+# Returns
+
+- `AbstractCollocation`: a descriptor accepted by `solve` for a `CasADiDynamicOptProblem`.
+
+# Examples
+
+```julia
+using ModelingToolkitBase, CasADi
+
+CasADiCollocation("ipopt")
+```
 """
 function CasADiCollocation end
+
 """
-Pyomo Collocation solver.
-- `solver`: an optimization solver such as Ipopt. Should be given as a string or symbol in all lowercase, e.g. "ipopt"
-- `derivative_method`: a derivative method from Pyomo. The choices here are ForwardEuler, BackwardEuler, MidpointEuler, LagrangeRadau, or LagrangeLegendre. The last two should additionally have a number indicating the number of collocation points per timestep, e.g. PyomoCollocation("ipopt", LagrangeRadau(3)). Defaults to LagrangeRadau(5).
+    PyomoCollocation(solver, derivative_method = LagrangeRadau(5)) -> AbstractCollocation
+
+Configure the collocation descriptor used to solve a [`PyomoDynamicOptProblem`](@ref).
+
+# Arguments
+
+- `solver`: the name of a Pyomo solver plugin, supplied as a `String` or `Symbol`, such
+  as `"ipopt"`.
+- `derivative_method`: a `Pyomo.DiscretizationMethod` used to transcribe the dynamics.
+  Defaults to `LagrangeRadau(5)`.
+
+# Returns
+
+- `AbstractCollocation`: a descriptor accepted by `solve` for a `PyomoDynamicOptProblem`.
+
+# Examples
+
+```julia
+using ModelingToolkitBase, Pyomo
+
+PyomoCollocation("ipopt", Pyomo.LagrangeRadau(3))
+```
 """
 function PyomoCollocation end
 

--- a/lib/ModelingToolkitBase/test/abstractcollocation.jl
+++ b/lib/ModelingToolkitBase/test/abstractcollocation.jl
@@ -1,0 +1,38 @@
+using ModelingToolkitBase, Test
+
+const PUBLIC_COLLOCATION_SELECTORS = (
+    :JuMPCollocation,
+    :InfiniteOptCollocation,
+    :CasADiCollocation,
+    :PyomoCollocation,
+)
+const INTERNAL_COLLOCATION_HOOKS = (
+    :prepare_and_optimize!,
+    :get_t_values,
+    :get_U_values,
+    :get_V_values,
+    :get_P_values,
+    :successful_solve,
+)
+
+@testset "AbstractCollocation public boundary" begin
+    public_names = names(ModelingToolkitBase)
+    @test :AbstractCollocation ∈ public_names
+    @test isabstracttype(ModelingToolkitBase.AbstractCollocation)
+
+    abstract_collocation_docs = sprint(
+        show, MIME"text/plain"(), Base.Docs.doc(ModelingToolkitBase.AbstractCollocation)
+    )
+    @test occursin("not a third-party extension interface", abstract_collocation_docs)
+    @test occursin("Do not subtype AbstractCollocation", abstract_collocation_docs)
+    @test occursin("solve(prob, solver)", abstract_collocation_docs)
+
+    for selector in PUBLIC_COLLOCATION_SELECTORS
+        @test selector ∈ public_names
+        @test Base.Docs.doc(getproperty(ModelingToolkitBase, selector)) !== nothing
+    end
+
+    for hook in INTERNAL_COLLOCATION_HOOKS
+        @test hook ∉ public_names
+    end
+end

--- a/lib/ModelingToolkitBase/test/runtests.jl
+++ b/lib/ModelingToolkitBase/test/runtests.jl
@@ -41,6 +41,7 @@ end
     if GROUP == "All" || GROUP == "InterfaceI"
         @testset "InterfaceI" begin
             @safetestset "AbstractSystem Test" include("abstractsystem.jl")
+            @safetestset "AbstractCollocation Public Boundary" include("abstractcollocation.jl")
             @safetestset "Variable Scope Tests" include("variable_scope.jl")
             @safetestset "Parsing Test" include("variable_parsing.jl")
             @safetestset "System Linearity Test" include("linearity.jl")


### PR DESCRIPTION
Documents `AbstractCollocation` as an opaque, developer-public base rather than a third-party extension point. The four supported backend selector factories now have direct SciMLStyle docstrings at their definition site, including typed returns and runnable examples; their rendered API page now states the actual Radau and Pyomo defaults.

Adds a focused public-boundary test. It asserts the abstract base and selectors are public, the backend hooks remain non-public, and the documented boundary is present. The documented JuMP and InfiniteOpt constructor examples also execute through the public factories and return `AbstractCollocation`.

## Verification

- `Runic.main(["--check", "--diff", "lib/ModelingToolkitBase/src/systems/optimal_control_interface.jl", "lib/ModelingToolkitBase/test/abstractcollocation.jl"])`
- `typos --format brief lib/ModelingToolkitBase/src/systems/optimal_control_interface.jl lib/ModelingToolkitBase/test/abstractcollocation.jl docs/src/API/dynamic_opt.md`
- `git diff --check`
- Direct boundary test: `19/19` passed.
- Public factory examples: `JuMPCollocation(Ipopt.Optimizer)` and `InfiniteOptCollocation(Ipopt.Optimizer)` both passed and returned `AbstractCollocation`.

## Not verified

A focused Documenter render exceeded its one-hour budget without a result. The full docs build is independently failing on clean master; that strict-docs backlog remains tracked in https://github.com/SciML/ModelingToolkit.jl/issues/4957. No documentation or QA setting was weakened.

Ignore until reviewed by @ChrisRackauckas.