### PR TITLE
docs: define the AbstractSystem interface contract

### DIFF
--- a/docs/pages.jl
+++ b/docs/pages.jl
@@ -37,6 +37,7 @@ pages = [
     ],
     "API" => Any[
         "API/System.md",
+        "API/abstract_system_interface.md",
         "API/variables.md",
         "API/model_building.md",
         "API/problems.md",

--- a/docs/src/API/System.md
+++ b/docs/src/API/System.md
@@ -10,6 +10,10 @@ System
 ModelingToolkit.AbstractSystem
 ```
 
+The rules that hold for every `AbstractSystem`, and the generic functions available on any
+subtype, are stated in
+[The `AbstractSystem` Interface](@ref abstract_system_interface).
+
 ## Utility constructors
 
 Several utility constructors also exist to easily construct alternative system formulations.
@@ -93,6 +97,7 @@ continuous_events
 ModelingToolkit.continuous_events_toplevel
 ModelingToolkit.has_discrete_events
 ModelingToolkit.get_discrete_events
+discrete_events
 ModelingToolkit.discrete_events_toplevel
 ModelingToolkit.has_assertions
 ModelingToolkit.get_assertions

--- a/docs/src/API/abstract_system_interface.md
+++ b/docs/src/API/abstract_system_interface.md
@@ -1,0 +1,243 @@
+# [The `AbstractSystem` Interface](@id abstract_system_interface)
+
+[`ModelingToolkit.AbstractSystem`](@ref) is the supertype of every ModelingToolkit system.
+This page states what a value is guaranteed to support purely by virtue of being an
+`AbstractSystem`, so that code which inspects, traverses, or reports on systems can be
+written against the abstraction instead of against the fields of one concrete type.
+
+The contracts below are written as dispatch signatures with the semantics that must hold.
+Where a function is only available when the system stores a particular piece of data, that
+is stated explicitly along with the query used to detect availability; everything else
+holds for every subtype.
+
+!!! warning "Interface scope"
+
+    This interface covers structural inspection of a system: its name, its subsystem
+    hierarchy, its independent variables, and the symbolic collections it stores. The
+    numerical pipeline — `mtkcompile`, problem and function construction, code generation,
+    initialization, and the indexing surface those produce — is defined on the concrete
+    [`System`](@ref System_type) type and is not part of the `AbstractSystem` contract. See
+    [Outside the interface](@ref abstract_system_interface_boundary).
+
+## Required Implementation
+
+A subtype must supply two pieces of information. Both have a default implementation that
+reads a field of the same name, so a subtype which declares those fields implements the
+requirement without writing any methods.
+
+| Signature                                                   | Default                | Meaning                            |
+|:----------------------------------------------------------- |:---------------------- |:---------------------------------- |
+| `Base.nameof(sys::AbstractSystem)::Symbol`                   | reads the `name` field | The name of this system.           |
+| `ModelingToolkit.get_systems(sys::AbstractSystem)::Vector`   | reads the `systems` field | The direct subsystems of this system. |
+
+The following rules apply to every subtype:
+
+  - [`nameof`](@ref) returns a `Symbol` and must be unique among the systems returned by
+    [`ModelingToolkit.get_systems`](@ref) of a common parent. Namespacing uses this name as
+    the prefix, so duplicate sibling names produce colliding variable names rather than an
+    error.
+  - [`ModelingToolkit.get_systems`](@ref) returns only the *direct* children, each of which
+    is itself an `AbstractSystem`. It never returns transitive descendants.
+  - The hierarchy reachable through [`ModelingToolkit.get_systems`](@ref) must be finite and
+    acyclic. Every generic accessor below recurses through it without cycle detection.
+  - Systems are treated as immutable values. A generic function may retain, compare, or hash
+    a system, and may assume that a system it received earlier still describes the same
+    model.
+
+## Optional Storage and the `has_x`/`get_x` Protocol
+
+Everything beyond the name and the subsystem list is optional storage. ModelingToolkit
+recognizes a fixed set of field names — those listed among
+[the accessor functions of `System`](@ref System_type) — and defines an accessor pair for
+each:
+
+```julia
+ModelingToolkit.has_x(sys::AbstractSystem)::Bool
+ModelingToolkit.get_x(sys::AbstractSystem)
+```
+
+  - `has_x` is defined for every `AbstractSystem` and never throws. It reports whether this
+    system stores `x` at all; it says nothing about whether the stored value is empty.
+  - `get_x` returns the value stored *locally* by `sys`, without namespacing and without
+    consulting subsystems. It throws if the system does not store `x`, so generic code must
+    guard it with `has_x`. The event accessors
+    [`ModelingToolkit.get_continuous_events`](@ref) and
+    [`ModelingToolkit.get_discrete_events`](@ref) are the documented exceptions: they return
+    an empty vector instead of throwing.
+  - The pair exists only for recognized field names. A subtype is free to hold additional
+    data under other field names, but ModelingToolkit will not expose it, and those fields
+    take no part in this interface.
+
+Because optional storage is genuinely optional, a generic function that needs a piece of
+data must decide what to do when it is absent, rather than assuming the layout of
+[`System`](@ref System_type).
+
+## Accessors Available for Every Subtype
+
+These functions are total on `AbstractSystem`: they are defined for every subtype and
+substitute a documented value when the storage they would read is absent.
+
+| Signature                                                                       | Value when the backing storage is absent |
+|:------------------------------------------------------------------------------- |:---------------------------------------- |
+| `ModelingToolkit.independent_variable(sys::AbstractSystem)`                       | `nothing`                                |
+| `ModelingToolkit.independent_variables(sys::AbstractSystem)::Vector`              | empty vector                             |
+| `ModelingToolkit.description(sys::AbstractSystem)::String`                        | `""`                                     |
+| `ModelingToolkit.iscomplete(sys::AbstractSystem)::Bool`                           | `false`                                  |
+| `ModelingToolkit.does_namespacing(sys::AbstractSystem)::Bool`                     | `!iscomplete(sys)`                       |
+| `ModelingToolkit.assertions(sys::AbstractSystem)::Dict`                           | empty dictionary                         |
+| `continuous_events(sys::AbstractSystem)::Vector`                                  | empty vector                             |
+| `discrete_events(sys::AbstractSystem)::Vector`                                    | empty vector                             |
+
+[`ModelingToolkit.independent_variable`](@ref ModelingToolkitBase.independent_variable) is
+the scalar extension point: a subtype that stores its independent variable under a different
+field name, or computes it, adds a method to that function. The vector-valued
+[`ModelingToolkit.independent_variables`](@ref ModelingToolkitBase.independent_variables) is
+derived from it and must not be extended.
+
+ModelingToolkit also implements the parts of the
+[SymbolicIndexingInterface](https://docs.sciml.ai/SymbolicIndexingInterface/stable/) that
+follow from the above for every subtype:
+
+```julia
+SymbolicIndexingInterface.independent_variable_symbols(sys::AbstractSystem)::Vector
+SymbolicIndexingInterface.constant_structure(sys::AbstractSystem)::Bool
+```
+
+## Accessors Backed by Optional Storage
+
+Each function below reads one optional field and therefore requires that the system stores
+it. Guard the call with the corresponding `has_x` query.
+
+| Accessor                                                                                                                 | Required storage       |
+|:------------------------------------------------------------------------------------------------------------------------ |:---------------------- |
+| [`equations`](@ref), [`ModelingToolkit.equations_toplevel`](@ref), [`alg_equations`](@ref), [`diff_equations`](@ref), [`has_alg_equations`](@ref), [`has_diff_equations`](@ref), [`ModelingToolkit.namespace_equations`](@ref) | `eqs`                  |
+| [`unknowns`](@ref), [`ModelingToolkit.unknowns_toplevel`](@ref)                                                            | `unknowns`             |
+| [`parameters`](@ref), [`ModelingToolkit.parameters_toplevel`](@ref)                                                        | `ps`                   |
+| [`observed`](@ref), [`observables`](@ref)                                                                                  | `observed`             |
+| [`initial_conditions`](@ref)                                                                                               | `initial_conditions`   |
+| [`guesses`](@ref)                                                                                                          | `guesses`              |
+| [`initialization_equations`](@ref)                                                                                         | `initialization_eqs`   |
+| [`constraints`](@ref)                                                                                                      | `constraints`          |
+| [`cost`](@ref)                                                                                                             | `costs`, `consolidate` |
+| [`brownians`](@ref)                                                                                                        | `brownians`            |
+| [`jumps`](@ref)                                                                                                            | `jumps`                |
+
+The variable and parameter queries of the SymbolicIndexingInterface are answered from
+[`unknowns`](@ref) and [`parameters`](@ref), so they carry the same storage requirement:
+
+```julia
+SymbolicIndexingInterface.variable_symbols(sys::AbstractSystem)
+SymbolicIndexingInterface.is_variable(sys::AbstractSystem, sym)
+SymbolicIndexingInterface.variable_index(sys::AbstractSystem, sym)
+SymbolicIndexingInterface.parameter_symbols(sys::AbstractSystem)
+SymbolicIndexingInterface.is_parameter(sys::AbstractSystem, sym)
+SymbolicIndexingInterface.parameter_index(sys::AbstractSystem, sym)
+```
+
+## Hierarchy and Namespacing Semantics
+
+The accessors in the previous section come in two families, and the difference between them
+is the whole of the hierarchy contract.
+
+A **hierarchical** accessor returns the locally stored value followed by the result of the
+same accessor on each system in [`ModelingToolkit.get_systems`](@ref), applied recursively
+and namespaced at each level. [`equations`](@ref), [`unknowns`](@ref),
+[`parameters`](@ref), [`observed`](@ref), [`observables`](@ref),
+[`initial_conditions`](@ref), [`guesses`](@ref), [`initialization_equations`](@ref),
+[`constraints`](@ref), [`cost`](@ref), [`brownians`](@ref), [`jumps`](@ref),
+[`continuous_events`](@ref), [`discrete_events`](@ref), and
+[`ModelingToolkit.assertions`](@ref) all behave this way, as do
+[`alg_equations`](@ref), [`diff_equations`](@ref), [`has_alg_equations`](@ref) and
+[`has_diff_equations`](@ref), which classify the result of [`equations`](@ref):
+
+  - Local entries come first, then subsystems in the order
+    [`ModelingToolkit.get_systems`](@ref) returns them. [`parameters`](@ref) additionally
+    removes duplicates, since the same parameter may be reachable through more than one
+    subsystem.
+  - A symbol `x` owned by subsystem `sub` appears as
+    [`ModelingToolkit.renamespace`](@ref)`(sub, x)`, which prefixes `nameof(sub)`. Nesting
+    composes, so a symbol two levels down carries both prefixes.
+  - The result is a fresh collection whenever the system has subsystems. When it has none,
+    the collection may alias the system's own storage. Treat every returned collection as
+    read-only.
+
+A **toplevel** accessor — [`ModelingToolkit.equations_toplevel`](@ref),
+[`ModelingToolkit.unknowns_toplevel`](@ref),
+[`ModelingToolkit.parameters_toplevel`](@ref),
+[`ModelingToolkit.continuous_events_toplevel`](@ref),
+[`ModelingToolkit.discrete_events_toplevel`](@ref) — returns only what the system stores
+itself, with no namespacing and no recursion. `ModelingToolkit.get_x` is the same view with
+no interpretation applied at all.
+
+## [Outside the interface](@id abstract_system_interface_boundary)
+
+The following are properties of the concrete [`System`](@ref System_type) type rather than of
+`AbstractSystem`, and a generic function must not assume them:
+
+  - **Compilation and numerics.** `complete`, `mtkcompile`, every problem and function
+    constructor, code generation, and initialization require a `System`.
+  - **Display, reconstruction, and metadata.** Printing a system, `Symbolics.rename`,
+    `ConstructionBase.setproperties`, `ModelingToolkit.toggle_namespacing`, and the
+    `SymbolicUtils` metadata accessors reconstruct the system from its fields and depend on
+    the internal representation used by `System`.
+  - **`getproperty` for subsystems.** `sys.subsystem` re-namespaces the retrieved subsystem
+    and therefore reconstructs it. Reach subsystems generically through
+    [`ModelingToolkit.get_systems`](@ref) instead.
+  - **The remaining SymbolicIndexingInterface surface.** `is_time_dependent`,
+    `all_symbols`, `all_variable_symbols`, `default_values`, and the observed-function
+    machinery are implemented for `System`.
+
+A package that needs one of these should build a [`System`](@ref System_type) rather than
+introduce a subtype, and should route data through the documented `System` constructors.
+
+## Example
+
+The system below implements the required part of the interface by declaring the `name` and
+`systems` fields, and opts into the equation, unknown, and parameter accessors by declaring
+those fields too.
+
+```@example abstract_system_interface
+using ModelingToolkit
+using ModelingToolkit: t_nounits as t, D_nounits as D
+
+struct ComponentSystem <: ModelingToolkit.AbstractSystem
+    eqs::Vector{Equation}
+    unknowns::Vector
+    ps::Vector
+    iv::Any
+    name::Symbol
+    systems::Vector
+end
+
+@variables x(t) y(t)
+@parameters p q
+
+leaf = ComponentSystem([D(x) ~ p * x], [x], [p], t, :leaf, [])
+root = ComponentSystem([D(y) ~ q * y], [y], [q], t, :root, [leaf])
+
+equations(root)
+```
+
+The hierarchical accessors namespace the contents of `leaf` under its name, while the
+toplevel accessors report only what `root` stores:
+
+```@example abstract_system_interface
+unknowns(root), ModelingToolkit.unknowns_toplevel(root)
+```
+
+Storage the subtype does not declare is reported as absent rather than as empty, and the
+accessor it backs must not be called. Here `iv` is declared and `observed` is not:
+
+```@example abstract_system_interface
+ModelingToolkit.has_iv(root), ModelingToolkit.has_observed(root)
+```
+
+## Validating a Subtype
+
+Exercise the subtype through the functions on this page only. A test that reads a field
+directly, or that calls an entry point listed under
+[Outside the interface](@ref abstract_system_interface_boundary), is testing the `System`
+implementation rather than the interface.
+
+`lib/ModelingToolkitBase/test/abstractsystem_interface.jl` is the executable form of this
+page: it defines minimal subtypes and asserts each rule stated here.

--- a/lib/ModelingToolkitBase/test/abstractsystem_interface.jl
+++ b/lib/ModelingToolkitBase/test/abstractsystem_interface.jl
@@ -1,0 +1,171 @@
+using ModelingToolkitBase
+using SymbolicIndexingInterface: SymbolicIndexingInterface as SII
+using Test
+MT = ModelingToolkitBase
+
+# Every call below is part of the documented `AbstractSystem` interface (see
+# `docs/src/API/abstract_system_interface.md`). Nothing here reads a field of a system
+# directly or calls an entry point that is specific to the `System` implementation.
+
+@independent_variables t
+@variables x(t) y(t)
+@parameters p q
+D = Differential(t)
+
+"A subtype carrying only the two required fields."
+struct MinimalSystem <: MT.AbstractSystem
+    name::Symbol
+    systems::Vector
+end
+
+"A subtype carrying the optional fields backing the equation/unknown/parameter accessors."
+struct ComponentSystem <: MT.AbstractSystem
+    eqs::Vector{Equation}
+    unknowns::Vector
+    ps::Vector
+    iv::Any
+    name::Symbol
+    systems::Vector
+end
+
+"A subtype which supplies its independent variable through the scalar extension point."
+struct RenamedIVSystem <: MT.AbstractSystem
+    time::Any
+    name::Symbol
+    systems::Vector
+end
+MT.independent_variable(sys::RenamedIVSystem) = getfield(sys, :time)
+
+leaf = ComponentSystem([D(x) ~ p * x], [x], [p], t, :leaf, [])
+branch = ComponentSystem([D(y) ~ q * y], [y], [q], t, :branch, [leaf])
+root = ComponentSystem(Equation[], [], [], t, :root, [branch])
+
+@testset "Required surface" begin
+    sys = MinimalSystem(:sys, [])
+    @test nameof(sys) === :sys
+    @test isempty(MT.get_systems(sys))
+
+    parent = MinimalSystem(:parent, [sys])
+    @test map(nameof, MT.get_systems(parent)) == [:sys]
+end
+
+@testset "Accessors defaulted for absent optional fields" begin
+    sys = MinimalSystem(:sys, [])
+    @test MT.independent_variable(sys) === nothing
+    @test isempty(independent_variables(sys))
+    @test MT.description(sys) == ""
+    @test MT.iscomplete(sys) == false
+    @test MT.does_namespacing(sys) == true
+    @test isempty(MT.assertions(sys))
+    @test isempty(MT.continuous_events(sys))
+    @test isempty(MT.discrete_events(sys))
+    @test isempty(SII.independent_variable_symbols(sys))
+    @test SII.constant_structure(sys)
+end
+
+@testset "`has_x` reports optional field availability" begin
+    minimal = MinimalSystem(:sys, [])
+
+    @test MT.has_name(minimal)
+    @test MT.has_name(leaf)
+
+    for hasfn in (MT.has_eqs, MT.has_unknowns, MT.has_ps, MT.has_iv)
+        @test hasfn(minimal) == false
+        @test hasfn(leaf) == true
+    end
+
+    # Neither subtype stores observed equations, so neither may be asked for them.
+    @test MT.has_observed(minimal) == false
+    @test MT.has_observed(leaf) == false
+
+    @test MT.get_eqs(leaf) == [D(x) ~ p * x]
+    @test isequal(MT.get_unknowns(leaf), [x])
+    @test isequal(MT.get_ps(leaf), [p])
+    @test isequal(MT.get_iv(leaf), t)
+
+    # `get_x` on absent storage throws, so generic code has to guard it with `has_x`.
+    @test_throws ErrorException MT.get_eqs(minimal)
+    @test_throws ErrorException MT.get_unknowns(minimal)
+    @test_throws ErrorException MT.get_ps(minimal)
+
+    # The event accessors are the documented exceptions: they default to empty.
+    @test MT.has_continuous_events(minimal) == false
+    @test MT.has_discrete_events(minimal) == false
+    @test isempty(MT.get_continuous_events(minimal))
+    @test isempty(MT.get_discrete_events(minimal))
+end
+
+@testset "Scalar independent variable extension point" begin
+    sys = RenamedIVSystem(t, :sys, [])
+    @test isequal(MT.independent_variable(sys), t)
+    @test isequal(independent_variables(sys), [t])
+    @test isequal(SII.independent_variable_symbols(sys), [t])
+end
+
+@testset "Hierarchical accessors namespace subsystem contents" begin
+    branch_y = MT.renamespace(branch, y)
+    branch_q = MT.renamespace(branch, q)
+    branch_leaf_x = MT.renamespace(branch, MT.renamespace(leaf, x))
+    branch_leaf_p = MT.renamespace(branch, MT.renamespace(leaf, p))
+
+    @test isequal(unknowns(root), [branch_y, branch_leaf_x])
+    @test isequal(parameters(root), [branch_q, branch_leaf_p])
+    @test equations(root) == [
+        D(branch_y) ~ branch_q * branch_y,
+        D(branch_leaf_x) ~ branch_leaf_p * branch_leaf_x,
+    ]
+
+    @test isequal(unknowns(leaf), [x])
+    @test isequal(parameters(leaf), [p])
+    @test equations(leaf) == [D(x) ~ p * x]
+
+    # Locally stored entries come first, then the subsystems in `get_systems` order.
+    leaf_x = MT.renamespace(leaf, x)
+    leaf_p = MT.renamespace(leaf, p)
+    @test isequal(unknowns(branch), [y, leaf_x])
+    @test isequal(parameters(branch), [q, leaf_p])
+    @test equations(branch) == [D(y) ~ q * y, D(leaf_x) ~ leaf_p * leaf_x]
+end
+
+@testset "Toplevel accessors ignore subsystems" begin
+    @test isempty(MT.equations_toplevel(root))
+    @test isempty(MT.unknowns_toplevel(root))
+    @test isempty(MT.parameters_toplevel(root))
+    @test isempty(MT.continuous_events_toplevel(root))
+    @test isempty(MT.discrete_events_toplevel(root))
+
+    @test MT.equations_toplevel(branch) == [D(y) ~ q * y]
+    @test isequal(MT.unknowns_toplevel(branch), [y])
+    @test isequal(MT.parameters_toplevel(branch), [q])
+end
+
+@testset "Equation classification" begin
+    algebraic = ComponentSystem([0 ~ p - x], [x], [p], t, :algebraic, [])
+
+    @test has_diff_equations(leaf)
+    @test !has_alg_equations(leaf)
+    @test diff_equations(leaf) == [D(x) ~ p * x]
+    @test isempty(alg_equations(leaf))
+
+    @test has_alg_equations(algebraic)
+    @test !has_diff_equations(algebraic)
+    @test alg_equations(algebraic) == [0 ~ p - x]
+    @test isempty(diff_equations(algebraic))
+end
+
+@testset "Namespacing helpers" begin
+    leaf_x = MT.renamespace(leaf, x)
+    leaf_p = MT.renamespace(leaf, p)
+    @test MT.namespace_equations(leaf) == [D(leaf_x) ~ leaf_p * leaf_x]
+end
+
+@testset "SymbolicIndexingInterface queries backed by optional fields" begin
+    @test isequal(SII.variable_symbols(leaf), [x])
+    @test isequal(SII.parameter_symbols(leaf), [p])
+    @test SII.is_variable(leaf, x)
+    @test !SII.is_variable(leaf, p)
+    @test SII.variable_index(leaf, x) == 1
+    @test SII.is_parameter(leaf, p)
+    @test !SII.is_parameter(leaf, x)
+    @test SII.parameter_index(leaf, p) == 1
+end

--- a/lib/ModelingToolkitBase/test/runtests.jl
+++ b/lib/ModelingToolkitBase/test/runtests.jl
@@ -41,6 +41,7 @@ end
     if GROUP == "All" || GROUP == "InterfaceI"
         @testset "InterfaceI" begin
             @safetestset "AbstractSystem Test" include("abstractsystem.jl")
+            @safetestset "AbstractSystem Interface Contract" include("abstractsystem_interface.jl")
             @safetestset "AbstractCollocation Public Boundary" include("abstractcollocation.jl")
             @safetestset "Variable Scope Tests" include("variable_scope.jl")
             @safetestset "Parsing Test" include("variable_parsing.jl")


### PR DESCRIPTION
Please ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

`ModelingToolkit.AbstractSystem` carries a one-line docstring ("Any custom system types must
subtype this"), and `docs/src/API/System.md` is a flat `@docs` list of roughly 120 accessors.
Nothing states which of those hold for an arbitrary `AbstractSystem` as opposed to for the
concrete `System`, so generic code has no documented basis for deciding what it may call.

This adds `docs/src/API/abstract_system_interface.md`, a contract page for the
`AbstractSystem` family in the style of the SciMLBase interfaces docs: purpose and scope,
required implementation with dispatch signatures, the `has_x`/`get_x` availability protocol,
the accessors that are total on `AbstractSystem` versus those backed by optional storage, the
hierarchy and namespacing semantics, an explicit statement of what is *outside* the interface,
and a runnable example. It also adds
`lib/ModelingToolkitBase/test/abstractsystem_interface.jl`, which asserts each rule on
purpose-built subtypes using only the functions the page documents — no field reads, no
`System`-specific entry points.

Every rule was derived by running the candidate function against four targets (a minimal
subtype with only `name`/`systems`, a subtype adding the equation/unknown/parameter fields,
`System`, and `PDESystem`) rather than from reading the code. Two findings shaped the page:

  - The `get_x` family throws on absent storage, **except** `get_continuous_events` and
    `get_discrete_events`, which return an empty vector. That asymmetry is now documented and
    pinned by a test.
  - The generic surface is narrower than `API/System.md` suggests. `complete`, `mtkcompile`,
    problem construction, the metadata API, `getproperty` subsystem access, `Base.show`,
    `Symbolics.rename`, and most of the SymbolicIndexingInterface (`is_time_dependent`,
    `all_symbols`, `default_values`, …) require `System`'s concrete representation. The page
    says so explicitly rather than leaving it to be discovered.

Two small related fixes: `discrete_events` is exported and has a docstring but had no `@docs`
entry (its `continuous_events` counterpart does), and `System.md` now links to the new page.

No source file is modified. There is no behavior change and nothing to bisect; the new tests
characterize behavior that already exists on master, so a failing-before/passing-after pair
does not apply.

## Verification

### `ModelingToolkitBase` `InterfaceI` (the group that runs the new file)

`GROUP=InterfaceI julia --project=lib/ModelingToolkitBase -e 'using Pkg; Pkg.test()'` on Julia
1.10.11:

```
Test Summary: | Pass  Broken  Total      Time
InterfaceI    | 1595       5   1600  34m48.2s
     Testing ModelingToolkitBase tests passed
```

The 5 `Broken` are pre-existing `@test_broken` entries elsewhere in the group. The new file
adds no `@test_broken` or `@test_skip` and loosens nothing.

Run standalone, the new file contributes 73 assertions across 9 testsets:

```
Required surface                                            |  3   3
Accessors defaulted for absent optional fields              | 10  10
`has_x` reports optional field availability                 | 23  23
Scalar independent variable extension point                 |  3   3
Hierarchical accessors namespace subsystem contents         |  9   9
Toplevel accessors ignore subsystems                        |  8   8
Equation classification                                     |  8   8
Namespacing helpers                                         |  1   1
SymbolicIndexingInterface queries backed by optional fields |  8   8
```

### Docs build

`julia --project=docs docs/make.jl` on Julia 1.10.11 (`lts`, matching the Documentation
workflow), under `xvfb-run` as CI does. **It exits 1 with 66 errors, and every one of them is
pre-existing.** Grouped by the file the error is reported in:

```
21  docs/src/API/problems.md
12  docs/src/API/codegen.md
 7  docs/src/internals/bipartite_graph.md
 6  docs/src/internals/structural_transformation.md
 6  docs/src/basics/DependencyGraphs.md
 5  docs/src/API/model_building.md
 3  docs/src/API/System.md
 2  docs/src/tutorials/linear_analysis.md
 1  docs/src/tutorials/fmi.md
 1  docs/src/API/variables.md
```

They are canonical-duplicate errors (the linearization/sensitivity docstrings duplicated
between `API/problems.md` and `API/System.md`, and the dependency-graph docstrings duplicated
in `internals/bipartite_graph.md`), unresolvable `@ref` targets, `no docs found` entries for
`StateSelection` bindings, one `linkcheck` 429 on the ColPrac README, and a
"37 docstrings not included in the manual" summary.

Attribution:

  - **`docs/src/API/abstract_system_interface.md` produces zero errors.** It appears nowhere
    in the build log: every `@ref` on the page resolves, all three `@example` blocks execute,
    and the `@id` anchors do not conflict. The page deliberately adds no `@docs` blocks, so it
    cannot introduce a canonical duplicate.
  - The 3 errors reported in `API/System.md` are two unresolved `@ref`s to
    `SymbolicMassActionJump` and one to `has_systems`, emitted from docstrings already
    rendered on master (`jumps`/`get_jumps` and `get_systems` are in that `@docs` block on
    master). My diff to that file is a prose paragraph — whose single `@ref` resolves — plus
    the `discrete_events` entry, and the `discrete_events` docstring contains no `@ref` at
    all, so neither addition can produce an unresolved reference.
  - The change **removes** one error: `ModelingToolkitBase.discrete_events` is absent from the
    "docstrings not included in the manual" list, which is now 37 rather than 38.

A baseline `docs/make.jl` run against unmodified `master` in a separate worktree is in flight
to confirm the error set is identical; I will post the diff as a follow-up comment. Until that
lands, the attribution above rests on the log contents plus the diff, not on a second
observed run.

## Observation for maintainers (not addressed here)

`SymbolicIndexingInterface.is_time_dependent` is defined only for `System`
(`lib/ModelingToolkitBase/src/systems/system.jl:1072`), so it raises a `MethodError` for
`PDESystem` even though `PDESystem` stores `ivs` and `independent_variables(pdesys)` works.
Internal code calls `is_time_dependent(sys::AbstractSystem)` in several places. Generalizing it
(e.g. `is_time_dependent(sys::AbstractSystem) = independent_variable(sys) !== nothing`) is a
behavior change rather than a docs change, so this PR documents the current state instead.

## Not verified

  - Only the `ModelingToolkitBase` `InterfaceI` group and the docs build were run. Other test
    groups, the root `ModelingToolkit` package's groups, QA, downstream, GPU, and FMI paths
    were not exercised. Nothing here touches source.
  - `julia pre` and the LTS/`1`/`pre` matrix were not run locally; only 1.10.11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01835hzUMMyFdBo7Xzy8deGf
