### PR TITLE
fix: keep callable parameter calls in `calculate_tgrad`

### DIFF
--- a/lib/ModelingToolkitBase/src/systems/codegen.jl
+++ b/lib/ModelingToolkitBase/src/systems/codegen.jl
@@ -284,8 +284,10 @@ end
 
 Calculate the gradient of the equations of `sys` with respect to the independent variable.
 `simplify` is forwarded to `Symbolics.expand_derivatives`.
+If `throw_no_derivative` is `false`, terms with no derivative rule are returned as
+unexpanded `Differential`s instead of throwing.
 """
-function calculate_tgrad(sys::System; simplify = false)
+function calculate_tgrad(sys::System; simplify = false, throw_no_derivative = true)
     check_symbolic_ad_allowed(sys)
     # We need to remove explicit time dependence on the unknown because when we
     # have `u(t) * t` we want to have the tgrad to be `u(t)` instead of `u'(t) *
@@ -295,10 +297,59 @@ function calculate_tgrad(sys::System; simplify = false)
     xs = unknowns(sys)
     rule = Dict(map((x, xt) -> xt => x, detime_dvs.(xs), xs))
     rhs = substitute.(rhs, Ref(rule))
-    tgrad = [expand_derivatives(Differential(iv)(r), simplify) for r in rhs]
+    tgrad = [
+        expand_derivatives(Differential(iv)(r), simplify; throw_no_derivative)
+            for r in rhs
+    ]
     reverse_rule = Dict(map((x, xt) -> x => xt, detime_dvs.(xs), xs))
     tgrad = Num.(substitute.(tgrad, Ref(reverse_rule)))
+    throw_no_derivative && check_tgrad_expanded(sys, tgrad)
     return tgrad
+end
+
+"""
+    $(TYPEDSIGNATURES)
+
+The first subterm of `ex` whose operation is a `Differential`, or `nothing` if there is
+none.
+"""
+function unexpanded_derivative(ex)
+    ex = unwrap(ex)
+    iscall(ex) || return nothing
+    operation(ex) isa Differential && return ex
+    for arg in arguments(ex)
+        res = unexpanded_derivative(arg)
+        res === nothing || return res
+    end
+    return nothing
+end
+
+"""
+    $(TYPEDSIGNATURES)
+
+Error if any entry of `tgrad` still contains a `Differential`. `Symbolics` leaves the
+derivative of a call to a callable parameter unexpanded, since derivative rules are
+defined per operation and a `Sym` operation has none; a function generated from such a
+gradient errors when called.
+"""
+function check_tgrad_expanded(sys::System, tgrad)
+    for (i, gr) in enumerate(tgrad)
+        term = unexpanded_derivative(gr)
+        term === nothing && continue
+        msg = """
+        Cannot differentiate equation $i of system $(nameof(sys)) with respect to \
+        $(get_iv(sys)): `$term` has no derivative rule. Calls to callable parameters \
+        have none, since the function is not known symbolically.
+        """
+        if show_api_guidance()
+            msg *= """
+            Leave `tgrad = false` (the default); the solver then computes the time \
+            gradient numerically.
+            """
+        end
+        throw(ArgumentError(msg))
+    end
+    return
 end
 
 """
@@ -753,7 +804,8 @@ function calculate_W_prototype(W_sparsity; u0 = nothing, sparse = false)
 end
 
 function isautonomous(sys::System)
-    tgrad = calculate_tgrad(sys; simplify = true)
+    # A gradient which cannot be expanded is not identically zero either.
+    tgrad = calculate_tgrad(sys; simplify = true, throw_no_derivative = false)
     return all(iszero, tgrad)
 end
 

--- a/lib/ModelingToolkitBase/src/utils.jl
+++ b/lib/ModelingToolkitBase/src/utils.jl
@@ -46,12 +46,15 @@ end
 """
     $(TYPEDSIGNATURES)
 
-Turn `x(t)` into `x`
+Turn `x(t)` into `x`.
+
+A call to a callable parameter also has a symbolic operation but is not an unknown, so it
+is kept and its arguments are detimed instead.
 """
 function detime_dvs(op)
     return if !iscall(op)
         op
