### PR TITLE
Fixes to better support 32-bit builds

### DIFF
--- a/lib/ModelingToolkitBase/src/discretedomain.jl
+++ b/lib/ModelingToolkitBase/src/discretedomain.jl
@@ -59,7 +59,7 @@ SymbolicUtils.promote_shape(::Shift, @nospecialize(x::SU.ShapeT)) = x
 Base.show(io::IO, D::Shift) = print(io, "Shift(", D.t, ", ", D.steps, ")")
 
 Base.:(==)(D1::Shift, D2::Shift) = isequal(D1.t, D2.t) && isequal(D1.steps, D2.steps)
-Base.hash(D::Shift, u::UInt) = hash(D.steps, hash(D.t, xor(u, 0x055640d6d952f101)))
+Base.hash(D::Shift, u::UInt) = hash(D.steps, hash(D.t, xor(u, 0x055640d6d952f101 % UInt)))
 
 Base.:^(D::Shift, n::Integer) = Shift(D.t, D.steps * n)
 Base.literal_pow(f::typeof(^), D::Shift, ::Val{n}) where {n} = Shift(D.t, D.steps * n)
@@ -245,7 +245,7 @@ SymbolicUtils.isbinop(::Sample) = false
 Base.show(io::IO, D::Sample) = print(io, "Sample(", D.clock, ")")
 
 Base.:(==)(D1::Sample, D2::Sample) = isequal(D1.clock, D2.clock)
-Base.hash(D::Sample, u::UInt) = hash(D.clock, xor(u, 0x055640d6d952f101))
+Base.hash(D::Sample, u::UInt) = hash(D.clock, xor(u, 0x055640d6d952f101 % UInt))
 
 function validate_operator(op::Sample, args, iv; context = nothing)
     arg = unwrap(only(args))

--- a/lib/ModelingToolkitBase/src/systems/codegen.jl
+++ b/lib/ModelingToolkitBase/src/systems/codegen.jl
@@ -630,7 +630,7 @@ function W_sparsity(sys::System)
     (n, n) = size(jac_sparsity)
     M = calculate_massmatrix(sys)
     M_sparsity = M isa UniformScaling ? sparse(I(n)) :
-        SparseMatrixCSC{Bool, Int64}((!iszero).(M))
+        SparseMatrixCSC{Bool, Int}((!iszero).(M))
     return jac_sparsity .| M_sparsity
 end
 

--- a/src/structural_transformation/symbolics_tearing.jl
+++ b/src/structural_transformation/symbolics_tearing.jl
@@ -26,7 +26,7 @@ end
 
 function safe_isinteger(@nospecialize(x::Number))
     if x isa Int64
-        return true
+        return typemin(Int) <= x <= typemax(Int)
     elseif x isa Int32
         return true
     elseif x isa BigInt

--- a/src/systems/codegen.jl
+++ b/src/systems/codegen.jl
@@ -592,6 +592,6 @@ function get_semiquadratic_W_sparsity(
         jac .+= Cjac
     end
     M_sparsity = mm isa UniformScaling ? sparse(I, M, N) :
-        SparseMatrixCSC{Bool, Int64}((!iszero).(mm))
+        SparseMatrixCSC{Bool, Int}((!iszero).(mm))
     return (!_iszero).(jac) .| M_sparsity
 end


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

What I found that looked 64-bit specific. With this patch, I was able to precompile MTK on win32 CI (branch with a bunch of other fixes to other packages).
