### PR TITLE
Fix AbstractSystem interface test on Julia LTS

### DIFF
--- a/lib/ModelingToolkitBase/test/abstractsystem_interface.jl
+++ b/lib/ModelingToolkitBase/test/abstractsystem_interface.jl
@@ -2,6 +2,7 @@ using ModelingToolkitBase
 using SymbolicIndexingInterface: SymbolicIndexingInterface as SII
 using Test
 MT = ModelingToolkitBase
+const MissingFieldError = isdefined(Base, :FieldError) ? getfield(Base, :FieldError) : ErrorException
 
 # Every call below is part of the documented `AbstractSystem` interface (see
 # `docs/src/API/abstract_system_interface.md`). Nothing here reads a field of a system
@@ -84,9 +85,9 @@ end
     @test isequal(MT.get_iv(leaf), t)
 
     # `get_x` on absent storage throws, so generic code has to guard it with `has_x`.
-    @test_throws FieldError MT.get_eqs(minimal)
-    @test_throws FieldError MT.get_unknowns(minimal)
-    @test_throws FieldError MT.get_ps(minimal)
+    @test_throws MissingFieldError MT.get_eqs(minimal)
+    @test_throws MissingFieldError MT.get_unknowns(minimal)
+    @test_throws MissingFieldError MT.get_ps(minimal)
 
     # The event accessors are the documented exceptions: they default to empty.
     @test MT.has_continuous_events(minimal) == false


### PR DESCRIPTION
This PR should be ignored until reviewed by @ChrisRackauckas.

## What changed and why

The `AbstractSystem` interface test used `FieldError` directly, but that public Base exception type was introduced in Julia 1.12 and is absent from ModelingToolkit's supported Julia 1.10 LTS. The test now selects `Base.FieldError` when it exists and the actual Julia 1.10 fallback exception type otherwise.

This failure was introduced by https://github.com/SciML/ModelingToolkit.jl/commit/3e166a8960a43ac96ffd728a30fba171bf877738 from https://github.com/SciML/ModelingToolkit.jl/pull/5004. It reproduced on unmodified current master in the downgrade-sublibraries Julia LTS job https://github.com/SciML/ModelingToolkit.jl/actions/runs/32902121365/job/97978265105.

## Verification

Failing before on unmodified ModelingToolkit master:

```text
$ GROUP=InterfaceI julia +lts --project=lib/ModelingToolkitBase -e 'using Pkg; Pkg.test()'
UndefVarError: `FieldError` not defined
AbstractSystem Interface Contract | 66 pass, 1 error
InterfaceI | 1526 pass, 2 errors, 4 broken
```

Passing after for the affected contract, using the same full InterfaceI command:

```text
AbstractSystem Interface Contract | 73 pass
InterfaceI | 1533 pass, 1 error, 4 broken
```

The sole remaining full-group error is the independent current-master bare `NelderMead` use in `test/modelingtoolkitize.jl:80`, handled separately. No test was skipped, silenced, or weakened.

```text
$ GROUP=QA julia +release --project=lib/ModelingToolkitBase -e 'using Pkg; Pkg.test()'
JET Tests | 54 pass
Quality Assurance | 20 pass, 1 fail
JET.report_package(...; mode = typo): 263 possible errors

$ julia +release -m Runic --check lib/ModelingToolkitBase/test/abstractsystem_interface.jl
# exit 0

$ typos lib/ModelingToolkitBase/test/abstractsystem_interface.jl
# exit 0

$ git diff --check
# exit 0
```

The QA failure is unchanged on unmodified current master and this branch: all 54 focused JET assertions pass, then the full-package JET typo report emits the same 263 existing diagnostics. It is tracked in https://github.com/SciML/ModelingToolkit.jl/issues/4670#issuecomment-5359295690 and upstream at https://github.com/aviatesk/JET.jl/issues/858; QA was not suppressed or weakened.

No package behavior, public API, documentation, or dependency changed. GPU and allowed-to-fail downstream jobs were not run locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://chatgpt.com/codex/tasks/01a03a04-70ae-77a0-ba1b-ec7a1ed9ef47
