### PR TITLE
fix: record array elements in collect_operator_variables

### DIFF
--- a/lib/ModelingToolkitBase/src/utils.jl
+++ b/lib/ModelingToolkitBase/src/utils.jl
@@ -714,7 +714,17 @@ function collect_operator_variables(eqs::Vector{Equation}, ::Type{op}) where {op
         SU.search_variables!(vars, eq; is_atomic = OperatorIsAtomic{op}())
         for v in vars
             isoperator(v, op) || continue
-            push!(diffvars, arguments(v)[1])
+            arg = arguments(v)[1]
+            # An operator applied to an array variable or slice, such as `D(u[2:4])`,
+            # names the array rather than its elements. Callers test membership of the
+            # scalar unknowns, so record the elements.
+            if symtype(arg) <: AbstractArray
+                for el in vec(collect(Symbolics.scalarize(wrap(arg))))
+                    push!(diffvars, unwrap(el))
+                end
+            else
+                push!(diffvars, arg)
+            end
         end
         empty!(vars)
     end

--- a/lib/ModelingToolkitBase/test/variable_utils.jl
+++ b/lib/ModelingToolkitBase/test/variable_utils.jl
@@ -1,5 +1,5 @@
 using ModelingToolkitBase, Test
-using ModelingToolkitBase: value, parse_variable
+using ModelingToolkitBase: value, parse_variable, unwrap
 using SymbolicUtils: <ₑ
 import SymbolicUtils as SU
 
@@ -43,6 +43,27 @@ aov = ModelingToolkitBase.collect_applied_operators(eq, Differential)
 
 ts = collect_ivs([eq])
 @test ts == Set([t])
+
+@testset "collect_differential_variables with array variables" begin
+    # A derivative of an array variable or of a slice names the array, not its elements.
+    # Callers such as `DAEProblem`'s `differential_vars` test membership of the scalar
+    # unknowns, so the elements have to be recorded.
+    @variables w(t)[1:4]
+    Dt = Differential(t)
+
+    whole = collect_differential_variables(Dt(w) ~ w)
+    @test whole == Set(Any[unwrap(el) for el in collect(w)])
+
+    sliced = collect_differential_variables(Dt(w[2:3]) ~ w[1:2])
+    @test sliced == Set(Any[unwrap(w[2]), unwrap(w[3])])
+
+    # scalar derivatives are unaffected
+    @test collect_differential_variables(Dt(w[1]) ~ w[2]) == Set(Any[unwrap(w[1])])
+
+    # and the elements are exactly what a `differential_vars` style membership test needs
+    sts = [unwrap(el) for el in collect(w)]
+    @test map(Base.Fix2(in, sliced), sts) == [false, true, true, false]
+end
 
 @testset "parse_variable with scalarized arrays" begin
     @variables scalarized_x(t)[1:2]


### PR DESCRIPTION
> [!NOTE]
> Draft — please ignore until reviewed by @ChrisRackauckas.

## The bug

`collect_operator_variables` records `arguments(v)[1]` for each operator application. When
the operator is applied to an array variable or a slice — `D(u[2:4])` — that argument is
the *array*, not its elements. Every caller tests membership of the **scalar** unknowns, so
nothing ever matches.

The visible consequence is in `DAEProblem`, which builds

```julia
diffvars = collect_differential_variables(sys)
differential_vars = map(Base.Fix2(in, diffvars), unknowns(sys))
```

so a system whose equations differentiate an array slice reports **every variable as
algebraic**, and DAE initialization then has nothing to work from.

## Failing before, passing after

```julia
@variables w(t)[1:4]
collect_differential_variables(D(w[2:3]) ~ w[1:2])
```

| | result | membership map over `unknowns` |
|---|---|---|
| before | `Set([w[2:3]])` | `[0, 0, 0, 0]` |
| after  | `Set([w[2], w[3]])` | `[0, 1, 1, 0]` |

Measured downstream on a real system (a MethodOfLines finite-difference discretization
that emits its interior as one array equation), `DAEProblem`'s `differential_vars` goes
from **0/21 to 19/21** at one grid size and **0/81 to 79/81** at another — 19 and 79 being
the interior points, with the two boundary points genuinely algebraic.

## The change

One function. When the operator's argument is array-valued, scalarize it and record the
elements; otherwise behave exactly as before, so scalar operators take an identical path.

## Tests

`lib/ModelingToolkitBase/test/variable_utils.jl` gains a testset covering a whole array
variable, a slice, an unaffected scalar derivative, and the `differential_vars`-style
membership test that motivated the fix. It fails on unpatched code with the
`[0, 0, 0, 0]` map shown above.

```
Test Summary:  | Pass  Total      Time
variable_utils |  145    145  11m03.2s
```

(145 = 141 pre-existing + 4 added.)

## Not verified

I ran the `variable_utils` file, not the full ModelingToolkitBase suite — the change is
additive and confined to one branch of one function, but a full run has not been done
locally. Other callers of `collect_operator_variables` (`collect_applied_operators`,
`Shift`-based discrete paths) are unaffected for scalar arguments and now see elements
rather than arrays for array ones, which is the intended correction but is worth a
reviewer's eye.

## Context

Found while making finite-difference PDE discretizations emit array (slice-form) equations
instead of one scalar equation per grid point — see SciML/MethodOfLines.jl#428. This is one
of several places where array equations lose their shape; the others (equation counting,
implicit-DAE codegen row indexing) are more invasive and will be proposed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S1dxUEPGysx27SSSpxtiQ9