### PR TITLE
docs: render remaining public API names that already have docstrings

### DIFF
--- a/docs/src/API/System.md
+++ b/docs/src/API/System.md
@@ -54,11 +54,13 @@ unknowns
 ModelingToolkit.unknowns_toplevel
 irreducibles
 maybe_zeros
+state_priorities
 ModelingToolkit.has_ps
 ModelingToolkit.get_ps
 parameters
 ModelingToolkit.parameters_toplevel
 tunable_parameters
+bound_parameters
 ModelingToolkit.has_brownians
 ModelingToolkit.get_brownians
 brownians
@@ -217,6 +219,7 @@ ModelingToolkit.collect_var_to_name!
 ModelingToolkit.collect_vars!
 ModelingToolkit.eqtype_supports_collect_vars
 ModelingToolkit.modified_unknowns!
+ModelingToolkitBase.convert_bindings_for_time_independent_system
 ```
 
 ## Namespace manipulation
@@ -228,6 +231,8 @@ following functions are useful for manipulating namespacing functionality.
 ```@docs
 ModelingToolkit.renamespace
 ModelingToolkit.namespace_equations
+@nonamespace
+@namespace
 ```
 
 ## Linearization and Analysis

--- a/docs/src/API/codegen.md
+++ b/docs/src/API/codegen.md
@@ -52,6 +52,14 @@ ModelingToolkit.calculate_control_jacobian
 ModelingToolkit.calculate_A_b
 ```
 
+A system can be marked as unsupported by symbolic automatic differentiation, in which case
+the `calculate_*` functions above throw instead of producing a wrong derivative.
+
+```@docs
+ModelingToolkitBase.SymbolicADDisallowed
+ModelingToolkitBase.check_symbolic_ad_allowed
+```
+
 All code generation eventually calls `build_function_wrapper`.
 
 ```@docs

--- a/docs/src/API/model_building.md
+++ b/docs/src/API/model_building.md
@@ -90,6 +90,7 @@ macro.
 connect
 domain_connect
 @connector
+Connection
 ```
 
 Connections can be expanded using `expand_connections`.
@@ -150,6 +151,7 @@ calls `complete` internally.
 
 ```@docs
 complete
+@mtkcomplete
 ```
 
 ### Exploring the results of simplification
@@ -191,6 +193,18 @@ section of the documentation. User-defined functions can be used via `Imperative
 
 ```@docs
 ModelingToolkit.ImperativeAffect
+```
+
+## Jump processes
+
+Systems can contain jumps, which are handled by
+[JumpProcesses.jl](https://docs.sciml.ai/JumpProcesses/stable/). The jump types of that
+package are used directly, with the exception of mass action jumps: symbolic rate
+expressions must already carry their combinatorial scaling, so ModelingToolkit provides a
+constructor that builds a `MassActionJump` without rescaling the rate.
+
+```@docs
+SymbolicMassActionJump
 ```
 
 ## Modelingtoolkitize

--- a/docs/src/API/problems.md
+++ b/docs/src/API/problems.md
@@ -10,6 +10,16 @@ and returning specific values. This format of argument and return value depends 
 the function and the problem. ModelingToolkit is capable of compiling and generating
 code for a variety of such numerical problems.
 
+## In-place and out-of-place problems
+
+Every problem and function constructor takes an `iip` type parameter selecting an in-place
+or out-of-place formulation. Problem constructors called without it defer the choice to
+construction time using a sentinel type.
+
+```@docs
+ModelingToolkitBase.Both
+```
+
 ## Dynamical systems
 
 ```@docs
@@ -27,7 +37,9 @@ SciMLBase.SDDEFunction
 SciMLBase.SDDEProblem
 JumpProcesses.JumpProblem
 SciMLBase.BVProblem
+SciMLBase.DiscreteFunction
 SciMLBase.DiscreteProblem
