### PR TITLE
Split Downgrade Sublibraries by MTKBase test group

### DIFF
--- a/.github/workflows/DowngradeSublibraries.yml
+++ b/.github/workflows/DowngradeSublibraries.yml
@@ -1,4 +1,5 @@
 name: Downgrade Sublibraries
+
 on:
   pull_request:
     branches:
@@ -10,12 +11,40 @@ on:
       - master
     paths-ignore:
       - 'docs/**'
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+
+# ModelingToolkitBase's full "All" suite exceeds the 6h job wall when Downgrade
+# no longer aborts early on floor bugs. Mirror Sublibrary CI: one Downgrade job
+# per test_groups.toml section for MTKBase, plus a separate SciCompDSL job.
 jobs:
-  downgrade-sublibraries:
+  downgrade-scicompdsl:
     uses: "SciML/.github/.github/workflows/sublibrary-downgrade.yml@v1"
     secrets: "inherit"
     with:
       julia-version: "lts"
+      projects: "lib/SciCompDSL"
+
+  downgrade-mtkbase:
+    strategy:
+      fail-fast: false
+      matrix:
+        group:
+          - InterfaceI
+          - InterfaceII
+          - Initialization
+          - SymbolicIndexingInterface
+          - Extended
+          - RegressionI
+          - Extensions
+          - Optimization
+          - QA
+    uses: "SciML/.github/.github/workflows/sublibrary-downgrade.yml@v1"
+    secrets: "inherit"
+    with:
+      julia-version: "lts"
+      projects: "lib/ModelingToolkitBase"
+      group-env-name: "GROUP"
+      group-env-value: ${{ matrix.group }}

--- a/lib/ModelingToolkitBase/Project.toml
+++ b/lib/ModelingToolkitBase/Project.toml
@@ -1,7 +1,7 @@
 name = "ModelingToolkitBase"
 uuid = "7771a370-6774-4173-bd38-47e70ca0b839"
 authors = ["Yingbo Ma <mayingbo5@gmail.com>", "Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
-version = "1.68.1"
+version = "1.68.2"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
@@ -119,7 +119,7 @@ DiffEqBase = "7.14"
 DiffEqCallbacks = "4"
 DiffEqNoiseProcess = "5"
 DiffRules = "1"
-DifferentiationInterface = "0.6.47, 0.7"
+DifferentiationInterface = "0.7.19"
 Distributed = "1"
 DocStringExtensions = "0.9"
 DomainSets = "0.7, 0.8"


### PR DESCRIPTION
## Summary
- After Differentiation ≥3.11 floors, Downgrade Sublibraries / ModelingToolkitBase runs far enough to hit the **6h job cancel** (no \`drain_jvp\`; 0 \`Test Failed\` in the cancelled log).
- Sublibrary CI already shards by \`test_groups.toml\`. Downgrade was still \`GROUP=All\` in one job.
- Split: SciCompDSL alone + MTKBase matrix over InterfaceI/II, Initialization, …, QA.
- Floor DifferentiationInterface ≥0.7.19 (\`forward_counterpart\` for EnzymeExt; matches Sublibrary resolves at 0.7.21).

Ignore until reviewed by @ChrisRackauckas.

## Test plan
- [ ] Each \`downgrade-mtkbase\` matrix cell completes without 6h cancel
- [ ] Compare InterfaceII / Optimization / QA first errors to Sublibrary CI (expect MATCH_FAIL or BETTER, not WORSE)
- [ ] SciCompDSL Downgrade still green

Made with [Cursor](https://cursor.com)