### PR TITLE
fix: reference Symbolics-owned names through Symbolics in tests

### DIFF
--- a/lib/ModelingToolkitBase/test/bigsystem.jl
+++ b/lib/ModelingToolkitBase/test/bigsystem.jl
@@ -57,7 +57,7 @@ f(du, u, nothing, 0.0)
 multithreadedf = eval(
     ModelingToolkitBase.build_function(
         du, u, fillzeros = true,
-        parallel = ModelingToolkitBase.MultithreadedForm()
+        parallel = Symbolics.MultithreadedForm()
     )[2]
 )
 
@@ -76,8 +76,8 @@ end
 
 #=
 jac = sparse(ModelingToolkit.jacobian(vec(du),vec(u)))
-fjac = eval(ModelingToolkit.build_function(jac,u,parallel=ModelingToolkit.SerialForm())[2])
-multithreadedfjac = eval(ModelingToolkit.build_function(jac,u,parallel=ModelingToolkit.MultithreadedForm())[2])
+fjac = eval(ModelingToolkit.build_function(jac,u,parallel=Symbolics.SerialForm())[2])
+multithreadedfjac = eval(ModelingToolkit.build_function(jac,u,parallel=Symbolics.MultithreadedForm())[2])
 
 u = rand(N,N,3)
 J = similar(jac,Float64)
@@ -96,7 +96,7 @@ maximum(J2 .- Array(J)) < 1e-5
 jac = ModelingToolkitBase.sparsejacobian(vec(du), vec(u))
 serialjac = eval(ModelingToolkitBase.build_function(vec(jac), u)[2])
 #multithreadedjac = eval(ModelingToolkit.build_function(vec(jac), u,
-#    parallel = ModelingToolkit.MultithreadedForm())[2])
+#    parallel = Symbolics.MultithreadedForm())[2])
 
 MyA = zeros(N, N)
 AMx = zeros(N, N)

--- a/lib/ModelingToolkitBase/test/ccompile.jl
+++ b/lib/ModelingToolkitBase/test/ccompile.jl
@@ -1,4 +1,5 @@
 using ModelingToolkitBase, Test
+using Symbolics: CTarget
 using ModelingToolkitBase: t_nounits as t, D_nounits as D
 
 @parameters a
@@ -9,7 +10,7 @@ eqs = [
 ]
 f = build_function(
     [x.rhs for x in eqs], [x, y], [a], t, expression = Val{false},
-    target = ModelingToolkitBase.CTarget()
+    target = CTarget()
 )
 f2 = eval(build_function([x.rhs for x in eqs], [x, y], [a], t)[2])
 du = rand(2);

--- a/lib/ModelingToolkitBase/test/nonlinearsystem.jl
+++ b/lib/ModelingToolkitBase/test/nonlinearsystem.jl
@@ -1,4 +1,5 @@
 using ModelingToolkitBase, StaticArrays, LinearAlgebra
+using Symbolics: hessian_sparsity
 using DiffEqBase, SparseArrays
 using Test
 using NonlinearSolve
@@ -92,9 +93,9 @@ jac = calculate_jacobian(ns)
 jac = generate_jacobian(ns)
 
 sH = calculate_hessian(ns)
-@test getfield.(ModelingToolkitBase.hessian_sparsity(ns), :colptr) ==
+@test getfield.(hessian_sparsity(ns), :colptr) ==
     getfield.(sparse.(sH), :colptr)
-@test getfield.(ModelingToolkitBase.hessian_sparsity(ns), :rowval) ==
+@test getfield.(hessian_sparsity(ns), :rowval) ==
     getfield.(sparse.(sH), :rowval)
 
 prob = NonlinearProblem(ns, [x => 1.0, y => 1.0, z => 1.0, σ => 1.0, ρ => 1.0, β => 1.0])

--- a/test/reduction.jl
+++ b/test/reduction.jl
@@ -267,7 +267,7 @@ sys = mtkcompile(sys0)
 eq = equations(tearing_substitution(sys))[1]
 vv = only(unknowns(sys))
 @test isequal(eq.lhs, D(vv))
-dvv = ModelingToolkit.value(ModelingToolkit.derivative(eq.rhs, vv))
+dvv = ModelingToolkit.value(Symbolics.derivative(eq.rhs, vv))
 @test dvv ≈ -60
 
 # Don't reduce inputs


### PR DESCRIPTION
## What broke

#4989 (mine) trimmed ModelingToolkitBase's `import Symbolics: ...` list using ExplicitImports' stale-import report. Five of the removed names were still reached as `ModelingToolkitBase.<name>` / `ModelingToolkit.<name>` from the test suite:

| name | referenced from |
|---|---|
| `hessian_sparsity` | `lib/ModelingToolkitBase/test/nonlinearsystem.jl:95,97` |
| `MultithreadedForm` | `lib/ModelingToolkitBase/test/bigsystem.jl:60,80` |
| `SerialForm` | `lib/ModelingToolkitBase/test/bigsystem.jl:79` |
| `CTarget` | `lib/ModelingToolkitBase/test/ccompile.jl:12` |
| `derivative` | `test/reduction.jl:270` |

ExplicitImports was right that `src` never uses them, but they were in ModelingToolkitBase's namespace *because of* those imports, and none of the five is exported by Symbolics (`Base.isexported(Symbolics, :hessian_sparsity) == false`, same for `MultithreadedForm`), so `@reexport using Symbolics` does not cover them.

Master is currently red as a result: `InterfaceII` on all three Julia versions and `Extended` on all three.

```
master @ 63f684c, tests/InterfaceII (julia 1):
  1037 passed, 0 failed, 3 errored, 7 broken
  UndefVarError: `hessian_sparsity` not defined in `ModelingToolkitBase`

master @ 63f684c, sublibrary [Extended] (julia 1):
  UndefVarError: `MultithreadedForm` not defined in `ModelingToolkitBase`
```

## The fix

Reference each through Symbolics, the module that owns them — consistent with #4989's intent rather than reverting it. Test-only changes; no `src` change, so the import hygiene stays as merged.

## Verification

`lib/ModelingToolkitBase/test/nonlinearsystem.jl` run directly against this branch:

```
EXIT: 0
Test Summary:             | Pass  Total  Time
...
```

Discriminating check — same branch, with only `nonlinearsystem.jl` reverted to master's version:

```
REVERTED EXIT: 1
  UndefVarError: `hessian_sparsity` not defined in `ModelingToolkitBase`
```

I searched for the complete set rather than fixing them one at a time: every identifier present in the import block before #4989 and absent after was cross-referenced against qualified `ModelingToolkit(Base).<name>` uses across `lib/`, `src/` and `test/`. That yielded exactly these five, and none remain.

`runic --check` clean on all four files.

## Not verified

I ran `nonlinearsystem.jl` directly, not the full `InterfaceII` or `Extended` groups (each ~50 min), and not `ccompile.jl`/`bigsystem.jl`, which need a C compiler and a large sparse build respectively. CI covers those.

---

**Please ignore until reviewed by @ChrisRackauckas.**
