### PR TITLE
docs: remove duplicate dependency graph entries

### DIFF
--- a/docs/src/internals/bipartite_graph.md
+++ b/docs/src/internals/bipartite_graph.md
@@ -27,15 +27,3 @@ The following primitive graph API is defined and versioned by the
 - Matching: `BipartiteGraphs.maximal_matching` and
   `BipartiteGraphs.construct_augmenting_path!`.
 - Vertex kinds: `BipartiteGraphs.SRC` and `BipartiteGraphs.DST`.
-
-## Dependency Graph Construction
-
-```@docs
-ModelingToolkitBase.equation_dependencies
-ModelingToolkitBase.variable_dependencies
-ModelingToolkitBase.eqeq_dependencies
-ModelingToolkitBase.varvar_dependencies
-ModelingToolkitBase.asgraph
-ModelingToolkitBase.asdigraph
-ModelingToolkit.map_variables_to_equations
-```


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed

This removes the repeated dependency-graph `@docs` block from the developer-only bipartite-graph page. The public APIs remain rendered in `docs/src/basics/DependencyGraphs.md`, their dedicated public page, which has documented this API since 2020. The internal page retains its contributor-oriented description and direct link to the owning BipartiteGraphs API.

The repeated internal block was added by https://github.com/SciML/ModelingToolkit.jl/commit/bc8ebdb727d994775c5f07d47753d10bb0d07deb. A formal exact-name bisect identified https://github.com/SciML/ModelingToolkit.jl/commit/060a3fb5d4dc42c9826427fc72180894e35c495f as the first commit where Documenter sees the duplicates, because that later commit owner-qualified the older canonical entries.

## Failing before

On unmodified upstream master, the local discriminator reports each binding twice:

```text
ModelingToolkitBase.equation_dependencies=2
ModelingToolkitBase.variable_dependencies=2
ModelingToolkitBase.eqeq_dependencies=2
ModelingToolkitBase.varvar_dependencies=2
ModelingToolkitBase.asgraph=2
ModelingToolkitBase.asdigraph=2
ModelingToolkit.map_variables_to_equations=2
discriminator=FAIL
```

The formal bisect command was:

```bash
git bisect start f3248317cb bc8ebdb727^
git bisect run bash -c 'for name in ModelingToolkitBase.equation_dependencies ModelingToolkitBase.variable_dependencies ModelingToolkitBase.eqeq_dependencies ModelingToolkitBase.varvar_dependencies ModelingToolkitBase.asgraph ModelingToolkitBase.asdigraph ModelingToolkit.map_variables_to_equations; do count=$(grep -hFx "$name" docs/src/basics/DependencyGraphs.md docs/src/internals/bipartite_graph.md 2>/dev/null | wc -l); test "$count" -le 1 || exit 1; done'
```

## Passing after

The same discriminator reports each binding exactly once and exits successfully.

On exact upstream `f3248317cb51e08e78fb3d1729286905ad61d6d4`, I ran:

```bash
DISPLAY=:0 JULIA_DEBUG=Documenter xvfb-run -a -s '-screen 0 1024x768x24' \
  julia +lts --startup-file=no --project=docs/ --code-coverage=user docs/make.jl
```

Documenter emitted zero duplicate diagnostics for this dependency-graph cluster. The only seven remaining duplicate diagnostics are the separate linear-analysis cluster fixed by https://github.com/SciML/ModelingToolkit.jl/pull/4977. The build exited 1 on the remaining clean-master `[:docs_block, :missing_docs, :cross_references, :linkcheck]` categories; link checking encountered transient remote failures.

## Other local verification

```bash
git diff --check
git diff --name-only --diff-filter=ACM | rg '\.jl$' | xargs -r runic --check
git diff --no-ext-diff | typos -
```

These pass; there are no changed Julia files for Runic.

`GROUP=QA julia +lts --startup-file=no --project -e 'using Pkg; Pkg.test()'` completed with `38 pass, 4 error`. The four existing clean-master ExplicitImports errors are `no_implicit_imports`, `no_stale_explicit_imports`, `all_explicit_imports_via_owners`, and `all_qualified_accesses_via_owners`.

I did not run GPU, downstream, or `GROUP=Everything` jobs.

## Links

- Repeated block commit: https://github.com/SciML/ModelingToolkit.jl/commit/bc8ebdb727d994775c5f07d47753d10bb0d07deb
- First Documenter-visible duplicate commit: https://github.com/SciML/ModelingToolkit.jl/commit/060a3fb5d4dc42c9826427fc72180894e35c495f
- Separate linear-analysis fix: https://github.com/SciML/ModelingToolkit.jl/pull/4977
- Clean-master docs job: https://github.com/SciML/ModelingToolkit.jl/actions/runs/31869817836/job/94981845495
