### PR TITLE
docs: audit and render the remaining public MTKBase API (stacked on #4970)

### DIFF
--- a/docs/src/API/System.md
+++ b/docs/src/API/System.md
@@ -54,11 +54,13 @@ unknowns
 ModelingToolkit.unknowns_toplevel
 irreducibles
 maybe_zeros
+state_priorities
 ModelingToolkit.has_ps
 ModelingToolkit.get_ps
 parameters
 ModelingToolkit.parameters_toplevel
 tunable_parameters
+bound_parameters
 ModelingToolkit.has_brownians
 ModelingToolkit.get_brownians
 brownians
@@ -217,6 +219,7 @@ ModelingToolkit.collect_var_to_name!
 ModelingToolkit.collect_vars!
 ModelingToolkit.eqtype_supports_collect_vars
 ModelingToolkit.modified_unknowns!
+ModelingToolkitBase.convert_bindings_for_time_independent_system
 ```
 
 ## Namespace manipulation
@@ -228,6 +231,8 @@ following functions are useful for manipulating namespacing functionality.
 ```@docs
 ModelingToolkit.renamespace
 ModelingToolkit.namespace_equations
+@nonamespace
+@namespace
 ```
 
 ## Linearization and Analysis

--- a/docs/src/API/System.md
+++ b/docs/src/API/System.md
@@ -13,12 +13,18 @@ ModelingToolkit.AbstractSystem
 ## Utility constructors
 
 Several utility constructors also exist to easily construct alternative system formulations.
+`NonlinearSystem`, `ODESystem`, `DiscreteSystem` and `ImplicitDiscreteSystem` are deprecated
+aliases for `System` kept for compatibility with ModelingToolkit v9; they emit a deprecation
+warning and are documented here so that the warning has a target to look up.
 
 ```@docs
 NonlinearSystem
 SDESystem
 JumpSystem
 OptimizationSystem
+ODESystem
+DiscreteSystem
+ImplicitDiscreteSystem
 ```
 
 ## Accessor functions
@@ -52,8 +58,14 @@ ModelingToolkit.has_unknowns
 ModelingToolkit.get_unknowns
 unknowns
 ModelingToolkit.unknowns_toplevel
+ModelingToolkit.has_irreducibles
+ModelingToolkit.get_irreducibles
 irreducibles
+ModelingToolkit.has_maybe_zeros
+ModelingToolkit.get_maybe_zeros
 maybe_zeros
+ModelingToolkit.has_state_priorities
+ModelingToolkit.get_state_priorities
 state_priorities
 ModelingToolkit.has_ps
 ModelingToolkit.get_ps
@@ -64,10 +76,18 @@ bound_parameters
 ModelingToolkit.has_brownians
 ModelingToolkit.get_brownians
 brownians
+ModelingToolkit.has_poissonians
+ModelingToolkit.get_poissonians
 ModelingToolkit.has_iv
 ModelingToolkit.get_iv
 ModelingToolkitBase.independent_variable
 ModelingToolkitBase.independent_variables
+ModelingToolkit.has_ivs
+ModelingToolkit.get_ivs
+ModelingToolkit.has_dvs
+ModelingToolkit.get_dvs
+ModelingToolkit.has_tspan
+ModelingToolkit.get_tspan
 ModelingToolkit.has_observed
 ModelingToolkit.get_observed
 observed
@@ -78,6 +98,8 @@ nameof
 ModelingToolkit.has_description
 ModelingToolkit.get_description
 ModelingToolkit.description
+ModelingToolkit.has_bindings
+ModelingToolkit.get_bindings
 bindings
 ModelingToolkit.has_initial_conditions
 ModelingToolkit.get_initial_conditions
@@ -85,6 +107,7 @@ initial_conditions
 ModelingToolkit.has_guesses
 ModelingToolkit.get_guesses
 guesses
+ModelingToolkit.has_systems
 ModelingToolkit.get_systems
 ModelingToolkit.has_initialization_eqs
 ModelingToolkit.get_initialization_eqs
@@ -95,6 +118,7 @@ continuous_events
 ModelingToolkit.continuous_events_toplevel
 ModelingToolkit.has_discrete_events
 ModelingToolkit.get_discrete_events
+discrete_events
 ModelingToolkit.discrete_events_toplevel
 ModelingToolkit.has_assertions
 ModelingToolkit.get_assertions
@@ -111,6 +135,16 @@ ModelingToolkit.get_tstops
 ModelingToolkit.symbolic_tstops
 ModelingToolkit.has_tearing_state
 ModelingToolkit.get_tearing_state
+ModelingToolkit.has_schedule
+ModelingToolkit.get_schedule
+ModelingToolkit.has_isscheduled
+ModelingToolkit.get_isscheduled
+ModelingToolkit.has_index_cache
+ModelingToolkit.get_index_cache
+ModelingToolkit.has_irstructure_tlv
+ModelingToolkit.get_irstructure_tlv
+ModelingToolkit.has_parameter_bindings_graph
+ModelingToolkit.get_parameter_bindings_graph
 ModelingToolkit.does_namespacing
 toggle_namespacing
 ModelingToolkit.iscomplete
@@ -121,7 +155,28 @@ ModelingToolkit.has_parent
 ModelingToolkit.get_parent
 ModelingToolkit.has_initializesystem
 ModelingToolkit.get_initializesystem
+ModelingToolkit.has_is_initializesystem
+ModelingToolkit.get_is_initializesystem
 ModelingToolkit.is_initializesystem
+ModelingToolkit.has_analytically_integrated
+ModelingToolkit.get_analytically_integrated
+analytically_integrated
+ModelingToolkit.has_connector_type
+ModelingToolkit.get_connector_type
+ModelingToolkit.has_ignored_connections
+ModelingToolkit.get_ignored_connections
+ModelingToolkit.has_is_discrete
+ModelingToolkit.get_is_discrete
+ModelingToolkit.has_bcs
+ModelingToolkit.get_bcs
+ModelingToolkit.has_domain
+ModelingToolkit.get_domain
+ModelingToolkit.has_var_to_name
+ModelingToolkit.get_var_to_name
+ModelingToolkit.has_gui_metadata
+ModelingToolkit.get_gui_metadata
+ModelingToolkit.has_tag
+ModelingToolkit.get_tag
 ```
 
 ## `getproperty` syntax
@@ -179,7 +234,11 @@ ModelingToolkit.dump_variable_metadata
 ## Inputs and outputs
 
 ```@docs
+ModelingToolkit.has_inputs
+ModelingToolkit.get_inputs
 ModelingToolkit.inputs
+ModelingToolkit.has_outputs
+ModelingToolkit.get_outputs
 ModelingToolkit.outputs
 ModelingToolkit.bound_inputs
 ModelingToolkit.unbound_inputs

--- a/docs/src/API/codegen.md
+++ b/docs/src/API/codegen.md
@@ -52,6 +52,14 @@ ModelingToolkit.calculate_control_jacobian
 ModelingToolkit.calculate_A_b
 ```
 
+A system can be marked as unsupported by symbolic automatic differentiation, in which case
+the `calculate_*` functions above throw instead of producing a wrong derivative.
+
+```@docs
+ModelingToolkitBase.SymbolicADDisallowed
+ModelingToolkitBase.check_symbolic_ad_allowed
+```
+
 All code generation eventually calls `build_function_wrapper`.
 
 ```@docs

--- a/docs/src/API/model_building.md
+++ b/docs/src/API/model_building.md
@@ -116,6 +116,13 @@ for more information.
 instream
 ```
 
+Connectors marked as 3D multibody frames carry a rotation matrix, from which the angular
+velocity of the frame can be computed.
+
+```@docs
+ModelingToolkit.get_w
+```
+
 ### System composition utilities
 
 ```@docs

--- a/docs/src/API/model_building.md
+++ b/docs/src/API/model_building.md
@@ -138,9 +138,15 @@ flatten
 and also perform other optimizations. This is done via the `mtkcompile` function. Connection expansion
 and flattening are preprocessing steps of simplification.
 
+`structural_simplify` and `@mtkbuild` are the deprecated ModelingToolkit v9 spellings. They
+forward to `mtkcompile`/`@mtkcompile` after emitting a deprecation warning, and are
+documented here so that the warning has a target to look up.
+
 ```@docs
 mtkcompile
 @mtkcompile
+structural_simplify
+@mtkbuild
 ```
 
 It is also possible (though not always advisable) to build numerical problems from systems without

--- a/docs/src/API/model_building.md
+++ b/docs/src/API/model_building.md
@@ -90,6 +90,7 @@ macro.
 connect
 domain_connect
 @connector
+Connection
 ```
 
 Connections can be expanded using `expand_connections`.
@@ -150,6 +151,7 @@ calls `complete` internally.
 
 ```@docs
 complete
+@mtkcomplete
 ```
 
 ### Exploring the results of simplification
@@ -191,6 +193,18 @@ section of the documentation. User-defined functions can be used via `Imperative
 
 ```@docs
 ModelingToolkit.ImperativeAffect
+```
+
+## Jump processes
+
+Systems can contain jumps, which are handled by
+[JumpProcesses.jl](https://docs.sciml.ai/JumpProcesses/stable/). The jump types of that
+package are used directly, with the exception of mass action jumps: symbolic rate
+expressions must already carry their combinatorial scaling, so ModelingToolkit provides a
+constructor that builds a `MassActionJump` without rescaling the rate.
+
+```@docs
+SymbolicMassActionJump
 ```
 
 ## Modelingtoolkitize

--- a/docs/src/API/problems.md
+++ b/docs/src/API/problems.md
@@ -10,6 +10,16 @@ and returning specific values. This format of argument and return value depends 
 the function and the problem. ModelingToolkit is capable of compiling and generating
 code for a variety of such numerical problems.
 
+## In-place and out-of-place problems
+
+Every problem and function constructor takes an `iip` type parameter selecting an in-place
+or out-of-place formulation. Problem constructors called without it defer the choice to
+construction time using a sentinel type.
+
+```@docs
+ModelingToolkitBase.Both
+```
+
 ## Dynamical systems
 
 ```@docs
@@ -27,7 +37,9 @@ SciMLBase.SDDEFunction
 SciMLBase.SDDEProblem
 JumpProcesses.JumpProblem
 SciMLBase.BVProblem
+SciMLBase.DiscreteFunction
 SciMLBase.DiscreteProblem
+SciMLBase.ImplicitDiscreteFunction
 SciMLBase.ImplicitDiscreteProblem
 ```
 

--- a/docs/src/API/variables.md
+++ b/docs/src/API/variables.md
@@ -3,8 +3,8 @@
 ModelingToolkit uses [Symbolics.jl](https://docs.sciml.ai/Symbolics/stable/) for the symbolic
 manipulation infrastructure. In fact, the `@variables` macro is defined in Symbolics.jl. In
 addition to `@variables`, ModelingToolkit defines `@parameters`, `@independent_variables`,
-`@constants` and `@brownians`. These macros function identically to `@variables` but allow
-ModelingToolkit to attach additional metadata.
+`@constants`, `@brownians`, `@poissonians` and `@discretes`. These macros function identically
+to `@variables` but allow ModelingToolkit to attach additional metadata.
 
 ```@docs
 @independent_variables
@@ -12,6 +12,8 @@ ModelingToolkit to attach additional metadata.
 @constants
 @brownians
 @brownian
+@poissonians
+@discretes
 ```
 
 Symbolic variables can have metadata attached to them. The defaults and guesses assigned

--- a/docs/src/API/variables.md
+++ b/docs/src/API/variables.md
@@ -40,6 +40,13 @@ ModelingToolkit.getdefault
 ModelingToolkit.setdefault
 ```
 
+The defaults of a system that has already been constructed are updated with `set_defaults`,
+which applies the same binding/initial condition semantics to an existing system.
+
+```@docs
+set_defaults
+```
+
 ## Variable descriptions
 
 Descriptive strings can be attached to variables using the `[description = "descriptive string"]` syntax:
@@ -213,6 +220,7 @@ getguess(u)
 ```@docs
 hasguess
 getguess
+ModelingToolkitBase.setguess
 ```
 
 When a system is constructed, the guesses of the involved variables are stored in a `Dict`
@@ -327,6 +335,15 @@ This metadata is used by the [`System`](@ref) constructor for automatically iden
 ModelingToolkit.VariableType
 ModelingToolkit.MTKVariableTypeCtx
 ModelingToolkit.isparameter
+```
+
+The `@parameters` and `@brownians` macros set this metadata on the variables they declare.
+The same can be done to an existing symbolic variable, which is useful when generating
+variables programmatically.
+
+```@docs
+ModelingToolkitBase.toparam
+ModelingToolkitBase.tobrownian
 ```
 
 ## Miscellaneous metadata

--- a/lib/ModelingToolkitBase/src/discretes.jl
+++ b/lib/ModelingToolkitBase/src/discretes.jl
@@ -16,8 +16,24 @@ end
 """
 $(SIGNATURES)
 
-Define one or more discrete variables, for use in events of continuous systems. All
-symbolics declare with this macro must be dependent variables.
+Define one or more discrete variables, for use in events of continuous systems. Every
+symbolic declared with this macro must be a dependent variable; declaring a
+time-independent one is an error, since `@parameters` already covers that case.
+
+Discrete variables are parameters of the system that events are allowed to write to, so
+they are passed in the parameter list of [`System`](@ref).
+
+# Examples
+
+```julia
+using ModelingToolkitBase
+using ModelingToolkitBase: t_nounits as t, D_nounits as D
+
+@variables x(t)
+@discretes c(t)
+event = [x ~ 1.0] => [c ~ c + 1]
+@named sys = System([D(x) ~ -c * x], t, [x], [c]; continuous_events = [event])
+```
 
 See also [`@independent_variables`](@ref),
 [`@variables`](https://docs.sciml.ai/Symbolics/stable/manual/variables/#Symbolics.@variables)

--- a/lib/ModelingToolkitBase/src/variables.jl
+++ b/lib/ModelingToolkitBase/src/variables.jl
@@ -725,9 +725,9 @@ end
 
 ## Brownian
 """
-    tobrownian(s::Sym)
+    tobrownian(s)
 
-Maps the brownianiable to an unknown.
+Maps the variable to a Brownian variable.
 """
 tobrownian(s::SymbolicT) = setmetadata(s, MTKVariableTypeCtx, BROWNIAN)
 tobrownian(s::Num) = Num(tobrownian(value(s)))

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -58,6 +58,67 @@ end
     @test g([1.0], [2.0], p, 3.0) ≈ [7.0]
 end
 
+# Names rendered by a canonical ```@docs``` block somewhere under `docs/src`, counted so a
+# name landing in two canonical blocks (which fails the Documenter build) is visible here.
+# `SciMLTesting.run_api_docs(...; rendered = true)` cannot stand in for this: it short
+# circuits to a pass as soon as any ```@autodocs``` block exists anywhere in the manual,
+# and this manual has two narrowly scoped ones.
+function canonical_docs_entries(docs_src)
+    counts = Dict{String, Int}()
+    for (root, _, files) in walkdir(docs_src), file in files
+        endswith(file, ".md") || continue
+        inblock = false
+        canonical = false
+        for line in eachline(joinpath(root, file))
+            stripped = strip(line)
+            if inblock
+                if stripped == "```"
+                    inblock = false
+                elseif canonical && !isempty(stripped)
+                    name = last(split(first(split(stripped, '(')), '.'))
+                    counts[name] = get(counts, name, 0) + 1
+                end
+            elseif startswith(stripped, "```@docs")
+                inblock = true
+                canonical = !occursin("canonical = false", stripped)
+            end
+        end
+    end
+    return counts
+end
+
+@testset "Public API is rendered in the manual" begin
+    docs_src = joinpath(dirname(dirname(@__DIR__)), "docs", "src")
+    @test isdir(docs_src)
+    entries = canonical_docs_entries(docs_src)
+    @test !isempty(entries)
+
+    # Every system field carries a `get_`/`has_` accessor pair, generated together with a
+    # docstring and declared `public`. Deriving the list from `SYS_PROPS` rather than
+    # pinning it means a newly added field fails here until it is documented too.
+    accessors = [
+        Symbol(prefix, prop)
+            for prop in [ModelingToolkitBase.SYS_PROPS; [:continuous_events, :discrete_events]]
+            for prefix in (:get_, :has_)
+    ]
+    # Public names whose only gap was rendering. `AnalysisPoint` is deliberately absent: it
+    # is rendered by #4969, and listing it in two canonical blocks is itself a build error.
+    audited = [
+        Symbol("@discretes"), Symbol("@mtkbuild"), Symbol("@poissonians"), :DiscreteSystem,
+        :ImplicitDiscreteSystem, :ODESystem, :analytically_integrated, :discrete_events,
+        :structural_simplify,
+    ]
+
+    for name in [accessors; audited]
+        @test isdefined(ModelingToolkitBase, name)
+        @static if VERSION >= v"1.11"
+            @test Base.ispublic(ModelingToolkitBase, name)
+        end
+        @test haskey(Base.Docs.meta(ModelingToolkitBase), Docs.Binding(ModelingToolkitBase, name))
+        @test get(entries, string(name), 0) == 1
+    end
+end
+
 # The exact set of externally-owned bindings ModelingToolkit deliberately exposes as part
 # of its own public API. ModelingToolkit is a facade: `@reexport using ModelingToolkitBase`
 # pulls up the modelling layer, which in turn `@reexport`s Symbolics (and, through it,

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -106,7 +106,7 @@ end
     audited = [
         Symbol("@discretes"), Symbol("@mtkbuild"), Symbol("@poissonians"), :DiscreteSystem,
         :ImplicitDiscreteSystem, :ODESystem, :analytically_integrated, :discrete_events,
-        :structural_simplify,
+        :get_w, :structural_simplify,
     ]
 
     for name in [accessors; audited]


### PR DESCRIPTION
**Please ignore this PR until it has been reviewed by @ChrisRackauckas.**

**Stacked on #4970** (`docs/render-remaining-public-api`). Base it against that branch, or
merge #4970 first — the diff shown against `master` will otherwise include #4970's five
files. This PR duplicates none of #4970's entries.

## What changed and why

#4970 rendered seventeen public MTKBase names and explicitly deferred two things: ten names
it left out of its inventory, and a bulk decision on the `get_*`/`has_*` field accessors.
This PR takes both.

**Verdict on the ten.** Nine are genuine public API and are rendered here. The tenth,
`AnalysisPoint`, is rendered by #4969 and is deliberately left alone — a name in two
canonical ```@docs``` blocks is itself a Documenter error, so rendering it here would break
that PR on merge.

| Name | Owner | Verdict | Rendered in |
| --- | --- | --- | --- |
| `@discretes` | `discretes.jl` | public: variable-declaration macro, sibling of `@brownians` | `API/variables.md` |
| `@poissonians` | `variables.jl` | public: same family | `API/variables.md` |
| `discrete_events` | `systems/callbacks.jl` | public accessor; its sibling `continuous_events` was already rendered | `API/System.md` |
| `analytically_integrated` | `systems/abstractsystem.jl` | public accessor | `API/System.md` |
| `ODESystem` | `deprecations.jl` | **deprecated alias** for `System` | `API/System.md` |
| `DiscreteSystem` | `deprecations.jl` | **deprecated alias** for `System` | `API/System.md` |
| `ImplicitDiscreteSystem` | `deprecations.jl` | **deprecated alias** for `System` | `API/System.md` |
| `structural_simplify` | `deprecations.jl` | **deprecated alias** for `mtkcompile` | `API/model_building.md` |
| `@mtkbuild` | `deprecations.jl` | **deprecated alias** for `@mtkcompile` | `API/model_building.md` |
| `AnalysisPoint` | `systems/analysis_points.jl` | public — **not touched, #4969 renders it** | — |

The five deprecated aliases are rendered rather than hidden, because the repo already renders
its other deprecated aliases: `NonlinearSystem` (same file, same shape) sits in the "Utility
constructors" block of `API/System.md`, and `@brownian` sits next to `@brownians` in
`API/variables.md`. The unrendered five were an inconsistency, not a policy. They are exported,
`Base.ispublic` is true for each, and each emits a `Base.depwarn` naming a replacement — a user
who hits that warning needs a manual entry to look up. Each is placed next to its replacement,
with one sentence saying it is deprecated.

**The `get_*`/`has_*` accessors.** These are public API by the repo's own version-controlled
decision, not by inference: every one of them is listed individually in `REEXPORTED_API` in
`test/qa/qa.jl`, whose comment reads "Removing an entry is a breaking change." All 104 are
`@public` in `ModelingToolkitBase`, re-declared `public` in `ModelingToolkit` by
`@import_mtkbase`, and carry a generated docstring. 53 of the 104 were rendered and 51 were not,
with no principle separating the two halves — `get_tearing_state` and `get_initializesystem`
were in, `get_index_cache` and `get_schedule` were out. The section header of `API/System.md`
already promises the whole family ("for every field `x` there exists a `has_x` function ... and
a `get_x` function"), so this PR makes that sentence true and renders all 51, in field order,
next to the accessors they belong with. `has_inputs`/`get_inputs`/`has_outputs`/`get_outputs`
go to the "Inputs and outputs" section instead, next to `inputs`/`outputs`.

**`get_w`** (second commit) matches the `get_*` prefix but is *not* a field accessor — it is the
3D multibody frame helper in `systems/connectors.jl` that computes angular velocity from a
rotation matrix. It was the one remaining `@public`, documented, unrendered `get_*` name, so it
is rendered too, in the connection-semantics section. Flagging it separately so it is not read
as part of the field-accessor sweep.

**No docstring was missing.** The task anticipated adding SciMLStyle docstrings at the
definition site; there were none to add. All 104 accessors and all ten names already had one:

```
$ julia --project=<mtkbase-env> probe.jl
nprops = 52
accessor problems: none
@discretes                 exported=true public=true docstring=true
@mtkbuild                  exported=true public=true docstring=true
@poissonians               exported=true public=true docstring=true
AnalysisPoint              exported=true public=true docstring=true
DiscreteSystem             exported=true public=true docstring=true
ImplicitDiscreteSystem     exported=true public=true docstring=true
ODESystem                  exported=true public=true docstring=true
analytically_integrated    exported=true public=true docstring=true
discrete_events            exported=true public=true docstring=true
structural_simplify        exported=true public=true docstring=true
```

(`accessor problems: none` covers all 104 `get_*`/`has_*` names for `NOT DEFINED`, `NOT PUBLIC`
and `NO DOCSTRING`.) The one docstring edit here is `@discretes`, which becomes user-visible for
the first time with this PR: it said "All symbolics declare with this macro must be dependent
variables", and had no example. Same rationale #4970 used for correcting `tobrownian`.

## Documenter's own missing-docs list is the ground truth here

The `Documentation` workflow has been red on `master` since well before this branch
([run on `fb95431a70`](https://github.com/SciML/ModelingToolkit.jl/actions/runs/31862676904)),
terminating with:

```
ERROR: LoadError: `makedocs` encountered errors [:docs_block, :missing_docs, :cross_references]
```

The `:missing_docs` half of that is the direct evidence for this PR. `checkdocs = :exports`
lists exactly which exported names have a docstring that reaches no canonical block, and on
unmodified `master` all ten audited names are in it:

```
┌ Error: 35 docstrings not included in the manual:
│     ModelingToolkitBase.structural_simplify :: Tuple{Any}
│     ModelingToolkitBase.@mtkbuild :: Tuple
│     ModelingToolkitBase.@discretes :: Tuple
│     ModelingToolkitBase.@poissonians :: Tuple
│     ModelingToolkitBase.ODESystem
│     ModelingToolkitBase.DiscreteSystem :: Tuple
│     ModelingToolkitBase.ImplicitDiscreteSystem :: Tuple
│     ModelingToolkitBase.discrete_events :: Tuple{ModelingToolkitBase.AbstractSystem}
│     ModelingToolkitBase.analytically_integrated :: Tuple{ModelingToolkitBase.AbstractSystem}
│     ModelingToolkitBase.AnalysisPoint
│     ModelingToolkitBase.AnalysisPoint :: Tuple{Symbol}
│     ...
```

Two things follow. First, this is not a judgement call about what "counts" as public — Documenter
is already reporting these nine (plus `AnalysisPoint`, #4969's) as a build error. Second, the
check **cannot** see the `get_*`/`has_*` accessors, because `:exports` only inspects `export`ed
names and the accessors are `@public`. That is why they accumulated silently and why the
regression test below reads `docs/src` directly rather than leaning on the shipped check.

The same run also contains:

```
┌ Error: Cannot resolve @ref for md"[`has_systems`](@ref)" in docs/src/API/System.md.
```

`get_systems` was rendered, `has_systems` was not, and the generated `get_systems` docstring ends
with ``See also [`has_systems`](@ref)``. Rendering the full family fixes that cross-reference as a
side effect; every generated accessor docstring points at its partner, so a half-rendered family
is a build error by construction.

## Verification

**Targeted public-doc QA, before and after.** The new `test/qa/qa.jl` testset run standalone
(it needs only `ModelingToolkitBase` and `Test`), against the branch base and against this branch:

```
===== BEFORE (branch base = PR #4970 head 2a0292e575) =====
Test Summary:                        | Pass  Fail  Total  Time
Public API is rendered in the manual |  397    61    458  3.8s

===== AFTER (this branch) =====
Test Summary:                        | Pass  Total  Time
Public API is rendered in the manual |  458    458  0.4s
```

61 = 51 accessors + 9 audited names + `get_w`. The test asserts, for each name, that it is
defined, `Base.ispublic`, has a docstring, and appears in **exactly one** canonical ```@docs```
block — so it fails on a duplicate block as well as on a missing one. The accessor list is
derived from `ModelingToolkitBase.SYS_PROPS` at runtime rather than pinned, so adding a field to
a system fails this test until its two accessors are documented. `AnalysisPoint` is excluded with
a comment saying why.

`SciMLTesting.run_api_docs(...; rendered = true)` is not a substitute and is not modified: as
#4970 documented, it short-circuits to a pass as soon as any ```@autodocs``` block exists
anywhere under `docs_src`, and this manual has two narrowly-scoped ones. No QA ignore entry, no
`@doc` alias, and no change to SciMLTesting.

**No new duplicate `@docs` entries.** Comparing the set of names appearing in more than one
canonical block, base vs. this branch:

```
$ python3 dupcheck.py  # on base, then on HEAD
NO NEW DUPLICATES INTRODUCED
```

The pre-existing duplicates (the `get_sensitivity`/`open_loop` family in `API/problems.md` vs
`API/System.md`, and the bipartite-graph names) are the `:docs_block` half of the master failure
and are untouched here.

**Docstring examples were executed**, not eyeballed. The `@discretes` example added here, and the
existing `@poissonians` examples that become user-visible with this PR:

```
=== @discretes ===
c = c(t)  isparameter = true
parameters(sys) = ...[c(t)]
=== @discretes rejects time-independent ===
errored as documented: `@discretes` cannot create time-independent variables. Encountered bad. Use `@parameters` for this purpose.
=== @poissonians ===
dN = dN vartype = POISSONIAN
dN1 = dN1 dN2 = dN2
dM1 = dM1 dM2 = dM2
ALL OK
```

**Runic and typos**, on the changed files:

```
$ julia --project=@format-check -e 'using Runic; exit(Runic.main(["--check", "lib/ModelingToolkitBase/src/discretes.jl", "test/qa/qa.jl"]))'
runic_exit=0
$ typos docs/src/API lib/ModelingToolkitBase/src/discretes.jl test/qa/qa.jl
typos_exit=0
```

Runic exit 0 was sanity-checked against a deliberately misformatted file, which returns
`sanity_check_misformatted_exit=1`, so the 0 above is a real pass and not a no-op invocation.

## What I did NOT verify

- **`linkcheck` did not run.** `docs/make.jl` was run locally on this branch and terminates
  at `RenderDocument`, before the link checker, with the same
  `[:docs_block, :missing_docs, :cross_references]` as `master`. Full result in the comment
  below: `:missing_docs` drops 35 → 14 (all nine audited names gone), and a diff of every
  `duplicate docs` / `no docs found` / `Cannot resolve @ref` error against the `master` run
  shows **zero new errors** and two fixed (`has_systems` from this PR, `SymbolicMassActionJump`
  from #4970). Docs CI on this PR will still be red, for the pre-existing `master` failures
  only.
- **The QA test group was not run end to end.** `test/qa/qa.jl` pulls in Aqua, JET, FMIImport
  and three OrdinaryDiffEq subpackages; I ran the added testset standalone against
  `ModelingToolkitBase` instead, which is what it actually depends on. Aqua/JET/ExplicitImports
  behaviour is unchanged — this PR adds a testset and touches no `run_qa` argument.
- **No other test group was run.** The only non-docs, non-test source change is one docstring
  string in `discretes.jl`; no code path is touched.

## Still unrendered after this PR, deliberately out of scope

The `:missing_docs` list has twelve further entries that are in neither this PR's inventory nor
#4970's, and each wants its own decision rather than being swept in here:

- `AbstractCollocation`, `JuMPCollocation`, `InfiniteOptCollocation`, `CasADiCollocation`,
  `PyomoCollocation`, `PyomoDynamicOptProblem` — the dynamic-optimization surface. Note the
  three *other* `*DynamicOptProblem` types are already rendered, so this is a partially-rendered
  family and should be finished as one PR.
- `NonPolynomialReason`, and one `isinitial` method signature.
- The `ModelingToolkit` and `ModelingToolkitBase` module docstrings.
- `StateSelection.bareiss.bareiss!` and `StateSelection.CLIL.SparseMatrixCLIL` — owned by
  StateSelection, so they belong in that repo or in its section of `docs/src/internals`.

The `:docs_block` (duplicate-block) and remaining `:cross_references` failures on `master` are
also untouched; they are independent of public-API coverage.

## Anything a reviewer should push back on

- **Rendering all 51 accessors rather than pruning the family.** Some of these are plainly
  implementation detail — `get_tag`, `get_irstructure_tlv`, `get_index_cache`,
  `get_parameter_bindings_graph`. I rendered them because `@public` plus a pinned entry in
  `REEXPORTED_API` is the package asserting they are API, and the alternative — public but
  undocumented — is the state this PR exists to remove. If you would rather they were not public,
  the fix is dropping them from `@public` and from `REEXPORTED_API` in a breaking release, which
  is a different PR and your call, not something to encode by leaving them hidden.
- **Rendering the five deprecated aliases.** The argument is consistency with `NonlinearSystem`
  and `@brownian` plus "the depwarn needs a lookup target". The counter-argument is that
  rendering a deprecated name advertises it. If you prefer, the alternative is removing
  `NonlinearSystem` and `@brownian` from the manual too and adding all seven to a
  `checkdocs_ignored_modules`-style exclusion — but that is a policy change, not this PR.
- **`ODESystem` sits under "Utility constructors"** in `API/System.md`. It is not really a
  utility constructor; it is a v9 compatibility shim. It is there because that is where
  `NonlinearSystem` already is, and splitting them across two sections seemed worse than one
  slightly-wrong heading.
- **`get_w` in the connection-semantics section.** The manual has no multibody content at all,
  so this is a one-name subsection, the same situation #4970 hit with `SymbolicMassActionJump`.

## Links

- This PR's base: https://github.com/SciML/ModelingToolkit.jl/pull/4970
- Concurrent branch that renders `AnalysisPoint`: https://github.com/SciML/ModelingToolkit.jl/pull/4969
- Failing docs build on `master` (`fb95431a70`) used as evidence above: https://github.com/SciML/ModelingToolkit.jl/actions/runs/31862676904
- ExplicitImports / non-public-access tracking issue referenced by `test/qa/qa.jl`: https://github.com/SciML/ModelingToolkit.jl/issues/4882

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019sAcMZxA2thJFBu42drjUZ
