### PR TITLE
Compile single-equation continuous event conditions to scalar functions

### DIFF
--- a/lib/ModelingToolkitBase/src/systems/callbacks.jl
+++ b/lib/ModelingToolkitBase/src/systems/callbacks.jl
@@ -801,29 +801,40 @@ Base.isempty(cb::AbstractCallback) = isempty(cb.conditions)
 ####### Compilation functions ######
 ####################################
 
-struct CompiledCondition{IsDiscrete, F}
+"""
+    CompiledCondition{IsDiscrete, IsScalar, F}
+
+Callable struct wrapping the compiled trigger condition `f` of a callback. It adapts the
+generated function's `(u, p, t)` (or `(out, u, p, t)`) signature to the
+`(u, t, integrator)` (or `(out, u, t, integrator)`) protocol SciMLBase expects, obtaining
+the parameter object via `SymbolicIndexingInterface.parameter_values`. The integrator is
+only used for that lookup, so any value implementing `parameter_values` works as one.
+
+The type parameters gate how the condition is called:
+
+- `IsDiscrete`: whether this is the condition of a `SymbolicDiscreteCallback`.
+- `IsScalar`: whether the compiled condition returns its value (called as
+  `(u, t, integrator)`) instead of writing it into an output buffer (called as
+  `(out, u, t, integrator)`). This is `true` for discrete conditions and for the
+  single-equation continuous conditions of a `ContinuousCallback`, and `false` for the
+  multi-equation continuous conditions of a `VectorContinuousCallback`.
+
+# Fields
+- `f`: the generated function wrapping the condition expression
+"""
+struct CompiledCondition{IsDiscrete, IsScalar, F}
     f::F
 end
 
-function CompiledCondition{ID}(f::F) where {ID, F}
-    return CompiledCondition{ID, F}(f)
+function CompiledCondition{ID, IS}(f::F) where {ID, IS, F}
+    return CompiledCondition{ID, IS, F}(f)
 end
 
-function (cc::CompiledCondition)(out, u, t, integ)
+function (cc::CompiledCondition{false, false})(out, u, t, integ)
     return cc.f(out, u, parameter_values(integ), t)
 end
 
-function (cc::CompiledCondition{false})(u, t, integ)
-    return if DiffEqBase.isinplace(SciMLBase.get_sol(integ).prob)
-        tmp, = DiffEqBase.get_tmp_cache(integ)
-        cc.f(tmp, u, parameter_values(integ), t)
-        tmp[1]
-    else
-        cc.f(u, parameter_values(integ), t)
-    end
-end
-
-function (cc::CompiledCondition{true})(u, t, integ)
+function (cc::CompiledCondition{ID, true})(u, t, integ) where {ID}
     return cc.f(u, parameter_values(integ), t)
 end
 
