### PR TITLE
Reduce TTFX for event-free system problems

### DIFF
--- a/lib/ModelingToolkitBase/src/systems/callbacks.jl
+++ b/lib/ModelingToolkitBase/src/systems/callbacks.jl
@@ -1622,6 +1622,10 @@ function process_events(sys; callback = nothing, tspan = nothing, kwargs...)
     return (discrete_cbs === nothing) ? cb : CallbackSet(contin_cbs, discrete_cbs...)
 end
 
+Base.@nospecializeinfer function _has_symbolic_events(sys)
+    return !isempty(continuous_events(sys)) || !isempty(discrete_events(sys))
+end
+
 """
     discrete_events(sys::AbstractSystem) :: Vector{SymbolicDiscreteCallback}
 

--- a/lib/ModelingToolkitBase/src/systems/problem_utils.jl
+++ b/lib/ModelingToolkitBase/src/systems/problem_utils.jl
@@ -2391,9 +2391,13 @@ function process_kwargs(
 
     if is_time_dependent(sys)
         if expression == Val{false} && !_skip_events
-            cbs = process_events(
-                sys; callback, eval_expression, eval_module, tspan, kwargs...
-            )
+            cbs = if _has_symbolic_events(sys)
+                @invokelatest process_events(
+                    sys; callback, eval_expression, eval_module, tspan, kwargs...
+                )
+            else
+                callback
+            end
             if cbs !== nothing
                 kwargs1 = merge(kwargs1, (callback = cbs,))
             end

--- a/lib/ModelingToolkitBase/test/symbolic_events.jl
+++ b/lib/ModelingToolkitBase/test/symbolic_events.jl
@@ -26,6 +26,15 @@ eqs = [D(x) ~ 1]
 affect = [x ~ 0]
 affect_neg = [x ~ 1]
 
+@testset "Symbolic event detection" begin
+    @named no_events = System([D(x) ~ 1], t)
+    @test !ModelingToolkitBase._has_symbolic_events(no_events)
+
+    @named child = System([D(x) ~ 1], t; continuous_events = [x ~ 1])
+    @named parent = System(Equation[], t; systems = [child])
+    @test ModelingToolkitBase._has_symbolic_events(parent)
+end
+
 @testset "SymbolicContinuousCallback constructors" begin
     e = SymbolicContinuousCallback(eqs[])
     @test e isa SymbolicContinuousCallback


### PR DESCRIPTION
Ignore until reviewed by @ChrisRackauckas.

## What changed and why

Event-free time-dependent systems now avoid entering `process_events` during problem construction. A non-specializing predicate detects symbolic events across the system hierarchy; only eventful systems cross an `@invokelatest` barrier into the existing event generator. Explicit user callbacks on event-free systems are preserved.

In a six-stage connector-based RC model, compiling event handling for a system with no events accounted for 1.94 seconds of cold `ODEProblem` construction. Avoiding that work reduced median cold construction by 23% without changing warm construction.

## Benchmark

Julia 1.12.4, one thread, three fresh processes per side, matched manifest and independent compiled caches:

| Metric | `upstream/master` | This PR | Change |
|---|---:|---:|---:|
| First `ODEProblem` | 5.926 s | 4.563 s | -23.0% |
| Compilation in first `ODEProblem` | 5.859 s | 4.507 s | -23.1% |
| First `ODEProblem` allocations | 480.3 MB | 451.7 MB | -28.6 MB |
| Second `ODEProblem` | 0.0210 s | 0.0214 s | unchanged |

Compiler trace totals for `process_events` changed from one 1,940.9 ms compilation on `upstream/master` to no compilation for the event-free model.

Commands:

```sh
JULIA_DEPOT_PATH="$PWD/.base-depot:$PWD/.local-depot:/home/crackauc/.julia" JULIA_NUM_THREADS=1 /home/crackauc/.local/bin/julia --startup-file=no --project=.worktrees/base .worktrees/base/.profile/component_timing.jl
JULIA_DEPOT_PATH="$PWD/.local-depot:/home/crackauc/.julia" JULIA_NUM_THREADS=1 /home/crackauc/.local/bin/julia --startup-file=no --project=. .profile/component_timing.jl
```

The sequence was base/candidate/candidate/base/candidate/base. The temporary benchmark and trace files were removed before committing.

## Verification

The regression assertion failed on unmodified `upstream/master`:

```text
Expression: !(ModelingToolkitBase._has_symbolic_events(no_events))
UndefVarError: `_has_symbolic_events` not defined in `ModelingToolkitBase`
ERROR: There was an error during testing
```

The same no-event and nested-event assertions pass on this PR:

```text
rebased symbolic-event detection: 2/2 passed
```

Full relevant group:

```sh
GROUP=InterfaceI JULIA_DEPOT_PATH="$PWD/.test-depot:$PWD/.local-depot:/home/crackauc/.julia" JULIA_NUM_PRECOMPILE_TASKS=1 /home/crackauc/.juliaup/bin/julia +1.12 --startup-file=no --project=lib/ModelingToolkitBase -e 'using Pkg; Pkg.test()'
```

```text
Test Summary: | Pass  Broken  Total      Time
InterfaceI    | 1601       5   1606  49m25.6s
Testing ModelingToolkitBase tests passed
```

Formatting and spelling:

```sh
/home/crackauc/.local/bin/julia --startup-file=no --project=@runic -m Runic --check --diff lib/ModelingToolkitBase/src/systems/callbacks.jl lib/ModelingToolkitBase/src/systems/problem_utils.jl lib/ModelingToolkitBase/test/symbolic_events.jl
git diff upstream/master..HEAD -U0 | /home/crackauc/.local/bin/typos -
git diff upstream/master..HEAD --check
```

All exited 0 with no output.

QA:

```sh
GROUP=QA JULIA_DEPOT_PATH="$PWD/.test-depot:$PWD/.local-depot:/home/crackauc/.julia" JULIA_NUM_PRECOMPILE_TASKS=1 /home/crackauc/.juliaup/bin/julia +1.12 --startup-file=no --project=lib/ModelingToolkitBase -e 'using Pkg; Pkg.test()'
```

Focused JET tests passed 54/54. Aqua passed 20/21 categories; its package-wide JET report found 263 existing diagnostics and failed identically on clean `upstream/master`. The independent direct scan reproduced all 263 reports in 1,184.33 seconds; investigation: https://github.com/SciML/ModelingToolkit.jl/issues/4670#issuecomment-5359295690

The root-routed `GROUP=ModelingToolkitBase_InterfaceI` command is also broken on `upstream/master` because the root harness omits sublibrary routing; that separate issue is tracked at https://github.com/SciML/ModelingToolkit.jl/issues/4997. The direct sublibrary group above is the supported passing validation used here.

## Not verified

- `GROUP=Everything`, GPU, downstream, and allowed-to-fail jobs were not run.
- Documentation was not built because this changes no public API, docstring, or documentation file.

The review judgment is the `@invokelatest` barrier on the eventful path. It preserves the existing behavior under the full symbolic-event suite while preventing event generator inference from affecting the common event-free path.
