### PR TITLE
docs: replace stale Pantelides link

### DIFF
--- a/docs/src/examples/modelingtoolkitize_index_reduction.md
+++ b/docs/src/examples/modelingtoolkitize_index_reduction.md
@@ -148,7 +148,7 @@ algebraic relationships.
 However, requiring the user to sit there and work through this process on
 potentially millions of equations is an unfathomable mental overhead. But,
 we can avoid this by using methods like
-[the Pantelides algorithm](https://ptolemy.berkeley.edu/projects/embedded/eecsx44/lectures/Spring2013/modelica-dae-part-2.pdf)
+[the Pantelides algorithm](https://specification.modelica.org/maint/3.6/modelica-dae-representation.html)
 for automatically performing this reduction to index 1. While this requires the
 ModelingToolkit symbolic form, we use `modelingtoolkitize` to transform
 the numerical code into symbolic code, run `dae_index_lowering` lowering,


### PR DESCRIPTION
> Please ignore this draft until it has been reviewed by @ChrisRackauckas.

## What changed and why

The Pantelides index-reduction tutorial linked to a Berkeley lecture PDF that no longer responds and causes the documentation link checker to time out. This replaces it with the maintained Modelica Language Specification 3.6 appendix, which explicitly describes applying the Pantelides algorithm to reduce DAE index.

This is a one-link documentation repair discovered while validating https://github.com/SciML/ModelingToolkit.jl/pull/5055. It does not change public API or runtime behavior.

## Verification

Failing before the change on clean `upstream/master` (`e91f13e48fc4f2fdda67e66ad7b2d9c67234ac2b`):

```text
$ TMPDIR=... julia --startup-file=no --project=docs docs/make.jl
┌ Error: `curl ... https://ptolemy.berkeley.edu/projects/embedded/eecsx44/lectures/Spring2013/modelica-dae-part-2.pdf --max-time 10 ...` failed:
│    failed process: Process(..., ProcessExited(28)) [28]
└ @ Documenter .../utilities.jl:47
ERROR: LoadError: `makedocs` encountered an error [:linkcheck]
```

The URL was introduced with the tutorial in commit https://github.com/SciML/ModelingToolkit.jl/commit/60594b93dade0f3ffe490e3af25d5b3248019fa8.

The replacement passes the exact HEAD request used by Documenter:

```text
$ curl -sI --proto =http,https,ftp,ftps -g -H 'accept-encoding: gzip, deflate, br' --user-agent 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/127.0.0.0 Safari/537.36' 'https://specification.modelica.org/maint/3.6/modelica-dae-representation.html' --max-time 10 -o /dev/null --write-out '%{http_code} %{url_effective} %{redirect_url}\n'
200 https://specification.modelica.org/maint/3.6/modelica-dae-representation.html
```

```text
$ TMPDIR=... GROUP=QA julia --startup-file=no --project=. -e 'using Pkg; Pkg.test()'
Test Summary: | Pass  Total     Time
QA            |   40     40  4m23.8s
     Testing ModelingToolkit tests passed
```

```text
$ typos docs/src/examples/modelingtoolkitize_index_reduction.md
# exit 0
$ git diff --check
# exit 0
```

The full fix-branch docs build completed doctests and template expansion and reached link checking without reporting an error for the replacement URL. It then stopped on a separate, intermittent master failure: GitHub returned HTTP 429 for `https://github.com/SciML/ModelingToolkit.jl/blob/master/NEWS.md`. An isolated clean-master investigation could not reproduce that error, and Documenter's exact request subsequently returned HTTP 200, confirming transient GitHub rate limiting; no source change was warranted. A separate local docs run for https://github.com/SciML/ModelingToolkit.jl/pull/5055 with the identical URL replacement completed document checks, rendering, HTML generation, and deployment detection without a Documenter error.

## Not verified

`GROUP=Everything`, GPU, and Julia `pre` jobs were not run. They are unrelated to this documentation-only link replacement.

## Reviewer note

The replacement points to a maintained language specification rather than another mirror of the old lecture PDF. Appendix B directly documents Pantelides index reduction and is the authoritative source for the linked claim.

🤖 Generated with Codex CLI 0.151.0 (model: gpt-5.6-sol; session: local session ID 01a057e2-edc7-7342-9835-8122a5c647eb).
