### PR TITLE
fix: use the typed `ImmutableDict` constructor in `shift2term`

### DIFF
--- a/lib/ModelingToolkitBase/src/variables.jl
+++ b/lib/ModelingToolkitBase/src/variables.jl
@@ -300,7 +300,7 @@ function shift2term(var::SymbolicT)
                     if metadata === nothing
                         metadata = Base.ImmutableDict{DataType, Any}(VariableUnshifted, unshifted)
                     elseif metadata isa Base.ImmutableDict{DataType, Any}
-                        metadata = Base.ImmutableDict(metadata, VariableUnshifted, unshifted)
+                        metadata = Base.ImmutableDict{DataType, Any}(metadata, VariableUnshifted, unshifted)
                     end
                     return BSImpl.Term{VartypeT}(getindex, newargs; type, shape, metadata)
                 end

--- a/lib/ModelingToolkitBase/test/variable_utils.jl
+++ b/lib/ModelingToolkitBase/test/variable_utils.jl
@@ -245,3 +245,14 @@ end
     )
     @test haskey(dd, bu)
 end
+
+@testset "`shift2term` on an already-shifted array variable" begin
+    @independent_variables tt
+    @variables arr(tt)[1:2]
+    Sh = ModelingToolkitBase.Shift
+    # the first lowering attaches `VariableUnshifted`, so the second one takes the
+    # branch that merges a new key into the existing metadata
+    once = ModelingToolkitBase.shift2term(unwrap(Sh(tt, -1)(arr[1])))
+    twice = ModelingToolkitBase.shift2term(unwrap(Sh(tt, -1)(once)))
+    @test isequal(twice, ModelingToolkitBase.shift2term(unwrap(Sh(tt, -2)(arr[1]))))
+end


### PR DESCRIPTION
> **Please ignore until reviewed by @ChrisRackauckas.** Opened as a draft.

## What changed and why

`shift2term` built metadata with `Base.ImmutableDict(metadata, VariableUnshifted, unshifted)`. Base defines no untyped three-argument `ImmutableDict` constructor — the 3-arg `(parent, key, value)` form is an **inner** constructor and so exists only on the parameterized type:

```julia
struct ImmutableDict{K,V} <: AbstractDict{K,V}
    ImmutableDict{K,V}(parent::ImmutableDict, key, value) where {K,V} = new(parent, key, value)  # typed only
end
ImmutableDict(t::ImmutableDict{K,V}, KV::Pair) where {K,V} = ...   # every outer ctor takes Pairs
```

That call only ever resolved because SymbolicUtils pirated the untyped form, and [SymbolicUtils v4.46.0 removed it](https://github.com/JuliaSymbolics/SymbolicUtils.jl/commit/3aeef075d36be1ef13bffaffbfa5b646594a2b7a). One line switches to the typed constructor. The sibling call two lines up already used the typed form, and the `Base.ImmutableDict(meta, kvp)` calls elsewhere in MTKBase pass a `Pair`, so they hit Base's own outer constructor and were never affected.

**This is not latent — it is red on master today.** `GROUP=InterfaceII` on unmodified master aborts:

```
Shifted array variables: Error During Test at lib/ModelingToolkitBase/test/discrete_system.jl:292
  Got exception outside of a @test
  MethodError: no method matching Base.ImmutableDict(::Base.ImmutableDict{DataType, Any}, ::Type{ModelingToolkitBase.VariableUnshifted}, ::…BasicSymbolicImpl…)
Stacktrace:
  [1] shift2term      @ lib/ModelingToolkitBase/src/variables.jl:303
  [2] default_toterm  @ lib/ModelingToolkitBase/src/variables.jl:271
  [3] __mtkcompile    @ lib/ModelingToolkitBase/src/systems/systems.jl:390
```

so `mtkcompile` on any discrete system with shifted array variables throws.

## Verification

Julia 1.12.7, `ModelingToolkitBase 1.68.0` + `Symbolics 7.37.0` + `SymbolicUtils 4.46.0`. Note Symbolics 7.37.0 already contains its own fix for the same removal ([Symbolics#1960](https://github.com/JuliaSymbolics/Symbolics.jl/pull/1960)) — this failure is a *separate* call site in MTKBase and is not fixed by that release:

```
ModelingToolkitBase 1.68.0 | Symbolics 7.37.0 | SymbolicUtils 4.46.0
Shift twice on array var: FAIL -> MethodError: no method matching Base.ImmutableDict(...)
  thrown from: .../ModelingToolkitBase/U91TJ/src/variables.jl:303
```

The new test in `variable_utils.jl` discriminates — same file, fix reverted vs applied:

```
### BEFORE ###
`shift2term` on an already-shifted array variable: Error During Test
  MethodError: no method matching Base.ImmutableDict(..., ::Type{ModelingToolkitBase.VariableUnshifted}, ...)
### AFTER ###
Test Summary:                                     | Pass  Total  Time
`shift2term` on an already-shifted array variable |    1      1  0.1s
```

`GROUP=InterfaceII`, this branch vs clean master:

| Testset | this branch | clean master |
|---|---|---|
| Code Generation / IndexCache | 29, 68 | 29, 68 |
| Variable Utils | **149** ✅ | 148 ✅ |
| Variable Metadata | 147 ✅ | 147 ✅ |
| **Discrete System** | **24 / 24 ✅** | **22 pass, 1 fail — aborts the group** |
| SteadyState / SDE / DDE / Nonlinear | 25, 147, 20, 102 ✅ | *never reached* |
| Homotopy ×4, PDE Construction | 102, 42 ✅ | *never reached* |
| JumpSystem | 4202 pass, **2 fail** | *never reached* |

Master only gets through 5 testsets before aborting; this branch runs all 16.

## The 2 JumpSystem failures

```
SDEs + jumps with symbolic tstops: Test Failed at test/jumpsystem.jl:1506
  Expression: ≈(sol(1.0+0.001; idxs=X) - sol(1.0-0.001; idxs=X), 100.0, atol = 2)
   Evaluated: 200.00091136468592 ≈ 100.0
SDEs + jumps with symbolic tstops: Test Failed at test/jumpsystem.jl:1507
   Evaluated: 400.00107595406223 ≈ 200.0
```

**Not caused by this PR, and not fixed by it.** Both are exactly 2x the expected jump magnitude (residuals 0.0009 / 0.0011 — not noise near the tolerance), consistent with an event affect being applied twice on the SDE+symbolic-tstops path. `jumpsystem.jl` contains no reference to `Shift` or `shift2term`, so this change cannot reach it. They were previously *unobservable* because master aborts at Discrete System before JumpSystem runs; this PR makes them visible, it does not introduce them. Under separate investigation — **I did not touch the tolerance.**

## Not verified

- Other test groups (`InterfaceI`, `Initialization`, `Extended`, `Regression*`), Downstream, and the sublibrary matrix.
- Docs build — this PR touches no docstring or public API.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C73qSfpoV1bHGbknXLX9Q2
