### PR TITLE
Allow intentional Symbolics facade reexports in QA

### DIFF
--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -178,9 +178,9 @@ const REEXPORTED_API = (
     Symbol("@acrule"), Symbol("@arrayop"), Symbol("@makearray"), Symbol("@rule"),
     Symbol("@syms"), :BS, :expand, :flatten_fractions, :get_canonical_expr, :get_reachability,
     :getmetadata, :hasmetadata, :ifelse_branching, :ifelse_eager, :IRStructure, :istree,
-    :populate_ir!, :print_ir, :quick_cancel, :Rewriters, :RuleSet, :SafeReal, :setmetadata,
-    :simplify, :simplify_fractions, :substitute, :SymbolicUtils, :SymReal, :Term, :term,
-    :toexpr, :TreeReal, :unwrap_const, :vartype,
+    :populate_ir!, :print_ir, :quick_cancel, :Rewriters, :RuleSet, :SafeReal, :scalarize,
+    :setmetadata, :shape, :simplify, :simplify_fractions, :substitute, :SymbolicUtils,
+    :SymReal, :Term, :term, :toexpr, :TreeReal, :Unknown, :unwrap, :unwrap_const, :vartype,
     # TermInterface: the term-manipulation interface, re-exported transitively by
     # SymbolicUtils.
     :arguments, :iscall, :operation, :sorted_arguments,


### PR DESCRIPTION
## What changed and why

Symbolics 7.38 replaced its blanket SymbolicUtils reexport with explicit bindings. That ownership correction made ModelingToolkit's strict reexport audit newly identify `Unknown`, `scalarize`, `shape`, and `unwrap`, even though all four were already part of the intentional ModelingToolkit/Symbolics facade API.

This adds those existing SymbolicUtils-owned facade names to `REEXPORTED_API`; it does not widen the user-facing API.

Ignore this PR until it has been reviewed by @ChrisRackauckas.

## Verification

Failing before the change on clean `master` with Symbolics 7.38.0:

```text
$ GROUP=QA julia +1.12 --project -e 'using Pkg; Pkg.instantiate(); Pkg.test()'
No unapproved public reexports: Test Failed
  Evaluated: isempty([:Unknown, :scalarize, :shape, :unwrap])
Test Summary: | Pass  Fail  Total
QA            |   39     1     40
ERROR: Some tests did not pass: 39 passed, 1 failed, 0 errored, 0 broken.
```

Passing after the change:

```text
$ GROUP=QA julia +1.12 --project -e 'using Pkg; Pkg.test()'
Test Summary: | Pass  Total
QA            |   40     40
Testing ModelingToolkit tests passed
```

Formatting and spelling:

```text
$ julia +1.12 -m Runic --check test/qa/qa.jl
$ typos test/qa/qa.jl
$ git diff --check
```

All three completed with exit code 0 and no output.

## Not verified

- Core and docs were not run because this changes only the QA allowlist.
- GPU, downstream, Julia pre-release, and allowed-to-fail jobs were not run locally.
- The separate clean-master InterfaceI failures are not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://chatgpt.com/codex/tasks/019f4028-d2ae-7a12-aff0-7d996bd9c791
