### PR TITLE
docs: remove duplicate linear analysis entries

### DIFF
--- a/docs/src/API/System.md
+++ b/docs/src/API/System.md
@@ -305,13 +305,6 @@ Functions for linearization and analysis of systems.
 ```@docs
 AnalysisPoint
 linearization_ap_transform
-get_sensitivity_function
-get_comp_sensitivity_function
-get_looptransfer_function
-get_sensitivity
-get_comp_sensitivity
-get_looptransfer
-open_loop
 isolate_subsystem
 ```
 


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed

This removes seven repeated `@docs` entries from `docs/src/API/System.md`. The dedicated **Linear analysis / Analysis point transformations** section in `docs/src/API/problems.md` remains the canonical rendered location, so no public documentation is removed.

The duplicate entries were introduced by https://github.com/SciML/ModelingToolkit.jl/commit/ad3cd801ba70394adc6e950cc87a3318faf5ac03. A formal bisect used:

```bash
git bisect start d4a73e1f12 ad3cd801ba^
git bisect run bash -c 'for name in get_sensitivity_function get_sensitivity get_comp_sensitivity_function get_comp_sensitivity get_looptransfer_function get_looptransfer open_loop; do count=$(grep -hFx "$name" docs/src/API/System.md docs/src/API/problems.md | wc -l); test "$count" -le 1 || exit 1; done'
```

and identified `ad3cd801ba70394adc6e950cc87a3318faf5ac03` as the first bad commit.

## Failing before

On clean upstream `d4a73e1f123ad93466ad8872ce3aa9ad9ba7f3f4`:

```bash
DISPLAY=:0 JULIA_DEBUG=Documenter xvfb-run -a -s '-screen 0 1024x768x24' \
  julia +lts --startup-file=no --project=docs/ --code-coverage=user docs/make.jl
```

Documenter emitted 14 `duplicate docs found` errors: all seven linear-analysis names plus seven independent dependency-graph names, then exited 1.

## Passing after

After rebasing to exact upstream `f3248317cb51e08e78fb3d1729286905ad61d6d4`, the same strict command emitted zero duplicate diagnostics for the seven linear-analysis names. Total duplicate diagnostics fell from 14 to 7; the remaining seven are the independent clean-master dependency-graph cluster in `docs/src/internals/bipartite_graph.md`. The build exited 1 only after reporting the remaining existing `[:docs_block, :missing_docs, :cross_references]` categories.

The canonical-location discriminator passes:

```text
docs/src/API/problems.md:148:get_sensitivity_function
docs/src/API/problems.md:149:get_sensitivity
docs/src/API/problems.md:150:get_comp_sensitivity_function
docs/src/API/problems.md:151:get_comp_sensitivity
docs/src/API/problems.md:152:get_looptransfer_function
docs/src/API/problems.md:153:get_looptransfer
docs/src/API/problems.md:154:open_loop
canonical_entry_count=7
```

## Other local verification

```bash
git diff --check
git diff --name-only --diff-filter=ACM | rg '\.jl$' | xargs -r runic --check
git diff --no-ext-diff | typos -
```

These pass; there are no changed Julia files for Runic.

`GROUP=QA julia --project -e 'using Pkg; Pkg.test()'` completed with `39 pass, 4 error`. All four errors reproduce on clean master and are the existing ExplicitImports checks (`no_implicit_imports`, `no_stale_explicit_imports`, `all_explicit_imports_via_owners`, and `all_qualified_accesses_via_owners`). Current master separately disables the pre-existing JET gate; the ExplicitImports failures are being investigated independently.

I did not run GPU, downstream, or `GROUP=Everything` jobs. The official clean-master docs job corroborates the remaining documentation failures.

## Links

- Introducing commit: https://github.com/SciML/ModelingToolkit.jl/commit/ad3cd801ba70394adc6e950cc87a3318faf5ac03
- Clean-master docs job: https://github.com/SciML/ModelingToolkit.jl/actions/runs/31869817836/job/94981845495
