### PR TITLE
Fix SciCompDSL model macro hygiene

### DIFF
--- a/lib/SciCompDSL/src/model_parsing.jl
+++ b/lib/SciCompDSL/src/model_parsing.jl
@@ -41,7 +41,7 @@ end
 
 function _model_macro(mod, fullname::Union{Expr, Symbol}, expr, isconnector)
     if fullname isa Symbol
-        name, type = fullname, :System
+        name, type = fullname, MTKBase.System
     else
         if fullname.head == :(::)
             name, type = fullname.args
@@ -71,9 +71,9 @@ function _model_macro(mod, fullname::Union{Expr, Symbol}, expr, isconnector)
     push!(exprs.args, :(variables = []))
     push!(exprs.args, :(parameters = []))
     # We build `System` by default
-    push!(exprs.args, :(systems = ModelingToolkitBase.System[]))
-    push!(exprs.args, :(equations = Union{Equation, Vector{Equation}}[]))
-    push!(exprs.args, :(defaults = Dict{Num, Union{Number, Symbol, Function}}()))
+    push!(exprs.args, :(systems = $MTKBase.System[]))
+    push!(exprs.args, :(equations = Union{$Equation, Vector{$Equation}}[]))
+    push!(exprs.args, :(defaults = Dict{$Num, Union{Number, Symbol, Function}}()))
 
     Base.remove_linenums!(expr)
     for arg in expr.args
@@ -165,7 +165,7 @@ function _model_macro(mod, fullname::Union{Expr, Symbol}, expr, isconnector)
 
     meta_exprs = quote
         for (k, v) in $model_meta
-            var"#___sys___" = setmetadata(var"#___sys___", $get_var($mod, k), v)
+            var"#___sys___" = $setmetadata(var"#___sys___", $get_var($mod, k), v)
         end
     end
     push!(exprs.args, meta_exprs)

--- a/lib/SciCompDSL/test/macro_hygiene.jl
+++ b/lib/SciCompDSL/test/macro_hygiene.jl
@@ -1,0 +1,27 @@
+using SciCompDSL, Test
+using ModelingToolkitBase: getmetadata, t_nounits as t, D_nounits as D
+
+@mtkmodel EmptyModel begin end
+
+@test EmptyModel(; name = :empty) !== nothing
+
+struct Author end
+
+@mtkmodel DecayModel begin
+    @metadata begin
+        Author = "Test Author"
+    end
+    @parameters begin
+        k = 1.0
+    end
+    @variables begin
+        x(t) = 1.0
+    end
+    @equations begin
+        D(x) ~ -k * x
+    end
+end
+
+decay = DecayModel(; name = :decay)
+@test decay !== nothing
+@test getmetadata(decay, Author, nothing) == "Test Author"

--- a/lib/SciCompDSL/test/runtests.jl
+++ b/lib/SciCompDSL/test/runtests.jl
@@ -8,6 +8,7 @@ const MTKPkgSpec = PackageSpec(; path = MTKPath)
 
 Pkg.develop([MTKBasePkgSpec, MTKPkgSpec]; preserve = Pkg.PRESERVE_ALL)
 
+@safetestset "Model macro hygiene" include("macro_hygiene.jl")
 @safetestset "Model parsing - MTKBase" include("model_parsing.jl")
 @safetestset "Model parsing - MTK" begin
     using ModelingToolkit


### PR DESCRIPTION
## Summary

SciCompDSL's `@mtkmodel` expansion emitted unqualified names from its own implementation into the caller module. A caller that imported only SciCompDSL therefore failed unless it happened to bind ModelingToolkitBase, Equation, Num, and setmetadata under the expected names.

This captures those owner-module bindings when the macro expands and adds a caller-hygiene regression covering an empty model, equations/defaults, and custom model metadata. No public API is added or changed.

Please ignore this draft until it has been reviewed by @ChrisRackauckas.

## Failing before / passing after

I ran the new test against the unfixed source, then restored the source change and ran the identical test:

```console
$ julia +1.12.7 --startup-file=no --project=.validation/root-env -e \
    'using Test; @testset "SciCompDSL macro hygiene" begin include("lib/SciCompDSL/test/macro_hygiene.jl") end'
ERROR: LoadError: UndefVarError: `ModelingToolkitBase` not defined in `Main`
```

With this commit:

```text
Test Summary:             | Pass  Total
SciCompDSL macro hygiene  |    3      3
```

The test imports SciCompDSL and selected public ModelingToolkitBase names, but deliberately does not bind the ModelingToolkitBase module name.

## Verification

Observed locally with Julia 1.12.7:

```text
SciCompDSL model parsing - MTKBase: 200 passed, 1 pre-existing broken
SciCompDSL model parsing - MTK:     205 passed
SciCompDSL macro hygiene:             3 passed
root QA:                              40 passed
direct SciCompDSL test runner:        passed
Runic check:                          passed
typos:                                passed
git diff --check:                     passed
```

The full docs build completed the examples and document checks, then failed during final link checking because this unchanged external URL did not answer within the configured 10 seconds:

```text
https://ptolemy.berkeley.edu/projects/embedded/eecsx44/lectures/Spring2013/modelica-dae-part-2.pdf
curl ... --max-time 10
ProcessExited(28)
makedocs encountered an error [:linkcheck]
```

A retry is running; this change does not touch docs, docstrings, or public API.

## Review notes

The interpolated bindings are public/exported from their owning modules. The change does not reach through a re-exporter and does not add a dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://chatgpt.com/codex/tasks/01a03a17-ad6f-7131-82fc-d0fd57ea6512
