### PR TITLE
Use public owner APIs in the Pyomo extension

### DIFF
--- a/lib/ModelingToolkitBase/Project.toml
+++ b/lib/ModelingToolkitBase/Project.toml
@@ -77,6 +77,7 @@ LabelledArrays = "2ee39098-c373-598a-b85f-a56591580800"
 Latexify = "23fbe1c1-3f47-55db-b15f-69d7ec21a316"
 Mooncake = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
 Pyomo = "0e8e1daf-01b5-4eba-a626-3897743a3816"
+PythonCall = "6099a3de-0909-46bc-b1f4-468b9a2dfc0d"
 Tracker = "9f7883ad-71c0-57eb-9f7f-b5c9e6d3789c"
 
 [extensions]
@@ -90,7 +91,7 @@ MTKJuliaFormatterExt = "JuliaFormatter"
 MTKLabelledArraysExt = "LabelledArrays"
 MTKLatexifyExt = "Latexify"
 MTKMooncakeExt = "Mooncake"
-MTKPyomoDynamicOptExt = "Pyomo"
+MTKPyomoDynamicOptExt = ["Pyomo", "PythonCall"]
 MTKTrackerExt = "Tracker"
 
 [compat]
@@ -168,6 +169,7 @@ PreallocationTools = "1"
 PrecompileTools = "1.2.1"
 Printf = "1"
 Pyomo = "2.0.2"
+PythonCall = "0.9.24"
 REPL = "1"
 Random = "1"
 ReadOnlyDicts = "1.0.0"

--- a/lib/ModelingToolkitBase/ext/MTKPyomoDynamicOptExt.jl
+++ b/lib/ModelingToolkitBase/ext/MTKPyomoDynamicOptExt.jl
@@ -6,9 +6,11 @@ using UnPack
 using NaNMath
 using Setfield
 using OrderedCollections: OrderedSet
-using Symbolics: SymbolicT, unwrap
+using PythonCall: pyconvert, pyfunc
+using Symbolics: Num, SymbolicT, unwrap, ≲, ≳
 import SymbolicUtils as SU
 const MTK = ModelingToolkitBase
+const GEQ_RELATIONAL_OP = (0 ≳ 0).relational_op
 
 function __init__()
     # Workaround for Julia 1.10 compiler bug (Issue #4211)
@@ -123,21 +125,21 @@ end
 
 function MTK.generate_state_variable!(m::ConcreteModel, u0, ns, ts)
     m.u_idxs = pyomo.RangeSet(1, ns)
-    init_f = Pyomo.pyfunc((m, i, t) -> (u0[Pyomo.pyconvert(Int, i)]))
+    init_f = pyfunc((m, i, t) -> u0[pyconvert(Int, i)])
     m.U = pyomo.Var(m.u_idxs, m.t, initialize = init_f)
     return PyomoVar(m.U)
 end
 
 function MTK.generate_input_variable!(m::ConcreteModel, c0, nc, ts)
     m.v_idxs = pyomo.RangeSet(1, nc)
-    init_f = Pyomo.pyfunc((m, i, t) -> (c0[Pyomo.pyconvert(Int, i)]))
+    init_f = pyfunc((m, i, t) -> c0[pyconvert(Int, i)])
     m.V = pyomo.Var(m.v_idxs, m.t, initialize = init_f)
     return PyomoVar(m.V)
 end
 
 function MTK.generate_tunable_params!(m::ConcreteModel, p0, np)
     m.p_idxs = pyomo.RangeSet(1, np)
-    init_f = Pyomo.pyfunc((m, i) -> (p0[Pyomo.pyconvert(Int, i)]))
+    init_f = pyfunc((m, i) -> p0[pyconvert(Int, i)])
     m.P = pyomo.Var(m.p_idxs, initialize = init_f)
     return PyomoVar(m.P)
 end
@@ -151,10 +153,9 @@ function MTK.add_constraint!(pmodel::PyomoDynamicOptModel, cons; n_idxs = 1)
     @unpack model, model_sym, t_sym, dummy_sym = pmodel
     expr = if cons isa Equation
         cons.lhs - cons.rhs == 0
