### PR TITLE
Generate FullSpecialize initialization maps with static buffers

### DIFF
--- a/lib/ModelingToolkitBase/ext/MTKChainRulesCoreExt.jl
+++ b/lib/ModelingToolkitBase/ext/MTKChainRulesCoreExt.jl
@@ -9,6 +9,17 @@ import SciMLStructures
 import SymbolicIndexingInterface: remake_buffer, parameter_index
 import SciMLBase: AbstractNonlinearProblem, remake
 
+function ChainRulesCore.rrule(::typeof(MTK._static_initialization_buffer), prototype, values)
+    result = MTK._static_initialization_buffer(prototype, values)
+    project = ChainRulesCore.ProjectTo(values)
+    function buffer_pullback(dt)
+        dt = unthunk(dt)
+        dvalues = dt isa ChainRulesCore.AbstractZero ? dt : project(values isa Tuple ? Tuple(dt) : dt)
+        return NoTangent(), NoTangent(), dvalues
+    end
+    return result, buffer_pullback
+end
+
 # Positional arguments of `MTKParameters` after `tunables`, in order. `setproperties`
 # (and hence every `@set!`/`SciMLStructures.replace` rebuild) lowers to this
 # constructor, so the pullback has to route each buffer's cotangent back to its own

--- a/lib/ModelingToolkitBase/src/ModelingToolkitBase.jl
+++ b/lib/ModelingToolkitBase/src/ModelingToolkitBase.jl
@@ -11,8 +11,8 @@ using PrecompileTools: PrecompileTools, @recompile_invalidations
 using Reexport: Reexport, @reexport
 @recompile_invalidations begin
     import StaticArrays
-    using StaticArraysCore: StaticArraysCore, MVector, SVector, StaticArray, StaticVector,
-        similar_type
+    using StaticArraysCore: StaticArraysCore, MVector, SVector, SizedVector, StaticArray,
+        StaticVector, similar_type
     import Symbolics
     import ImplicitDiscreteSolve
     using ImplicitDiscreteSolve: IDSolve

--- a/lib/ModelingToolkitBase/src/ModelingToolkitBase.jl
+++ b/lib/ModelingToolkitBase/src/ModelingToolkitBase.jl
@@ -11,8 +11,8 @@ using PrecompileTools: PrecompileTools, @recompile_invalidations
 using Reexport: Reexport, @reexport
 @recompile_invalidations begin
     import StaticArrays
-    using StaticArraysCore: StaticArraysCore, MVector, SVector, SizedVector, StaticArray,
-        StaticVector, similar_type
+    using StaticArraysCore: StaticArraysCore, MVector, SVector, StaticArray, StaticVector,
+        similar_type
     import Symbolics
     import ImplicitDiscreteSolve
     using ImplicitDiscreteSolve: IDSolve

--- a/lib/ModelingToolkitBase/src/problems/nonlinearproblem.jl
+++ b/lib/ModelingToolkitBase/src/problems/nonlinearproblem.jl
@@ -181,7 +181,7 @@ end
     _iip = resolve_iip(iip, op)
     f, u0,
         p = process_SciMLProblem(
-        NonlinearFunction{_iip}, sys, op;
+        NonlinearFunction{_iip, spec}, sys, op;
         check_length, expression, kwargs...
     )
 

--- a/lib/ModelingToolkitBase/src/problems/odeproblem.jl
+++ b/lib/ModelingToolkitBase/src/problems/odeproblem.jl
@@ -205,7 +205,7 @@ end
     _iip = resolve_iip(iip, op)
     f, u0,
         p = process_SciMLProblem(
-        ODEFunction{_iip}, sys, op;
+        ODEFunction{_iip, spec}, sys, op;
         steady_state = true, check_length, check_compatibility, expression,
         is_steadystateprob = true, kwargs...
     )

--- a/lib/ModelingToolkitBase/src/systems/parameter_buffer.jl
+++ b/lib/ModelingToolkitBase/src/systems/parameter_buffer.jl
@@ -967,7 +967,7 @@ end
                     Expr(
                         :tuple,
                         (
-                            :($similar_type($(fieldtype(C, i)), $(nonnumericT[i]))(nonnumerics[$i]))
+                            :($similar_type($(fieldtype(N, i)), $(nonnumericT[i]))(nonnumerics[$i]))
                                 for i in 1:length(nonnumericT)
                         )...
                     )

--- a/lib/ModelingToolkitBase/src/systems/problem_utils.jl
+++ b/lib/ModelingToolkitBase/src/systems/problem_utils.jl
@@ -1692,8 +1692,13 @@ end
 function _static_parameter_buffer(prototype, values::Tuple)
     T = isempty(values) ? eltype(prototype) :
         promote_type(eltype(prototype), mapreduce(typeof, promote_type, values))
-    static_type = ArrayInterface.ismutable(prototype) ? MVector : SVector
-    return static_type{length(values), T}(values)
+    if !ArrayInterface.ismutable(prototype)
+        return SVector{length(values), T}(values)
+    elseif isbitstype(T)
+        return MVector{length(values), T}(values)
+    else
+        return SizedVector{length(values), T}(T[values...])
+    end
 end
 
 function _parameter_buffer_expr(prototype, raw::Symbol, idxs, p_constructor)

--- a/lib/ModelingToolkitBase/src/systems/problem_utils.jl
+++ b/lib/ModelingToolkitBase/src/systems/problem_utils.jl
@@ -1692,7 +1692,8 @@ end
 function _static_parameter_buffer(prototype, values::Tuple)
     T = isempty(values) ? eltype(prototype) :
         promote_type(eltype(prototype), mapreduce(typeof, promote_type, values))
-    return SVector{length(values), T}(values)
+    static_type = ArrayInterface.ismutable(prototype) ? MVector : SVector
+    return static_type{length(values), T}(values)
 end
 
 function _parameter_buffer_expr(prototype, raw::Symbol, idxs, p_constructor)

