### PR TITLE
Document interactive integrator workflow

### DIFF
--- a/docs/pages.jl
+++ b/docs/pages.jl
@@ -27,6 +27,7 @@ pages = [
             "examples/higher_order.md",
             "examples/spring_mass.md",
             "examples/modelingtoolkitize_index_reduction.md",
+            "examples/interactive_simulation.md",
             "examples/remake.md",
         ],
         "Advanced Examples" => Any[

--- a/docs/src/examples/interactive_simulation.md
+++ b/docs/src/examples/interactive_simulation.md
@@ -50,7 +50,7 @@ not to divide one continuous run into display intervals.
 
 ## Parameters and time-varying inputs
 
-An ordinary `@parameter` is treated as time-invariant when a saved solution evaluates
+A value declared with `@parameters` is treated as time-invariant when a saved solution evaluates
 parameter-dependent observables. Mutating one during an interactive run updates future
 dynamics, but it does not create a history of its previous values. Record the input in the
 application, as the example does for display values, when only the live interface needs that

--- a/docs/src/examples/interactive_simulation.md
+++ b/docs/src/examples/interactive_simulation.md
@@ -1,0 +1,67 @@
+# Interactive simulation with a long-lived integrator
+
+Interactive applications often receive a new input, advance the model for a short interval,
+and update a plot. Initialize one integrator for the full simulation horizon and keep advancing
+that integrator. Reinitializing between intervals is unnecessary and can rerun ModelingToolkit
+initialization or discard solver state.
+
+The following model uses a parameter as an externally controlled input:
+
+```julia
+using ModelingToolkit
+using OrdinaryDiffEq
+using ModelingToolkit: t_nounits as t, D_nounits as D
+
+@variables x(t)
+@parameters input
+@mtkcompile sys = System([D(x) ~ -x + input], t)
+
+prob = ODEProblem(sys, [x => 0.0, input => 0.0], (0.0, 4.0))
+integrator = init(prob, Tsit5(); saveat = 0.0:0.05:4.0)
+
+display_times = Float64[]
+display_values = Float64[]
+display_inputs = Float64[]
+for level in (0.0, 1.0, -1.0, 0.0)
+    integrator.ps[input] = level
+    step!(integrator, 1.0, true)
+    push!(display_times, integrator.t)
+    push!(display_values, integrator[x])
+    push!(display_inputs, level)
+end
+
+sol = integrator.sol
+```
+
+`integrator.ps[input] = level` uses the
+[`SymbolicIndexingInterface`](https://docs.sciml.ai/SymbolicIndexingInterface/stable/)
+parameter interface. It works with the parameter storage produced by structural
+transformation and tells the integrator that its derivative data must be refreshed before
+the next step. Avoid mutating the internal `integrator.p` storage directly.
+
+`step!(integrator, interval, true)` advances by `interval` and stops exactly at its endpoint.
+The integrator's solution accumulates the saved state history, while `integrator.t` and
+`integrator[x]` provide the values needed to update live plot observables after each block.
+Use a time span covering the intended session and express `saveat` in absolute simulation
+times.
+
+Use `reinit!` when the simulation really is restarting from a new initial condition or time,
+not to divide one continuous run into display intervals.
+
+## Parameters and time-varying inputs
+
+An ordinary `@parameter` is treated as time-invariant when a saved solution evaluates
+parameter-dependent observables. Mutating one during an interactive run updates future
+dynamics, but it does not create a history of its previous values. Record the input in the
+application, as the example does for display values, when only the live interface needs that
+history.
+
+When the input is part of the model's saved history, declare it with `@discretes input(t)`.
+Discrete variables represent piecewise-constant, time-dependent values. Updates performed by
+ModelingToolkit callbacks can be saved and later retrieved through symbolic solution indexing;
+see [Saving discrete values](@ref save_discretes).
+
+If all input-change times are known before the solve, a symbolic discrete event is usually a
+better model than an external stepping loop. The long-lived-integrator pattern is intended for
+inputs that arrive while the simulation is running, such as UI controls or measurements from
+another process.


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

Add a basic example for interactive and externally driven simulations. It initializes one integrator over the full horizon, mutates a symbolic input through `integrator.ps`, advances fixed wall-clock blocks with `step!(integrator, Δt, true)`, and reads current and accumulated results without `reinit!`.

The page also distinguishes ordinary parameters from registered discrete inputs and directs known-time changes to symbolic events. This documents the simpler workflow requested in https://github.com/SciML/ModelingToolkit.jl/issues/5006#issuecomment-5476557277.

This depends on the parameter-cache invalidation fix in https://github.com/SciML/SciMLBase.jl/pull/1575. The documentation environment used that local SciMLBase branch for executable validation. The pre-existing Berkeley link timeout encountered by full docs is fixed separately in https://github.com/SciML/ModelingToolkit.jl/pull/5056; its full documentation CI passed at https://github.com/SciML/ModelingToolkit.jl/actions/runs/33472398454/job/99744640476.

## Verification

The documented loop ran with analytic value assertions after each one-second block:

```text
(display_times = [1.0, 2.0, 3.0, 4.0],
 display_values = [0.0, 0.6319011220085275, -0.39965118092464247, -0.14702457157937263],
 display_inputs = [0.0, 1.0, -1.0, 0.0],
 saved_points = 81)
[exit code 0]
```

The same workflow was also run against the mass-spring model in the issue comment:

```text
(block_end = [1.0, 2.0, 3.0, 4.0],
 position = [0.0, 0.4597655446581379, 1.8760519582895256, 3.866004436795883],
 input = [0.0, 1.0, 2.0, 3.0],
 saved_points = 81)
[exit code 0]
```

```text
$ GROUP=QA julia --startup-file=no --project=. -e 'using Pkg; Pkg.test()'
Test Summary: | Pass  Total     Time
QA            |   40     40  4m58.9s
Testing ModelingToolkit tests passed

$ GROUP=SymbolicIndexingInterface julia --startup-file=no --project=. -e 'using Pkg; Pkg.test()'
Test Summary:             | Pass  Total     Time
SymbolicIndexingInterface | 1984   1984  6m49.3s
Testing ModelingToolkit tests passed

$ julia --startup-file=no -m Runic --check docs/pages.jl
[exit code 0]

$ typos docs/pages.jl docs/src/examples/interactive_simulation.md
[exit code 0]

$ git diff --check upstream/master...HEAD
[exit code 0]

$ TMPDIR=/home/crackauc/sandbox/tmp_20260831_125419_177237/.tmp julia --startup-file=no --project=docs docs/make.jl
[observed: doctests, template expansion, cross-references, document checks, index population, and HTML rendering completed; local deployment was skipped]
```

The full docs run used the one-link replacement from https://github.com/SciML/ModelingToolkit.jl/pull/5056 for the pre-existing Berkeley PDF timeout identified on `master`. The temporary link edit was removed after validation so this workflow PR remains focused.

## Review notes and unverified paths

No public API changes. `Everything`, GPU, Julia pre-release, and unrelated test groups were not run locally.

🤖 Generated with Codex CLI 0.151.0 (model: gpt-5.6-sol; session: local session ID 01a057e2-edc7-7342-9835-8122a5c647eb).
