### PR TITLE
test: disable inline linear SCCs in linearization DD test

### DIFF
--- a/test/downstream/linearization_dd.jl
+++ b/test/downstream/linearization_dd.jl
@@ -2,6 +2,7 @@
 # The call to Link(; m = 0.2, l = 10, I = 1, g = -9.807) hangs forever on Julia v1.6
 using LinearAlgebra
 using ModelingToolkit
+import ModelingToolkitTearing as MTKTearing
 using ModelingToolkitStandardLibrary
 using ModelingToolkitStandardLibrary.Blocks
 using ModelingToolkitStandardLibrary.Mechanical.MultiBody2D
@@ -63,7 +64,8 @@ ps = poles(G)
 
 lin_fun, ssys = ModelingToolkit.linearization_function(
     model, lin_inputs, lin_outputs, allow_symbolic = true, op = op,
-    zero_dummy_der = false, guesses = guesses
+    zero_dummy_der = false, guesses = guesses,
+    reassemble_alg = MTKTearing.DefaultReassembleAlgorithm(; inline_linear_sccs = false)
 );
 lsys, = ModelingToolkit.linearize(ssys, lin_fun; op, allow_input_derivatives = true);
 lsyss,


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