-    elseif issym(operation(op))
+    elseif issym(operation(op)) && !isparameter(operation(op))
         SSym(nameof(operation(op)); type = Real, shape = SU.shape(op))
     else
         maketerm(

--- a/lib/ModelingToolkitBase/test/odesystem.jl
+++ b/lib/ModelingToolkitBase/test/odesystem.jl
@@ -1765,3 +1765,50 @@ end
     ss = mtkcompile(sys)
     @test length(equations(ss)) == length(unknowns(ss)) == 0
 end
+
+@testset "`calculate_tgrad` with callable parameters" begin
+    @parameters (fn::Function)(..) c
+    @variables u(t)
+
+    # `detime_dvs` keeps calls to callable parameters so that the derivative reaches
+    # their arguments
+    @test isequal(ModelingToolkitBase.detime_dvs(unwrap(fn(c))), unwrap(fn(c)))
+
+    # arguments which do not involve `t`: the gradient is exact
+    @named sys = System([D(u) ~ fn(c) * t + u], t, [u], [fn, c])
+    sys = mtkcompile(sys)
+    @test isequal(calculate_tgrad(sys), [fn(c)])
+    prob = ODEProblem(
+        sys, [u => 1.0, fn => (x -> 3x), c => 2.0], (0.0, 1.0); tgrad = true
+    )
+    @test prob.f.tgrad([1.5], prob.p, 0.4) ≈ [6.0]
+    fd = (prob.f([1.5], prob.p, 0.4 + 1.0e-6)[1] - prob.f([1.5], prob.p, 0.4 - 1.0e-6)[1]) /
+        2.0e-6
+    @test prob.f.tgrad([1.5], prob.p, 0.4)[1] ≈ fd rtol = 1.0e-6
+
+    # arguments which involve only unknowns: they are held fixed, so the gradient is zero
+    @named sys2 = System([D(u) ~ fn(u)], t, [u], [fn])
+    sys2 = mtkcompile(sys2)
+    @test iszero(calculate_tgrad(sys2))
+    @test ModelingToolkitBase.isautonomous(sys2)
+
+    # called with `t`: no derivative rule, so this must throw rather than return zero
+    @named sys3 = System([D(u) ~ fn(t) * u], t, [u], [fn])
+    sys3 = mtkcompile(sys3)
+    @test_throws ["derivative", "sys3"] calculate_tgrad(sys3)
+    @test_throws ArgumentError ODEFunction(sys3; tgrad = true)
+    tg = calculate_tgrad(sys3; throw_no_derivative = false)
+    @test Symbolics.hasderiv(unwrap(tg[1]))
+    @test !ModelingToolkitBase.isautonomous(sys3)
+
+    # a registered function with a derivative rule is unaffected
+    @named sys4 = System([D(u) ~ sin(t) * u], t, [u], [])
+    sys4 = mtkcompile(sys4)
+    @test isequal(calculate_tgrad(sys4), [cos(t) * u])
+    @test !ModelingToolkitBase.isautonomous(sys4)
+
+    # a plain system is unaffected
+    @named sys5 = System([D(u) ~ u * t + sin(t)], t)
+    sys5 = mtkcompile(sys5)
+    @test isequal(calculate_tgrad(sys5), [u + cos(t)])
+end


### PR DESCRIPTION
`detime_dvs` collapses any call whose operation is a `Sym` to a bare symbol. That is meant for unknowns (`x(t) → x`), but a callable parameter's call `g(x, t)` has a `Sym` operation too, so the whole call — `t` argument included — vanished before `calculate_tgrad` differentiated, and every callable parameter contributed zero to the time gradient. `D(x) ~ g(t)*x` with `g` a callable parameter gave `tgrad = [0]` against the analytic `cos(0.3)*2`; `tgrad = true` then produced a wrong Rosenbrock trajectory silently.

- `detime_dvs` keeps calls whose operation `isparameter` and detimes their arguments (`utils.jl`). The other callers pass unknowns/dummy derivatives, which are never parameters; inputs promoted with `toparam` (marks the term, not the operation) and DDE terms `x(t-1)` detime as before.
- Symbolics cannot expand a callable parameter's `t`-derivative (rules dispatch on the operation; a `Sym` has none), so `calculate_tgrad` now throws with the offending term instead of returning zeros; `throw_no_derivative = false` returns the unexpanded gradient. `isautonomous` uses that and no longer reports `true` for such systems.
- 13 assertions in `lib/ModelingToolkitBase/test/odesystem.jl`.

Found while adding Jacobians to the FMI import (#5001 follow-up): `tgrad = true` on a Model Exchange FMU passed only because the FMU call had been erased.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ivCjhadBrX4qh4tjca6tL
