### PR TITLE
Route sublibrary groups from the root test harness

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,6 +7,7 @@ const RepoRoot = dirname(@__DIR__)
 const EnvParents = [MTKBasePath, RepoRoot]
 
 run_tests(;
+    lib_dir = joinpath(RepoRoot, "lib"),
     groups = Dict(
         "InterfaceI" => joinpath(@__DIR__, "group_interfacei.jl"),
         "Initialization" => joinpath(@__DIR__, "group_initialization.jl"),


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

Pass the repository's `lib` directory to SciMLTesting's root `run_tests` call. This enables the existing monorepo router to resolve prefixed groups such as `ModelingToolkitBase_Extensions` and run the requested sublibrary tests.

This is a one-line test-harness correction. It changes no package source, public API, dependency, or version.

## Root cause

The harness conversion in https://github.com/SciML/ModelingToolkit.jl/commit/d647d61ac46f3a5696021f4a0e52769aacb2194c from https://github.com/SciML/ModelingToolkit.jl/pull/4610 adopted SciMLTesting but omitted `lib_dir` from the root call.

Its parent accepts the prefixed command but silently performs zero tests:

```text
0.000040 seconds (59 allocations)
```

Current master exposes the omission as a hard routing error instead. The existing report is https://github.com/SciML/ModelingToolkit.jl/issues/4997.

## Failing before

On clean current master `38d91d81dcd77319a70abb93882ba6da13510600`:

```sh
GROUP=ModelingToolkitBase_Extensions julia +1.12 --project=. -e 'using Pkg; Pkg.test()'
```

exits before any owning test runs:

```text
run_tests: group entry must be a function or vector, got Nothing
_group_spec(... Nothing)
Testing ModelingToolkit tests failed
```

## Passing after

The identical root command now dispatches to the actual sublibrary suite and exits 0:

```text
HomotopyContinuation | 76/76
LabelledArrays        | 18/18
BifurcationKit        | 7/7
Despecialized MTKParameters AD | 2/2
Testing ModelingToolkitBase tests passed
Testing ModelingToolkit tests passed
```

The root QA group also passes:

```text
GROUP=QA
QA | 52/52
Testing ModelingToolkit tests passed
```

Whole-repository Runic, spelling over the diff, and `git diff --check` pass.

## Not verified

Other prefixed sublibrary groups were not each run locally; this change supplies the generic `lib_dir` consumed by the shared router. Docs were not run because only the test harness changed. Julia LTS/prerelease were not repeated locally.
