### PR TITLE
Release ModelingToolkitBase 1.68.1

### DIFF
--- a/lib/ModelingToolkitBase/Project.toml
+++ b/lib/ModelingToolkitBase/Project.toml
@@ -1,7 +1,7 @@
 name = "ModelingToolkitBase"
 uuid = "7771a370-6774-4173-bd38-47e70ca0b839"
 authors = ["Yingbo Ma <mayingbo5@gmail.com>", "Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
-version = "1.68.0"
+version = "1.68.1"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"


### PR DESCRIPTION
Releases the unreleased `lib/ModelingToolkitBase` changes since 1.68.0:

- #5035 — `fix: use the typed ImmutableDict constructor in shift2term`. `Base.ImmutableDict(metadata, key, value)` has no untyped 3-argument constructor — the `(parent, key, value)` form is an inner constructor and exists only on the parameterised type, so the untyped call was a `MethodError`.
- #5020 — use public owner APIs in the Pyomo extension.
- plus the test-side fixes from #5016/#5021/#5022.

**Patch**: no exported or `public` name is added or removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014FEzNTLFutCmTEAZ3zBg5R