+SciMLBase.ImplicitDiscreteFunction
 SciMLBase.ImplicitDiscreteProblem
 ```
 

--- a/docs/src/API/variables.md
+++ b/docs/src/API/variables.md
@@ -40,6 +40,13 @@ ModelingToolkit.getdefault
 ModelingToolkit.setdefault
 ```
 
+The defaults of a system that has already been constructed are updated with `set_defaults`,
+which applies the same binding/initial condition semantics to an existing system.
+
+```@docs
+set_defaults
+```
+
 ## Variable descriptions
 
 Descriptive strings can be attached to variables using the `[description = "descriptive string"]` syntax:
@@ -213,6 +220,7 @@ getguess(u)
 ```@docs
 hasguess
 getguess
+ModelingToolkitBase.setguess
 ```
 
 When a system is constructed, the guesses of the involved variables are stored in a `Dict`
@@ -327,6 +335,15 @@ This metadata is used by the [`System`](@ref) constructor for automatically iden
 ModelingToolkit.VariableType
 ModelingToolkit.MTKVariableTypeCtx
 ModelingToolkit.isparameter
+```
+
+The `@parameters` and `@brownians` macros set this metadata on the variables they declare.
+The same can be done to an existing symbolic variable, which is useful when generating
+variables programmatically.
+
+```@docs
+ModelingToolkitBase.toparam
+ModelingToolkitBase.tobrownian
 ```
 
 ## Miscellaneous metadata

--- a/lib/ModelingToolkitBase/src/variables.jl
+++ b/lib/ModelingToolkitBase/src/variables.jl
@@ -725,9 +725,9 @@ end
 
 ## Brownian
 """
-    tobrownian(s::Sym)
+    tobrownian(s)
 
-Maps the brownianiable to an unknown.
+Maps the variable to a Brownian variable.
 """
 tobrownian(s::SymbolicT) = setmetadata(s, MTKVariableTypeCtx, BROWNIAN)
 tobrownian(s::Num) = Num(tobrownian(value(s)))


### PR DESCRIPTION
**Please ignore this PR until it has been reviewed by @ChrisRackauckas.**

## What changed and why

Follow-up to the public API audit. Seventeen names that are exported or `@public` from
`ModelingToolkitBase` already carried a definition-site docstring but appeared in no
```@docs``` block, so they were public API the rendered manual never showed. This adds a
docs entry for each, in the API page matching what the name does. No new docstrings, no
`@doc` aliases, no QA ignore entries.

Owner module is used for names that are not exported from `ModelingToolkit` itself
(`ModelingToolkitBase.`), and for the two SciMLBase-owned constructors whose `System`
method docstring lives in this repo (`SciMLBase.`), following the convention set in #4968
(`StateSelection.find_solvables!`, `ModelingToolkitTearing.TearingState`). Exported names
are rendered bare, matching every other exported entry on those pages.

| Name | Public via | Rendered in |
| --- | --- | --- |
| `state_priorities`, `bound_parameters` | `export` | `API/System.md` (accessor functions) |
| `@nonamespace`, `@namespace` | `export` | `API/System.md` (namespace manipulation) |
| `convert_bindings_for_time_independent_system` | `@public` | `API/System.md` (utility functions) |
| `set_defaults` | `export` | `API/variables.md` (variable defaults) |
| `setguess` | `@public` | `API/variables.md` (guess) |
| `toparam`, `tobrownian` | `@public` | `API/variables.md` (variable type) |
| `Connection` | `export` | `API/model_building.md` (connection semantics) |
| `@mtkcomplete` | `export` | `API/model_building.md` (system simplification) |
| `SymbolicMassActionJump` | `export` | `API/model_building.md` (new "Jump processes" section) |
| `Both` | `@public` | `API/problems.md` (new "In-place and out-of-place problems" section) |
| `DiscreteFunction`, `ImplicitDiscreteFunction` | SciMLBase, docstring owned here | `API/problems.md` (dynamical systems) |
| `SymbolicADDisallowed`, `check_symbolic_ad_allowed` | `@public` | `API/codegen.md` (after the `calculate_*` block) |

The `tobrownian` docstring is also corrected. It documented a signature that does not exist
(`tobrownian(s::Sym)`; the methods are `::SymbolicT` and `::Num`) and described the wrong
result ("Maps the brownianiable to an unknown"). It becomes user-visible for the first time
with this PR, so it is fixed here rather than left to render as-is.

## The shipped QA check cannot see this, and that is worth flagging

`SciMLTesting.run_api_docs(...; rendered = true)` runs inside `run_qa` and is supposed to
catch exactly this. It passes on unmodified master:

```
$ julia --project=qa -e 'using ModelingToolkitBase, SciMLTesting, Test; run_api_docs(ModelingToolkitBase)'
Test Summary:            | Pass  Total  Time
Public API documentation |    2      2  0.2s
```

The reason is `SciMLTesting._rendered_doc_names`: it passes the rendered check wholesale as
soon as **any** ```@autodocs``` block exists anywhere under `docs_src`. This manual has two,
in `docs/src/tutorials/linear_analysis.md` and `docs/src/tutorials/disturbance_modeling.md`,
and both are narrowly scoped (`Modules = [ModelingToolkit]`, `Pages = ["systems/analysis_points.jl"]`)
— they render analysis points and nothing else. So the whole-repo escape hatch fires on two
blocks covering one source file, and the rendered check has been vacuous for this repo.

That is a SciMLTesting issue (the short-circuit should be scoped to what the `@autodocs`
block actually renders), not something to paper over here, so this PR changes no QA
configuration. It does mean the shipped check passes both before and after and proves
nothing either way.

## Verification

Because the shipped check is vacuous here, the discriminating evidence comes from a script
that reuses SciMLTesting's own `public_api_names` / `_requires_local_rendering` /
`_doc_entry_name` and drops only the `autodocs` short-circuit.

**Before (unmodified master, `fb95431a70`)** — all 17 are public, all 17 have a docstring,
none is rendered:

```
docs_src = .../ModelingToolkit.jl/docs/src
rendered @docs entries = 387
@mtkcomplete                                   public=true  docstring=true  rendered=false
@namespace                                     public=true  docstring=true  rendered=false
@nonamespace                                   public=true  docstring=true  rendered=false
Both                                           public=true  docstring=true  rendered=false
Connection                                     public=true  docstring=true  rendered=false
DiscreteFunction                               public=true  docstring=true  rendered=false
ImplicitDiscreteFunction                       public=true  docstring=true  rendered=false
SymbolicADDisallowed                           public=true  docstring=true  rendered=false
SymbolicMassActionJump                         public=true  docstring=true  rendered=false
bound_parameters                               public=true  docstring=true  rendered=false
check_symbolic_ad_allowed                      public=true  docstring=true  rendered=false
convert_bindings_for_time_independent_system   public=true  docstring=true  rendered=false
set_defaults                                   public=true  docstring=true  rendered=false
setguess                                       public=true  docstring=true  rendered=false
state_priorities                               public=true  docstring=true  rendered=false
tobrownian                                     public=true  docstring=true  rendered=false
toparam                                        public=true  docstring=true  rendered=false
Test Summary: | Pass  Fail  Total  Time
inventory     |   34    17     51  8.2s
```

**After (this branch)**:

```
docs_src = .../ModelingToolkit.jl/docs/src
rendered @docs entries = 398
@mtkcomplete                                   public=true  docstring=true  rendered=true
@namespace                                     public=true  docstring=true  rendered=true
@nonamespace                                   public=true  docstring=true  rendered=true
Both                                           public=true  docstring=true  rendered=true
Connection                                     public=true  docstring=true  rendered=true
DiscreteFunction                               public=true  docstring=true  rendered=true
ImplicitDiscreteFunction                       public=true  docstring=true  rendered=true
SymbolicADDisallowed                           public=true  docstring=true  rendered=true
SymbolicMassActionJump                         public=true  docstring=true  rendered=true
bound_parameters                               public=true  docstring=true  rendered=true
check_symbolic_ad_allowed                      public=true  docstring=true  rendered=true
convert_bindings_for_time_independent_system   public=true  docstring=true  rendered=true
set_defaults                                   public=true  docstring=true  rendered=true
setguess                                       public=true  docstring=true  rendered=true
state_priorities                               public=true  docstring=true  rendered=true
tobrownian                                     public=true  docstring=true  rendered=true
toparam                                        public=true  docstring=true  rendered=true
Test Summary: | Pass  Total  Time
inventory     |   51     51  4.7s
```

Shipped QA, after the change (unchanged, for the reason above):

```
$ julia --project=qa -e 'using ModelingToolkitBase, SciMLTesting, Test; run_api_docs(ModelingToolkitBase)'
Test Summary:            | Pass  Total  Time
Public API documentation |    2      2  0.2s
```

Formatter and spelling, on the changed files:

```
$ julia --project=@format-check -e 'using Runic; exit(Runic.main(["--check", "--diff", "lib/ModelingToolkitBase/src/variables.jl"]))'
exit=0
$ typos docs/src/API/*.md lib/ModelingToolkitBase/src/variables.jl
exit=0
```

Duplicate canonical blocks: none. All 17 names appeared in zero ```@docs``` blocks before
this PR (see the `rendered=false` column above), so every entry added here is the first and
only canonical block for that name. No `; canonical = false` was needed.

## What I did not verify

- **The Documenter build did not run.** `docs/` env instantiation and precompilation was
  still running when this PR was opened; I have not observed a `docs/make.jl` build with
  these entries. Docs CI is the check to watch here.
- **A pre-existing broken cross-reference is likely to become louder.** The already-rendered
  `SciMLBase.ODEFunction` docstring set contains ``[`SciMLFunctionOptions`](@ref)``, and
  `SciMLFunctionOptions` is in no ```@docs``` block anywhere in the manual. The
  `DiscreteFunction`/`ImplicitDiscreteFunction` docstrings added here carry the same
  ``@ref``. If that reference is currently resolving, so will the new ones; if the docs
  build is already failing on it on master, this PR adds two more instances of an existing
  failure rather than a new class of one. Rendering `SciMLFunctionOptions` is out of scope
  for this PR (it is not in the audit inventory and is not `public`), but it should be the
  next follow-up if docs CI flags it.
- Test groups other than the API-doc QA were not run; this PR touches no code path, only
  markdown plus one docstring string.

## Out of scope, deliberately

Ten further public MTKBase names are still unrendered and are **not** in this PR's
inventory: `@discretes`, `@mtkbuild`, `@poissonians`, `AnalysisPoint`, `DiscreteSystem`,
`ImplicitDiscreteSystem`, `ODESystem`, `analytically_integrated`, `discrete_events`,
`structural_simplify`. Several are deprecated aliases (`@mtkbuild`, `ODESystem`,
`structural_simplify`), and `AnalysisPoint` is being handled on a concurrent branch. There
are also ~52 unrendered `get_*`/`has_*` field accessors, which want a bulk decision rather
than this PR's per-name treatment.

## Anything a reviewer should push back on

- **`Both` as rendered public API.** It is `@public`, and its behaviour (`iip = false` when
  the operating point is a `StaticArray`, `true` otherwise) is user-observable, so I
  rendered it. It is also a low-level sentinel that no documented workflow spells out. If
  you consider it developer-only, the right fix is dropping `@public Both` in a breaking
  release, not leaving it public-but-hidden — but that is your call, and I would drop the
  `API/problems.md` section here if so.
- **Placement of `set_defaults`** in `API/variables.md` rather than `API/System.md`. It is a
  system-level operation, but its docstring is entirely about default/binding/initial-condition
  semantics, which is what that section explains.
- **Placement of `SymbolicMassActionJump`** in a new "Jump processes" section in
  `API/model_building.md`. The manual has essentially no jump documentation, so there was no
  existing home; this is a one-name section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CyfVD9BrtYMQFKjoreryu6
