### PR TITLE
Release 1 sub-library

### DIFF
--- a/lib/SciCompDSL/Project.toml
+++ b/lib/SciCompDSL/Project.toml
@@ -1,7 +1,7 @@
 name = "SciCompDSL"
 uuid = "91a8cdf1-4ca6-467b-a780-87fda3fff15e"
 authors = ["Aayush Sabharwal <aayush.sabharwal@gmail.com>"]
-version = "1.0.2"
+version = "1.0.3"
 
 [deps]
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"


### PR DESCRIPTION
Sub-libraries whose registered tree has drifted from `master` are bumped and released together.

- `SciCompDSL` 1.0.2 -> 1.0.3 (patch)

Inter-sub-library `[compat]` lower bounds are raised to the new versions in the same commit, so a resolved set never mixes a new sub-library with an older sibling it was not tested against. All bumps are patch/minor - no exported name is removed anywhere in this set, so nothing here is breaking and no retroactive cap is required.

For `0.x` sub-libraries the patch slot is used, since the minor is the breaking axis under Julia's SemVer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014FEzNTLFutCmTEAZ3zBg5R