### PR TITLE
Remove accidental internal reexports

### DIFF
--- a/lib/ModelingToolkitBase/src/ModelingToolkitBase.jl
+++ b/lib/ModelingToolkitBase/src/ModelingToolkitBase.jl
@@ -343,7 +343,6 @@ export calculate_jacobian, generate_jacobian, generate_rhs, generate_custom_func
 export calculate_control_jacobian, generate_control_jacobian
 export calculate_tgrad, generate_tgrad
 export generate_cost, calculate_cost_gradient, generate_cost_gradient
-export generate_trajectory
 export calculate_cost_hessian, generate_cost_hessian
 export calculate_massmatrix, generate_diffusion_function
 export generate_control_function, build_explicit_observed_function
@@ -391,7 +390,6 @@ export AbstractCollocation, JuMPCollocation, InfiniteOptCollocation,
     CasADiCollocation, PyomoCollocation
 export DynamicOptSolution
 export MissingGuessValue
-export MiscSystemData
 
 export AssignmentAffect
 

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -132,7 +132,7 @@ const REEXPORTED_API = (
     :is_diff_equation, :iscomplete, :isdisturbance, :isinitial, :isinput, :isirreducible,
     :isoutput, :isparameter, :istunable, :JuMPCollocation, :JuMPDynamicOptProblem, :jumps,
     :JumpSystem, :linear_fractional_to_ordinary, :liouville_transform, :LocalScope,
-    :maybe_zeros, :MiscSystemData, :MissingGuessValue, :ModelingToolkitBase,
+    :maybe_zeros, :MissingGuessValue, :ModelingToolkitBase,
     :modelingtoolkitize, :modified_unknowns!, :mtkcompile, :MTKParameters,
     :MTKVariableTypeCtx, :namespace_equations, :noise_to_brownians, :NonlinearSystem,
     :observables, :observed, :ODESystem, :open_loop, :OptimizationSystem, :outputs,
@@ -359,6 +359,19 @@ const STRUCTURAL_TYPES = (
     ModelingToolkitTearing.TearingState,
     StateSelection.DiffGraph,
 )
+
+@testset "Internal bindings are not public" begin
+    for name in (:generate_trajectory, :MiscSystemData)
+        @test isdefined(ModelingToolkitBase, name)
+        @test isdefined(ModelingToolkit, name)
+        @test !Base.isexported(ModelingToolkitBase, name)
+        @test !Base.isexported(ModelingToolkit, name)
+        @static if VERSION >= v"1.11"
+            @test !Base.ispublic(ModelingToolkitBase, name)
+            @test !Base.ispublic(ModelingToolkit, name)
+        end
+    end
+end
 
 run_qa(
     ModelingToolkit;


### PR DESCRIPTION
## Summary

Remove the accidental `generate_trajectory` and `MiscSystemData` exports from `ModelingToolkitBase`, so `@reexport using ModelingToolkitBase` no longer exposes them from `ModelingToolkit`. Their definitions and qualified/internal uses remain intact. Remove the stale `MiscSystemData` reexport allowlist entry and retain a QA contract asserting both bindings stay defined but are neither exported nor public.

These are undocumented and unrendered accidental reexports, so this does not require a major release.

## Verification

- Before the source change, the direct visibility regression check failed as expected: `4 passed, 8 failed, 12 total`; both names were exported/public from `ModelingToolkitBase` and reexported/public from `ModelingToolkit`.
- After the source change, the same check passed: `12 passed, 12 total`.
- `Runic.jl 1.7.0 --check --diff .`: exit 0.
- `typos --diff $(git diff --name-only)`: exit 0.
- `git diff --check`: exit 0.
- `GROUP=QA julia --project --startup-file=no -e 'using Pkg; Pkg.test()'`: the new `Internal bindings are not public` test passed `12/12`; `No unapproved public reexports` also passed. The QA summary reported `49 passed, 2 failed, 2 errored` for unrelated existing package-wide findings: 22 JET findings in structural-transformation/problem code, ExplicitImports unable to analyze the dynamic include in `src/precompile.jl`, and the pre-existing undocumented public `StructuralTransformations` name. The outer command later reached its one-hour timeout while Pkg awaited the failed test subprocess.\n\nDocs were not touched, so no docs build was run.\n\nIgnore this PR until it has been reviewed by @ChrisRackauckas.