### PR TITLE
docs: repair strict cross-references

### DIFF
--- a/docs/src/API/variables.md
+++ b/docs/src/API/variables.md
@@ -410,8 +410,9 @@ ModelingToolkit.dump_parameters
 ## Symbolic operators
 
 ModelingToolkit makes heavy use of "operators". These are custom functions that are applied
-to symbolic variables. The most common operator is the Differential operator, defined in
-Symbolics.jl.
+to symbolic variables. The most common operator is the
+[Differential operator](https://docs.sciml.ai/Symbolics/stable/manual/derivatives/), defined
+in Symbolics.jl.
 
 ModelingToolkit also defines a plethora of custom operators.
 

--- a/docs/src/tutorials/fmi.md
+++ b/docs/src/tutorials/fmi.md
@@ -35,7 +35,7 @@ Following are the variables in the FMU (both states and parameters):
 fmu.modelDescription.modelVariables
 ```
 
-Next, [`FMIComponent`](@ref) is used to import the FMU as an MTK component. We provide the FMI
+Next, [`FMIComponent`](@ref ModelingToolkit.FMIComponent) is used to import the FMU as an MTK component. We provide the FMI
 major version as a `Val` to the constructor, along with the loaded FMU and the type as keyword
 arguments.
 

--- a/lib/ModelingToolkitBase/src/problems/daeproblem.jl
+++ b/lib/ModelingToolkitBase/src/problems/daeproblem.jl
@@ -50,7 +50,7 @@ end
     SciMLBase.DAEFunction{iip, spec}(sys::System, opts::SciMLFunctionOptions; kwargs...)
 
 Public entry point that builds a `DAEFunction` directly from a pre-assembled
-[`SciMLFunctionOptions`](@ref), bypassing the `kwargs...` wrapper above.
+`SciMLFunctionOptions`, bypassing the `kwargs...` wrapper above.
 """
 function SciMLBase.DAEFunction{iip, spec}(
         sys::System, opts::SciMLFunctionOptions{E};

--- a/lib/ModelingToolkitBase/src/problems/ddeproblem.jl
+++ b/lib/ModelingToolkitBase/src/problems/ddeproblem.jl
@@ -18,7 +18,7 @@ end
     SciMLBase.DDEFunction{iip, spec}(sys::System, opts::SciMLFunctionOptions)
 
 Public entry point that builds a `DDEFunction` directly from a pre-assembled
-[`SciMLFunctionOptions`](@ref), bypassing the `kwargs...` wrapper above.
+`SciMLFunctionOptions`, bypassing the `kwargs...` wrapper above.
 """
 function SciMLBase.DDEFunction{iip, spec}(
         sys::System, opts::SciMLFunctionOptions{E}

--- a/lib/ModelingToolkitBase/src/problems/discreteproblem.jl
+++ b/lib/ModelingToolkitBase/src/problems/discreteproblem.jl
@@ -18,7 +18,7 @@ end
     SciMLBase.DiscreteFunction{iip, spec}(sys::System, opts::SciMLFunctionOptions)
 
 Public entry point that builds a `DiscreteFunction` directly from a pre-assembled
-[`SciMLFunctionOptions`](@ref), bypassing the `kwargs...` wrapper above.
+`SciMLFunctionOptions`, bypassing the `kwargs...` wrapper above.
 """
 function SciMLBase.DiscreteFunction{iip, spec}(
         sys::System, opts::SciMLFunctionOptions{E}

--- a/lib/ModelingToolkitBase/src/problems/implicitdiscreteproblem.jl
+++ b/lib/ModelingToolkitBase/src/problems/implicitdiscreteproblem.jl
@@ -20,7 +20,7 @@ end
     SciMLBase.ImplicitDiscreteFunction{iip, spec}(sys::System, opts::SciMLFunctionOptions)
 
 Public entry point that builds an `ImplicitDiscreteFunction` directly from a pre-assembled
-[`SciMLFunctionOptions`](@ref), bypassing the `kwargs...` wrapper above.
+`SciMLFunctionOptions`, bypassing the `kwargs...` wrapper above.
 """
 function SciMLBase.ImplicitDiscreteFunction{iip, spec}(
         sys::System, opts::SciMLFunctionOptions{E}

--- a/lib/ModelingToolkitBase/src/problems/intervalnonlinearproblem.jl
+++ b/lib/ModelingToolkitBase/src/problems/intervalnonlinearproblem.jl
@@ -18,7 +18,7 @@ end
     SciMLBase.IntervalNonlinearFunction(sys::System, opts::SciMLFunctionOptions)
 
 Public entry point that builds an `IntervalNonlinearFunction` directly from a pre-assembled
-[`SciMLFunctionOptions`](@ref), bypassing the `kwargs...` wrapper above.
+`SciMLFunctionOptions`, bypassing the `kwargs...` wrapper above.
 """
 function SciMLBase.IntervalNonlinearFunction(sys::System, opts::SciMLFunctionOptions{E}) where {E}
     check_complete(sys, IntervalNonlinearFunction)

--- a/lib/ModelingToolkitBase/src/problems/linearproblem.jl
+++ b/lib/ModelingToolkitBase/src/problems/linearproblem.jl
@@ -39,7 +39,7 @@ end
     LinearFunction{iip}(sys::System, opts::SciMLFunctionOptions; kwargs...)
 
 Public entry point that builds a `LinearFunction` directly from a pre-assembled
-[`SciMLFunctionOptions`](@ref), bypassing the `kwargs...` wrapper above.
+`SciMLFunctionOptions`, bypassing the `kwargs...` wrapper above.
 """
 function LinearFunction{iip}(
         sys::System, opts::SciMLFunctionOptions{E};

--- a/lib/ModelingToolkitBase/src/problems/nonlinearproblem.jl
+++ b/lib/ModelingToolkitBase/src/problems/nonlinearproblem.jl
@@ -20,7 +20,7 @@ end
     SciMLBase.NonlinearFunction{iip, spec}(sys::System, opts::SciMLFunctionOptions; kwargs...)
 
 Public entry point that builds a `NonlinearFunction` directly from a pre-assembled
-[`SciMLFunctionOptions`](@ref), bypassing the `kwargs...` wrapper above.
+`SciMLFunctionOptions`, bypassing the `kwargs...` wrapper above.
 """
 function SciMLBase.NonlinearFunction{iip, spec}(
         sys::System, opts::SciMLFunctionOptions{E};

--- a/lib/ModelingToolkitBase/src/problems/odeproblem.jl
+++ b/lib/ModelingToolkitBase/src/problems/odeproblem.jl
@@ -42,7 +42,7 @@ end
     SciMLBase.ODEFunction{iip, spec}(sys::System, opts::SciMLFunctionOptions; kwargs...)
 
 Public entry point that builds an `ODEFunction` directly from a pre-assembled
-[`SciMLFunctionOptions`](@ref), bypassing the `kwargs...` wrapper above. Useful for callers
+`SciMLFunctionOptions`, bypassing the `kwargs...` wrapper above. Useful for callers
 that already hold (or want to share/reuse) an options struct, since — unlike the `kwargs...`
 wrapper — this method does not need to re-validate or re-assemble the option set.
 """

--- a/lib/ModelingToolkitBase/src/problems/optimizationproblem.jl
+++ b/lib/ModelingToolkitBase/src/problems/optimizationproblem.jl
@@ -25,7 +25,7 @@ end
     SciMLBase.OptimizationFunction{iip}(sys::System, opts::SciMLFunctionOptions; kwargs...)
 
 Public entry point that builds an `OptimizationFunction` directly from a pre-assembled
-[`SciMLFunctionOptions`](@ref), bypassing the `kwargs...` wrapper above.
+`SciMLFunctionOptions`, bypassing the `kwargs...` wrapper above.
 """
 function SciMLBase.OptimizationFunction{iip}(
         sys::System, opts::SciMLFunctionOptions{E};

--- a/lib/ModelingToolkitBase/src/problems/sddeproblem.jl
+++ b/lib/ModelingToolkitBase/src/problems/sddeproblem.jl
@@ -19,7 +19,7 @@ end
     SciMLBase.SDDEFunction{iip, spec}(sys::System, opts::SciMLFunctionOptions)
 
 Public entry point that builds an `SDDEFunction` directly from a pre-assembled
-[`SciMLFunctionOptions`](@ref), bypassing the `kwargs...` wrapper above.
+`SciMLFunctionOptions`, bypassing the `kwargs...` wrapper above.
 """
 function SciMLBase.SDDEFunction{iip, spec}(
         sys::System, opts::SciMLFunctionOptions{E}

--- a/lib/ModelingToolkitBase/src/problems/sdeproblem.jl
+++ b/lib/ModelingToolkitBase/src/problems/sdeproblem.jl
@@ -21,7 +21,7 @@ end
     SciMLBase.SDEFunction{iip, spec}(sys::System, opts::SciMLFunctionOptions; kwargs...)
 
 Public entry point that builds an `SDEFunction` directly from a pre-assembled
-[`SciMLFunctionOptions`](@ref), bypassing the `kwargs...` wrapper above.
+`SciMLFunctionOptions`, bypassing the `kwargs...` wrapper above.
 """
 function SciMLBase.SDEFunction{iip, spec}(
         sys::System, opts::SciMLFunctionOptions{E};

--- a/lib/ModelingToolkitBase/src/systems/analysis_points.jl
+++ b/lib/ModelingToolkitBase/src/systems/analysis_points.jl
@@ -12,7 +12,9 @@ Where `out` is the output being connected to the inputs `in...`. All involved
 connectors (input and outputs) are required to either have an unknown named
 `u` or a single unknown, all of which should have the same size.
 
-See also [`get_sensitivity`](@ref), [`get_comp_sensitivity`](@ref), [`get_looptransfer`](@ref), [`open_loop`](@ref)
+See also [`get_sensitivity`](@ref ModelingToolkit.get_sensitivity),
+[`get_comp_sensitivity`](@ref ModelingToolkit.get_comp_sensitivity),
+[`get_looptransfer`](@ref ModelingToolkit.get_looptransfer), and [`open_loop`](@ref).
 
 # Fields
 

--- a/lib/ModelingToolkitBase/src/systems/callbacks.jl
+++ b/lib/ModelingToolkitBase/src/systems/callbacks.jl
@@ -351,7 +351,7 @@ const Affect = Union{AffectSystem, ImperativeAffect}
                                affect_neg = affect, initialize = nothing, finalize = nothing,
                                rootfind = SciMLBase.LeftRootFind, initialize_save_discretes = true)
 
-A [`ContinuousCallback`](@ref SciMLBase.ContinuousCallback) specified symbolically. Takes a vector of equations `eq`
+A [`ContinuousCallback`](https://docs.sciml.ai/DiffEqDocs/stable/features/callback_functions/) specified symbolically. Takes a vector of equations `eq`
 as well as the positive-edge `affect` and negative-edge `affect_neg` that apply when *any* of `eq` are satisfied.
 By default `affect_neg = affect`; to only get rising edges specify `affect_neg = nothing`.
 
@@ -366,7 +366,7 @@ sharp discontinuity between integrator steps (which in this example would not no
 guaranteed to be triggered.
 
 Once detected the integrator will "wind back" through a root-finding process to identify the point when the condition became active; the method used
-is specified by `rootfind` from [`SciMLBase.RootfindOpt`](@ref). If we denote the time when the condition becomes active as `tc`,
+is specified by `rootfind` from [`SciMLBase.RootfindOpt`](https://docs.sciml.ai/DiffEqDocs/stable/features/callback_functions/). If we denote the time when the condition becomes active as `tc`,
 the value in the integrator after windback will be:
 * `u[tc-epsilon], p[tc-epsilon], tc` if `LeftRootFind` is used,
 * `u[tc+epsilon], p[tc+epsilon], tc` if `RightRootFind` is used,

--- a/lib/ModelingToolkitBase/src/systems/codegen_utils.jl
+++ b/lib/ModelingToolkitBase/src/systems/codegen_utils.jl
@@ -73,7 +73,7 @@ _gfo_bool(b::Bool) = b
     GeneratedFunctionOptions{expression, wrap_gfw}(; kwargs...)
 
 Options for the code-generation entry points (`generate_rhs`, `generate_jacobian`, ...):
-the "output/compile" layer sitting one level above [`BuildFunctionWrapperOptions`](@ref).
+the "output/compile" layer sitting one level above `BuildFunctionWrapperOptions`.
 It controls how the generated code is realized (returned as an `Expr` vs compiled to a
 callable, and whether wrapped in a `GeneratedFunctionWrapper`) and holds a nested
 `Symbolics.CodegenFunctionOptions` (`codegen`) with the low-level code-generation options
@@ -750,7 +750,7 @@ end
     build_function_wrapper(sys::AbstractSystem, expr, args...; kwargs...)
 
 Backwards-compatibility keyword-argument form of `build_function_wrapper`. The keyword
-arguments (documented on [`BuildFunctionWrapperOptions`](@ref)) are bundled into a
+arguments (documented on `BuildFunctionWrapperOptions`) are bundled into a
 `BuildFunctionWrapperOptions` and forwarded to the primary method,
 [`build_function_wrapper(sys, expr, args, opts::BuildFunctionWrapperOptions)`](@ref). This
 method exists only for backwards compatibility; new code should construct a
@@ -790,7 +790,7 @@ A wrapper around `build_function` which performs the necessary transformations f
 code generation of all types of systems. `expr` is the expression returned from the
 generated functions, and `args` is the `Vector{Any}` of arguments.
 
-Options are supplied as a [`BuildFunctionWrapperOptions`](@ref); see its docstring for the
+Options are supplied as a `BuildFunctionWrapperOptions`; see its docstring for the
 available options. This is the primary method — the keyword-argument form of
 `build_function_wrapper` is a backwards-compatibility shim that bundles its keywords into a
 `BuildFunctionWrapperOptions` and calls this method.

--- a/lib/ModelingToolkitBase/src/systems/optimal_control_interface.jl
+++ b/lib/ModelingToolkitBase/src/systems/optimal_control_interface.jl
@@ -291,7 +291,7 @@ end
     SciMLBase.ODEInputFunction{iip, specialize}(sys::System, opts::SciMLFunctionOptions; kwargs...)
 
 Public entry point that builds an `ODEInputFunction` directly from a pre-assembled
-[`SciMLFunctionOptions`](@ref), bypassing the `kwargs...` wrapper above.
+`SciMLFunctionOptions`, bypassing the `kwargs...` wrapper above.
 """
 function SciMLBase.ODEInputFunction{iip, specialize}(
         sys::System, opts::SciMLFunctionOptions;

--- a/lib/ModelingToolkitBase/src/systems/problem_utils.jl
+++ b/lib/ModelingToolkitBase/src/systems/problem_utils.jl
@@ -1759,7 +1759,7 @@ end
 
 Bundle of options for [`process_SciMLProblem`](@ref)/`__process_SciMLProblem`, which build
 the `SciMLFunction` (and its `u0`/`p`/`du0`) shared by every `SciMLBase.*Problem`
-constructor. Nests a [`SciMLFunctionOptions`](@ref) (`fn_opts`) for the options that are
+constructor. Nests a `SciMLFunctionOptions` (`fn_opts`) for the options that are
 ultimately relevant to the `SciMLFunction` being constructed (`t`, `eval_expression`,
 `eval_module`, `compiler_options`, and everything else `SciMLFunctionOptions` recognizes),
 plus the fields specific to processing the operating point and building the initialization

--- a/lib/ModelingToolkitBase/src/variables.jl
+++ b/lib/ModelingToolkitBase/src/variables.jl
@@ -972,7 +972,7 @@ EvalAt(1.0)(D(x))  # Returns D(x) evaluated at t=1.0
 # Errors
 - Throws an error when applied to variables with more than one argument (e.g., `z(u, t)`)
 
-See also: [`Differential`](@ref)
+See also: [`Differential`](https://docs.sciml.ai/Symbolics/stable/manual/derivatives/)
 """
 struct EvalAt <: Symbolics.Operator
     t::Union{SymbolicT, Number}

--- a/src/problems/docs.jl
+++ b/src/problems/docs.jl
@@ -4,7 +4,7 @@ struct SemilinearODEProblem{iip, spec} end
 const SEMILINEAR_EXTRA_BODY = """
 This is a special form of an ODE which uses a `SplitFunction` internally. The equations are
 separated into linear, quadratic and general terms and phrased as matrix operations. See
-[`calculate_semiquadratic_form`](@ref) for information on how the equations are split. This
+`calculate_semiquadratic_form` for information on how the equations are split. This
 formulation allows leveraging split ODE solvers such as `KenCarp4` and is useful for systems
 where the stiff and non-stiff terms can be separated out in such a manner. Typically the linear
 part of the equations is the stiff part, but the keywords `stiff_linear`, `stiff_quadratic` and `stiff_nonlinear` can
@@ -23,6 +23,6 @@ const SEMILINEAR_A_B_C_KWARGS = """
 
 const SEMILINEAR_A_B_C_CONSTRAINT = """
 Note that all three of `stiff_linear`, `stiff_quadratic`, `stiff_nonlinear` cannot be identical, and at least
-two of `A`, `B`, `C` returned from [`calculate_semiquadratic_form`](@ref) must be
+two of `A`, `B`, `C` returned from `calculate_semiquadratic_form` must be
 non-`nothing`. In other words, both of the functions in the split form must be non-empty.
 """

--- a/src/problems/semilinearodeproblem.jl
+++ b/src/problems/semilinearodeproblem.jl
@@ -23,7 +23,7 @@ end
     SemilinearODEFunction{iip, specialize}(sys::System, opts::SciMLFunctionOptions; kwargs...)
 
 Public entry point that builds a `SemilinearODEFunction` directly from a pre-assembled
-[`SciMLFunctionOptions`](@ref), bypassing the `kwargs...` wrapper above.
+`SciMLFunctionOptions`, bypassing the `kwargs...` wrapper above.
 """
 function SemilinearODEFunction{iip, specialize}(
         sys::System, opts::SciMLFunctionOptions{E};
@@ -167,7 +167,7 @@ end
     $(TYPEDSIGNATURES)
 
 Add the necessary parameters for [`SemilinearODEProblem`](@ref) given the matrices
-`A`, `B`, `C` returned from [`calculate_semiquadratic_form`](@ref).
+`A`, `B`, `C` returned from `calculate_semiquadratic_form`.
 """
 function add_semiquadratic_parameters(sys::System, A, B, C)
     eqs = equations(sys)

--- a/src/systems/codegen.jl
+++ b/src/systems/codegen.jl
@@ -118,7 +118,7 @@ const LINEAR_MATRIX_PARAM_NAME = :linear_Aₘₜₖ
     $(TYPEDSIGNATURES)
 
 Return a symbolic variable representing the `A` matrix returned from
-[`calculate_semiquadratic_form`](@ref).
+`calculate_semiquadratic_form`.
 """
 function get_linear_matrix_param(size::NTuple{2, Int})
     m, n = size
@@ -129,7 +129,7 @@ end
     $(TYPEDSIGNATURES)
 
 Return the name of the `i`th matrix in `B` returned from
-[`calculate_semiquadratic_form`](@ref).
+`calculate_semiquadratic_form`.
 """
 function get_quadratic_form_name(i::Int)
     return Symbol(:quadratic_Bₘₜₖ_, i)
@@ -139,7 +139,7 @@ end
     $(TYPEDSIGNATURES)
 
 Return a symbolic variable representing the `i`th matrix in `B` returned from
-[`calculate_semiquadratic_form`](@ref).
+`calculate_semiquadratic_form`.
 """
 function get_quadratic_form_param(sz::NTuple{2, Int}, i::Int)
     m, n = sz
@@ -190,8 +190,8 @@ end
 
 Generate `f1` and `f2` for [`SemilinearODEFunction`](@ref) (internally represented as a
 `SplitFunction`). `A`, `B`, `C` are the matrices returned from
-[`calculate_semiquadratic_form`](@ref). This expects that the system has the necessary
-extra parameters added by [`add_semiquadratic_parameters`](@ref).
+`calculate_semiquadratic_form`. This expects that the system has the necessary
+extra parameters added by `add_semiquadratic_parameters`.
 
 ## Keyword Arguments
 
@@ -382,9 +382,9 @@ end
 
 Generate the jacobian of `f1` for [`SemilinearODEFunction`](@ref) (internally represented as a
 `SplitFunction`). `A`, `B`, `C` are the matrices returned from
-[`calculate_semiquadratic_form`](@ref). `Cjac` is the jacobian of `C` with respect to the
+`calculate_semiquadratic_form`. `Cjac` is the jacobian of `C` with respect to the
 unknowns of the system, or `nothing` if `C === nothing`. This expects that the system has the
-necessary extra parameters added by [`add_semiquadratic_parameters`](@ref).
+necessary extra parameters added by `add_semiquadratic_parameters`.
 
 ## Keyword Arguments
 
@@ -555,9 +555,9 @@ end
 
 Return the sparsity pattern of the  jacobian of `f1` for [`SemilinearODEFunction`](@ref)
 (internally represented as a `SplitFunction`). `A`, `B`, `C` are the matrices returned from
-[`calculate_semiquadratic_form`](@ref). `Cjac` is the jacobian of `C` with respect to the
+`calculate_semiquadratic_form`. `Cjac` is the jacobian of `C` with respect to the
 unknowns of the system, or `nothing` if `C === nothing`. This expects that the system has the
-necessary extra parameters added by [`add_semiquadratic_parameters`](@ref).
+necessary extra parameters added by `add_semiquadratic_parameters`.
 
 ## Keyword Arguments
 


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed

Strict Documenter exposed 34 unresolved cross-references on current `master`.

This PR keeps local ModelingToolkit references as qualified Documenter references, links dependency-owned APIs to their canonical SciML documentation, and renders internal-only helper names as code instead of pretending they are public documentation targets. It does not change behavior or public API.

## Failure before

On the unmodified `f3248317cb51e08e78fb3d1729286905ad61d6d4` base:

```sh
DISPLAY=:0 JULIA_DEBUG=Documenter xvfb-run -a -s '-screen 0 1024x768x24' \
  julia +lts --startup-file=no --project=docs/ --code-coverage=user docs/make.jl
```

The command exited 1, and:

```text
$ rg -c 'Cannot resolve @ref' docs-before.log
34
ERROR: LoadError: `makedocs` encountered errors [:docs_block, :missing_docs, :cross_references] -- terminating build before rendering.
```

The same failure is visible in the clean-master docs job:
https://github.com/SciML/ModelingToolkit.jl/actions/runs/31869817836/job/94981845495

A formal bisect of the strict cross-reference gate identified `92c27bb9fdcaa024ff190feb3d665452e33f9bd8` (`Adopt SciMLTesting 2.4 strict QA`) as the first bad commit.

## Verification after

On this branch, based directly on `f3248317cb51e08e78fb3d1729286905ad61d6d4`:

```sh
DISPLAY=:0 JULIA_DEBUG=Documenter xvfb-run -a -s '-screen 0 1024x768x24' \
  julia +lts --startup-file=no --project=docs/ --code-coverage=user docs/make.jl
```

The command still exits 1 for the independently tracked duplicate-doc and missing-doc failures, but the cross-reference discriminator is clean:

```text
$ rg 'Cannot resolve @ref' docs-after-crossrefs.log | wc -l
0
ERROR: LoadError: `makedocs` encountered errors [:docs_block, :missing_docs] -- terminating build before rendering.
```

Both new canonical external links returned HTTP 200 during Documenter link checking.

Mechanical checks:

```sh
git diff --name-only --diff-filter=ACM | rg '\.jl$' |
  xargs julia +lts --startup-file=no -e 'using Runic; exit(Runic.main(ARGS))' -- --check
git diff --check
git diff --name-only --diff-filter=ACM -z | xargs -0 typos
```

All three exited 0.

QA:

```sh
GROUP=QA julia +lts --startup-file=no --project -e 'using Pkg; Pkg.test()'
```

The command reproduced the current-master ExplicitImports failure without a branch-specific regression:

```text
Some tests did not pass: 38 passed, 0 failed, 4 errored, 0 broken.
ExplicitImports | 4 errors
```

GPU, downstream, Julia pre, and non-QA test groups were not run because this is a documentation-only change.