### PR TITLE
Format files with Runic 1.10

### DIFF
--- a/lib/ModelingToolkitBase/ext/MTKBifurcationKitExt.jl
+++ b/lib/ModelingToolkitBase/ext/MTKBifurcationKitExt.jl
@@ -45,17 +45,17 @@ struct ObservableRecordFromSolution{S, T}
         # Gets the (base) substitution values for observables.
         subs_vals_obs = [
             obs.lhs => substitute(
-                    obs.rhs,
-                    [subs_vals_states; subs_vals_params]
-                )
+                obs.rhs,
+                [subs_vals_states; subs_vals_params]
+            )
                 for obs in observed(nsys)
         ]
         # Sometimes observables depend on other observables, hence we make a second update to this vector.
         subs_vals_obs = [
             obs.lhs => substitute(
-                    obs.rhs,
-                    [subs_vals_states; subs_vals_params; subs_vals_obs]
-                )
+                obs.rhs,
+                [subs_vals_states; subs_vals_params; subs_vals_obs]
+            )
                 for obs in observed(nsys)
         ]
         # During the bifurcation process, the value of some states, parameters, and observables may vary (and are calculated in each step). Those that are not are stored in this vector

--- a/lib/ModelingToolkitBase/src/systems/parameter_buffer.jl
+++ b/lib/ModelingToolkitBase/src/systems/parameter_buffer.jl
@@ -120,11 +120,11 @@ function MTKParameters(
     )
     disc_buffer = Tuple(
         BlockedArray(
-                Vector{subbuffer_sizes[1].type}(
-                    undef, sum(x -> x.length, subbuffer_sizes)
-                ),
-                map(x -> x.length, subbuffer_sizes)
-            )
+            Vector{subbuffer_sizes[1].type}(
+                undef, sum(x -> x.length, subbuffer_sizes)
+            ),
+            map(x -> x.length, subbuffer_sizes)
+        )
             for subbuffer_sizes in ic.discrete_buffer_sizes
     )
     const_buffer = Tuple(

--- a/lib/ModelingToolkitBase/test/accessor_functions.jl
+++ b/lib/ModelingToolkitBase/test/accessor_functions.jl
@@ -204,8 +204,8 @@ let
     )
     @test all(
         sym_issubset(
-                continuous_events_toplevel(sys), get_continuous_events(sys)
-            )
+            continuous_events_toplevel(sys), get_continuous_events(sys)
+        )
             for sys in [sys_bot, sys_mid2, sys_mid1, sys_top]
     )
     @test all(


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

Runic v1.10.0, used by the repository CI action, rejects three files that were clean under the previously installed local Runic v1.7.0. This PR applies only the v1.10.0 indentation changes so behavioral PRs do not need to mix mechanical formatting into their diffs.

## Verification

```text
$ Runic v1.10.0 --check .
exit 0

$ typos <three modified files>
exit 0

$ git diff --check
exit 0
```

`GROUP=QA` was not rerun after these whitespace-only changes. On clean upstream/master commit `f9131984d9`, it was run and failed with two existing package-wide checks: 263 JET typo-mode diagnostics and four unapproved public reexports. A separate investigation is in progress.

No docs build or behavioral test group was run because this PR contains only formatter output and changes no code behavior, public API, docstring, or documentation.

Unblocks the Runic check on https://github.com/SciML/ModelingToolkit.jl/pull/5045.

🤖 Generated with Codex (version unknown; model: unknown; session: local session ID `01a04feb-43da-7ce1-99e4-a68438c69833`).
