### PR TITLE
Restore the intentional MiscSystemData and generate_trajectory exports

### DIFF
--- a/docs/src/API/System_accessors.md
+++ b/docs/src/API/System_accessors.md
@@ -95,6 +95,7 @@ ModelingToolkit.has_metadata
 ModelingToolkit.get_metadata
 SymbolicUtils.getmetadata(::ModelingToolkit.AbstractSystem, ::DataType, ::Any)
 SymbolicUtils.setmetadata(::ModelingToolkit.AbstractSystem, ::DataType, ::Any)
+ModelingToolkitBase.MiscSystemData
 ModelingToolkit.has_is_dde
 ModelingToolkit.get_is_dde
 ModelingToolkit.is_dde

--- a/docs/src/API/codegen.md
+++ b/docs/src/API/codegen.md
@@ -12,6 +12,7 @@ ModelingToolkit.generate_W
 ModelingToolkit.generate_dae_jacobian
 ModelingToolkit.generate_history
 ModelingToolkit.generate_boundary_conditions
+ModelingToolkitBase.generate_trajectory
 ModelingToolkit.generate_cost
 ModelingToolkit.generate_cost_gradient
 ModelingToolkit.generate_cost_hessian

--- a/docs/src/API/dynamic_opt.md
+++ b/docs/src/API/dynamic_opt.md
@@ -30,6 +30,7 @@ ModelingToolkitBase.InfiniteOptCollocation
 ModelingToolkitBase.CasADiCollocation
 ModelingToolkitBase.PyomoCollocation
 ModelingToolkitBase.DynamicOptSolution
+CommonSolve.solve(::SciMLBase.AbstractDynamicOptProblem, ::ModelingToolkitBase.AbstractCollocation)
 ```
 
 ### Problem constructors

--- a/docs/src/internals/systems.md
+++ b/docs/src/internals/systems.md
@@ -36,17 +36,6 @@ ModelingToolkit.alias_elimination
 ModelingToolkitBase.SymScope
 ```
 
-## Developer hooks
-
-These lower-level hooks are used by backend implementations and code-generation
-extensions. They are versioned for developers, not intended as the default user workflow.
-
-```@docs
-ModelingToolkitBase.MiscSystemData
-ModelingToolkitBase.generate_trajectory
-CommonSolve.solve(::SciMLBase.AbstractDynamicOptProblem, ::ModelingToolkitBase.AbstractCollocation)
-```
-
 ## Contracts of the type
 
 The inner constructor for `System` takes the fields in order. While the order of fields doesn't

