### PR TITLE
Use OptimizationOptimJL's public algorithm namespace in docs

### DIFF
--- a/docs/src/examples/remake.md
+++ b/docs/src/examples/remake.md
@@ -90,7 +90,7 @@ We can perform the optimization as below:
 
 ```@example Remake
 using Optimization
-using OptimizationOptimJL
+using OptimizationOptimJL: Optim
 using SymbolicIndexingInterface
 
 # manually create an OptimizationFunction to ensure usage of `ForwardDiff`, which will
@@ -106,7 +106,7 @@ diffcache = DiffCache(copy(canonicalize(Tunable(), parameter_values(odeprob))[1]
 optprob = OptimizationProblem(
     optfn, rand(4), (odeprob, timesteps, data, setter, diffcache),
     lb = 0.1zeros(4), ub = 3ones(4))
-sol = solve(optprob, BFGS())
+sol = solve(optprob, Optim.BFGS())
 ```
 
 # Re-creating the problem

--- a/docs/src/tutorials/optimization.md
+++ b/docs/src/tutorials/optimization.md
@@ -17,7 +17,8 @@ The package can also build optimization systems.
 Let's optimize the classical _Rosenbrock function_ in two dimensions.
 
 ```@example optimization
-using ModelingToolkit, Optimization, OptimizationOptimJL
+using ModelingToolkit, Optimization
+using OptimizationOptimJL: Optim
 @variables begin
     x = 1.0, [bounds = (-2.0, 2.0)]
     y = 3.0, [bounds = (-1.0, 3.0)]
@@ -53,7 +54,7 @@ u0 = [y => 2.0]
 p = [b => 100.0]
 
 prob = OptimizationProblem(sys, vcat(u0, p), grad = true, hess = true)
-u_opt = solve(prob, GradientDescent())
+u_opt = solve(prob, Optim.GradientDescent())
 ```
 
 A visualization of the Rosenbrock function is depicted below.
@@ -75,7 +76,8 @@ Non-linear equality and inequality constraints can be added to the `Optimization
 Let's add an inequality constraint to the previous example:
 
 ```@example optimization_constrained
-using ModelingToolkit, Optimization, OptimizationOptimJL
+using ModelingToolkit, Optimization
+using OptimizationOptimJL: Optim
 
 @variables begin
     x = 0.14, [bounds = (-2.0, 2.0)]
@@ -88,7 +90,7 @@ cons = [
 ]
 @mtkcompile sys = OptimizationSystem(rosenbrock, [x, y], [a, b], constraints = cons)
 prob = OptimizationProblem(sys, [], grad = true, hess = true, cons_j = true, cons_h = true)
-u_opt = solve(prob, IPNewton())
+u_opt = solve(prob, Optim.IPNewton())
 ```
 
 Inequality constraints are constructed via a `≲` (or `≳`).


### PR DESCRIPTION
This PR should be ignored until reviewed by @ChrisRackauckas.

## What changed and why

OptimizationOptimJL 0.4.19 stopped exporting each Optim algorithm and retained `Optim` as its public owner namespace. The ModelingToolkit documentation still used bare `BFGS`, `GradientDescent`, and `IPNewton`, so full example evaluation failed on current master. These examples now import `Optim` explicitly and construct the algorithms through that public owner API.

The export boundary is https://github.com/SciML/Optimization.jl/commit/0c726c0cf0b2f4c150b26ca03c4117e8a35434af from https://github.com/SciML/Optimization.jl/pull/1307. The clean-master failure was observed in https://github.com/SciML/ModelingToolkit.jl/actions/runs/32902120713/job/97978099406.

## Verification

Failing before on unmodified ModelingToolkit master (`173e83e71abbdbb1609a43224723f5fbb07a7af4`):

```text
$ julia +lts --project=docs docs/make.jl
UndefVarError: `BFGS` not defined
UndefVarError: `GradientDescent` not defined
UndefVarError: `IPNewton` not defined
ERROR: `makedocs` encountered errors
```

Passing after with this commit, using the same full docs command:

```text
$ julia +lts --project=docs docs/make.jl
[ Info: CheckDocument: running document checks.
[ Info: RenderDocument: rendering HTML pages.
[ Info: Automatic `version="11.40.0"` for inventory from ../Project.toml
[ Warning: Documenter could not auto-detect the building environment. Skipping deployment.
```

The process exited 0. Link checking remained enabled.

```text
$ GROUP=QA julia +release --project=. -e 'using Pkg; Pkg.test()'
Test Summary: | Pass  Total     Time
QA            |   40     40  6m50.7s
Testing ModelingToolkit tests passed

$ JULIA_DEPOT_PATH=/home/crackauc/sandbox/tmp_20260825_174238_75437/format-depot julia +release --project=/home/crackauc/sandbox/tmp_20260825_174238_75437/format-env -m Runic --check .
# exit 0

$ typos docs/src/examples/remake.md docs/src/tutorials/optimization.md
# exit 0

$ git diff --check
# exit 0
```

No public API or dependency changed. GPU and allowed-to-fail downstream jobs were not run locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://chatgpt.com/codex/tasks/01a03a04-70ae-77a0-ba1b-ec7a1ed9ef47
