### PR TITLE
Update redirected documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Join the chat at https://julialang.zulipchat.com #sciml-bridged](https://img.shields.io/static/v1?label=Zulip&message=chat&color=9558b2&labelColor=389826)](https://julialang.zulipchat.com/#narrow/stream/279055-sciml-bridged)
 [![Global Docs](https://img.shields.io/badge/docs-SciML-blue.svg)](https://docs.sciml.ai/ModelingToolkit/stable/)
 
-[![codecov](https://codecov.io/gh/SciML/ModelingToolkit.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/SciML/ModelingToolkit.jl)
+[![codecov](https://codecov.io/gh/SciML/ModelingToolkit.jl/branch/master/graph/badge.svg)](https://app.codecov.io/gh/SciML/ModelingToolkit.jl)
 [![Coverage Status](https://coveralls.io/repos/github/SciML/ModelingToolkit.jl/badge.svg?branch=master)](https://coveralls.io/github/SciML/ModelingToolkit.jl?branch=master)
 [![Build Status](https://github.com/SciML/ModelingToolkit.jl/workflows/CI/badge.svg)](https://github.com/SciML/ModelingToolkit.jl/actions?query=workflow%3ACI)
 

--- a/docs/src/comparison.md
+++ b/docs/src/comparison.md
@@ -11,7 +11,7 @@
     is a language with a single canonical open-source implementation.
   - All current Modelica compiler implementations are fixed and not extendable
     by the users from the Modelica language itself. For example, the Dymola
-    compiler [shares its symbolic processing pipeline](https://www.claytex.com/tech-blog/model-translation-and-symbolic-manipulation/),
+    compiler [shares its symbolic processing pipeline](https://blog.technia.com/en/mbse/model-translation-and-symbolic-manipulation/),
     which is roughly equivalent to the `dae_index_lowering` and `mtkcompile`
     of ModelingToolkit.jl. ModelingToolkit.jl is an open and hackable transformation
     system which allows users to add new non-standard transformations and control
@@ -87,7 +87,7 @@
     and thus the Julia expressions follow Julia semantics and can be manipulated
     using a computer algebra system (CAS).
   - Modia's compilation pipeline is similar to the
-    [Dymola symbolic processing pipeline](https://www.claytex.com/tech-blog/model-translation-and-symbolic-manipulation/)
+    [Dymola symbolic processing pipeline](https://blog.technia.com/en/mbse/model-translation-and-symbolic-manipulation/)
     with some improvements. ModelingToolkit.jl has an open transformation pipeline
     that allows for users to extend and reorder transformation passes, where
     `mtkcompile` is an adaptation of the Modia.jl-improved alias elimination


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

Update two references to the Dymola symbolic-processing article to the current Technia URL and update the Codecov badge target to the current app URL. The old targets now return permanent HTTP 301 redirects, which strict Documenter link checking reports as `:linkcheck` errors.

Git history traces the article URL to https://github.com/SciML/ModelingToolkit.jl/commit/00ea6bac16cde2a4cac1286010bf1850a262db80 and the Codecov target to https://github.com/SciML/ModelingToolkit.jl/commit/d04c62cca36a2b1819c2c3663a16dfd703ff72c7. The redirect changes themselves are external server-side changes.

## Verification

Failing before the change, from clean upstream `master` at `6b06080fe1c19a0fc99f5e1e32ed3309b847e201`:

```text
DISPLAY=:0 xvfb-run -s '-screen 0 1024x768x24' julia +lts --project=docs/ --code-coverage=user docs/make.jl

linkcheck 'https://www.claytex.com/tech-blog/model-translation-and-symbolic-manipulation/' status: 301, redirects to 'https://blog.technia.com/en/mbse/model-translation-and-symbolic-manipulation/'
linkcheck 'https://www.claytex.com/tech-blog/model-translation-and-symbolic-manipulation/' status: 301, redirects to 'https://blog.technia.com/en/mbse/model-translation-and-symbolic-manipulation/'
linkcheck 'https://codecov.io/gh/SciML/ModelingToolkit.jl' status: 301, redirects to 'https://app.codecov.io/gh/SciML/ModelingToolkit.jl'
ERROR: `makedocs` encountered an error [:linkcheck]
docs_before_exit=1
real 72m59.833s
```

After the change, the same full docs command ran through all doctests and link checking in 29m48.532s. None of the three redirect diagnostics appeared. It still exited 1 solely for two unchanged external checks: the Berkeley PDF connection timed out (`curl` exit 28), and GitHub returned HTTP 429 for the ColPrac README during that run. A direct recheck of the GitHub URL subsequently returned HTTP 200. No ignore, warning downgrade, or unrelated link change was added.

Direct checks of the replacement targets:

```text
https://blog.technia.com/en/mbse/model-translation-and-symbolic-manipulation/ status=200 redirects=0
https://app.codecov.io/gh/SciML/ModelingToolkit.jl status=200 redirects=0
```

Final checks after rebasing onto upstream `master` at `5509368fa6`:

```text
Runic 1.10.0 --check README.md docs/src/comparison.md
runic_exit=0

git diff upstream/master...HEAD -- README.md docs/src/comparison.md | typos --config .typos.toml -
typos_exit=0

git diff --check upstream/master...HEAD
diff_check_exit=0
```

## Not verified locally

- The full docs command did not reach exit 0 locally because the unrelated Berkeley endpoint was unreachable from this host and GitHub transiently rate-limited the ColPrac check. CI must independently verify those external endpoints.
- `GROUP=QA` was not completed locally. An auxiliary run on the pre-rebase base was interrupted during precompilation after upstream `master` advanced; this PR changes only Markdown link targets.

## Links

- Original failing CI job: https://github.com/SciML/ModelingToolkit.jl/actions/runs/33361465157/job/99393498380
- Claytex-link introduction: https://github.com/SciML/ModelingToolkit.jl/commit/00ea6bac16cde2a4cac1286010bf1850a262db80
- Codecov-link introduction: https://github.com/SciML/ModelingToolkit.jl/commit/d04c62cca36a2b1819c2c3663a16dfd703ff72c7

🤖 Generated with Codex CLI 0.151.0 (model: unknown; session: local session ID 01a04fa1-cfe0-7260-b416-72fe8a15d17d).