@@ -1016,9 +1027,14 @@ end
 (ifw::InitFinalizeWrapper)(c, u, t, integ) = ifw.f(integ)
 
 """
-    compile_condition(cb::AbstractCallback, sys, dvs, ps; expression, kwargs...)
+    compile_condition(cb::AbstractCallback, sys, dvs, ps, opts::GeneratedFunctionOptions)
 
-Returns a function `condition(u,t,integrator)`, condition(out,u,t,integrator)` returning the `condition(cb)`.
+Compile `conditions(cb)` into a [`CompiledCondition`](@ref).
+
+Discrete conditions and single-equation continuous conditions (the ones attached to a
+`ContinuousCallback`) compile to a scalar out-of-place `condition(u, t, integrator)`.
+Multi-equation continuous conditions (the ones attached to a `VectorContinuousCallback`)
+compile to an in-place `condition(out, u, t, integrator)`.
 """
 Base.@nospecializeinfer function compile_condition(
         @nospecialize(cbs::Union{AbstractCallback, Vector{<:AbstractCallback}}),
@@ -1034,7 +1050,19 @@ Base.@nospecializeinfer function compile_condition(
         condit = reduce(vcat, flatten_equations(Vector{Equation}(condit)))
         condit = condit isa AbstractVector ? [c.lhs - c.rhs for c in condit] :
             [condit.lhs - condit.rhs]
+        # A single-equation continuous callback is attached as a `ContinuousCallback`, whose
+        # condition must return a scalar. Generating the scalar expression rather than a
+        # length-1 vector keeps the condition allocation-free and lets it be evaluated with
+        # nothing but `parameter_values(integrator)` (relevant for sensitivity analysis,
+        # which differentiates the condition through a stand-in integrator).
+        # See SciML/ModelingToolkit.jl#5018.
+        if length(condit) == 1
+            condit = only(condit)
+        end
     end
+    # Discrete conditions are scalar (boolean) expressions and are always called
+    # out-of-place, as are single-equation continuous conditions.
+    is_scalar = is_discrete(cbs) || !(condit isa AbstractVector)
 
     fs = build_function_wrapper(
         sys, condit, [Any[u]; p; Any[t]], BuildFunctionWrapperOptions(;
@@ -1042,10 +1070,16 @@ Base.@nospecializeinfer function compile_condition(
             codegen_function_options = opts.codegen
         )
     )
-    fs = GeneratedFunctionWrapper{(2, 3, is_split(sys))}(
-        Val{false}, fs...; eval_expression, eval_module
-    )
-    return CompiledCondition{is_discrete(cbs)}(fs)
+    fs = if is_scalar
+        GeneratedFunctionWrapper{(2, 3, is_split(sys))}(
+            Val{false}, fs[1], nothing; eval_expression, eval_module
+        )
+    else
+        GeneratedFunctionWrapper{(2, 3, is_split(sys))}(
+            Val{false}, fs...; eval_expression, eval_module
+        )
+    end
+    return CompiledCondition{is_discrete(cbs), is_scalar}(fs)
 end
 
 is_discrete(cb::AbstractCallback) = cb isa SymbolicDiscreteCallback

--- a/lib/ModelingToolkitBase/test/symbolic_events.jl
+++ b/lib/ModelingToolkitBase/test/symbolic_events.jl
@@ -11,6 +11,7 @@ using Symbolics
 
 using StableRNGs
 import SciMLBase
+import ForwardDiff
 using SymbolicIndexingInterface
 using Setfield
 using LinearAlgebra
@@ -257,13 +258,10 @@ end
     @test get_callback(prob) isa ModelingToolkitBase.DiffEqCallbacks.ContinuousCallback
     cb = ModelingToolkitBase.generate_continuous_callbacks(sys)
     cond = cb.condition
-    out = [0.0]
-    cond.f(out, [0], p0, t0)
-    @test out[] ≈ -1 # signature is u,p,t
-    cond.f(out, [1], p0, t0)
-    @test out[] ≈ 0  # signature is u,p,t
-    cond.f(out, [2], p0, t0)
-    @test out[] ≈ 1  # signature is u,p,t
+    # a single-equation continuous callback compiles to a scalar out-of-place condition
+    @test cond.f([0], p0, t0) ≈ -1 # signature is u,p,t
+    @test cond.f([1], p0, t0) ≈ 0  # signature is u,p,t
+    @test cond.f([2], p0, t0) ≈ 1  # signature is u,p,t
 
     prob = ODEProblem(sys, Pair[], (0.0, 2.0))
     prob_nosplit = ODEProblem(sys_nosplit, Pair[], (0.0, 2.0))
@@ -421,6 +419,84 @@ end
     @test -minimum(sol[y]) ≈ maximum(sol[y]) ≈ sqrt(2)  # the ball will never go further than √2 in either direction (gravity was changed to 1 to get this particular number)
     @test 0 <= minimum(sol_nosplit[x]) <= 1.0e-10 # the ball never went through the floor but got very close
     @test -minimum(sol_nosplit[y]) ≈ maximum(sol_nosplit[y]) ≈ sqrt(2)  # the ball will never go further than √2 in either direction (gravity was changed to 1 to get this particular number)
+end
+
+# Minimal stand-in for an integrator: implements only the `SymbolicIndexingInterface`
+# methods a compiled continuous condition is allowed to use. It is not a `DEIntegrator`, so
+# a condition reaching for solver internals (the solution object, the temporary cache, ...)
+# errors instead of silently working.
+struct ConditionIntegratorStub{U, P, T}
+    u::U
+    p::P
+    t::T
+end
+SymbolicIndexingInterface.parameter_values(integ::ConditionIntegratorStub) = integ.p
+SymbolicIndexingInterface.state_values(integ::ConditionIntegratorStub) = integ.u
+SymbolicIndexingInterface.current_time(integ::ConditionIntegratorStub) = integ.t
+
+# https://github.com/SciML/ModelingToolkit.jl/issues/5018
+@testset "Scalar continuous conditions" begin
+    @variables x(t) = 1.0 v(t) = 0.0
+    eqs = [D(x) ~ v, D(v) ~ -9.8]
+
+    @named ball = System(eqs, t; continuous_events = [[x ~ 0] => [v ~ -Pre(v)]])
+    ball = mtkcompile(ball)
+    prob = ODEProblem(ball, Pair[], (0.0, 5.0))
+    cb = get_callback(prob)
+    @test cb isa ModelingToolkitBase.DiffEqCallbacks.ContinuousCallback
+
+    integ = ConditionIntegratorStub(prob.u0, prob.p, 0.0)
+    xidx = variable_index(ball, x)
+    u = copy(prob.u0)
+    u[xidx] = 0.25
+    val = cb.condition(u, 0.0, integ)
+    @test val isa Number
+    @test val ≈ 0.25
+
+    # the condition must be differentiable w.r.t. `u` through `ForwardDiff`
+    dval = cb.condition(ForwardDiff.Dual.(u, 1.0), 0.0, integ)
+    @test dval isa ForwardDiff.Dual
+    @test ForwardDiff.value(dval) ≈ 0.25
+    @test ForwardDiff.partials(dval, 1) ≈ 1.0
+    grad = ForwardDiff.gradient(uu -> cb.condition(uu, 0.0, integ), u)
+    @test grad[xidx] ≈ 1.0
+    @test grad[variable_index(ball, v)] ≈ 0.0
+
+    sol = solve(prob, Tsit5())
+    @test 0 <= minimum(sol[x]) <= 1.0e-10
+
+    # ... and w.r.t. `t`, for a time-dependent condition
+    @named tsys = System(eqs, t; continuous_events = [[x ~ t] => [v ~ -Pre(v)]])
+    tsys = mtkcompile(tsys)
+    tprob = ODEProblem(tsys, Pair[], (0.0, 5.0))
+    tcb = get_callback(tprob)
+    @test tcb isa ModelingToolkitBase.DiffEqCallbacks.ContinuousCallback
+    tinteg = ConditionIntegratorStub(tprob.u0, tprob.p, 0.0)
+    tu = copy(tprob.u0)
+    tu[variable_index(tsys, x)] = 0.25
+    @test tcb.condition(tu, 0.1, tinteg) ≈ 0.15
+    tdval = tcb.condition(tu, ForwardDiff.Dual(0.1, 1.0), tinteg)
+    @test tdval isa ForwardDiff.Dual
+    @test ForwardDiff.value(tdval) ≈ 0.15
+    @test ForwardDiff.partials(tdval, 1) ≈ -1.0
+    @test solve(tprob, Tsit5()).retcode == SciMLBase.ReturnCode.Success
+
+    # a multi-equation event still compiles to an in-place `VectorContinuousCallback`
+    @variables y(t) = 0.0
+    @named vsys = System(
+        [eqs; D(y) ~ 1], t;
+        continuous_events = [[x ~ 0] => [v ~ -Pre(v)], [y ~ 1] => [y ~ 0]]
+    )
+    vsys = mtkcompile(vsys)
+    vprob = ODEProblem(vsys, Pair[], (0.0, 5.0))
+    vcb = get_callback(vprob)
+    @test vcb isa ModelingToolkitBase.DiffEqCallbacks.VectorContinuousCallback
+    vout = zeros(2)
+    vcb.condition(vout, vprob.u0, 0.0, ConditionIntegratorStub(vprob.u0, vprob.p, 0.0))
+    @test vout ≈ [1.0, -1.0]
+    vsol = solve(vprob, Tsit5())
+    @test 0 <= minimum(vsol[x]) <= 1.0e-10
+    @test maximum(vsol[y]) ≈ 1.0
 end
 
 # issue https://github.com/SciML/ModelingToolkitBase.jl/issues/1386


### PR DESCRIPTION
Part of #5018 (companion: SciML/SciMLSensitivity.jl#1629).

Single-equation continuous event conditions now compile to a scalar out-of-place function; `CompiledCondition{IsDiscrete, IsScalar}` only needs `parameter_values(integrator)`, no more `get_sol`/`get_tmp_cache`, so the condition can be evaluated (and differentiated) through a stand-in integrator. Vector and discrete paths unchanged.

Tested: new "Scalar continuous conditions" testset in `symbolic_events.jl`; ModelingToolkitBase `InterfaceI` group 1620 pass / 5 broken (pre-existing) / 0 fail.