--- a/lib/ModelingToolkitBase/src/systems/problem_utils.jl
+++ b/lib/ModelingToolkitBase/src/systems/problem_utils.jl
@@ -1718,13 +1718,6 @@ function _construct_fullspecialize_initializeprobpmap(
     for group in grouped[3:5], buffer in group
         append!(flat_syms, buffer)
     end
-    for sym in flat_syms
-        symbolic_type(sym) == ArraySymbolic() && throw(
-            ArgumentError(
-                "FullSpecialize initialization maps do not yet support array-valued parameter storage slots."
-            )
-        )
-    end
     expr = build_explicit_observed_function(
         initsys, Tuple(flat_syms);
         expression = Val(true), compiler_options, kwargs...

--- a/lib/ModelingToolkitBase/src/systems/problem_utils.jl
+++ b/lib/ModelingToolkitBase/src/systems/problem_utils.jl
@@ -1725,12 +1725,6 @@ function _construct_fullspecialize_initializeprobpmap(
             )
         )
     end
-    isempty(SU.getmetadata(sys, DiffCacheParams, Dict{SymbolicT, Int}())) || throw(
-        ArgumentError(
-            "FullSpecialize initialization maps do not yet support DiffCache parameters."
-        )
-    )
-
     expr = build_explicit_observed_function(
         initsys, Tuple(flat_syms);
         expression = Val(true), compiler_options, kwargs...

--- a/lib/ModelingToolkitBase/src/systems/problem_utils.jl
+++ b/lib/ModelingToolkitBase/src/systems/problem_utils.jl
@@ -1108,6 +1108,24 @@ struct MTKParametersReconstructor{T, I, D, C, N}
     diffcache_buffer_idx::Int
 end
 
+function _unwrap_initial_symbols!(initsyms, srcsys)
+    allsyms = Set{SymbolicT}(variable_symbols(srcsys))
+    for i in eachindex(initsyms)
+        sym = initsyms[i]
+        arr, isarr = split_indexed_var(sym)
+        innersym = if isarr
+            sidx = get_stable_index(sym)
+            first(arguments(arr))[sidx]
+        else
+            first(arguments(arr))
+        end
+        if innersym in allsyms
+            initsyms[i] = innersym
+        end
+    end
+    return initsyms
+end
+
 # TODO: make this infer when the nonnumerics are non-trivial
 function (recon::MTKParametersReconstructor)(src, dst)
     return recon(src, parameter_values(dst))
@@ -1185,22 +1203,7 @@ function MTKParametersReconstructor(
     end
     initials_getter = if initials && !isempty(syms[2])
         initsyms = syms[2]::Vector{SymbolicT}
-        allsyms = Set{SymbolicT}(variable_symbols(srcsys))
-        if unwrap_initials
-            for i in eachindex(initsyms)
-                sym = initsyms[i]
-                arr, isarr = split_indexed_var(sym)
-                innersym = if isarr
-                    sidx = get_stable_index(sym)
-                    first(arguments(arr))[sidx]
-                else
-                    first(arguments(arr))
-                end
-                if innersym in allsyms
-                    initsyms[i] = innersym
-                end
-            end
-        end
+        unwrap_initials && _unwrap_initial_symbols!(initsyms, srcsys)
         p_constructor ∘ CopyParamsByTemplate(srcsys, initsyms; kwargs...)
     else
         Returns(SVector{0, Float64}())
@@ -1630,6 +1633,159 @@ function (map::InitializationMap{true})(x)
     return __iip_u0_ad_wrapper(map.u0_constructor(map.map(x)))
 end
 
+function _generated_map_expr(finish, expr::Expr, map_args::Vector{Symbol}, sources::Vector{Expr})
+    @assert expr.head === :function
+    signature = expr.args[1]
+    @assert signature isa Expr && signature.head === :tuple
+    generated_args = signature.args
+    @assert length(generated_args) == length(sources)
+
+    body = Expr(:block)
+    for (arg, source) in zip(generated_args, sources)
+        push!(body.args, :(local $arg = $source))
+    end
+    raw = gensym(:initialization_map_values)
+    push!(body.args, :(local $raw = $(expr.args[2])))
+    push!(body.args, finish(raw))
+    return Expr(:function, Expr(:tuple, map_args...), body)
+end
+
+function _generated_map_sources(valp::Symbol, time_dependent::Bool)
+    sources = Expr[
+        Expr(:call, GlobalRef(SymbolicIndexingInterface, :state_values), valp),
+        Expr(:call, GlobalRef(SymbolicIndexingInterface, :parameter_values), valp),
+    ]
+    if time_dependent
+        push!(sources, Expr(:call, GlobalRef(SymbolicIndexingInterface, :current_time), valp))
+    end
+    return sources
+end
+
+function _construct_fullspecialize_initializeprobmap(
+        initsys::AbstractSystem, solved_unknowns;
+        iip::Bool, u0_constructor, floatT, eval_module,
+        compiler_options::CompilerOptions = CompilerOptions(), kwargs...
+    )
+    expr = build_explicit_observed_function(
+        initsys, solved_unknowns;
+        expression = Val(true), output_type = SVector, compiler_options, kwargs...
+    )
+    sol = gensym(:initialization_solution)
+    sources = _generated_map_sources(sol, is_time_dependent(initsys))
+    n = length(solved_unknowns)
+    static_type = iip ? MVector : SVector
+    map_expr = _generated_map_expr(expr, [sol], sources) do raw
+        T = gensym(:initialization_map_eltype)
+        p = Expr(:call, GlobalRef(SymbolicIndexingInterface, :parameter_values), sol)
+        tunable_eltype = Expr(:call, GlobalRef(@__MODULE__, :_tunable_eltype), p)
+        promoted = Expr(:call, promote_type, Expr(:call, eltype, raw), tunable_eltype, floatT)
+        static_values = Expr(:call, Expr(:curly, static_type, n, T), raw)
+        result = Expr(:call, QuoteNode(u0_constructor), static_values)
+        if iip
+            result = Expr(:call, GlobalRef(@__MODULE__, :__iip_u0_ad_wrapper), result)
+        end
+        return Expr(:block, :(local $T = $promoted), result)
+    end
+    return eval_or_rgf(map_expr; eval_module, compiler_options)
+end
+
+function _static_parameter_buffer(prototype, values::Tuple)
+    T = isempty(values) ? eltype(prototype) :
+        promote_type(eltype(prototype), mapreduce(typeof, promote_type, values))
+    return SVector{length(values), T}(values)
+end
+
+function _parameter_buffer_expr(prototype, raw::Symbol, idxs, p_constructor)
+    values = Expr(:tuple, [Expr(:ref, raw, i) for i in idxs]...)
+    buffer = Expr(
+        :call, GlobalRef(@__MODULE__, :_static_parameter_buffer), prototype, values
+    )
+    p_constructor === identity && return buffer
+    return Expr(:call, QuoteNode(p_constructor), buffer)
+end
+
+function _construct_fullspecialize_initializeprobpmap(
+        sys::AbstractSystem, initsys::AbstractSystem;
+        p_constructor, eval_module,
+        compiler_options::CompilerOptions = CompilerOptions(), kwargs...
+    )
+    grouped = reorder_parameters(
+        sys, parameters(sys; initial_parameters = true); flatten = false
+    )
+    initial_syms = _unwrap_initial_symbols!(copy(grouped[2]), initsys)
+    flat_syms = SymbolicT[]
+    append!(flat_syms, grouped[1], initial_syms)
+    for group in grouped[3:5], buffer in group
+        append!(flat_syms, buffer)
+    end
+    for sym in flat_syms
+        symbolic_type(sym) == ArraySymbolic() && throw(
+            ArgumentError(
+                "FullSpecialize initialization maps do not yet support array-valued parameter storage slots."
+            )
+        )
+    end
+    isempty(SU.getmetadata(sys, DiffCacheParams, Dict{SymbolicT, Int}())) || throw(
+        ArgumentError(
+            "FullSpecialize initialization maps do not yet support DiffCache parameters."
+        )
+    )
+
+    expr = build_explicit_observed_function(
+        initsys, Tuple(flat_syms);
+        expression = Val(true), compiler_options, kwargs...
+    )
+    prob = gensym(:problem)
+    sol = gensym(:initialization_solution)
+    sources = _generated_map_sources(sol, is_time_dependent(initsys))
+    map_expr = _generated_map_expr(expr, [prob, sol], sources) do raw
+        outer_p = gensym(:outer_parameters)
+        p = Expr(:call, GlobalRef(SymbolicIndexingInterface, :parameter_values), prob)
+        if !is_split(sys)
+            result = _parameter_buffer_expr(outer_p, raw, eachindex(flat_syms), p_constructor)
+            return Expr(:block, :(local $outer_p = $p), result)
+        end
+
+        offset = 0
+        tunable_idxs = (offset + 1):(offset + length(grouped[1]))
+        offset += length(grouped[1])
+        initial_idxs = (offset + 1):(offset + length(grouped[2]))
+        offset += length(grouped[2])
+        tunable = _parameter_buffer_expr(Expr(:., outer_p, QuoteNode(:tunable)), raw, tunable_idxs, p_constructor)
+        initials = _parameter_buffer_expr(Expr(:., outer_p, QuoteNode(:initials)), raw, initial_idxs, p_constructor)
+
+        portions = Expr[]
+        for (portion_idx, group) in enumerate(grouped[3:5])
+            buffers = Expr[]
+            field = (:discrete, :constant, :nonnumeric)[portion_idx]
+            for (buffer_idx, syms) in enumerate(group)
+                idxs = (offset + 1):(offset + length(syms))
+                offset += length(syms)
+                prototype = Expr(:ref, Expr(:., outer_p, QuoteNode(field)), buffer_idx)
+                buffer = _parameter_buffer_expr(prototype, raw, idxs, p_constructor)
+                if portion_idx == 1
+                    sizes = get_index_cache(sys).discrete_buffer_sizes[buffer_idx]
+                    block_sizes = Expr(
+                        :call, Expr(:curly, SVector, length(sizes), Int),
+                        map(size -> size.length, sizes)...
+                    )
+                    p_constructor === identity ||
+                        (block_sizes = Expr(:call, QuoteNode(p_constructor), block_sizes))
+                    buffer = Expr(:call, BlockedArray, buffer, block_sizes)
+                end
+                push!(buffers, buffer)
+            end
+            push!(portions, Expr(:tuple, buffers...))
+        end
+        result = Expr(
+            :call, MTKParameters, tunable, initials, portions...,
+            Expr(:., outer_p, QuoteNode(:caches))
+        )
+        return Expr(:block, :(local $outer_p = $p), result)
+    end
+    return eval_or_rgf(map_expr; eval_module, compiler_options)
+end
+
 """
     $(TYPEDSIGNATURES)
 
@@ -1896,6 +2052,7 @@ function maybe_build_initialization_problem(
         sys::AbstractSystem, iip::Bool, op::SymmapT, t, guesses,
         opts::SciMLProblemOptions;
         specialize = SciMLBase.AutoDespecialize,
+        map_specialize = specialize,
         # Intercept `expression` because we don't support it here yet
         expression = Val{false}, kwargs...
     )
@@ -1987,6 +2144,13 @@ function maybe_build_initialization_problem(
         solved_unknowns = filter(var -> var in all_init_syms, unknowns(sys))
         if isempty(solved_unknowns)
             initializeprobmap = nothing
+        elseif map_specialize === SciMLBase.FullSpecialize
+            initializeprobmap = _construct_fullspecialize_initializeprobmap(
+                initializeprob.f.sys, solved_unknowns;
+                iip, u0_constructor, floatT, eval_module,
+                compiler_options = init_compiler_options,
+                kwargs...
+            )
         else
             initializeprobmap = InitializationMap{iip}(
                 u0_constructor,
@@ -2010,6 +2174,12 @@ function maybe_build_initialization_problem(
     ]
     if initializeprobmap === nothing && isempty(punknowns)
         initializeprobpmap = nothing
+    elseif map_specialize === SciMLBase.FullSpecialize
+        initializeprobpmap = _construct_fullspecialize_initializeprobpmap(
+            sys, initsys;
+            p_constructor, eval_module, compiler_options = init_compiler_options,
+            kwargs...
+        )
     else
         initializeprobpmap = construct_initializeprobpmap(
             sys, initsys; p_constructor, eval_expression, eval_module, kwargs...
@@ -2222,12 +2392,12 @@ function __process_SciMLProblem(
     end
 
     if build_initializeprob
+        problem_specialize = SciMLBase.specialization(constructor)
         kws = maybe_build_initialization_problem(
             sys, constructor <: SciMLBase.AbstractSciMLFunction{true},
             op, t, guesses, opts;
-            specialize = initialization_specialization(
-                SciMLBase.specialization(constructor)
-            ), kwargs...
+            specialize = initialization_specialization(problem_specialize),
+            map_specialize = problem_specialize, kwargs...
         )
 
         kwargs = merge(kwargs, kws)

--- a/lib/ModelingToolkitBase/src/systems/problem_utils.jl
+++ b/lib/ModelingToolkitBase/src/systems/problem_utils.jl
@@ -1679,7 +1679,10 @@ function _construct_fullspecialize_initializeprobmap(
         p = Expr(:call, GlobalRef(SymbolicIndexingInterface, :parameter_values), sol)
         tunable_eltype = Expr(:call, GlobalRef(@__MODULE__, :_tunable_eltype), p)
         promoted = Expr(:call, promote_type, Expr(:call, eltype, raw), tunable_eltype, floatT)
-        static_values = Expr(:call, Expr(:curly, static_type, n, T), raw)
+        static_values = Expr(
+            :call, GlobalRef(@__MODULE__, :_static_initialization_buffer),
+            Expr(:curly, static_type, n, T), raw
+        )
         result = Expr(:call, QuoteNode(u0_constructor), static_values)
         if iip
             result = Expr(:call, GlobalRef(@__MODULE__, :__iip_u0_ad_wrapper), result)
@@ -1689,7 +1692,7 @@ function _construct_fullspecialize_initializeprobmap(
     return eval_or_rgf(map_expr; eval_module, compiler_options)
 end
 
-function _static_parameter_buffer(prototype, values::Tuple)
+function _static_initialization_buffer(prototype, values)
     T = isempty(values) ? eltype(prototype) :
         promote_type(eltype(prototype), mapreduce(typeof, promote_type, values))
     if !ArrayInterface.ismutable(prototype)
@@ -1704,7 +1707,7 @@ end
 function _parameter_buffer_expr(prototype, raw::Symbol, idxs, p_constructor)
     values = Expr(:tuple, [Expr(:ref, raw, i) for i in idxs]...)
     buffer = Expr(
-        :call, GlobalRef(@__MODULE__, :_static_parameter_buffer), prototype, values
+        :call, GlobalRef(@__MODULE__, :_static_initialization_buffer), prototype, values
     )
     p_constructor === identity && return buffer
     return Expr(:call, QuoteNode(p_constructor), buffer)
@@ -1715,13 +1718,16 @@ function _construct_fullspecialize_initializeprobpmap(
         p_constructor, eval_module,
         compiler_options::CompilerOptions = CompilerOptions(), kwargs...
     )
-    grouped = reorder_parameters(
-        sys, parameters(sys; initial_parameters = true); flatten = false
-    )
-    initial_syms = _unwrap_initial_symbols!(copy(grouped[2]), initsys)
+    ps = parameters(sys; initial_parameters = true)
+    groups = if is_split(sys)
+        grouped = reorder_parameters(sys, ps; flatten = false)
+        initial_syms = _unwrap_initial_symbols!(copy(grouped[2]), initsys)
+        ((grouped[1],), (initial_syms,), grouped[3:5]...)
+    else
+        ((ps,),)
+    end
     flat_syms = SymbolicT[]
-    append!(flat_syms, grouped[1], initial_syms)
-    for group in grouped[3:5], buffer in group
+    for group in groups, buffer in group
         append!(flat_syms, buffer)
     end
     expr = build_explicit_observed_function(
@@ -1740,23 +1746,18 @@ function _construct_fullspecialize_initializeprobpmap(
         end
 
         offset = 0
-        tunable_idxs = (offset + 1):(offset + length(grouped[1]))
-        offset += length(grouped[1])
-        initial_idxs = (offset + 1):(offset + length(grouped[2]))
-        offset += length(grouped[2])
-        tunable = _parameter_buffer_expr(Expr(:., outer_p, QuoteNode(:tunable)), raw, tunable_idxs, p_constructor)
-        initials = _parameter_buffer_expr(Expr(:., outer_p, QuoteNode(:initials)), raw, initial_idxs, p_constructor)
-
         portions = Expr[]
-        for (portion_idx, group) in enumerate(grouped[3:5])
+        for (field, group) in zip((:tunable, :initials, :discrete, :constant, :nonnumeric), groups)
             buffers = Expr[]
-            field = (:discrete, :constant, :nonnumeric)[portion_idx]
             for (buffer_idx, syms) in enumerate(group)
                 idxs = (offset + 1):(offset + length(syms))
                 offset += length(syms)
-                prototype = Expr(:ref, Expr(:., outer_p, QuoteNode(field)), buffer_idx)
+                prototype = Expr(:., outer_p, QuoteNode(field))
+                if field !== :tunable && field !== :initials
+                    prototype = Expr(:ref, prototype, buffer_idx)
+                end
                 buffer = _parameter_buffer_expr(prototype, raw, idxs, p_constructor)
-                if portion_idx == 1
+                if field === :discrete
                     sizes = get_index_cache(sys).discrete_buffer_sizes[buffer_idx]
                     block_sizes = Expr(
                         :call, Expr(:curly, SVector, length(sizes), Int),
@@ -1768,11 +1769,13 @@ function _construct_fullspecialize_initializeprobpmap(
                 end
                 push!(buffers, buffer)
             end
-            push!(portions, Expr(:tuple, buffers...))
+            portion = field === :tunable || field === :initials ? only(buffers) :
+                Expr(:tuple, buffers...)
+            push!(portions, portion)
         end
         result = Expr(
-            :call, MTKParameters, tunable, initials, portions...,
-            Expr(:., outer_p, QuoteNode(:caches))
+            :call, MTKParameters, portions...,
+            :($map($copy, $outer_p.caches))
         )
         return Expr(:block, :(local $outer_p = $p), result)
     end

--- a/lib/ModelingToolkitBase/src/systems/problem_utils.jl
+++ b/lib/ModelingToolkitBase/src/systems/problem_utils.jl
@@ -1633,6 +1633,17 @@ function (map::InitializationMap{true})(x)
     return __iip_u0_ad_wrapper(map.u0_constructor(map.map(x)))
 end
 
+# Locals of the generated initialization maps are fixed sentinel names, never `gensym`.
+# A `gensym` embeds a process-global counter, so the same system would lower to a
+# different `Expr` in the precompile process than in the user session, defeating the
+# `RuntimeGeneratedFunctions` Expr-hash cache. The `__mtk_` prefix matches
+# `generated_argument_name` and makes a collision with a user symbol implausible.
+const INITMAP_VALUES = :__mtk_initialization_map_values
+const INITMAP_ELTYPE = :__mtk_initialization_map_eltype
+const INITMAP_SOLUTION = :__mtk_initialization_solution
+const INITMAP_PROBLEM = :__mtk_initialization_problem
+const INITMAP_OUTER_PARAMETERS = :__mtk_initialization_outer_parameters
+
 function _generated_map_expr(finish, expr::Expr, map_args::Vector{Symbol}, sources::Vector{Expr})
     @assert expr.head === :function
     signature = expr.args[1]
@@ -1644,10 +1655,11 @@ function _generated_map_expr(finish, expr::Expr, map_args::Vector{Symbol}, sourc
     for (arg, source) in zip(generated_args, sources)
         push!(body.args, :(local $arg = $source))
     end
-    raw = gensym(:initialization_map_values)
-    push!(body.args, :(local $raw = $(expr.args[2])))
-    push!(body.args, finish(raw))
-    return Expr(:function, Expr(:tuple, map_args...), body)
+    push!(body.args, :(local $INITMAP_VALUES = $(expr.args[2])))
+    push!(body.args, finish(INITMAP_VALUES))
+    fn_args = Expr(:tuple)
+    append!(fn_args.args, map_args)
+    return Expr(:function, fn_args, body)
 end
 
 function _generated_map_sources(valp::Symbol, time_dependent::Bool)
@@ -1670,12 +1682,12 @@ function _construct_fullspecialize_initializeprobmap(
         initsys, solved_unknowns;
         expression = Val(true), output_type = SVector, compiler_options, kwargs...
     )
-    sol = gensym(:initialization_solution)
+    sol = INITMAP_SOLUTION
     sources = _generated_map_sources(sol, is_time_dependent(initsys))
     n = length(solved_unknowns)
     static_type = iip ? MVector : SVector
     map_expr = _generated_map_expr(expr, [sol], sources) do raw
-        T = gensym(:initialization_map_eltype)
+        T = INITMAP_ELTYPE
         p = Expr(:call, GlobalRef(SymbolicIndexingInterface, :parameter_values), sol)
         tunable_eltype = Expr(:call, GlobalRef(@__MODULE__, :_tunable_eltype), p)
         promoted = Expr(:call, promote_type, Expr(:call, eltype, raw), tunable_eltype, floatT)
@@ -1700,12 +1712,15 @@ function _static_initialization_buffer(prototype, values)
     elseif isbitstype(T)
         return MVector{length(values), T}(values)
     else
-        return SizedVector{length(values), T}(T[values...])
+        return SizedVector{length(values), T}(collect(T, values))
     end
 end
 
 function _parameter_buffer_expr(prototype, raw::Symbol, idxs, p_constructor)
-    values = Expr(:tuple, [Expr(:ref, raw, i) for i in idxs]...)
+    values = Expr(:tuple)
+    for i in idxs
+        push!(values.args, Expr(:ref, raw, i))
+    end
     buffer = Expr(
         :call, GlobalRef(@__MODULE__, :_static_initialization_buffer), prototype, values
     )
@@ -1719,12 +1734,21 @@ function _construct_fullspecialize_initializeprobpmap(
         compiler_options::CompilerOptions = CompilerOptions(), kwargs...
     )
     ps = parameters(sys; initial_parameters = true)
-    groups = if is_split(sys)
+    # One entry per `MTKParameters` portion, each holding that portion's buffers. Kept a
+    # concretely typed `Vector` rather than a tuple of tuples: the portions are iterated,
+    # not indexed heterogeneously, and a tuple here would force the whole loop below to
+    # specialize per system.
+    groups = Vector{Vector{SymbolicT}}[]
+    if is_split(sys)
         grouped = reorder_parameters(sys, ps; flatten = false)
-        initial_syms = _unwrap_initial_symbols!(copy(grouped[2]), initsys)
-        ((grouped[1],), (initial_syms,), grouped[3:5]...)
+        push!(groups, Vector{SymbolicT}[grouped[1]::Vector{SymbolicT}])
+        initial_syms = _unwrap_initial_symbols!(copy(grouped[2]::Vector{SymbolicT}), initsys)
+        push!(groups, Vector{SymbolicT}[initial_syms])
+        for i in 3:5
+            push!(groups, grouped[i]::Vector{Vector{SymbolicT}})
+        end
     else
-        ((ps,),)
+        push!(groups, Vector{SymbolicT}[ps])
     end
     flat_syms = SymbolicT[]
     for group in groups, buffer in group
@@ -1734,11 +1758,11 @@ function _construct_fullspecialize_initializeprobpmap(
         initsys, Tuple(flat_syms);
         expression = Val(true), compiler_options, kwargs...
     )
-    prob = gensym(:problem)
-    sol = gensym(:initialization_solution)
+    prob = INITMAP_PROBLEM
+    sol = INITMAP_SOLUTION
     sources = _generated_map_sources(sol, is_time_dependent(initsys))
     map_expr = _generated_map_expr(expr, [prob, sol], sources) do raw
-        outer_p = gensym(:outer_parameters)
+        outer_p = INITMAP_OUTER_PARAMETERS
         p = Expr(:call, GlobalRef(SymbolicIndexingInterface, :parameter_values), prob)
         if !is_split(sys)
             result = _parameter_buffer_expr(outer_p, raw, eachindex(flat_syms), p_constructor)
@@ -1759,24 +1783,28 @@ function _construct_fullspecialize_initializeprobpmap(
                 buffer = _parameter_buffer_expr(prototype, raw, idxs, p_constructor)
                 if field === :discrete
                     sizes = get_index_cache(sys).discrete_buffer_sizes[buffer_idx]
-                    block_sizes = Expr(
-                        :call, Expr(:curly, SVector, length(sizes), Int),
-                        map(size -> size.length, sizes)...
-                    )
+                    block_sizes = Expr(:call, Expr(:curly, SVector, length(sizes), Int))
+                    for sz in sizes
+                        push!(block_sizes.args, sz.length)
+                    end
                     p_constructor === identity ||
                         (block_sizes = Expr(:call, QuoteNode(p_constructor), block_sizes))
                     buffer = Expr(:call, BlockedArray, buffer, block_sizes)
                 end
                 push!(buffers, buffer)
             end
-            portion = field === :tunable || field === :initials ? only(buffers) :
-                Expr(:tuple, buffers...)
+            portion = if field === :tunable || field === :initials
+                only(buffers)
+            else
+                tup = Expr(:tuple)
+                append!(tup.args, buffers)
+                tup
+            end
             push!(portions, portion)
         end
-        result = Expr(
-            :call, MTKParameters, portions...,
-            :($map($copy, $outer_p.caches))
-        )
+        result = Expr(:call, MTKParameters)
+        append!(result.args, portions)
+        push!(result.args, :($map($copy, $outer_p.caches)))
         return Expr(:block, :(local $outer_p = $p), result)
     end
     return eval_or_rgf(map_expr; eval_module, compiler_options)

--- a/lib/ModelingToolkitBase/src/systems/problem_utils.jl
+++ b/lib/ModelingToolkitBase/src/systems/problem_utils.jl
@@ -1712,7 +1712,7 @@ function _static_initialization_buffer(prototype, values)
     elseif isbitstype(T)
         return MVector{length(values), T}(values)
     else
-        return SizedVector{length(values), T}(collect(T, values))
+        return collect(T, values)
     end
 end
 
@@ -1892,6 +1892,11 @@ function get_p_constructor(p_constructor, pType::Type, floatT::Type)
     p_constructor === identity || return p_constructor
     pType <: StaticArray || return p_constructor
     return function (vals)
+        # Only isbits buffers become static. A buffer whose elements are heap objects
+        # (nonnumeric parameters, array-valued discretes) gains nothing from a
+        # `StaticArray` — the elements are still pointers — and `MArray` cannot
+        # `setindex!` a non-isbits eltype at all.
+        isbitstype(eltype(vals)) || return vals
         return SymbolicUtils.Code.create_array(
             pType, eltype(vals) <: AbstractFloat ? floatT : nothing, Val(ndims(vals)), Val(size(vals)), vals...
         )

--- a/lib/ModelingToolkitBase/test/extensions/initialization_maps_ad.jl
+++ b/lib/ModelingToolkitBase/test/extensions/initialization_maps_ad.jl
@@ -1,6 +1,7 @@
 using ForwardDiff, ModelingToolkitBase, Test, Zygote
 using ModelingToolkitBase: t_nounits as t, D_nounits as D, SciMLBase
 using SymbolicIndexingInterface: ProblemState
+using SciMLStructures: Tunable, replace
 
 @testset "FullSpecialize parameter buffer gradients" begin
     for prototype in ([0.0], ModelingToolkitBase.SVector(0.0), Any[0.0])
@@ -15,10 +16,11 @@ using SymbolicIndexingInterface: ProblemState
     @test only(Zygote.gradient(tagged_loss, 2.0)) == 4.0
 end
 
-@testset "FullSpecialize state map gradients" begin
+@testset "FullSpecialize initialization map gradients" begin
     @variables x(t) y(t)
+    @parameters a = 1.0
     @mtkcompile sys = System(
-        [D(x) ~ -x, D(y) ~ -y], t;
+        [D(x) ~ -a * x, D(y) ~ -y], t;
         initialization_eqs = [x^3 + x ~ 2, y ~ 2x + 1]
     )
     prob = ODEProblem{true, SciMLBase.FullSpecialize}(
@@ -28,4 +30,13 @@ end
     initprob = data.initializeprob
     loss(u) = sum(abs2, data.initializeprobmap(ProblemState(; u, p = initprob.p, t = 0.0)))
     @test only(Zygote.gradient(loss, initprob.u0)) ≈ ForwardDiff.gradient(loss, initprob.u0)
+
+    function parameter_loss(p)
+        state = ProblemState(; u = initprob.u0, p = replace(Tunable(), initprob.p, p), t = 0.0)
+        return sum(abs2, data.initializeprobpmap(prob, state).tunable)
+    end
+    p = initprob.p.tunable
+    expected = ForwardDiff.gradient(parameter_loss, p)
+    @test expected == 2p
+    @test only(Zygote.gradient(parameter_loss, p)) ≈ expected
 end

--- a/lib/ModelingToolkitBase/test/extensions/initialization_maps_ad.jl
+++ b/lib/ModelingToolkitBase/test/extensions/initialization_maps_ad.jl
@@ -1,0 +1,31 @@
+using ForwardDiff, ModelingToolkitBase, Test, Zygote
+using ModelingToolkitBase: t_nounits as t, D_nounits as D, SciMLBase
+using SymbolicIndexingInterface: ProblemState
+
+@testset "FullSpecialize parameter buffer gradients" begin
+    for prototype in ([0.0], ModelingToolkitBase.SVector(0.0), Any[0.0])
+        loss(x) = sum(abs2, ModelingToolkitBase._static_initialization_buffer(prototype, (x,)))
+        @test only(Zygote.gradient(loss, 2.0)) == 4.0
+    end
+
+    function tagged_loss(x)
+        buffer = ModelingToolkitBase._static_initialization_buffer([Val(1)], (Val(1),))
+        return x^2 + length(buffer)
+    end
+    @test only(Zygote.gradient(tagged_loss, 2.0)) == 4.0
+end
+
+@testset "FullSpecialize state map gradients" begin
+    @variables x(t) y(t)
+    @mtkcompile sys = System(
+        [D(x) ~ -x, D(y) ~ -y], t;
+        initialization_eqs = [x^3 + x ~ 2, y ~ 2x + 1]
+    )
+    prob = ODEProblem{true, SciMLBase.FullSpecialize}(
+        sys, [], (0.0, 1.0); guesses = [x => 1.0, y => 1.0]
+    )
+    data = prob.f.initialization_data
+    initprob = data.initializeprob
+    loss(u) = sum(abs2, data.initializeprobmap(ProblemState(; u, p = initprob.p, t = 0.0)))
+    @test only(Zygote.gradient(loss, initprob.u0)) ≈ ForwardDiff.gradient(loss, initprob.u0)
+end

--- a/lib/ModelingToolkitBase/test/initializationsystem.jl
+++ b/lib/ModelingToolkitBase/test/initializationsystem.jl
@@ -1845,8 +1845,9 @@ end
 
 @testset "FullSpecialize initialization maps are generated functions" begin
     @variables map_x(t) map_y(t)
+    @parameters map_rate = 1.0 map_scale::Int = 2 [tunable = false]
     @mtkcompile map_sys = System(
-        [D(map_x) ~ -map_x, D(map_y) ~ -map_y], t;
+        [D(map_x) ~ -map_rate * map_x, D(map_y) ~ -map_scale * map_y], t;
         initialization_eqs = [map_x^3 + map_x ~ 2, map_y ~ 2map_x + 1]
     )
     guesses = [map_x => 1.0, map_y => 1.0]
@@ -1860,13 +1861,10 @@ end
     full_data = full_prob.f.initialization_data
 
     @test auto_data.initializeprobmap isa ModelingToolkitBase.InitializationMap
-    @test !(auto_data.initializeprobmap isa RuntimeGeneratedFunction)
     @test full_data.initializeprobmap isa RuntimeGeneratedFunction
     @test full_data.initializeprobpmap isa RuntimeGeneratedFunction
     @test isbitstype(typeof(full_data.initializeprobmap))
     @test isbitstype(typeof(full_data.initializeprobpmap))
-    @test getfield(full_data.initializeprobmap, :body) === nothing
-    @test getfield(full_data.initializeprobpmap, :body) === nothing
 
     auto_u = auto_data.initializeprobmap(auto_data.initializeprob)
     full_u = full_data.initializeprobmap(full_data.initializeprob)
@@ -1882,10 +1880,23 @@ end
     @test full_p.discrete == auto_p.discrete
     @test full_p.constant == auto_p.constant
     @test full_p.nonnumeric == auto_p.nonnumeric
-    replacement = fill(3.0, length(full_p.tunable))
-    SciMLStructures.replace!(Tunable(), full_p, replacement)
-    @test full_p.tunable == replacement
-    nonbits = ModelingToolkitBase._static_parameter_buffer(Any[Ref(1)], (Ref(2),))
+    cached_p = ModelingToolkitBase.MTKParameters(
+        full_p.tunable, full_p.initials, full_p.discrete, full_p.constant,
+        full_p.nonnumeric, ([1.0, 2.0],)
+    )
+    mapped_p = full_data.initializeprobpmap(
+        ProblemState(; u = full_prob.u0, p = cached_p, t = 0.0), full_data.initializeprob
+    )
+    @test mapped_p.caches == cached_p.caches
+    @test only(mapped_p.caches) !== only(cached_p.caches)
+    for portion in (Tunable(), SciMLStructures.Constants())
+        values = SciMLStructures.canonicalize(portion, full_p)[1]
+        @test !isempty(values)
+        replacement = fill(3, length(values))
+        SciMLStructures.replace!(portion, full_p, replacement)
+        @test SciMLStructures.canonicalize(portion, full_p)[1] == replacement
+    end
+    nonbits = ModelingToolkitBase._static_initialization_buffer(Any[Ref(1)], (Ref(2),))
     @test nonbits isa SizedVector
     nonbits[1] = Ref(3)
     @test only(nonbits)[] == 3
@@ -1906,13 +1917,33 @@ end
     )
     array_data = array_prob.f.initialization_data
     array_p = array_data.initializeprobpmap(array_prob, array_data.initializeprob)
-    array_groups = ModelingToolkitBase.reorder_parameters(
-        array_sys, parameters(array_sys; initial_parameters = true); flatten = false
-    )
-
-    @test SU.shape(only(only(array_groups[5]))) == [1:2]
     @test array_data.initializeprobpmap isa RuntimeGeneratedFunction
     @test only(only(array_p.nonnumeric)) === array_parameter
+
+    static_constructor(values) = SVector{length(values)}(values)
+    for split in (true, false)
+        sys = mtkcompile(
+            System(
+                [D(map_x) ~ -map_rate * map_x, D(map_y) ~ -map_scale * map_y], t; name = :static_map,
+                initialization_eqs = [map_x^3 + map_x ~ 2, map_y ~ 2map_x + 1]
+            ); split
+        )
+        auto = ODEProblem{false, SciMLBase.AutoSpecialize}(
+            sys, [], (0.0, 1.0); guesses,
+            u0_constructor = static_constructor, p_constructor = static_constructor
+        )
+        full = ODEProblem{false, SciMLBase.FullSpecialize}(
+            sys, [], (0.0, 1.0); guesses,
+            u0_constructor = static_constructor, p_constructor = static_constructor
+        )
+        adata, fdata = auto.f.initialization_data, full.f.initialization_data
+        u = fdata.initializeprobmap(fdata.initializeprob)
+        p = fdata.initializeprobpmap(full, fdata.initializeprob)
+        @test isbits(u)
+        @test isbits(p)
+        @test u == adata.initializeprobmap(adata.initializeprob)
+        @test p == adata.initializeprobpmap(auto, adata.initializeprob)
+    end
 end
 
 @testset "Issue#3570, #3552: `Initial`s/guesses are copied to `u0` during `solve`/`init`" begin

--- a/lib/ModelingToolkitBase/test/initializationsystem.jl
+++ b/lib/ModelingToolkitBase/test/initializationsystem.jl
@@ -2,6 +2,7 @@ using ModelingToolkitBase, OrdinaryDiffEq, NonlinearSolve, Test
 using OrdinaryDiffEqBDF
 using StochasticDiffEq, DelayDiffEq, JumpProcesses
 using ForwardDiff, StaticArrays
+using RuntimeGeneratedFunctions: RuntimeGeneratedFunction
 using SymbolicIndexingInterface, SciMLStructures
 using SciMLStructures: Tunable
 using ModelingToolkitBase: t_nounits as t, D_nounits as D, observed
@@ -1840,6 +1841,47 @@ end
         @inferred remake(prob; u0 = 2 .* prob.u0, p = prob.p)
         @inferred solve(prob)
     end
+end
+
+@testset "FullSpecialize initialization maps are generated functions" begin
+    @variables map_x(t) map_y(t)
+    @mtkcompile map_sys = System(
+        [D(map_x) ~ -map_x, D(map_y) ~ -map_y], t;
+        initialization_eqs = [map_x^3 + map_x ~ 2, map_y ~ 2map_x + 1]
+    )
+    guesses = [map_x => 1.0, map_y => 1.0]
+    auto_prob = ODEProblem{true, SciMLBase.AutoSpecialize}(
+        map_sys, [], (0.0, 1.0); guesses
+    )
+    full_prob = ODEProblem{true, SciMLBase.FullSpecialize}(
+        map_sys, [], (0.0, 1.0); guesses
+    )
+    auto_data = auto_prob.f.initialization_data
+    full_data = full_prob.f.initialization_data
+
+    @test auto_data.initializeprobmap isa ModelingToolkitBase.InitializationMap
+    @test !(auto_data.initializeprobmap isa RuntimeGeneratedFunction)
+    @test full_data.initializeprobmap isa RuntimeGeneratedFunction
+    @test full_data.initializeprobpmap isa RuntimeGeneratedFunction
+    @test isbitstype(typeof(full_data.initializeprobmap))
+    @test isbitstype(typeof(full_data.initializeprobpmap))
+    @test getfield(full_data.initializeprobmap, :body) === nothing
+    @test getfield(full_data.initializeprobpmap, :body) === nothing
+
+    auto_u = auto_data.initializeprobmap(auto_data.initializeprob)
+    full_u = full_data.initializeprobmap(full_data.initializeprob)
+    @test full_u isa StaticVector
+    @test full_u == auto_u
+
+    auto_p = auto_data.initializeprobpmap(auto_prob, auto_data.initializeprob)
+    full_p = full_data.initializeprobpmap(full_prob, full_data.initializeprob)
+    @test full_p.tunable isa StaticVector
+    @test full_p.initials isa StaticVector
+    @test full_p.tunable == auto_p.tunable
+    @test full_p.initials == auto_p.initials
+    @test full_p.discrete == auto_p.discrete
+    @test full_p.constant == auto_p.constant
+    @test full_p.nonnumeric == auto_p.nonnumeric
 end
 
 @testset "Issue#3570, #3552: `Initial`s/guesses are copied to `u0` during `solve`/`init`" begin

--- a/lib/ModelingToolkitBase/test/initializationsystem.jl
+++ b/lib/ModelingToolkitBase/test/initializationsystem.jl
@@ -1885,6 +1885,10 @@ end
     replacement = fill(3.0, length(full_p.tunable))
     SciMLStructures.replace!(Tunable(), full_p, replacement)
     @test full_p.tunable == replacement
+    nonbits = ModelingToolkitBase._static_parameter_buffer(Any[Ref(1)], (Ref(2),))
+    @test nonbits isa SizedVector
+    nonbits[1] = Ref(3)
+    @test only(nonbits)[] == 3
 
     array_parameter(x) = SVector(x, 2x)
     @parameters (array_fn::typeof(array_parameter))(..)[1:2] = array_parameter [tunable = false]

--- a/lib/ModelingToolkitBase/test/initializationsystem.jl
+++ b/lib/ModelingToolkitBase/test/initializationsystem.jl
@@ -1882,6 +1882,31 @@ end
     @test full_p.discrete == auto_p.discrete
     @test full_p.constant == auto_p.constant
     @test full_p.nonnumeric == auto_p.nonnumeric
+
+    array_parameter(x) = SVector(x, 2x)
+    @parameters (array_fn::typeof(array_parameter))(..)[1:2] = array_parameter [tunable = false]
+    @variables array_input(t) array_output(t) array_x(t) = 1.0
+    array_block = System(
+        [array_output ~ array_fn(array_input)[1]], t,
+        [array_input, array_output], [array_fn]; name = :array_block
+    )
+    @mtkcompile array_sys = System(
+        [D(array_x) ~ array_block.array_output, array_block.array_input ~ array_x], t;
+        systems = [array_block]
+    )
+    array_prob = ODEProblem{true, SciMLBase.FullSpecialize}(
+        array_sys, [], (0.0, 1.0)
+    )
+    array_data = array_prob.f.initialization_data
+    array_p = array_data.initializeprobpmap(array_prob, array_data.initializeprob)
+    array_groups = ModelingToolkitBase.reorder_parameters(
+        array_sys, parameters(array_sys; initial_parameters = true); flatten = false
+    )
+
+    @test ModelingToolkitBase.symbolic_type(only(only(array_groups[5]))) ==
+        ModelingToolkitBase.ArraySymbolic()
+    @test array_data.initializeprobpmap isa RuntimeGeneratedFunction
+    @test only(only(array_p.nonnumeric)) === array_parameter
 end
 
 @testset "Issue#3570, #3552: `Initial`s/guesses are copied to `u0` during `solve`/`init`" begin

--- a/lib/ModelingToolkitBase/test/initializationsystem.jl
+++ b/lib/ModelingToolkitBase/test/initializationsystem.jl
@@ -1910,7 +1910,7 @@ end
         array_sys, parameters(array_sys; initial_parameters = true); flatten = false
     )
 
-    @test ModelingToolkitBase.shape(only(only(array_groups[5]))) == [1:2]
+    @test SU.shape(only(only(array_groups[5]))) == [1:2]
     @test array_data.initializeprobpmap isa RuntimeGeneratedFunction
     @test only(only(array_p.nonnumeric)) === array_parameter
 end

--- a/lib/ModelingToolkitBase/test/initializationsystem.jl
+++ b/lib/ModelingToolkitBase/test/initializationsystem.jl
@@ -1910,8 +1910,7 @@ end
         array_sys, parameters(array_sys; initial_parameters = true); flatten = false
     )
 
-    @test ModelingToolkitBase.symbolic_type(only(only(array_groups[5]))) ==
-        ModelingToolkitBase.ArraySymbolic()
+    @test ModelingToolkitBase.shape(only(only(array_groups[5]))) == [1:2]
     @test array_data.initializeprobpmap isa RuntimeGeneratedFunction
     @test only(only(array_p.nonnumeric)) === array_parameter
 end

--- a/lib/ModelingToolkitBase/test/initializationsystem.jl
+++ b/lib/ModelingToolkitBase/test/initializationsystem.jl
@@ -1882,6 +1882,9 @@ end
     @test full_p.discrete == auto_p.discrete
     @test full_p.constant == auto_p.constant
     @test full_p.nonnumeric == auto_p.nonnumeric
+    replacement = fill(3.0, length(full_p.tunable))
+    SciMLStructures.replace!(Tunable(), full_p, replacement)
+    @test full_p.tunable == replacement
 
     array_parameter(x) = SVector(x, 2x)
     @parameters (array_fn::typeof(array_parameter))(..)[1:2] = array_parameter [tunable = false]

--- a/lib/ModelingToolkitBase/test/initializationsystem.jl
+++ b/lib/ModelingToolkitBase/test/initializationsystem.jl
@@ -1944,6 +1944,23 @@ end
         @test u == adata.initializeprobmap(adata.initializeprob)
         @test p == adata.initializeprobpmap(auto, adata.initializeprob)
     end
+
+    # The generated maps name their locals with fixed sentinels, so lowering the same
+    # system twice has to produce the same `Expr` and hence the same `RuntimeGeneratedFunction`
+    # type. A `gensym`ed local makes each lowering a fresh type, defeating the RGF cache.
+    second_prob = ODEProblem{true, SciMLBase.FullSpecialize}(
+        mtkcompile(
+            System(
+                [D(map_x) ~ -map_rate * map_x, D(map_y) ~ -map_scale * map_y], t;
+                name = nameof(map_sys),
+                initialization_eqs = [map_x^3 + map_x ~ 2, map_y ~ 2map_x + 1]
+            )
+        ), [], (0.0, 1.0); guesses
+    )
+    second_data = second_prob.f.initialization_data
+    @test typeof(second_data.initializeprobmap) === typeof(full_data.initializeprobmap)
+    @test typeof(second_data.initializeprobpmap) === typeof(full_data.initializeprobpmap)
+    @test second_data.initializeprobmap(second_data.initializeprob) == full_u
 end
 
 @testset "Issue#3570, #3552: `Initial`s/guesses are copied to `u0` during `solve`/`init`" begin

--- a/lib/ModelingToolkitBase/test/initializationsystem.jl
+++ b/lib/ModelingToolkitBase/test/initializationsystem.jl
@@ -1896,8 +1896,12 @@ end
         SciMLStructures.replace!(portion, full_p, replacement)
         @test SciMLStructures.canonicalize(portion, full_p)[1] == replacement
     end
+    # Only isbits buffers become static. A `StaticArray` over heap elements is not
+    # GPU-resident anyway (the elements are pointers), `MArray` cannot `setindex!` a
+    # non-isbits eltype, and a `SizedVector` sends `remake`'s `similar_type`
+    # reconstruction into infinite recursion.
     nonbits = ModelingToolkitBase._static_initialization_buffer(Any[Ref(1)], (Ref(2),))
-    @test nonbits isa SizedVector
+    @test !(nonbits isa StaticArray)
     nonbits[1] = Ref(3)
     @test only(nonbits)[] == 3
 
@@ -1961,6 +1965,29 @@ end
     @test typeof(second_data.initializeprobmap) === typeof(full_data.initializeprobmap)
     @test typeof(second_data.initializeprobpmap) === typeof(full_data.initializeprobpmap)
     @test second_data.initializeprobmap(second_data.initializeprob) == full_u
+
+    # A callable parameter closing over an array is nonnumeric and not isbits. Its buffer
+    # must stay on the heap while the isbits buffers still go static.
+    nonbits_fn = let d = [2.0]
+        x -> d[1] * x
+    end
+    @test !isbitstype(typeof(nonbits_fn))
+    @variables nonbits_x(t)
+    @parameters nonbits_rate = 1.0
+    @parameters (nonbits_scale::typeof(nonbits_fn))(..) = nonbits_fn [tunable = false]
+    @mtkcompile nonbits_sys = System(
+        [D(nonbits_x) ~ -nonbits_rate * nonbits_scale(nonbits_x)], t;
+        initialization_eqs = [nonbits_x^3 + nonbits_x ~ 2]
+    )
+    nonbits_prob = ODEProblem{true, SciMLBase.FullSpecialize}(
+        nonbits_sys, [], (0.0, 1.0); guesses = [nonbits_x => 1.0]
+    )
+    nonbits_init = nonbits_prob.f.initialization_data
+    nonbits_p = nonbits_init.initializeprobpmap(nonbits_prob, nonbits_init.initializeprob)
+    @test nonbits_p.tunable isa StaticArray
+    @test nonbits_p.initials isa StaticArray
+    @test !any(buf -> buf isa StaticArray, nonbits_p.nonnumeric)
+    @test remake(nonbits_prob, p = [nonbits_rate => 3.0]).p.tunable == [3.0]
 end
 
 @testset "Issue#3570, #3552: `Initial`s/guesses are copied to `u0` during `solve`/`init`" begin

--- a/lib/ModelingToolkitBase/test/runtests.jl
+++ b/lib/ModelingToolkitBase/test/runtests.jl
@@ -139,6 +139,7 @@ end
         @safetestset "LabelledArrays Test" include("extensions/labelledarrays.jl")
         @safetestset "BifurcationKit Extension Test" include("extensions/bifurcationkit.jl")
         @safetestset "Despecialized MTKParameters AD Test" include("extensions/despecialized_parameters_ad.jl")
+        @safetestset "Initialization maps AD" include("extensions/initialization_maps_ad.jl")
         # @safetestset "Auto Differentiation Test" include("extensions/ad.jl")
     end
 

--- a/test/group_extensions.jl
+++ b/test/group_extensions.jl
@@ -2,4 +2,5 @@ include("shared/mtktestset.jl")
 
 @mtktestset("HomotopyContinuation Extension Test", "extensions/homotopy_continuation.jl")
 @mtktestset("BifurcationKit Extension Test", "extensions/bifurcationkit.jl")
+@mtktestset("Initialization maps AD", "extensions/initialization_maps_ad.jl")
 # @mtktestset("Auto Differentiation Test", "extensions/ad.jl")


### PR DESCRIPTION
## Scope

Generate the state and parameter initialization maps as individual runtime-generated functions only for explicitly requested `FullSpecialize`. Preserve the existing default host-map path. Static buffers reduce warm map allocations; this is not an in-place preallocation API.

The implementation shares one buffer constructor and one reverse-mode rule. It preserves mutable parameter buffers, copies cache buffers instead of aliasing them, handles `split=false`, and retains array-valued callable parameters. Immutable static constructors produce isbits results in the tested case; mutable non-isbits buffers use `SizedVector` storage.

Addresses https://github.com/SciML/ModelingToolkit.jl/issues/5043. Related GPU workaround: https://github.com/SciML/DiffEqGPU.jl/pull/516.

## Review round (@AayushSabharwal, 2026-09-09)

Seven inline comments, all addressed in https://github.com/SciML/ModelingToolkit.jl/commit/fed8cdb77b, and each answered on its own thread.

**1. `gensym` — this was a real defect, not style.** The five `gensym`ed locals in the new codegen are now fixed sentinels (`INITMAP_VALUES`, `INITMAP_ELTYPE`, `INITMAP_SOLUTION`, `INITMAP_PROBLEM`, `INITMAP_OUTER_PARAMETERS`), following the rationale already recorded for `HOMOTOPY_LAMBDA` in `homotopy_operator.jl`: a `gensym` embeds a process-global counter, so the same system lowers to a different `Expr` every time and the `RuntimeGeneratedFunctions` Expr-hash cache never hits.

This is the cause of the generated-map type churn the earlier revision of this body reported as an open problem.

Failing on the unfixed branch (`git stash` of the fix only, same probe, same session):

```text
generated map type reuse across identical systems: Test Failed
  Expression: typeof(d1.initializeprobpmap) === typeof(d2.initializeprobpmap)
   Evaluated: RuntimeGeneratedFunction{(Symbol("##problem#280"), Symbol("##initialization_solution#281")), …, (0x8298bbd3, 0xbcbc4d5b, 0x7a096718, 0x43533499, 0x57e4022b), Nothing} ===
              RuntimeGeneratedFunction{(Symbol("##problem#287"), Symbol("##initialization_solution#288")), …, (0x44632bf6, 0x42fe7ec6, 0x4d5618c1, 0xb6d83a49, 0x2afa037a), Nothing}
Test Summary:                                     | Pass  Fail  Total   Time
generated map type reuse across identical systems |    2     2      4  10.6s
```

Passing with the fix:

```text
Test Summary:                                     | Pass  Total  Time
generated map type reuse across identical systems |    4      4  7.0s
```

Checked in as three assertions at the end of the `FullSpecialize initialization maps are generated functions` testset, which is why that group's count moved from 698 to 701.

**2-6. Splats in `Expr` construction.** `_generated_map_expr`, `_parameter_buffer_expr`, the `discrete` block sizes, the portion tuple, and the `MTKParameters` call all build their `Expr`s by `push!`/`append!` onto `.args` now. `_static_initialization_buffer`'s `T[values...]` became `collect(T, values)`. No splats remain in the added code other than `kwargs...` forwarding.

**7. `groups` as a tuple of tuples.** Now a `Vector{Vector{Vector{SymbolicT}}}` built with type asserts against `ReorderedParametersT`'s `Union` element type, so both the `flat_syms` loop and the buffer loop are concretely typed instead of specializing on each system's shape. Nothing indexed `groups` heterogeneously — it is only iterated alongside the field names — so the tuple bought nothing.

Rebased onto `35818b8328`. The CasADi compat bump and the `Optimization` runner pin that used to show in this diff have landed on master separately and are gone from it.

## Second review round (@AayushSabharwal, 2026-09-11 — approved)

One inline comment: pass an options struct instead of `kwargs...`. Done in
https://github.com/SciML/ModelingToolkit.jl/commit/16ef998c28 — both map builders take a
`GeneratedFunctionOptions` positionally and call the struct method of
`build_explicit_observed_function`, with `_fullspecialize_map_options` deriving it from
the problem's own `opts.fn_opts.codegen`.

Two behaviour fixes fall out of it. The old `kwargs...` path went through the keyword
compat shim, which built a **fresh** `CodegenFunctionOptions` from whatever was left in
the bag — so the maps were not inheriting the problem's `checkbounds`/`cse`. And
`eval_expression` is now honoured; previously the builders never received it, so the maps
were unconditionally `RuntimeGeneratedFunction`s even with `eval_expression = true`,
unlike the default map path. Both are called out on the thread in case the second is not
wanted.

## Local verification

Julia 1.12.7, on `16ef998c28`. `JULIA_NUM_PRECOMPILE_TASKS=1`, `--heap-size-hint=8G`.

```sh
julia +1.12 --project=<runicenv> -m Runic --check <changed Julia files>   # exit 0
git diff upstream/master --check                                          # exit 0
git diff upstream/master --unified=0 | sed -n '/^+++ /d; s/^+//p' | typos -  # exit 0
```

```text
GROUP=Initialization
  Guess Propagation         |  11 pass |  11 total | 3m13.3s
  InitializationSystem Test | 706 pass | 12 broken | 718 total | 20m43.6s
  Initial Values Test       |  65 pass |  65 total | 6m00.6s     (0 errors)

GROUP=Extensions
  HomotopyContinuation Extension Test |  76 pass |  76 total | 10m07.9s
  LabelledArrays Test                 |  18 pass |  18 total | 31.1s
  BifurcationKit Extension Test       |   7 pass |   7 total | 1m25.4s
  Despecialized MTKParameters AD Test |   2 pass |   2 total | 7m07.9s
  Initialization maps AD              |   7 pass |   7 total | 17.2s

GROUP=FMI
  FMI | 60 pass | 60 total | 15m35.4s
```

All three groups exited 0. The 12 broken tests in `InitializationSystem Test` are
pre-existing `@test_broken`s on master; none were added, removed, skipped or loosened.

The MTKStdlib reproducer below also runs clean against this commit (`solve` → `remake`
→ `solve`), outside CI.

## Allocation measurement and limits

A warmed, two-state initialization example without user parameters measured allocations for both map calls together, taking the minimum of ten calls behind a function barrier:

| FullSpecialize map configuration | Bytes/call pair |
| --- | ---: |
| Existing host maps | 784 |
| Generated maps, mutable buffers | 80 |
| Generated maps, immutable static constructors | 0 |

This is a map microbenchmark, not a solver benchmark or a general zero-allocation guarantee.

**On TTFX.** The generated map types are now reused across identical systems, which is what the earlier revision of this body reported as an unresolved code-generation/cache concern. That measurement was taken before the `gensym` fix and no longer describes the branch. I have **not** re-run the fresh-process TTFX comparison since the fix, so this PR still makes no TTFX claim in either direction — only that the specific type-churn defect behind it is gone and now has a regression guarding it. The default path remains unchanged.

## What was not verified

- **GPU execution.** This machine has no GPU. The static/isbits CPU assertions are not a substitute for a device execution test.
- **Fresh-process TTFX**, as above.
- **`GROUP=QA` is red, from a pre-existing master failure.** Rerun on the rebased branch: targeted `JET Tests` pass **54/54**, `Aqua Tests` are **20 passed / 1 failed / 21**, and the single failure is the package-wide JET typo-mode scan reporting **234 possible errors**. Every one of the 234 is the known `##And#` (182) / `##Call#` (52) Moshi `@match` codegen category tracked in https://github.com/SciML/ModelingToolkit.jl/issues/5063, which is still open after https://github.com/SciML/ModelingToolkit.jl/pull/5065 cleared the non-Moshi ones. None of the 234 diagnostics point anywhere inside the code this PR adds (`problem_utils.jl:1636-1810`). No QA suppression or dependency override is included here.
- **The `StructuralIdentifiability.jl/Core/1/` downstream job fails, and it is not this PR.** It passed on the pre-rebase head `438703fbe4` and fails on clean master `35818b8328` — the exact base this branch was rebased onto. It regressed on master between `f21201f889` (pass) and `9b458b059d` (fail); a separate bisect is running and will get its own issue. Nothing in this diff touches it.
- **Not rerun since the rebase:** LTS/prerelease Julia, FMI, Optimization, SymbolicIndexingInterface, the neural-network downstream suite, and the full downstream matrix. Their pre-rebase results are listed above.
- **Docs build** — no docs, docstrings, or public API are changed.

An initial source-loading test run exposed an independently reproduced LinearSolve world-age failure, reported separately at https://github.com/SciML/LinearSolve.jl/issues/1282; no LinearSolve workaround is included here.

## Anything a reviewer should push back on

- The sentinel names (`__mtk_initialization_*`) are module-level `const`s in `ModelingToolkitBase`. They are internal and unexported, but they are five new names in the module namespace where a single `NamedTuple` or a naming function would also work.
- `_static_initialization_buffer`'s `collect(T, values)` change was not one of the review comments; it is a splat in the same function and I removed it for consistency. It is on the runtime path (the non-isbits `SizedVector` branch), covered by the `Any[Ref(1)]` assertion in the Initialization group.
- The `groups` rewrite carries the same behaviour as before for an empty `parameters(sys; initial_parameters = true)`: `grouped[1]` would throw, because `reorder_parameters` returns early on empty `ps`. I did not add a guard, since that would be a behaviour change beyond the review, but it is reachable in principle.
- @ChrisRackauckas asked for the `gensym` rule to be written down. https://github.com/SciML/ModelingToolkit.jl/pull/5105 adds a root `AGENTS.md` (the repo had none) with that rule plus the splat and container-typing ones. Kept separate so this diff stays behaviour-only.

## Buffer types: only isbits buffers go static

`FullSpecialize` was turning *every* parameter buffer into a `StaticArray`, heap-element
ones included. That is what broke `ModelingToolkitStandardLibrary.jl/Core/1/`, and the
`SizedVector` branch added earlier for FMI was aimed at the wrong buffer. Fixed in
https://github.com/SciML/ModelingToolkit.jl/commit/b8c603d04a.

The FMI `setindex!` failure is not about size — `MArray`'s `setindex!` bounds-checks first,
then hard-`error()`s on any non-isbits eltype, because it mutates an inline `NTuple`
through a raw pointer (StaticArrays #27). The buffer was an **array-valued discrete**,
`MVector{1, Vector{Float64}}`, written by an FMI `imperative_affect`:

```text
[3] setindex!  @ BlockArrays/blockedarray.jl:249 [inlined]
[4] set_parameter!(p::MTKParameters{…, Tuple{BlockedVector{Vector{Float64},
      MVector{1, Vector{Float64}}, …}}, …},
      val::Vector{Float64}, pidx::ParameterIndex{Discrete, Tuple{Int64, Int64}})
```

Making such a buffer static buys nothing: the elements are still pointers, so an
`MVector{1, Vector{Float64}}` is no more GPU-resident than a `Vector{Vector{Float64}}`.
Gating on `isbitstype` therefore costs nothing that matters, and every buffer that could
be GPU-resident stays an `MVector`. Same FMI model, only `spec` changed:

| buffer | `AutoSpecialize` | `FullSpecialize` after this commit |
| --- | --- | --- |
| tunable | `Vector{Float64}` | **`MVector{7, Float64}`** |
| initials | `Vector{Float64}` | **`MVector{8, Float64}`** |
| discrete block sizes | `Vector{Int64}` | **`SVector{1, Int64}`** |
| discrete storage | `Vector{Vector{Float64}}` | `Vector{Vector{Float64}}` |
| nonnumeric | `Vector{FMI2CSFunctor}` | `Vector{FMI2CSFunctor}` |

The gate has to go in **two** places or the generated map and `MTKParametersReconstructor`
disagree on the buffer type: `_static_initialization_buffer`, and the `get_p_constructor`
closure the reconstructor routes through. `get_p_constructor` returns `identity` unless
`pType <: StaticArray`, and this PR is what makes `pType` static — so it only started
applying `create_array` to non-isbits buffers because of this PR.

Each variant measured separately, one change at a time:

| non-isbits buffer | MTKStdlib `remake` | FMI |
| --- | --- | --- |
| `MVector` | passes | `setindex!` error |
| `SizedVector` (previous revision) | `StackOverflowError` | 60/60 |
| `Vector`, gate in one place | typeassert, `Vector` vs `MVector` | 60/60 |
| **`Vector`, gate in both** | **passes** | **60/60** |

Failing before / passing after, same testset, fix stashed and restored in one session:

```text
before:  FullSpecialize initialization maps are generated functions | 38 pass | 2 fail | 40 total
after:   FullSpecialize initialization maps are generated functions | 40 pass |  40 total | 26.8s
```

The two new assertions pin both halves — non-isbits buffers stay on the heap, and
tunable/initials stay `StaticArray` so the gate cannot silently over-apply. `SizedVector`
is now unused and its import is dropped.

**Ignore this draft until reviewed by @ChrisRackauckas.**

---

Commits through `9a652005c8` were produced with Codex CLI 0.153.4 (model gpt-6-astra), local session `01a070db-f817-7f93-9295-aae2232fc2c7` (no shareable conversation URL exposed).

The review-response commit `fed8cdb77b` was produced with 🤖 [Claude Code](https://claude.com/claude-code) 2.0.14 (model: claude-opus-5[1m])

https://claude.ai/code/session_01GdSpCLd7NBZuuePJmcDzU7
