### PR TITLE
qa: approve newly exported Symbolics API

### DIFF
--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -180,9 +180,9 @@ const REEXPORTED_API = (
     Symbol("@acrule"), Symbol("@arrayop"), Symbol("@makearray"), Symbol("@rule"),
     Symbol("@syms"), :BS, :expand, :flatten_fractions, :get_canonical_expr, :get_reachability,
     :getmetadata, :hasmetadata, :ifelse_branching, :ifelse_eager, :IRStructure, :istree,
-    :populate_ir!, :print_ir, :quick_cancel, :Rewriters, :RuleSet, :SafeReal, :setmetadata,
-    :simplify, :simplify_fractions, :substitute, :SymbolicUtils, :SymReal, :Term, :term,
-    :toexpr, :TreeReal, :unwrap_const, :vartype,
+    :populate_ir!, :print_ir, :quick_cancel, :Rewriters, :RuleSet, :SafeReal, :scalarize,
+    :setmetadata, :shape, :simplify, :simplify_fractions, :substitute, :SymbolicUtils,
+    :SymReal, :Term, :term, :toexpr, :TreeReal, :Unknown, :unwrap, :unwrap_const, :vartype,
     # TermInterface: the term-manipulation interface, re-exported transitively by
     # SymbolicUtils.
     :arguments, :iscall, :operation, :sorted_arguments,


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

Add `Unknown`, `scalarize`, `shape`, and `unwrap` to ModelingToolkit's version-controlled list of intentional public reexports. Symbolics v7.38.0 deliberately changed these names from public-only to exported in https://github.com/JuliaSymbolics/Symbolics.jl/pull/1957, so they now flow through ModelingToolkitBase and ModelingToolkit's facade reexports.

The Symbolics v7.38.0 release notes explicitly identify this API expansion: https://github.com/JuliaSymbolics/Symbolics.jl/releases/tag/v7.38.0. Removing or hiding these names in ModelingToolkit would conflict with that upstream public-API decision; approving them in the existing facade audit records the dependency-driven expansion for review.

## Failing before

On unmodified ModelingToolkit commit `6b06080fe1c19a0fc99f5e1e32ed3309b847e201`, with Symbolics 7.39.0 and SciMLTesting 2.13.0:

```text
No unapproved public reexports: Test Failed
  Expression: isempty(reexported)
   Evaluated: isempty([:Unknown, :scalarize, :shape, :unwrap])

Test Summary: | Pass  Fail  Total     Time
QA            |   39     1     40  4m34.8s
```

A version-boundary probe with SymbolicUtils 4.46.1 confirmed that a facade using `@reexport using Symbolics` exposes none of the four names with Symbolics 7.37.0, while all four are exported and public through the same facade with Symbolics 7.38.0. The introducing commit is https://github.com/JuliaSymbolics/Symbolics.jl/commit/de0731d6255be56bed82ebafa8d59243ea84e42f.

## Passing after

```sh
export JULIA_DEPOT_PATH="$PWD/../../validation-depots/ModelingToolkitPublicReexports:/home/crackauc/.julia"
export TMPDIR="$PWD/../../work-tmp/ModelingToolkitPublicReexports"
export JULIA_NUM_PRECOMPILE_TASKS=1
export GROUP=QA
~/.juliaup/bin/julia +release --project -e 'using Pkg; Pkg.test()'
```

```text
Test Summary: | Pass  Total     Time
QA            |   40     40  4m30.9s
     Testing ModelingToolkit tests passed
```

Additional checks:

```text
Runic 1.10.0 --check test/qa/qa.jl: exit 0
typos test/qa/qa.jl: exit 0
git diff --check: exit 0
```

Post-push CI has also passed the targeted [QA job](https://github.com/SciML/ModelingToolkit.jl/actions/runs/33361465661/job/99393685495), [Runic check](https://github.com/SciML/ModelingToolkit.jl/actions/runs/33361465514/job/99393499269), and [spelling check](https://github.com/SciML/ModelingToolkit.jl/actions/runs/33361465546/job/99393499449).

The independent [Optimization job on Julia 1](https://github.com/SciML/ModelingToolkit.jl/actions/runs/33361465661/job/99393685404) is red. The same job was already red on both the immediately preceding [homotopy PR](https://github.com/SciML/ModelingToolkit.jl/actions/runs/33305355631/job/99245053358) and [Runic-only PR](https://github.com/SciML/ModelingToolkit.jl/actions/runs/33298117959/job/99221244724); it is not changed or suppressed here.

## Not verified

The documentation build, GPU tests, downstream tests, and non-QA test groups were not run locally. This changes only the QA allow-list; it does not change implementation code, documentation, dependencies, or public declarations. The four names are documented by their owning packages, and the passing QA run includes both public API documentation checks.

## Reviewer judgment

This PR treats Symbolics' explicitly exported names as intentional ModelingToolkit facade API, consistent with the existing `REEXPORTED_API` policy. A reviewer should push back if ModelingToolkit should instead stop forwarding some of Symbolics' exported surface in a separate, potentially breaking API change.

🤖 Generated with Codex CLI 0.151.0 (model: unknown; session: local session ID 01a04fa1-cfe0-7260-b416-72fe8a15d17d).
