### PR TITLE
Fix dependency owner references in InterfaceI tests

### DIFF
--- a/test/reduction.jl
+++ b/test/reduction.jl
@@ -1,6 +1,7 @@
 using ModelingToolkit, OrdinaryDiffEq, Test, NonlinearSolve, LinearAlgebra
 using BipartiteGraphs
 using Symbolics
+import ModelingToolkitBase
 using OrdinaryDiffEqRosenbrock
 using ModelingToolkit: topsort_equations, t_nounits as t, D_nounits as D, unwrap
 
@@ -293,7 +294,7 @@ eqs = [
 ]
 @named model = System(eqs, t)
 sys = mtkcompile(model)
-Js = ModelingToolkit.jacobian_sparsity(sys)
+Js = ModelingToolkitBase.jacobian_sparsity(sys)
 @test size(Js) == (3, 3)
 @test Js == Diagonal([0, 1, 1])
 

--- a/test/structural_transformation/tearing.jl
+++ b/test/structural_transformation/tearing.jl
@@ -1,7 +1,6 @@
 using Test
 using ModelingToolkit
 using ModelingToolkit: Equation, observed
-using ModelingToolkit.StructuralTransformations: SystemStructure
 using NonlinearSolve
 using LinearAlgebra
 using UnPack

--- a/test/structural_transformation/utils.jl
+++ b/test/structural_transformation/utils.jl
@@ -8,6 +8,8 @@ using Symbolics: unwrap
 using DataInterpolations
 using OrdinaryDiffEq, NonlinearSolve, StochasticDiffEq
 import DiffEqNoiseProcess
+import BipartiteGraphs
+import ModelingToolkitBase
 import SymbolicUtils as SU
 import StateSelection
 import ModelingToolkitTearing as MTKTearing
@@ -41,7 +43,7 @@ end
 
 se = collect(StructuralTransformations.edges(graph))
 @test se == mapreduce(vcat, enumerate(graph.fadjlist)) do (s, d)
-    StructuralTransformations.BipartiteEdge.(s, d)
+    BipartiteGraphs.BipartiteEdge.(s, d)
 end
 
 @testset "observed2graph handles unknowns inside callable parameters" begin
@@ -124,25 +126,34 @@ end
 
     # Expand shifts
     @test isequal(
-        ST.distribute_shift(Shift(t, -1)(x + y)), Shift(t, -1)(x) + Shift(t, -1)(y)
+        ModelingToolkitBase.distribute_shift(Shift(t, -1)(x + y)),
+        Shift(t, -1)(x) + Shift(t, -1)(y)
     )
 
     expr = a * Shift(t, -2)(x) + Shift(t, 2)(y) + b
     @test isequal(
-        ST.simplify_shifts(ST.distribute_shift(Shift(t, 2)(expr))),
+        ModelingToolkitBase.simplify_shifts(
+            ModelingToolkitBase.distribute_shift(Shift(t, 2)(expr))
+        ),
         a * x + Shift(t, 4)(y) + b
     )
-    @test isequal(ST.distribute_shift(Shift(t, 2)(exp(z))), exp(Shift(t, 2)(z)))
-    @test isequal(ST.distribute_shift(Shift(t, 2)(exp(a) + b)), exp(a) + b)
+    @test isequal(
+        ModelingToolkitBase.distribute_shift(Shift(t, 2)(exp(z))), exp(Shift(t, 2)(z))
+    )
+    @test isequal(
+        ModelingToolkitBase.distribute_shift(Shift(t, 2)(exp(a) + b)), exp(a) + b
+    )
 
     expr = a^x - log(b * y) + z * x
     @test isequal(
-        ST.distribute_shift(Shift(t, -3)(expr)),
+        ModelingToolkitBase.distribute_shift(Shift(t, -3)(expr)),
         a^(Shift(t, -3)(x)) - log(b * Shift(t, -3)(y)) + Shift(t, -3)(z) * Shift(t, -3)(x)
     )
 
     expr = x(k + 1) ~ x + x(k - 1)
-    @test isequal(ST.distribute_shift(Shift(t, -1)(expr)), x ~ x(k - 1) + x(k - 2))
+    @test isequal(
+        ModelingToolkitBase.distribute_shift(Shift(t, -1)(expr)), x ~ x(k - 1) + x(k - 2)
+    )
 end
 
 @testset "`map_variables_to_equations`" begin


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed

InterfaceI tests now access `jacobian_sparsity`, `BipartiteEdge`, `distribute_shift`, and `simplify_shifts` through the dependency modules that own them. The unused `SystemStructure` import from `ModelingToolkit.StructuralTransformations` is removed.

This is test-only: it does not restore stale compatibility bindings or change package behavior/API.

## Root cause

The import cleanup in commit `03c130782349ca8ed91e4f9a92da08d590c53ffe` removed internal dependency aliases from `ModelingToolkit` and `ModelingToolkit.StructuralTransformations`, but these three test files still reached five names through those modules. The source boundary is adjacent and independently reproducible: parent `64ced006057dfef83d26f8941767c2a74653e1e6` was green, while the cleanup commit and every current master/PR Julia leg below report the same nine errors.

