### PR TITLE
Fix modelingtoolkitize Optim imports

### DIFF
--- a/lib/ModelingToolkitBase/test/modelingtoolkitize.jl
+++ b/lib/ModelingToolkitBase/test/modelingtoolkitize.jl
@@ -1,6 +1,6 @@
 using OrdinaryDiffEq, ModelingToolkitBase, DataStructures, Test
 using OrdinaryDiffEqRosenbrock
-using Optimization, RecursiveArrayTools, OptimizationOptimJL
+using Optimization, RecursiveArrayTools, OptimizationOptimJL, OptimizationOptimJL.Optim
 using SymbolicIndexingInterface
 using ModelingToolkitBase: t_nounits as t, D_nounits as D
 using Symbolics: value


### PR DESCRIPTION
## What changed and why

Import the public `OptimizationOptimJL.Optim` owner module in the ModelingToolkitBase `modelingtoolkitize` test. OptimizationOptimJL 0.4.19 stopped blanket-reexporting Optim's algorithm names, so the test's bare `NelderMead`, `BFGS`, and `Newton` references are otherwise undefined.

The behavior change was introduced by https://github.com/SciML/Optimization.jl/commit/0c726c0cf0b2f4c150b26ca03c4117e8a35434af in https://github.com/SciML/Optimization.jl/pull/1307. A clean version-boundary check found `NelderMead` in `Main` after `using OptimizationOptimJL` with 0.4.18, but not with 0.4.19; it remains available through the exported `OptimizationOptimJL.Optim` module.

## Verification

### Failing before

On clean ModelingToolkit master `173e83e71abbdbb1609a43224723f5fbb07a7af4`, with clean Symbolics master `043d7d2b480fc0c58a799f80bef114892be93cdf`:

```console
$ JULIA_DEPOT_PATH="$PWD/mtk-interface-depot" julia +1.12 --project=tmp/jl_bvBe2w -e 'using SafeTestsets; @safetestset "Modelingtoolkitize Test" include(abspath("ModelingToolkit-neldermead/lib/ModelingToolkitBase/test/modelingtoolkitize.jl"))'
Modelingtoolkitize Test: Error During Test at .../modelingtoolkitize.jl:80
  Test threw exception
  Expression: sol.minimum < 0.05
  UndefVarError: `NelderMead` not defined in `Main.##Modelingtoolkitize Test#273`
Test Summary:           | Error  Total      Time
Modelingtoolkitize Test |     1      1  17m14.9s
```

The complete downstream group reproduced the reported clean-master failure:

```console
$ GROUP=InterfaceI JULIA_DEPOT_PATH="$PWD/mtk-interface-depot" julia +1.12 --project=ModelingToolkit-neldermead -e 'using Pkg; Pkg.develop([PackageSpec(path = "Symbolics-mtk-interface-master"), PackageSpec(path = "ModelingToolkit-neldermead/lib/ModelingToolkitBase")]); Pkg.update(); Pkg.test()'
Test Summary: | Pass  Error  Broken  Total      Time
InterfaceI    | 1421      1       3   1425  52m57.7s
ERROR: Package ModelingToolkit errored during testing
```

### Passing after

The same targeted test with this commit:

```console
$ JULIA_DEPOT_PATH="$PWD/mtk-interface-fix-depot" julia +1.12 --project=tmp/jl_zLWbEc -e 'using SafeTestsets; @safetestset "Modelingtoolkitize Test" include(abspath("ModelingToolkit-neldermead-fix/lib/ModelingToolkitBase/test/modelingtoolkitize.jl"))'
Test Summary:           | Pass  Broken  Total      Time
Modelingtoolkitize Test |   68       1     69  18m49.6s
```

The complete downstream group also passed:

```console
$ GROUP=InterfaceI JULIA_DEPOT_PATH="$PWD/mtk-interface-fix-depot" julia +1.12 --project=ModelingToolkit-neldermead-fix -e 'using Pkg; Pkg.develop([PackageSpec(path = "Symbolics-mtk-interface-master"), PackageSpec(path = "ModelingToolkit-neldermead-fix/lib/ModelingToolkitBase")]); Pkg.update(); Pkg.test()'
Test Summary: | Pass  Broken  Total      Time
InterfaceI    | 1491       3   1494  54m37.3s
     Testing ModelingToolkit tests passed
```

QA and local static checks passed:

```console
$ GROUP=QA JULIA_DEPOT_PATH="$PWD/mtk-qa-depot" julia +1.12 --project=ModelingToolkit-neldermead-fix -e 'using Pkg; Pkg.test()'
Test Summary: | Pass  Total     Time
QA            |   40     40  4m41.1s
     Testing ModelingToolkit tests passed

$ julia +1.12 --project=formatter-env -m Runic --check ModelingToolkit-neldermead-fix/lib/ModelingToolkitBase/test/modelingtoolkitize.jl
$ typos ModelingToolkit-neldermead-fix/lib/ModelingToolkitBase/test/modelingtoolkitize.jl
$ git -C ModelingToolkit-neldermead-fix diff --check
```

These three static checks exited successfully with no findings.

## Not verified

`GROUP=Everything` was not run. The docs build was not run because this changes only a private test import and touches no docs, docstrings, or public API. No GPU or credential-dependent paths are involved.

Ignore this PR until it has been reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://chatgpt.com/codex/tasks/01a03a04-70ae-77a0-ba1b-ec7a1ed9ef47
