### PR TITLE
Allow Symbolics facade reexports in MTKBase QA

### DIFF
--- a/lib/ModelingToolkitBase/test/qa/aqua.jl
+++ b/lib/ModelingToolkitBase/test/qa/aqua.jl
@@ -148,9 +148,9 @@ const REEXPORTED_API = (
     Symbol("@acrule"), Symbol("@arrayop"), :BS, :expand, :flatten_fractions,
     :get_reachability, :getmetadata, :hasmetadata, :ifelse_branching, :ifelse_eager,
     :IRStructure, :istree, Symbol("@makearray"), :populate_ir!, :print_ir, :quick_cancel,
-    :Rewriters, Symbol("@rule"), :RuleSet, :SafeReal, :setmetadata, :simplify,
-    :simplify_fractions, :substitute, :SymbolicUtils, :SymReal, Symbol("@syms"), :Term,
-    :term, :TreeReal, :unwrap_const, :vartype,
+    :Rewriters, Symbol("@rule"), :RuleSet, :SafeReal, :scalarize, :setmetadata, :shape,
+    :simplify, :simplify_fractions, :substitute, :SymbolicUtils, :SymReal, Symbol("@syms"),
+    :Term, :term, :TreeReal, :Unknown, :unwrap, :unwrap_const, :vartype,
     # SymbolicUtils.Code
     :toexpr,
     # TermInterface


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

Symbolics 7.38 replaced its blanket SymbolicUtils reexport with explicit exports. That ownership correction made ModelingToolkitBase's strict reexport audit newly identify `Unknown`, `scalarize`, `shape`, and `unwrap`, even though all four are already part of the intentional ModelingToolkitBase/Symbolics facade API.

This adds those existing SymbolicUtils-owned facade names to `REEXPORTED_API`; it does not widen the user-facing API. This is the ModelingToolkitBase counterpart to https://github.com/SciML/ModelingToolkit.jl/pull/5039.

## Verification

Failing before the change on clean `upstream/master` at `f9131984d97460057c62830b60790380ee5fc2f1` with Julia 1.12.7 and Symbolics 7.39.0:

```text
$ GROUP=QA julia +1.12 --startup-file=no --project=. -e 'using Pkg; Pkg.test()'
No unapproved public reexports: Test Failed
  Evaluated: isempty([:Unknown, :scalarize, :shape, :unwrap])
Test Summary: | Pass  Fail  Total
Aqua Tests    |   19     2     21
```

The other failure was the pre-existing package-wide JET result (`263 possible errors`), tracked at https://github.com/SciML/ModelingToolkit.jl/issues/4958. The exact JET lane was already red with the same 263 reports in its first CI run after introduction by https://github.com/SciML/ModelingToolkit.jl/commit/92c27bb9fdcaa024ff190feb3d665452e33f9bd8:
https://github.com/SciML/ModelingToolkit.jl/actions/runs/31478008118/job/93737918032

Focused reexport audit after the change:

```text
UNAPPROVED_REEXPORTS=Symbol[]
```

Full post-change QA:

```text
$ GROUP=QA julia +1.12 --startup-file=no --project=. -e 'using Pkg; Pkg.test()'
═════ 263 possible errors found ═════
Test Summary:                      | Pass  Fail  Total
Aqua Tests                         |   20     1     21
  No unapproved public reexports   |    1            1
```

Formatting and spelling:

```text
$ julia +1.12 --project=@runic -e 'using Runic; exit(Runic.main(ARGS))' -- --check lib/ModelingToolkitBase/test/qa/aqua.jl
$ typos lib/ModelingToolkitBase/test/qa/aqua.jl
$ git diff --check
```

All three completed with exit code 0 and no output.

## Not verified

- Full QA remains blocked by the pre-existing JET generated-guard reports; no test was skipped, disabled, or silenced. The upstream reductions are https://github.com/aviatesk/JET.jl/issues/858 and https://github.com/JuliaLang/julia/issues/62745.
- Docs were not built because this changes only the QA allowlist and neither source, docstrings, public API, nor `docs/`.
- GPU, downstream, Julia pre-release, and allowed-to-fail jobs were not run locally.
- No dependency or compatibility entry changed.

## Links

- Symbolics 7.38 release: https://github.com/JuliaSymbolics/Symbolics.jl/releases/tag/v7.38.0
- Parallel root-package fix: https://github.com/SciML/ModelingToolkit.jl/pull/5039
- MTK JET tracking issue and history evidence: https://github.com/SciML/ModelingToolkit.jl/issues/4958#issuecomment-5467366299
- Upstream JET issue: https://github.com/aviatesk/JET.jl/issues/858
- Upstream Julia issue: https://github.com/JuliaLang/julia/issues/62745

🤖 Generated with Codex (harness version: unknown; model: gpt-5; session: local session ID `01a04feb-43da-7ce1-99e4-a68438c69833`).
