### PR TITLE
Fix ModelingToolkitBase QA imports on Julia 1.11

### DIFF
--- a/lib/ModelingToolkitBase/src/ModelingToolkitBase.jl
+++ b/lib/ModelingToolkitBase/src/ModelingToolkitBase.jl
@@ -132,9 +132,9 @@ import SciMLBase: @add_kwonly
 export independent_variables, unknowns, observables, parameters, bound_parameters,
     continuous_events, discrete_events, analytically_integrated
 @reexport using Symbolics
-@reexport using UnPack
 import UnPack
-using UnPack: @unpack
+@reexport using UnPack
+import UnPack: @unpack
 RuntimeGeneratedFunctions.init(@__MODULE__)
 
 import DifferentiationInterface as DI

--- a/lib/ModelingToolkitBase/test/qa/aqua.jl
+++ b/lib/ModelingToolkitBase/test/qa/aqua.jl
@@ -100,6 +100,8 @@ const NONPUBLIC_QUALIFIED_ACCESSES = (
     :similar_type,
     # UnPack
     :unpack,
+    # Base.Iterators (documented APIs not declared public until Julia 1.12)
+    :filter, :map, :reverse,
     # Base
     Symbol("@__doc__"), :Callable, :Cartesian, :deepcopy_internal, :Experimental,
     :HasEltype, :JLOptions, :literal_pow, Symbol("@nospecializeinfer"), Symbol("@ntuple"),


### PR DESCRIPTION
## Failing before

On clean `upstream/master` at `24e9206e21263ae41c43148434bd4c2dd1bf1977`, Julia 1.11.9 failed the ModelingToolkitBase QA group:

```bash
GROUP=ModelingToolkitBase_QA ~/.juliaup/bin/julia +1.11 --project=lib/ModelingToolkitBase -e 'using Pkg; Pkg.test()'
```

```text
Test Summary: | Pass  Total     Time
JET Tests     |   54     54  3m39.9s

Test Summary:                                  | Pass  Error  Total     Time
Aqua Tests                                     |   19      2     21  5m06.8s
    ExplicitImports                            |    4      2      6    39.3s
      no_implicit_imports                      |           1      1     7.1s
      all_qualified_accesses_are_public        |           1      1     4.7s
ERROR: Package ModelingToolkitBase errored during testing
```

The two findings were the implicitly imported `UnPack` binding and Julia 1.11's missing `public` metadata for the documented `Base.Iterators.filter`, `map`, and `reverse` APIs.

## Passing after

The same command passes with this PR:

```text
Test Summary: | Pass  Total     Time
JET Tests     |   54     54  4m02.7s

Test Summary: | Pass  Total     Time
Aqua Tests    |   21     21  5m21.7s
571.292962 seconds (412.98 M allocations: 20.602 GiB, 3.46% gc time, 31.16% compilation time: 8% of which was recompilation)
     Testing ModelingToolkitBase tests passed
```

## What changed

`UnPack` and `@unpack` are now explicitly imported while retaining the existing reexport. The three documented iterator APIs are recorded in the existing qualified-access compatibility list because Julia 1.11 does not declare them `public`; Julia 1.12 does.

This addresses the Julia 1.11 findings exposed by https://github.com/SciML/ModelingToolkit.jl/pull/4989 without changing the iterator implementations or runtime behavior.

## Additional verification

```bash
~/.juliaup/bin/julia +1.11 --project=../.runic-env -e 'using Runic; exit(Runic.main(ARGS))' -- --check --diff lib/ModelingToolkitBase/src/ModelingToolkitBase.jl lib/ModelingToolkitBase/test/qa/aqua.jl
typos lib/ModelingToolkitBase/src/ModelingToolkitBase.jl lib/ModelingToolkitBase/test/qa/aqua.jl
git diff --check
```

All three commands exited successfully with no findings.

No documentation or public API changed, so the documentation build was not run. Test groups outside `ModelingToolkitBase_QA` were not run.

Ignore this PR until it has been reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://chatgpt.com/codex/tasks/01a03a17-ad6f-7131-82fc-d0fd57ea6512
