### PR TITLE
Use the Optim owner namespace in OptimizationSystem tests

### DIFF
--- a/lib/ModelingToolkitBase/test/optimization/optimizationsystem.jl
+++ b/lib/ModelingToolkitBase/test/optimization/optimizationsystem.jl
@@ -1,6 +1,7 @@
-using ModelingToolkitBase, SparseArrays, Test, Optimization, OptimizationOptimJL,
-    OptimizationMOI, Ipopt, AmplNLWriter, SymbolicIndexingInterface,
+using ModelingToolkitBase, SparseArrays, Test, Optimization, OptimizationMOI,
+    Ipopt, AmplNLWriter, SymbolicIndexingInterface,
     LinearAlgebra
+using OptimizationOptimJL: Optim
 using Ipopt: Ipopt_jll
 using Symbolics: value
 
@@ -82,7 +83,7 @@ end
     @test prob.f.cons_expr isa Vector{Expr}
     @test prob.f.expr isa Expr
     @test prob.f.sys === sys
-    sol = solve(prob, IPNewton())
+    sol = solve(prob, Optim.IPNewton())
     @test sol.objective < 1.0
     sol = solve(prob, Ipopt.Optimizer(); print_level = 0)
     @test sol.objective < 1.0
@@ -110,7 +111,7 @@ end
         sys, [x => 0.0, y => 0.0, z => 0.0, a => 1.0, b => 1.0],
         grad = true, hess = true, cons_j = true, cons_h = true
     )
-    sol = solve(prob, IPNewton())
+    sol = solve(prob, Optim.IPNewton())
     @test sol.objective < 1.0
     @test sol[[x, z]] ≈ [0.808, -0.064] atol = 1.0e-3
     @test sol[x]^2 + sol[y]^2 ≈ 1.0
@@ -135,7 +136,7 @@ end
     p = [1.0, 100.0]
     f = OptimizationFunction(rosenbrock, Optimization.AutoSymbolics())
     prob = OptimizationProblem(f, x0, p)
-    sol = solve(prob, Newton())
+    sol = solve(prob, Optim.Newton())
     @test sol.u ≈ [1.0, 1.0]
 end
 
@@ -263,7 +264,7 @@ end
      prob = OptimizationProblem(sys2, [x => 0.0, y => 0.0], [a => 1.0, b => 100.0],
          grad = true, hess = true, cons_j = true, cons_h = true)
      @test prob.f.sys === sys2
-     sol = solve(prob, IPNewton())
+     sol = solve(prob, Optim.IPNewton())
      @test sol.objective < 1.0
      sol = solve(prob, Ipopt.Optimizer(); print_level = 0)
      @test sol.objective < 1.0
@@ -384,7 +385,7 @@ end
     @variables x = 1.0
     @mtkcompile sys = OptimizationSystem((x - 3)^2, [x], [])
     prob = @test_nowarn OptimizationProblem(sys, nothing)
-    @test_nowarn solve(prob, NelderMead())
+    @test_nowarn solve(prob, Optim.NelderMead())
 end
 
 if @isdefined(ModelingToolkit)


### PR DESCRIPTION
This PR should be ignored until reviewed by @ChrisRackauckas.

## What changed and why

OptimizationOptimJL 0.4.19 stopped exporting each Optim algorithm and retained `Optim` as its public owner namespace. ModelingToolkitBase's OptimizationSystem tests still constructed bare `IPNewton`, `Newton`, and `NelderMead`, so the Julia LTS Optimization group failed on current master. The test now imports `Optim` explicitly and constructs all four affected algorithms through that public owner API.

The export boundary is https://github.com/SciML/Optimization.jl/commit/0c726c0cf0b2f4c150b26ca03c4117e8a35434af from https://github.com/SciML/Optimization.jl/pull/1307. The failure reproduced in https://github.com/SciML/ModelingToolkit.jl/actions/runs/32902121466/job/97980114181.

## Verification

Failing before on unmodified ModelingToolkit master:

```text
$ GROUP=Optimization julia +lts --project=lib/ModelingToolkitBase -e 'using Pkg; Pkg.test()'
UndefVarError: `IPNewton` not defined       # two testsets
UndefVarError: `Newton` not defined
UndefVarError: `NelderMead` not defined
OptimizationSystem Test | 40 pass, 4 errors, 1 broken
```

Passing after for the affected suite, using the same full Optimization command:

```text
OptimizationSystem Test | 54 pass, 1 broken
InfiniteOpt Extension Test | 5 pass
```

The full group then reaches a separate current-master `UndefVarError: pyfunc` in the Pyomo dynamic-optimization extension, handled in a separate PR. With that independent fix stacked locally, the entire remaining dynamic suite also passed 117/117. No test was skipped, silenced, or weakened.

```text
$ GROUP=QA julia +release --project=lib/ModelingToolkitBase -e 'using Pkg; Pkg.test()'
JET Tests | 54 pass
Quality Assurance | 20 pass, 1 fail
JET.report_package(...; mode = typo): 263 possible errors

$ julia +release -m Runic --check lib/ModelingToolkitBase/test/optimization/optimizationsystem.jl
# exit 0

$ typos lib/ModelingToolkitBase/test/optimization/optimizationsystem.jl
# exit 0

$ git diff --check
# exit 0
```

The QA failure is unchanged on unmodified current master and this branch: all 54 focused JET assertions pass, then the full-package JET typo report emits the same 263 existing diagnostics. It is tracked in https://github.com/SciML/ModelingToolkit.jl/issues/4670#issuecomment-5359295690 and upstream at https://github.com/aviatesk/JET.jl/issues/858; QA was not suppressed or weakened.

No package behavior, public API, documentation, or dependency changed. GPU and allowed-to-fail downstream jobs were not run locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://chatgpt.com/codex/tasks/01a03a04-70ae-77a0-ba1b-ec7a1ed9ef47
