### PR TITLE
Replace nonsymbolic equation operator calls

### DIFF
--- a/lib/ModelingToolkitBase/src/systems/analysis_points.jl
+++ b/lib/ModelingToolkitBase/src/systems/analysis_points.jl
@@ -156,11 +156,11 @@ function to_connection(ap::AnalysisPoint)
     if ap.input isa System
         vs = System[ap.input]
         append!(vs, ap.outputs::Vector{System})
-        return Connection() ~ Connection(vs)
+        return Equation(Connection(), Connection(vs))
     elseif ap.input isa SymbolicT
         vs = SymbolicT[ap.input]
         append!(vs, ap.outputs::Vector{SymbolicT})
-        return Connection() ~ Connection(vs)
+        return Equation(Connection(), Connection(vs))
     else
         error("Unreachable!")
     end
@@ -183,7 +183,9 @@ renamespace(names::AbstractVector, ap::AnalysisPoint) = _renamespace(names, ap)
 
 # create analysis points via `connect`
 function connect(in, ap::AnalysisPoint, outs...; verbose = true)
-    return AnalysisPoint() ~ AnalysisPoint(unwrap(in), ap.name, collect(unwrap.(outs)); verbose)
+    return Equation(
+        AnalysisPoint(), AnalysisPoint(unwrap(in), ap.name, collect(unwrap.(outs)); verbose)
+    )
 end
 
 """
@@ -224,7 +226,9 @@ typically is not (unless the model is an inverse model).
   warning if you are analyzing an inverse model.
 """
 function connect(in::AbstractSystem, name::Symbol, out, outs...; verbose = true)
