### PR TITLE
Fix PDESystem analytic generation with defaulted parameters

### DIFF
--- a/lib/ModelingToolkitBase/src/systems/pde/pdesystem.jl
+++ b/lib/ModelingToolkitBase/src/systems/pde/pdesystem.jl
@@ -124,7 +124,8 @@ struct PDESystem <: AbstractSystem
             if isnothing(analytic_func)
                 analytic_func = map(analytic) do eq
                     args = arguments(eq.lhs)
-                    p = ps isa SciMLBase.NullParameters ? [] : ps
+                    p = ps isa SciMLBase.NullParameters ? [] :
+                        map(p -> p isa Pair ? first(p) : p, ps)
                     args = vcat(DestructuredArgs(p), args)
                     ex = Func(args, [], eq.rhs) |> toexpr
                     eq.lhs => drop_expr(

--- a/lib/ModelingToolkitBase/test/pdesystem.jl
+++ b/lib/ModelingToolkitBase/test/pdesystem.jl
@@ -35,6 +35,14 @@ dt = 0:0.1:1
         analytic_function([2], disct, discx) for disct in dt, discx in dx
 )
 
+@named pdesys_with_default = PDESystem(
+    eq, bcs, domains, [t, x], [u], [h => 1], analytic = analytic
+)
+@test all(
+    pdesys_with_default.analytic_func[u(t, x)]([2], disct, discx) ≈
+        analytic_function([2], disct, discx) for disct in dt, discx in dx
+)
+
 # Test sys.x accessor pattern for PDESystem
 using ModelingToolkitBase: renamespace, does_namespacing
 


### PR DESCRIPTION
> [!IMPORTANT]
> Ignore this PR until it has been reviewed by @ChrisRackauckas.

This is stacked on https://github.com/SciML/ModelingToolkit.jl/pull/5031 and should be reviewed only after that prerequisite. Until the prerequisite merges, this PR includes its compatibility commit in the comparison.

## What changed

`PDESystem` accepts parameter defaults as pairs such as `h => 1`, but analytic-function generation passed those pairs directly to `DestructuredArgs`. The generated function consequently attempted to use a `Pair` as an assignment target and failed with `syntax: invalid assignment location Pair(...)`.

This change unwraps only `Pair` entries while building the analytic function's parameter arguments and adds a regression test beside the existing bare-parameter test. It deliberately does not change the system's stored parameter/default representation.

## Regression evidence

The same focused test failed before the source fix:

```console
$ timeout 3600 ~/.juliaup/bin/julia +1.10 --project=/home/crackauc/tmp/jl_eq71VG lib/ModelingToolkitBase/test/pdesystem.jl
Error During Test at /home/crackauc/sandbox/tmp_20260825_180339_53321/pdesystem-defaults-bisect/lib/ModelingToolkitBase/test/pdesystem.jl:41
  Test threw exception
  Expression: all(((pdesys_with_default.analytic_func[u(t, x)])([2], disct, discx) ≈ analytic_function([2], disct, discx) for disct = dt, discx = dx))
  syntax: invalid assignment location "Pair{Symbolics.Num, Int64}(..., second=1)" around /home/crackauc/.julia/packages/RuntimeGeneratedFunctions/AgFU2/src/RuntimeGeneratedFunctions.jl:243
ERROR: LoadError: There was an error during testing
```

The generated `Pair` payload in the syntax-error line is shortened above; the exception type, source location, expression, and `second=1` value are verbatim from the run.

With the fix applied, the exact same command exited 0:

```console
Test Summary:                       | Pass  Total  Time
PDESystem property accessor (sys.x) |   21     21  0.3s
Test Summary:                    | Pass  Total  Time
PDESystem input and output roles |   14     14  0.8s
Test Summary:                                  | Pass  Total  Time
PDESystem property accessor without parameters |    3      3  0.0s
Test Summary:                               | Pass  Total  Time
PDESystem property accessor with subsystems |    2      2  0.1s
```

The regression boundary is the adjacent history pair `f04331935f96737b7160874a8cc281f0feead01c` (passes) and `b54d08729b600479f1ab467f9b1081fbf61da64e` (fails). The latter commit fixed bare-symbol parameters but replaced the earlier pair extraction instead of supporting both representations.

## Verification

Full relevant group:

```console
$ GROUP=InterfaceII timeout 7200 ~/.juliaup/bin/julia +1.10 --project=lib/ModelingToolkitBase -e 'using Pkg; Pkg.test()'
Test Summary:         | Pass  Total  Time
PDE Construction Test |   43     43  6.0s
Test Summary:                       | Pass  Broken  Total      Time
Optimal Control + Constraints Tests |   31       2     33  24m20.3s
4082.851622 seconds (1.92 G allocations: 338.855 GiB, 3.40% gc time, 52.43% compilation time: 3% of which was recompilation)
     Testing ModelingToolkitBase tests passed
```

The Julia 1.11 QA group passed with the two independently identified clean-master prerequisites applied temporarily: fork commit `26a70733803c43dc137b531f429c867a83f54154` and `SymbolicUtils = "=4.45.0"`. Neither temporary prerequisite is included in this branch.

```console
$ GROUP=QA timeout 3600 ~/.juliaup/bin/julia +1.11 --project=lib/ModelingToolkitBase -e 'using Pkg; Pkg.test()'
Test Summary: | Pass  Total     Time
JET Tests     |   54     54  4m22.6s
Test Summary: | Pass  Total     Time
Aqua Tests    |   21     21  6m51.2s
681.806365 seconds (413.20 M allocations: 20.613 GiB, 3.97% gc time, 28.61% compilation time: 7% of which was recompilation)
     Testing ModelingToolkitBase tests passed
```

Formatting and spelling:

```console
$ ~/.juliaup/bin/julia +1.12 --project=@runic -m Runic --check --diff lib/ModelingToolkitBase/src/systems/pde/pdesystem.jl lib/ModelingToolkitBase/test/pdesystem.jl
$ typos --format brief lib/ModelingToolkitBase/src/systems/pde/pdesystem.jl lib/ModelingToolkitBase/test/pdesystem.jl
$ git diff --check
```

All three exited 0 with no output.

## Scope and current blockers

The normalization is intentionally local to analytic-function code generation. A mixed pair/bare collection generates and evaluates its analytic function, but broader `PDESystem` parameter/default normalization remains outside this PR.

A fresh unmodified resolution currently selects SymbolicUtils 4.46.0 and exposes a fixed-but-unreleased Symbolics 7.36.0 `ImmutableDict` bug. Separately, clean-master ModelingToolkitBase ExplicitImports QA failures are tracked in https://github.com/SciML/ModelingToolkit.jl/issues/5032. Docs were not built because this changes neither documentation nor public API. GPU and downstream groups were not run.

## Links

- Prerequisite PR: https://github.com/SciML/ModelingToolkit.jl/pull/5031
- Introducing commit: https://github.com/SciML/ModelingToolkit.jl/commit/b54d08729b600479f1ab467f9b1081fbf61da64e
- Temporary QA prerequisite commit: https://github.com/ChrisRackauckas-Claude/ModelingToolkit.jl/commit/26a70733803c43dc137b531f429c867a83f54154
- Clean-master QA issue: https://github.com/SciML/ModelingToolkit.jl/issues/5032
- Merged, unreleased Symbolics fix: https://github.com/JuliaSymbolics/Symbolics.jl/pull/1960

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://chatgpt.com/codex/tasks/01a03a17-ad6f-7131-82fc-d0fd57ea6512