Restoring the aliases is not a valid fix: I ran `GROUP=QA` with that version and ExplicitImports rejected all five as stale explicit imports. Qualifying the existing tests through `ModelingToolkitBase` and `BipartiteGraphs` preserves the import-cleanup invariant.

The exact downgraded graph used locally included ModelingToolkitBase 1.66.0, ModelingToolkitTearing 1.19.2, BipartiteGraphs 0.1.4, StateSelection 1.11.0, Symbolics 7.32.1, SymbolicUtils 4.37.0, SymbolicIndexingInterface 0.3.46, SciMLBase 3.48.0, and OrdinaryDiffEqCore 4.12.0.

## Verification

### Failure before

At clean master SHA `3fe375e19031102e95c7775c4d8a6aac9895767b`, the exact local Julia 1.10.12 downgrade run reproduced all nine existing `UndefVarError`s for the five names. Four temporary diagnostic binding assertions made the aggregate:

```text
InterfaceI | 1330 pass | 4 fail | 9 error | 3 broken | 1346 total | 31m18.4s
```

Those diagnostic assertions are not in this diff. The clean-master CI job without them reports `1330 pass / 9 error / 3 broken`.

### Passing after

```sh
JULIA_DEPOT_PATH=/home/crackauc/sandbox/tmp_20260811_090509_69787/.mtk-downgrade-interface-depot \
  GROUP=InterfaceI timeout 7200 julia +1.10.12 --startup-file=no --color=no \
  --project=. -e 'using Pkg; Pkg.test()'
```

```text
InterfaceI | 1486 pass | 3 broken | 1489 total | 31m26.4s
Testing ModelingToolkit tests passed
```

```sh
JULIA_DEPOT_PATH=/home/crackauc/sandbox/tmp_20260811_090509_69787/.mtk-downgrade-interface-depot \
  GROUP=QA timeout 7200 julia +1.12 --startup-file=no --color=no \
  --project=. -e 'using Pkg; Pkg.test()'
```

```text
QA | 52 pass | 52 total | 4m36.8s
Testing ModelingToolkit tests passed
```

Also passed:

```sh
julia +1.12 --startup-file=no -m Runic --check \
  test/reduction.jl test/structural_transformation/utils.jl \
  test/structural_transformation/tearing.jl
git diff --no-ext-diff --unified=0 | typos -
git diff --check
```

Docs were not run because the patch changes only tests and does not touch documentation, docstrings, or public API. `GROUP=Everything`, sublibrary groups, GPU paths, and allowed-to-fail Julia-pre/downstream paths were not run locally.

The separate sublibrary downgrade failure is nine `OrdinaryDiffEqCore.DEOptions` constructor errors, not this missing-name cluster. The downgraded BoundaryValueDiffEqMIRK `CartesianIndex + Int` precompile workload and Moshi method-overwrite precompile errors also reproduced locally; `Pkg.test()` continued past them. None is changed here.

## Links

- Import-cleanup regression commit: https://github.com/SciML/ModelingToolkit.jl/commit/03c130782349ca8ed91e4f9a92da08d590c53ffe
- Import-cleanup PR: https://github.com/SciML/ModelingToolkit.jl/pull/4981
- Adjacent green parent commit: https://github.com/SciML/ModelingToolkit.jl/commit/64ced006057dfef83d26f8941767c2a74653e1e6
- Parent downgrade InterfaceI green job: https://github.com/SciML/ModelingToolkit.jl/actions/runs/32001487846/job/95302536363
- Parent Julia LTS InterfaceI green job: https://github.com/SciML/ModelingToolkit.jl/actions/runs/32001488065/job/95302763022
- Regression-commit downgrade failure: https://github.com/SciML/ModelingToolkit.jl/actions/runs/31979485212/job/95243884040
- Regression-commit Julia LTS failure: https://github.com/SciML/ModelingToolkit.jl/actions/runs/31979485393/job/95243960709
- Current PR downgrade failure: https://github.com/SciML/ModelingToolkit.jl/actions/runs/32030028232/job/95387734186
- Clean-master downgrade failure: https://github.com/SciML/ModelingToolkit.jl/actions/runs/32009364736/job/95325414514
- Current PR Julia LTS failure: https://github.com/SciML/ModelingToolkit.jl/actions/runs/32030028413/job/95391980650
- Clean-master Julia LTS failure: https://github.com/SciML/ModelingToolkit.jl/actions/runs/32009364908/job/95337392143
- Current PR current-Julia failure: https://github.com/SciML/ModelingToolkit.jl/actions/runs/32030028413/job/95391980640
- Clean-master current-Julia failure: https://github.com/SciML/ModelingToolkit.jl/actions/runs/32009364908/job/95337392039
- Current PR Julia-pre failure: https://github.com/SciML/ModelingToolkit.jl/actions/runs/32030028413/job/95391980983
- Clean-master Julia-pre failure: https://github.com/SciML/ModelingToolkit.jl/actions/runs/32009364908/job/95337391921
- Separate PR sublibrary downgrade failure: https://github.com/SciML/ModelingToolkit.jl/actions/runs/32030028226/job/95392285138
- Separate clean-master sublibrary downgrade failure: https://github.com/SciML/ModelingToolkit.jl/actions/runs/32009364804/job/95334645642
