### PR TITLE
feat: pass a system's ProblemTypeCtx metadata to DAEProblem

### DIFF
--- a/lib/ModelingToolkitBase/Project.toml
+++ b/lib/ModelingToolkitBase/Project.toml
@@ -1,7 +1,7 @@
 name = "ModelingToolkitBase"
 uuid = "7771a370-6774-4173-bd38-47e70ca0b839"
 authors = ["Yingbo Ma <mayingbo5@gmail.com>", "Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
-version = "1.65.0"
+version = "1.66.0"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
@@ -174,7 +174,7 @@ ReferenceTests = "0.10"
 RuntimeGeneratedFunctions = "0.5.12"
 SCCNonlinearSolve = "1.13"
 SafeTestsets = "0.1"
-SciMLBase = "3.44"
+SciMLBase = "3.48"
 SciMLPublic = "1.0.0"
 SciMLStructures = "1.7"
 SciMLTesting = "2.4"

--- a/lib/ModelingToolkitBase/src/problems/daeproblem.jl
+++ b/lib/ModelingToolkitBase/src/problems/daeproblem.jl
@@ -148,7 +148,8 @@ end
     sts = unknowns(sys)
     differential_vars = map(Base.Fix2(in, diffvars), sts)
 
-    args = (; f, du0, u0, tspan, p)
+    ptype = getmetadata(sys, ProblemTypeCtx, SciMLBase.StandardDAEProblem())
+    args = (; f, du0, u0, tspan, p, ptype)
     kwargs = (; differential_vars, kwargs...)
 
     return maybe_codegen_scimlproblem(expression, DAEProblem{_iip}, args; kwargs...)

--- a/lib/ModelingToolkitBase/test/odesystem.jl
+++ b/lib/ModelingToolkitBase/test/odesystem.jl
@@ -1701,6 +1701,13 @@ end
     )
     prob = ODEProblem(sys, [x => 1.0], (0.0, 1.0))
     @test prob.problem_type == "A"
+
+    daeprob = DAEProblem(sys, [x => 1.0, D(x) => 1.0], (0.0, 1.0))
+    @test daeprob.problem_type == "A"
+
+    @mtkcompile plain = System([D(x) ~ x], t)
+    @test DAEProblem(plain, [x => 1.0, D(x) => 1.0], (0.0, 1.0)).problem_type isa
+        SciMLBase.StandardDAEProblem
 end
 
 @testset "`substitute` retains events and metadata" begin


### PR DESCRIPTION
## What and why

`ODEProblem` and `NonlinearProblem` construction reads `ProblemTypeCtx` off the system and stores it in the problem's `problem_type` field:

```julia
ptype = getmetadata(sys, ProblemTypeCtx, StandardODEProblem())
args = (; f, u0, tspan, p, ptype)
```

`DAEProblem` construction dropped it. `problem_type(prob)` is what `SciMLBase.wrap_sol` dispatches on, so a discretizer that attaches its metadata via `ProblemTypeCtx` — MethodOfLines does — got no wrapping on the DAE path: solutions came back as raw `DAESolution` indexed by discretized variables instead of by the PDE's own `u(t, x)`.

This adds the same two lines to `daeproblem.jl`.

## Dependency

Requires SciML/SciMLBase.jl#1536, which adds the `problem_type` field to `DAEProblem`. That is merged and **SciMLBase v3.48.0 is registered** (JuliaRegistries/General#164703), so compat is bumped to `SciMLBase = "3.48"` and this resolves normally. The first CI run predates the registration and failed on resolution (`restricted to versions 3.48.0 - 3 by ModelingToolkitBase — no versions left`); CI has been re-triggered against the registered version.

## Verification

Extended the existing `ProblemTypeCtx` testset in `lib/ModelingToolkitBase/test/odesystem.jl` to cover `DAEProblem`, including that a system without the metadata still gets `StandardDAEProblem`.

Failing before the change (the metadata is dropped, so the marker is the default):