-    elseif cons.relational_op === Symbolics.geq
-        cons.lhs - cons.rhs ≥ 0
     else
-        cons.lhs - cons.rhs ≤ 0
+        op = cons.relational_op === GEQ_RELATIONAL_OP ? (>=) : (<=)
+        SU.term(op, cons.lhs - cons.rhs, 0; type = Bool)
     end
     expr = Symbolics.substitute(
         Symbolics.unwrap(expr), SPECIAL_FUNCTIONS_DICT, fold = Val(false)
@@ -163,10 +164,10 @@ function MTK.add_constraint!(pmodel::PyomoDynamicOptModel, cons; n_idxs = 1)
     cons_sym = Symbol("cons", hash(cons))
     return if SU.query(isequal(Symbolics.unwrap(t_sym)), expr)
         f = eval(Symbolics.build_function(expr, model_sym, t_sym))
-        setproperty!(model, cons_sym, pyomo.Constraint(model.t, rule = Pyomo.pyfunc(f)))
+        setproperty!(model, cons_sym, pyomo.Constraint(model.t, rule = pyfunc(f)))
     else
         f = eval(Symbolics.build_function(expr, model_sym, dummy_sym))
-        setproperty!(model, cons_sym, pyomo.Constraint(rule = Pyomo.pyfunc(f)))
+        setproperty!(model, cons_sym, pyomo.Constraint(rule = pyfunc(f)))
     end
 end
 
@@ -201,10 +202,10 @@ function MTK.set_objective!(pmodel::PyomoDynamicOptModel, expr)
     expr = Symbolics.substitute(expr, SPECIAL_FUNCTIONS_DICT, fold = Val(false))
     return if SU.query(isequal(Symbolics.unwrap(t_sym)), expr)
         f = eval(Symbolics.build_function(expr, model_sym, t_sym))
-        model.obj = pyomo.Objective(model.t, rule = Pyomo.pyfunc(f))
+        model.obj = pyomo.Objective(model.t, rule = pyfunc(f))
     else
         f = eval(Symbolics.build_function(expr, model_sym, dummy_sym))
-        model.obj = pyomo.Objective(rule = Pyomo.pyfunc(f))
+        model.obj = pyomo.Objective(rule = pyfunc(f))
     end
 end
 
@@ -218,7 +219,7 @@ end
 function MTK.lowered_integral(m::PyomoDynamicOptModel, arg, lo, hi)
     @unpack model, model_sym, t_sym, dummy_sym = m
     total = 0
-    dt = Pyomo.pyconvert(Float64, (model.t.at(-1) - model.t.at(1)) / (model.steps - 1))
+    dt = pyconvert(Float64, (model.t.at(-1) - model.t.at(1)) / (model.steps - 1))
     f = Symbolics.build_function(arg, model_sym, t_sym, expression = false)
     for (i, t) in enumerate(model.t)
         if Bool(lo < t) && Bool(t < hi)
@@ -293,23 +294,23 @@ end
 
 function MTK.get_U_values(output::PyomoOutput)
     m = output.model
-    return [[Pyomo.pyconvert(Float64, pyomo.value(m.U[i, t])) for i in m.u_idxs] for t in m.t]
+    return [[pyconvert(Float64, pyomo.value(m.U[i, t])) for i in m.u_idxs] for t in m.t]
 end
 function MTK.get_V_values(output::PyomoOutput)
     m = output.model
-    return [[Pyomo.pyconvert(Float64, pyomo.value(m.V[i, t])) for i in m.v_idxs] for t in m.t]
+    return [[pyconvert(Float64, pyomo.value(m.V[i, t])) for i in m.v_idxs] for t in m.t]
 end
 function MTK.get_P_values(output::PyomoOutput)
     m = output.model
-    return [Pyomo.pyconvert(Float64, pyomo.value(m.P[i])) for i in m.p_idxs]
+    return [pyconvert(Float64, pyomo.value(m.P[i])) for i in m.p_idxs]
 end
 function MTK.get_t_values(output::PyomoOutput)
     m = output.model
-    return Pyomo.pyconvert(Float64, pyomo.value(m.tₛ)) * [Pyomo.pyconvert(Float64, t) for t in m.t]
+    return pyconvert(Float64, pyomo.value(m.tₛ)) * [pyconvert(Float64, t) for t in m.t]
 end
 
 function MTK.objective_value(output::PyomoOutput)
-    return Pyomo.pyconvert(Float64, pyomo.value(output.model.obj))
+    return pyconvert(Float64, pyomo.value(output.model.obj))
 end
 
 function MTK.successful_solve(output::PyomoOutput)


### PR DESCRIPTION
This PR should be ignored until reviewed by @ChrisRackauckas.

## What changed and why

The Pyomo dynamic-optimization extension accessed `pyfunc` and `pyconvert` through Pyomo even though PythonCall owns and documents those APIs. Pyomo's strict public-API cleanup stopped forwarding those names, so every dynamic-optimization solve failed on current ModelingToolkit master. The extension now declares PythonCall as a weak dependency, activates only when both Pyomo and PythonCall are loaded, and imports the two functions directly from their public owner.

The same audit replaces the non-public `Symbolics.geq` access with Symbolics' public inequality operators and SymbolicUtils' public `term` constructor. PythonCall and ModelingToolkit are both MIT-licensed.

The forwarding boundary is https://github.com/SciML/Pyomo.jl/commit/a418459beae10d637268a0abc8ee6a88fe224e08 from https://github.com/SciML/Pyomo.jl/pull/19. The failure reproduced in https://github.com/SciML/ModelingToolkit.jl/actions/runs/32902121466/job/97980114181.

## Verification

Failing before on unmodified ModelingToolkit master:

```text
$ julia +lts --project=lib/ModelingToolkitBase/test/optimization lib/ModelingToolkitBase/test/optimization/dynamic_optimization.jl
UndefVarError: `pyfunc` not defined
ODE Solution, no cost | 3 pass, 1 error
```

Passing after with the same direct dynamic-optimization command and SciML/Pyomo.jl pull request 25 developed locally:

```text
ODE Solution, no cost | 13 pass
Linear systems | 26 pass
Rocket launch | 6 pass
Cart-pole problem | 3 pass
Parameter estimation | 9 pass
...
16 testsets, 117/117 total; process exit 0
```

The full Optimization group on this branch reaches the four independent bare OptimizationOptimJL algorithm failures before this dynamic suite; those tests are handled in a separate PR. With both independent owner-import fixes stacked locally, the full group passed OptimizationSystem 54/54 non-broken assertions, InfiniteOpt 5/5, and dynamic optimization 117/117. No test was skipped, silenced, or weakened.

```text
$ GROUP=QA julia +release --project=lib/ModelingToolkitBase -e 'using Pkg; Pkg.test()'
JET Tests | 54 pass
Quality Assurance | 20 pass, 1 fail
JET.report_package(...; mode = typo): 263 possible errors

$ julia +release -m Runic --check lib/ModelingToolkitBase/ext/MTKPyomoDynamicOptExt.jl
# exit 0

$ typos lib/ModelingToolkitBase/Project.toml lib/ModelingToolkitBase/ext/MTKPyomoDynamicOptExt.jl
# exit 0

$ git diff --check
# exit 0
```

The QA failure is unchanged on unmodified current master and this branch: all 54 focused JET assertions pass, then the full-package JET typo report emits the same 263 existing diagnostics. It is tracked in https://github.com/SciML/ModelingToolkit.jl/issues/4670#issuecomment-5359295690 and upstream at https://github.com/aviatesk/JET.jl/issues/858; QA was not suppressed or weakened.

No public ModelingToolkit API or documentation changed. GPU and allowed-to-fail downstream jobs were not run locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://chatgpt.com/codex/tasks/01a03a04-70ae-77a0-ba1b-ec7a1ed9ef47
