### PR TITLE
Reduce DAEFunction specialization latency

### DIFF
--- a/lib/ModelingToolkitBase/src/problems/daeproblem.jl
+++ b/lib/ModelingToolkitBase/src/problems/daeproblem.jl
@@ -25,13 +25,14 @@ function generate_DAENLStepData(sys, u0, p, mm, nlstep_compile, nlstep_scc; jac 
 end
 
 """$(function_docstring(DAEFunction, true, [:jac, :tgrad]))"""
-@fallback_iip_specialize function SciMLBase.DAEFunction{iip, spec}(
-        sys::System; u0 = nothing, p = nothing, tgrad = false, jac = false,
+Base.@nospecializeinfer @fallback_iip_specialize function SciMLBase.DAEFunction{iip, spec}(
+        sys::System; @nospecialize(u0 = nothing), @nospecialize(p = nothing),
+        tgrad = false, jac = false,
         t = nothing, eval_expression = false, eval_module = @__MODULE__,
         sparse = false,
         steady_state = false, checkbounds = false, sparsity = false,
-        analytic = nothing,
-        simplify = false, initialization_data = nothing,
+        @nospecialize(analytic = nothing),
+        simplify = false, @nospecialize(initialization_data = nothing),
         expression = Val{false}, check_compatibility = true, nlstep = false,
         nlstep_compile = true, nlstep_scc = false, optimize = nothing,
         compiler_options::CompilerOptions = CompilerOptions(), kwargs...


### PR DESCRIPTION
> [!IMPORTANT]
> Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

Apply `Base.@nospecializeinfer` to the ModelingToolkit `DAEFunction` wrapper and avoid specializing its model-specific `u0`, `p`, `analytic`, and `initialization_data` keyword values. This matches the existing `ODEFunction` wrapper strategy and reduces inference work during standard DAE construction without changing the public API or runtime behavior.

## Compile-latency evidence

I measured a three-state Robertson DAE with default initialization on Julia 1.12.7, one Julia thread, and a fresh Julia process for every sample. Package loading happened before the `@timed DAEProblem(...)` interval. Each constructed residual evaluated to `[0.0, 0.0, 0.0]`.

| Exact current-base comparison (median of 3) | Parent `e91f13e48f` | This PR `f0a0b8aab2` | Change |
|---|---:|---:|---:|
| `DAEProblem` time | 9.738 s | 9.501 s | -2.44% |
| compilation time | 9.679 s | 9.442 s | -2.45% |
| allocations | 844,725,672 bytes | 843,232,560 bytes | -0.18% |

The individual total-time samples were `9.436, 9.799, 9.738` seconds on the parent and `9.272, 9.726, 9.501` seconds on this PR.

An earlier isolated-depot run on the immediately preceding upstream commit showed a larger effect: median constructor time `11.696 -> 9.833` seconds and compilation time `11.616 -> 9.774` seconds (-15.9% for both). Trace-compile timing in that environment reduced the typed `DAEFunction` constructor from 3.49 s to 1.76 s and its model-specific keyword wrapper from 2.12 s to 1.57 s. The exact-current-base result above is the conservative headline measurement.

The benchmark script was temporary and was removed after collecting the samples, as required for local development scripts.

## Verification

```text
GROUP=InterfaceI julia +1.12 --startup-file=no --project=lib/ModelingToolkitBase -e 'using Pkg; Pkg.test()'
Test Summary: | Pass  Broken  Total      Time
InterfaceI    | 1601       5   1606  42m05.5s
Testing ModelingToolkitBase tests passed
```

```text
julia --startup-file=no --project=@runic -m Runic --check --diff lib/ModelingToolkitBase/src/problems/daeproblem.jl
git diff -U0 -- lib/ModelingToolkitBase/src/problems/daeproblem.jl | typos -
git diff --check
```

All three commands exited 0 with no output.

`GROUP=QA` was also run. It reported 20 passing checks and 1 failing package-wide JET check. The identical command reproduced the same failure on a detached clean `upstream/master` at `e91f13e48f`: JET returned 450 reports. A parallel investigation bisected the QA-lane boundary to https://github.com/SciML/ModelingToolkit.jl/commit/92c27bb9fdcaa024ff190feb3d665452e33f9bd8 and added current reproduction evidence to https://github.com/SciML/ModelingToolkit.jl/issues/4958#issuecomment-5488241865. No test was skipped, disabled, allowlisted, or silenced.

## CI audit

The full PR matrix reached a terminal state with 97 passed checks, 7 failed checks, 2 canceled checks, and 1 skipped check.

- The package-wide QA JET failure reproduced identically on the exact upstream parent and is tracked at https://github.com/SciML/ModelingToolkit.jl/issues/4958.
- Four Optimization failures reproduced on the exact upstream parent and were reduced to a regression in CasADi.jl 1.3.0. The fix is merged at https://github.com/SciML/CasADi.jl/pull/42; the 1.3.1 release PR is green at https://github.com/SciML/CasADi.jl/pull/44.
- The downgraded QA failure reproduced on the exact upstream parent. It comes from test extras promoted into runtime dependencies by `julia-downgrade-compat`; the separate workflow fix is green at https://github.com/SciML/.github/pull/131.
- The docs failure reproduced in a complete clean-parent docs build and is an existing stale-link failure. Its focused fix has a green docs job at https://github.com/SciML/ModelingToolkit.jl/pull/5056.
- Two Optimization Julia LTS jobs reached their two-hour job limit without a test error annotation. One exact-parent counterpart also timed out; the other exact-parent counterpart passed. GitHub did not permit targeted reruns of either matrix job, so the second cancellation remains inconclusive rather than established as an upstream baseline.

No behavior-specific test was added because this change consists only of compiler specialization annotations; the existing InterfaceI coverage exercises DAE construction, while the fresh-process benchmark is the discriminating performance check.

## Not verified locally

- `GROUP=Everything`, GPU, and downstream groups were not run locally.
- The docs build was not run locally for this branch because it changes no public API, docstring, or documentation file.

🤖 Generated with Codex CLI 0.151.0 (model: gpt-5.6-sol; session: 01a059b1-5fa2-76a2-937a-33502aa35de5).