```
Test Summary:                       | Pass  Fail  Total   Time
`ProblemTypeCtx` reaches DAEProblem |    2     1      3  10.7s
ERROR: LoadError: Some tests did not pass: 2 passed, 1 failed, 0 errored, 0 broken.
```

Passing after:

```
Test Summary:                       | Pass  Total  Time
`ProblemTypeCtx` reaches DAEProblem |    3      3  8.1s
```

End-to-end, the motivating case — a MethodOfLines heat equation discretized to array form and built as a `DAEProblem` (no `mtkcompile`), solved with `DFBDF`:

```
problem_type(prob) = MOLMetadata
typeof(sol) = PDETimeSeriesSolution
sol[u(t,x)] size = (2, 21)
max|u-exact| = 0.0007565021749123546
interp at (0.1, 0.5) = 0.3734643410283503  exact = 0.37270783885343794
retcode = Success
```

Re-verified after registration against the released SciMLBase — a clean environment with only this branch `dev`ed, no patched dependencies:

```
resolved SciMLBase v3.48.0 from /home/crackauc/.julia/packages/SciMLBase/FOBdl

Test Summary:                       | Pass  Total  Time
`ProblemTypeCtx` reaches DAEProblem |    3      3  7.8s
```

`runic --check` is clean on the diff.

## Not verified

I did not run the full MTK test suite locally — only the `ProblemTypeCtx` testset above and the end-to-end MethodOfLines solve. CI now covers the rest.

## CI triage

After re-running against the registered SciMLBase, the counts are **74 pass / 17 red / 3 skipped**. Every red one reproduces on `master` or is a timeout, none is caused by this change:

| Red check | Verdict |
|---|---|
| 6× Catalyst downstream | `ReleaseTest`/`IntegrationTest` are red on master's last 5 runs |
| `downgrade-sublibraries` | Red on master's last 5 runs. Failure is a `DEOptions` constructor arity mismatch in the DelayDiffEq/**DDE** stack |
| `tests / QA (julia 1)`, `sublibrary-ci [QA]` | Red on master's `Tests` run. The "unapproved public reexports" list is entirely Symbolics macros (`@acrule`, `@arrayop`, `@derivatives`, `:taylor`) — no DAE symbols |
| `tests / InterfaceI (julia pre)` | Red on master's `Tests` run. `sublibrary-ci [InterfaceI] / Julia pre` passes |
| 4× `Optimization` | **Cancelled**, not failed — hit the 2h job timeout. Master's Optimization jobs cancel at 2h01m identically |
| `build` (Documentation) | Red on master's last 5 runs: `duplicate docs found for 'get_sensitivity_function'` in `docs/src/API/problems.md` |
| 2× `Initialization (lts)` | Pre-existing — see below |

The `Initialization` failure deserved a real check, because master's `Tests` run fails on *different* jobs and this PR is the first to pull in SciMLBase 3.48.0. It is `@test_broken @inferred remake(prob)` / `@inferred solve(prob)` on an **ODEProblem** at `initializationsystem.jl:1837-1838`, which this change does not touch. Reproduced on Julia 1.10 (CI's `lts`) against **unmodified `master`**, pinning SciMLBase either side of the release:

```
julia 1.10.11  SciMLBase v3.47.1
  remake: ErrorException -> return type ODEProblem{...} does not match inferred...
  solve:  ErrorException -> return type ODESolution{...} does not match inferred...

julia 1.10.11  SciMLBase v3.48.0
  remake: ErrorException -> return type ODEProblem{...} does not match inferred...
  solve:  ErrorException -> return type ODESolution{...} does not match inferred...
```

Identical on both, and present without this branch — a pre-existing 1.10 inference regression, not a 3.48.0 fallout.

The test added here lives in `odesystem.jl` (`InterfaceI` group), which is green on `tests` Julia 1 + lts and on `sublibrary-ci` Julia 1 + lts + pre.

---

**Please ignore until reviewed by @ChrisRackauckas.**