-    return AnalysisPoint() ~ AnalysisPoint(in, name, System[out; collect(outs)]; verbose)
+    return Equation(
+        AnalysisPoint(), AnalysisPoint(in, name, System[out; collect(outs)]; verbose)
+    )
 end
 
 function connect(
@@ -238,8 +242,9 @@ function connect(
         push!(allvars, unwrap(var))
     end
     validate_causal_variables_connection(allvars)
-    return AnalysisPoint() ~ AnalysisPoint(
-        allvars[1], name, allvars[2:end]; verbose
+    return Equation(
+        AnalysisPoint(),
+        AnalysisPoint(allvars[1], name, allvars[2:end]; verbose)
     )
 end
 

--- a/lib/ModelingToolkitBase/test/input_output_handling.jl
+++ b/lib/ModelingToolkitBase/test/input_output_handling.jl
@@ -32,7 +32,7 @@ end
 @test has_var(x ~ 1, x)
 @test has_var(1 ~ x, x)
 @test has_var(x + x, x)
-@test !has_var(2 ~ 1, x)
+@test !has_var(Equation(2, 1), x)
 
 @test get_namespace(x) == ""
 @test get_namespace(sys.x) == "sys"

--- a/src/structural_transformation/pantelides.jl
+++ b/src/structural_transformation/pantelides.jl
@@ -2,7 +2,7 @@
 ### Reassemble: structural information -> system
 ###
 
-const NOTHING_EQ = nothing ~ nothing
+const NOTHING_EQ = Equation(nothing, nothing)
 
 """
     pantelides_reassemble(state::TearingState, var_eq_matching)

--- a/src/systems/substitute_component.jl
+++ b/src/systems/substitute_component.jl
@@ -133,9 +133,11 @@ function recreate_connections(sys::AbstractSystem)
             return newarg
         end
         if eq.lhs isa Connection
-            return eq.lhs ~ Connection(newargs)
+            return Equation(eq.lhs, Connection(newargs))
         else
-            return eq.lhs ~ AnalysisPoint(newargs[1], eq.rhs.name, newargs[2:end])
+            return Equation(
+                eq.lhs, AnalysisPoint(newargs[1], eq.rhs.name, newargs[2:end])
+            )
         end
     end
     @set! sys.eqs = eqs

--- a/test/structural_transformation/index_reduction.jl
+++ b/test/structural_transformation/index_reduction.jl
@@ -7,6 +7,11 @@ using OrdinaryDiffEq
 using LinearAlgebra
 using ModelingToolkit: t_nounits as t, D_nounits as D
 
+@test isequal(
+    ModelingToolkit.StructuralTransformations.NOTHING_EQ,
+    ModelingToolkit.Equation(nothing, nothing)
+)
+
 # Define some variables
 @parameters L g
 @variables x(t) y(t) z(t) w(t) T(t)


### PR DESCRIPTION
> Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed

Replace internal equations whose operands are both nonsymbolic with explicit `Equation` construction. This covers the Pantelides sentinel, connection and analysis-point bookkeeping, component connection recreation, and a constant-equation test. It allows Symbolics to remove its pirated `~(::Any, ::Any)` method without breaking ModelingToolkit.

This is a companion prerequisite for https://github.com/JuliaSymbolics/Symbolics.jl/pull/1971.

## Verification

With the strict Symbolics branch developed locally, the unchanged ModelingToolkit source failed before any test could run:

```text
ERROR: LoadError: MethodError: no method matching ~(::Nothing, ::Nothing)
Stacktrace:
 [1] top-level scope
   @ src/structural_transformation/pantelides.jl:5
```

The full InterfaceI run then exposed the other two nonsymbolic operator paths before this patch:

```text
MethodError: no method matching ~(::Int64, ::Int64)
  @ lib/ModelingToolkitBase/test/input_output_handling.jl:35

MethodError: no method matching ~(::ModelingToolkitBase.AnalysisPoint,
                                  ::ModelingToolkitBase.AnalysisPoint)
  @ lib/ModelingToolkitBase/src/systems/analysis_points.jl:227
```

After the patch, the focused check completed with exit code 0 (4 assertions):

```sh
julia +1.12 --project=. -e 'using Test, ModelingToolkit; @variables x t input(t) output(t); @test isequal(ModelingToolkit.StructuralTransformations.NOTHING_EQ, ModelingToolkit.Equation(nothing, nothing)); @test !ModelingToolkit.has_var(ModelingToolkit.Equation(2, 1), x); ap = ModelingToolkit.AnalysisPoint(:ap); eq = ModelingToolkit.connect(input, ap, output; verbose = false); @test eq isa ModelingToolkit.Equation; concrete_ap = ModelingToolkit.AnalysisPoint(ModelingToolkit.unwrap(input), :ap, [ModelingToolkit.unwrap(output)]; verbose = false); @test ModelingToolkit.to_connection(concrete_ap) isa ModelingToolkit.Equation'
```

Additional local checks:

```text
Runic over all five changed files                         | clean
typos over all five changed files                         | clean
git diff --check                                          | clean
GROUP=QA                                                  | 39 passed, 1 failed, 40 total
GROUP=InterfaceI                                          | 1445 passed, 1 failed, 8 errored, 3 broken, 1457 total
```

The QA failure is a current-master reexport-list failure, also visible at https://github.com/SciML/ModelingToolkit.jl/actions/runs/33109001172/job/98659766016. Its separately validated fix is https://github.com/SciML/ModelingToolkit.jl/pull/5039. Of the eight InterfaceI errors, two were the nonsymbolic equation calls shown above and are covered by the passing focused check. The other InterfaceI failures are unrelated metadata-renaming/unit-validation failures in unchanged code and reproduce on current master with both current Julia and LTS: https://github.com/SciML/ModelingToolkit.jl/actions/runs/33109001172/job/98659766122 and https://github.com/SciML/ModelingToolkit.jl/actions/runs/33109001172/job/98659766232.

Docs were not built because this changes no public API, docstring, or rendered documentation. GPU, Julia pre, downstream, and the full `Everything` matrix were not run locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://chatgpt.com/codex/tasks/019f4028-d2ae-7a12-aff0-7d996bd9c791