--- a/lib/ModelingToolkitBase/Project.toml
+++ b/lib/ModelingToolkitBase/Project.toml
@@ -1,7 +1,7 @@
 name = "ModelingToolkitBase"
 uuid = "7771a370-6774-4173-bd38-47e70ca0b839"
 authors = ["Yingbo Ma <mayingbo5@gmail.com>", "Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
-version = "1.67.0"
+version = "1.68.0"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/lib/ModelingToolkitBase/src/ModelingToolkitBase.jl
+++ b/lib/ModelingToolkitBase/src/ModelingToolkitBase.jl
@@ -405,6 +405,7 @@ export calculate_jacobian, generate_jacobian, generate_rhs, generate_custom_func
 export calculate_control_jacobian, generate_control_jacobian
 export calculate_tgrad, generate_tgrad
 export generate_cost, calculate_cost_gradient, generate_cost_gradient
+export generate_trajectory
 export calculate_cost_hessian, generate_cost_hessian
 export calculate_massmatrix, generate_diffusion_function
 export generate_control_function, build_explicit_observed_function
@@ -452,6 +453,7 @@ export AbstractCollocation, JuMPCollocation, InfiniteOptCollocation,
     CasADiCollocation, PyomoCollocation
 export DynamicOptSolution
 export MissingGuessValue
+export MiscSystemData
 
 export AssignmentAffect
 

--- a/lib/ModelingToolkitBase/src/systems/system.jl
+++ b/lib/ModelingToolkitBase/src/systems/system.jl
@@ -20,6 +20,11 @@ const MutableCacheT = Dict{DataType, Any}
     $TYPEDEF
 
 Utility metadata key for adding miscellaneous/one-off metadata to systems.
+
+```julia
+sys = setmetadata(sys, MiscSystemData, mydata)
+getmetadata(sys, MiscSystemData, nothing)
+```
 """
 abstract type MiscSystemData end
 

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -98,9 +98,10 @@ const REEXPORTED_API = (
     :generate_cost_gradient,
     :generate_cost_hessian, :generate_custom_function, :generate_diffusion_function,
     :generate_initializesystem, :generate_jacobian, :generate_rhs, :generate_tgrad,
-    :generate_W, :get_alg_eqs, :get_analytically_integrated, :get_assertions, :get_bcs,
-    :get_bindings, :get_brownians, :get_connector_type, :get_consolidate, :get_constraints,
-    :get_continuous_events, :get_costs, :get_description, :get_diff_eqs, :get_discrete_events,
+    :generate_trajectory, :generate_W, :get_alg_eqs, :get_analytically_integrated,
+    :get_assertions, :get_bcs, :get_bindings, :get_brownians, :get_connector_type,
+    :get_consolidate, :get_constraints, :get_continuous_events, :get_costs,
+    :get_description, :get_diff_eqs, :get_discrete_events,
     :get_domain, :get_dvs, :get_eqs, :get_guesses, :get_gui_metadata,
     :get_ignored_connections, :get_index_cache, :get_initial_conditions,
     :get_initialization_eqs, :get_initializesystem, :get_inputs, :get_irreducibles,
@@ -132,7 +133,7 @@ const REEXPORTED_API = (
     :is_diff_equation, :iscomplete, :isdisturbance, :isinitial, :isinput, :isirreducible,
     :isoutput, :isparameter, :istunable, :JuMPCollocation, :JuMPDynamicOptProblem, :jumps,
     :JumpSystem, :linear_fractional_to_ordinary, :liouville_transform, :LocalScope,
-    :maybe_zeros, :MissingGuessValue, :ModelingToolkitBase,
+    :maybe_zeros, :MiscSystemData, :MissingGuessValue, :ModelingToolkitBase,
     :modelingtoolkitize, :modified_unknowns!, :mtkcompile, :MTKParameters,
     :MTKVariableTypeCtx, :namespace_equations, :noise_to_brownians, :NonlinearSystem,
     :observables, :observed, :ODESystem, :open_loop, :OptimizationSystem, :outputs,
@@ -344,19 +345,6 @@ const STRUCTURAL_TYPES = (
     ModelingToolkitTearing.TearingState,
     StateSelection.DiffGraph,
 )
-
-@testset "Internal bindings are not public" begin
-    for name in (:generate_trajectory, :MiscSystemData)
-        @test isdefined(ModelingToolkitBase, name)
-        @test isdefined(ModelingToolkit, name)
-        @test !Base.isexported(ModelingToolkitBase, name)
-        @test !Base.isexported(ModelingToolkit, name)
-        @static if VERSION >= v"1.11"
-            @test !Base.ispublic(ModelingToolkitBase, name)
-            @test !Base.ispublic(ModelingToolkit, name)
-        end
-    end
-end
 
 run_qa(
     ModelingToolkit;


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

`MiscSystemData` and `generate_trajectory` were both deliberately exported by the contributors who added them; https://github.com/SciML/ModelingToolkit.jl/pull/4962 reclassified them as accidental internal reexports and removed both exports, which dropped public API in a minor release. This restores the exports, documents both names on the public API pages instead of the internals page, and removes the QA testset that asserted they were internal.

- `MiscSystemData` — added and exported in b79914dde6e35c053cd32ecd3ef5f554fbbba583 by @AayushSabharwal as the user-facing key for one-off system metadata (`setmetadata(sys, MiscSystemData, x)`).
- `generate_trajectory` — added and exported in 5be3f9ee73d0a59a0a5b4fdb9dfc261ff195be07 alongside the rest of the exported `generate_*` codegen family (`generate_cost`, `generate_jacobian`, `generate_control_function`, …).

https://github.com/SciML/ModelingToolkit.jl/pull/4979 then filed both docstrings under `docs/src/internals/systems.md`, whose page banner reads "These APIs may change without notice" — the wrong home for exported API. They move to the pages their siblings live on: `MiscSystemData` next to the system `setmetadata`/`getmetadata` entries in `API/System_accessors.md`, `generate_trajectory` into `API/codegen.md`. The collocation `solve` method that #4979 filed in the same internals section moves to `API/dynamic_opt.md`, the page that documents that exact workflow.

ModelingToolkitBase goes 1.67.0 → 1.68.0, in its own commit: widening the public API is a minor bump.

This is the upstream half of https://github.com/SciML/Catalyst.jl/pull/1538, where @AayushSabharwal flagged that `MiscSystemData` is intentionally exported. No Catalyst follow-up is needed — its `LEGACY_DEPENDENCY_REEXPORTS` allowlist already carries both names.

## Failing before / passing after

MWE run against the working tree, Julia 1.12.4:

```julia
using ModelingToolkit
using ModelingToolkit: t_nounits as t, D_nounits as D

for name in (:MiscSystemData, :generate_trajectory)
    println("$name exported from ModelingToolkit: ", Base.isexported(ModelingToolkit, name))
    println("$name public in ModelingToolkit:     ", Base.ispublic(ModelingToolkit, name))
end

@variables x(t)
@named sys = System([D(x) ~ -x], t)
sys = setmetadata(sys, MiscSystemData, "payload")
println("round-tripped metadata: ", getmetadata(sys, MiscSystemData, nothing))
```

On unmodified master (837ca4da2b):

```console
$ julia --startup-file=no --project=. mwe.jl
MiscSystemData exported from ModelingToolkit: false
MiscSystemData public in ModelingToolkit:     false
generate_trajectory exported from ModelingToolkit: false
generate_trajectory public in ModelingToolkit:     false
ERROR: LoadError: UndefVarError: `MiscSystemData` not defined in `Main`
```

With this PR applied:

```console
$ julia --startup-file=no --project=. mwe.jl
MiscSystemData exported from ModelingToolkit: true
MiscSystemData public in ModelingToolkit:     true
generate_trajectory exported from ModelingToolkit: true
generate_trajectory public in ModelingToolkit:     true
round-tripped metadata: payload
```

## Verification

`GROUP=QA` on this branch, Julia 1.12.4 — the Aqua / ExplicitImports / `public_reexports` lane, which is what actually asserts that these two names are deliberate API rather than leaked internals:

```console
$ GROUP=QA julia --startup-file=no --project=. -e 'using Pkg; Pkg.test()'
Test Summary: | Pass  Total     Time
QA            |   40     40  4m36.1s
     Testing ModelingToolkit tests passed
```

Same lane on unmodified master (837ca4da2b), for the baseline:

```console
$ GROUP=QA julia --startup-file=no --project=. -e 'using Pkg; Pkg.test()'
Test Summary: | Pass  Total     Time
QA            |   52     52  4m26.7s
     Testing ModelingToolkit tests passed
```

Both are green. The 52 → 40 drop is exactly the deleted testset: 6 assertions (`isdefined`, `!isexported`, `!ispublic`, each against ModelingToolkitBase and ModelingToolkit) × 2 names. Nothing else was removed or loosened — in particular `public_reexports` still runs and now passes with both names back in `REEXPORTED_API`.

Docs build (`checkdocs = :exports`, `doctest = true`, `linkcheck = true`) — this is the check that gates the restored exports having rendered docs entries, since an exported name with no `@docs` entry fails `CheckDocument`:

```console
$ julia --startup-file=no --project=docs -e 'using Pkg; Pkg.develop([PackageSpec(path="."), PackageSpec(path="lib/ModelingToolkitBase")]); Pkg.instantiate(); include("docs/make.jl")'
[ Info: Doctest: running doctests.
[ Info: ExpandTemplates: expanding markdown templates.
[ Info: CrossReferences: building cross-references.
[ Info: CheckDocument: running document checks.
[ Info: Populate: populating indices.
[ Info: RenderDocument: rendering document.
[ Info: HTMLWriter: rendering HTML pages.
[ Info: Automatic `version="11.39.1"` for inventory from ../Project.toml
docs exit=0
```

The only warnings are the pre-existing ones on master: `size_threshold_warn` on three large API pages, the 60 `@example` `text/html` notice, and two linkcheck 301 redirects (claytex.com, codecov.io).

Runic (`--check --diff`, `@runic` env), `typos` over the added diff lines, and `git diff --check` all pass.

## Not verified

- Julia LTS (1.10) and prerelease. Everything above ran on 1.12.4. The deleted testset was the only `VERSION >= v"1.11"`-gated code touched here, so there is no version-specific branch left in the diff, but I did not run the LTS lane.
- GPU, FMI, and downstream/ReleaseTest lanes.
- The other test groups (`InterfaceI`, `InterfaceII`, `Initialization`, …). This diff adds two `export` lines, moves docs entries, and deletes a QA testset; it changes no solver or codegen behaviour, so I ran the lanes that can actually observe it (QA, docs) rather than the full matrix.

## Anything a reviewer should push back on

- Whether `generate_trajectory` should be exported at all, or only `@public`. It was exported by its author and every neighbouring `generate_*` entry point is exported, so this restores it as an export; if the intent was developer-only, `@public` plus a docs entry would be the alternative and that is a judgement call, not a mechanical one.
- ModelingToolkit's `[compat]` floor on ModelingToolkitBase is left at `"1.64"`. Only the 1.66/1.67 window lacks these exports, and MTK/MTKBase release in lockstep from this monorepo, so raising the floor to `"1.68"` seemed like more churn than the two-version gap warrants. Say the word if you would rather pin it.
