### PR TITLE
Fix stale torn-system Jacobian sparsity

### DIFF
--- a/src/systems/codegen.jl
+++ b/src/systems/codegen.jl
@@ -5,6 +5,7 @@ function MTKBase.torn_system_jacobian_sparsity(sys::System)
     @unpack graph, var_to_diff = structure
 
     neqs = nsrcs(graph)
+    neqs == length(full_equations(sys)) == length(unknowns(sys)) || return nothing
     nsts = ndsts(graph)
     states_idxs = findall(!Base.Fix1(StateSelection.isdervar, structure), 1:nsts)
     var2idx = StructuralTransformations.uneven_invmap(nsts, states_idxs)

--- a/test/reduction.jl
+++ b/test/reduction.jl
@@ -298,6 +298,20 @@ Js = ModelingToolkitBase.jacobian_sparsity(sys)
 @test size(Js) == (3, 3)
 @test Js == Diagonal([0, 1, 1])
 
+@variables input_x(t)[1:4] output_x(t)[1:4] n(t)[1:4] algebraic(t)
+eqs = [
+    sum(input_x) ~ 1.0
+    sum(output_x) ~ 1.0
+    [output_x[i] ~ input_x[i] for i in 1:3]...
+    [D(n[i]) ~ output_x[i] for i in 1:4]...
+    0 ~ algebraic^2 - n[1]
+]
+@named model = System(eqs, t)
+sys = mtkcompile(model; inputs = collect(input_x))
+@test length(unknowns(sys)) == length(equations(sys)) == 5
+@test size(ModelingToolkitBase.jacobian_sparsity(sys)) == (5, 5)
+@test size(ModelingToolkitBase.W_sparsity(sys)) == (5, 5)
+
 # MWE for #1722
 vars = @variables a(t) w(t) phi(t)
 eqs = [


### PR DESCRIPTION
## What changed

Fall back to symbolic Jacobian sparsity when a system's retained tearing graph no longer matches the final equation and unknown counts. This prevents `W_sparsity` from combining a stale 6×6 torn-graph pattern with a 5×5 mass matrix after compilation removes a redundant equation.

The regression test is a standalone ModelingToolkit system distilled from ProcessSimulator.jl's `simple_cstr` failure.

## Verification

Failing before the source fix, with the regression test present:

```text
Test Failed at test/reduction.jl:312
  Expression: size(ModelingToolkitBase.jacobian_sparsity(sys)) == (5, 5)
   Evaluated: (6, 6) == (5, 5)
```

Passing after the source fix:

```text
length(unknowns(compiled)) = 5
length(equations(compiled)) = 5
size(ModelingToolkitBase.jacobian_sparsity(compiled)) = (5, 5)
size(ModelingToolkitBase.W_sparsity(compiled)) = (5, 5)
```

Additional local checks:

```text
test/reduction.jl: exit 0
GROUP=QA: 40 passed, 40 total, 20m23.5s
runic --check src/systems/codegen.jl test/reduction.jl: exit 0
typos src/systems/codegen.jl test/reduction.jl: exit 0
git diff --check: exit 0
```

The complete `GROUP=InterfaceI` run did not finish within the one-hour local validation window; `test/reduction.jl`, which contains this change's regression test, was therefore also run directly. No docs build was run because this does not change public API or documentation. GPU, downstream, and allowed-to-fail jobs were not run.

Julia 1.12.6 emitted an internal type-inference warning while precompiling ModelingToolkit, but precompilation completed and the QA process exited 0.

The prerequisite clean-base QA repair is merged. This PR's only diff is the sparsity guard and its regression test.

Please ignore this PR until it has been reviewed by @ChrisRackauckas.

🤖 Generated with Codex CLI 0.151.0 (model: unknown; session: local session ID 01a04fa1-cfe0-7260-b416-72fe8a15d17d).