### PR TITLE
Guard write_possibly_indexed_array! against zero-length parent arrays

### DIFF
--- a/lib/ModelingToolkitBase/src/atomic_array_dict.jl
+++ b/lib/ModelingToolkitBase/src/atomic_array_dict.jl
@@ -123,6 +123,7 @@ function write_possibly_indexed_array!(dd::AtomicArrayDict{SymbolicT}, k::Symbol
         else
             fill(default, size(arr))
         end
+        isempty(buffer) && return dd
         idx = get_stable_index(k)
         buffer[idx] = v
         if all(SU.isconst, buffer)

--- a/lib/ModelingToolkitBase/test/variable_utils.jl
+++ b/lib/ModelingToolkitBase/test/variable_utils.jl
@@ -201,3 +201,17 @@ end
     @test value(only(arguments(EvalAt(1)(_x)))) == 1
     @test EvalAt(1)(D(x)) isa Num
 end
+
+@testset "write_possibly_indexed_array! ignores elements of zero-length parents" begin
+    t = ModelingToolkitBase.t_nounits
+    @variables a(t)[1:0] b(t)[1:2]
+    au = value(a)
+    bu = value(b)
+    dd = ModelingToolkitBase.AtomicArrayDict{ModelingToolkitBase.SymbolicT}()
+    ModelingToolkitBase.write_possibly_indexed_array!(dd, au[SU.StableIndex([1])],
+        ModelingToolkitBase.COMMON_NOTHING, ModelingToolkitBase.COMMON_NOTHING)
+    @test isempty(dd)
+    ModelingToolkitBase.write_possibly_indexed_array!(dd, bu[SU.StableIndex([1])],
+        ModelingToolkitBase.COMMON_NOTHING, ModelingToolkitBase.COMMON_NOTHING)
+    @test haskey(dd, bu)
+end

--- a/lib/ModelingToolkitBase/test/variable_utils.jl
+++ b/lib/ModelingToolkitBase/test/variable_utils.jl
@@ -208,10 +208,14 @@ end
     au = value(a)
     bu = value(b)
     dd = ModelingToolkitBase.AtomicArrayDict{ModelingToolkitBase.SymbolicT}()
-    ModelingToolkitBase.write_possibly_indexed_array!(dd, au[SU.StableIndex([1])],
-        ModelingToolkitBase.COMMON_NOTHING, ModelingToolkitBase.COMMON_NOTHING)
+    ModelingToolkitBase.write_possibly_indexed_array!(
+        dd, au[SU.StableIndex([1])],
+        ModelingToolkitBase.COMMON_NOTHING, ModelingToolkitBase.COMMON_NOTHING
+    )
     @test isempty(dd)
-    ModelingToolkitBase.write_possibly_indexed_array!(dd, bu[SU.StableIndex([1])],
-        ModelingToolkitBase.COMMON_NOTHING, ModelingToolkitBase.COMMON_NOTHING)
+    ModelingToolkitBase.write_possibly_indexed_array!(
+        dd, bu[SU.StableIndex([1])],
+        ModelingToolkitBase.COMMON_NOTHING, ModelingToolkitBase.COMMON_NOTHING
+    )
     @test haskey(dd, bu)
 end


### PR DESCRIPTION
**Problem.** `mtkcompile` throws `BoundsError: attempt to access 0-element Vector ... at index [1]` for a system whose unknowns include a zero-length array that no equation touches. Zero-length arrays are easy to hit in practice, e.g. fluid connectors size their composition arrays by the medium's species count, which is 0 for a single-substance medium.

```julia
using ModelingToolkit
using ModelingToolkit: t_nounits as t, D_nounits as D
@variables x(t) a(t)[1:0]
@named sys = System([D(x) ~ -x], t, Any[x, a], [])
mtkcompile(sys)   # BoundsError; compiles with this PR
```

**Cause.** TearingState's cleanup of bindings/initial conditions for unknowns that appear in no equation (MTKTearing, tearingstate.jl) passes an element of the zero-length array to `write_possibly_indexed_array!`, which sizes its buffer from the parent (`fill(default, size(arr))`, 0 elements) and writes index [1] without handling the empty case. On MTKTearing 1.17.1 this compiled, because that version had no call to this function, so zero-length arrays never took this path.

**Fix.** One guard line: an element of a zero-length array has nothing to record, so return the dict unchanged. Positive-length paths are untouched. A function-level regression test is included.

**Additional context.** The element reference is produced by `SymbolicUtils.stable_eachindex`, whose iterator for a zero-length array reports `length == 0` yet yields index 1; that inconsistency may deserve its own fix in SymbolicUtils, independent of this PR.