### PR TITLE
Develop all MTK lib/* in Downstream CI; drop MOL_Interface2

### DIFF
--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -42,7 +42,6 @@ jobs:
           - {user: SciML, repo: ModelingToolkitStandardLibrary.jl, group: Core, subpkg: ""}
           - {user: SciML, repo: ModelOrderReduction.jl, group: Core, subpkg: ""}
           - {user: SciML, repo: MethodOfLines.jl, group: MOL_Interface1, subpkg: ""}
-          - {user: SciML, repo: MethodOfLines.jl, group: MOL_Interface2, subpkg: ""}
           - {user: SciML, repo: MethodOfLines.jl, group: 2D_Diffusion, subpkg: ""}
           - {user: SciML, repo: MethodOfLines.jl, group: DAE, subpkg: ""}
           - {user: SciML, repo: ModelingToolkitNeuralNets.jl, group: Core, subpkg: ""}
@@ -64,8 +63,12 @@ jobs:
         shell: julia --color=yes --project=downstream {0}
         run: |
           using Pkg
-          Pkg.develop(PackageSpec(path="./lib/ModelingToolkitBase"))
           Pkg.develop(PackageSpec(path="."))
+          if isdir("lib")
+              Pkg.develop(map(name -> PackageSpec(; path = joinpath("lib", name)),
+                              filter(name -> isfile(joinpath("lib", name, "Project.toml")),
+                                     readdir("lib"))))
+          end
           subpkg = "${{ matrix.package.subpkg }}"
           if subpkg != ""
             Pkg.develop(PackageSpec(path=joinpath("./downstream/lib", subpkg)))


### PR DESCRIPTION
Workflow-only. Two IntegrationTest wiring bugs:

1. The inline job `Pkg.develop`'d `lib/ModelingToolkitBase` but not `lib/SciCompDSL` (listed in `[sources]`). Downstream tests then saw registry SciCompDSL instead of the PR.
2. MethodOfLines no longer declares `MOL_Interface2` (`test/test_groups.toml` has `MOL_Interface1` only). SciMLTesting folder-discovery errors on the unknown GROUP.

## What changed

- Develop the repo root plus every `lib/*/Project.toml`.
- Drop the `MOL_Interface2` matrix cell. `MOL_Interface1` / `2D_Diffusion` / `DAE` stay.

## Verification

Parsed post-change YAML: `MOL_Interface2` gone; remaining MethodOfLines groups are toml keys; Julia step `readdir("lib")`.

Did not wait for GitHub Actions. GPU / self-hosted / allowed-to-fail not re-run.

This PR should be ignored until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)