### PR TITLE
Remove stale non-public sparsity bindings from docs

### DIFF
--- a/docs/src/API/codegen.md
+++ b/docs/src/API/codegen.md
@@ -36,10 +36,8 @@ are `calculate_*` equivalents to obtain the symbolic result without building a f
 ```@docs
 ModelingToolkit.calculate_tgrad
 ModelingToolkit.calculate_jacobian
-ModelingToolkitBase.jacobian_sparsity
 ModelingToolkit.jacobian_dae_sparsity
 ModelingToolkit.calculate_hessian
-ModelingToolkitBase.hessian_sparsity
 ModelingToolkit.calculate_massmatrix
 ModelingToolkit.W_sparsity
 ModelingToolkit.calculate_W_prototype


### PR DESCRIPTION
> **Please ignore this draft until it has been reviewed by @ChrisRackauckas.**

## What changed

Remove `ModelingToolkitBase.jacobian_sparsity` and `ModelingToolkitBase.hessian_sparsity` from the public code-generation `@docs` block.

ModelingToolkitBase no longer binds these names after https://github.com/SciML/ModelingToolkit.jl/pull/4989. The underlying Symbolics names are neither exported nor declared `public`, so switching the docs to `Symbolics.*` would preserve a non-public dependency. This patch removes only the two invalid entries.

## Failing before the fix

The full CI-equivalent LTS docs command was run on clean current master `38d91d81dcd77319a70abb93882ba6da13510600`:

```sh
timeout 7200 env JULIA_DEBUG=Documenter DISPLAY=:0 \
  xvfb-run -a -s '-screen 0 1024x768x24' \
  julia +lts --project=docs/ --startup-file=no docs/make.jl
```

It exited 1 and reported:

```text
Error: undefined binding `ModelingToolkitBase.hessian_sparsity` in @docs block
docs/src/API/codegen.md:36-53
```

That run also encountered a transient HTTP 429 from the external ColPrac link. A direct retry returned HTTP 200; no link check was disabled.

A source-history bisect identifies https://github.com/SciML/ModelingToolkit.jl/commit/63f684c451d7eae081ebbf2a8eadd975f25de5fc as the binding boundary. The same owner-migration fixed sibling test references in https://github.com/SciML/ModelingToolkit.jl/pull/4991, but the docs entry remained.

## Passing after the fix

The identical full LTS docs command exited 0:

```text
linkcheck 'https://github.com/SciML/ColPrac/blob/master/README.md' status: 200
[ Info: RenderDocument: rendering document
exit 0
```

Additional local gates:

```sh
GROUP=QA julia +1.12 --project=. -e 'using Pkg; Pkg.test()'
julia +1.12 --startup-file=no -m Runic -c .
typos docs/src/API/codegen.md
git diff --check
```

```text
QA | 52/52
Testing ModelingToolkit tests passed
Runic: exit 0
typos: exit 0
git diff --check: exit 0
```

The diff is two deletions in one docs file. No source, dependency, or public API declaration changes. Julia 1/pre test groups were not run locally; the owning docs gate was run on LTS to match CI.