### PR TITLE
Fix JET typo-mode findings in ModelingToolkitBase

### DIFF
--- a/lib/ModelingToolkitBase/src/discretedomain.jl
+++ b/lib/ModelingToolkitBase/src/discretedomain.jl
@@ -26,7 +26,7 @@ struct Shift <: Operator
     steps::Int
     Shift(t, steps = 1) = new(unwrap(t), steps)
 end
-Shift(steps::Int) = new(nothing, steps)
+Shift(steps::Int) = Shift(nothing, steps)
 normalize_to_differential(s::Shift) = Differential(s.t)^s.steps
 Base.nameof(::Shift) = :Shift
 SymbolicUtils.isbinop(::Shift) = false

--- a/lib/ModelingToolkitBase/src/modelingtoolkitize/common.jl
+++ b/lib/ModelingToolkitBase/src/modelingtoolkitize/common.jl
@@ -103,6 +103,19 @@ names, or `nothing` to automatically generate names.
 The returned value has the same structure as `p`, but symbolic variables instead of
 values.
 """
+struct ModelingtoolkitizeParametersNotSupportedError <: Exception
+    type::Type
+end
+
+function Base.showerror(io::IO, err::ModelingtoolkitizeParametersNotSupportedError)
+    return print(
+        io,
+        "`modelingtoolkitize` does not support parameters of type `$(err.type)`. Supported \
+        parameter containers are numbers, arrays, tuples, named tuples, dictionaries and \
+        `MTKParameters`."
+    )
+end
+
 function define_params(p, t, _ = nothing)
     throw(ModelingtoolkitizeParametersNotSupportedError(typeof(p)))
 end

--- a/lib/ModelingToolkitBase/src/problems/bvproblem.jl
+++ b/lib/ModelingToolkitBase/src/problems/bvproblem.jl
@@ -47,6 +47,7 @@ end
             checkbounds, time_dependent_init = false, expression, kwargs...
         )
         f_prototype = nothing
+        mass_matrix = nothing
     else
         # Like `process_DynamicOptProblem`: a plain `ODEFunction` on a compiled
         # system would freeze the inputs at their operating-point parameter values

--- a/lib/ModelingToolkitBase/src/systems/abstractsystem.jl
+++ b/lib/ModelingToolkitBase/src/systems/abstractsystem.jl
@@ -252,13 +252,17 @@ end
 
 function SymbolicIndexingInterface.is_timeseries_parameter(sys::AbstractSystem, sym)
     is_time_dependent(sys) || return false
-    has_index_cache(sys) && (ic = get_index_cache(sys)) !== nothing || return false
+    has_index_cache(sys) || return false
+    ic = get_index_cache(sys)
+    ic === nothing && return false
     return is_timeseries_parameter(ic, sym)
 end
 
 function SymbolicIndexingInterface.timeseries_parameter_index(sys::AbstractSystem, sym)
     is_time_dependent(sys) || return nothing
-    has_index_cache(sys) && (ic = get_index_cache(sys)) !== nothing || return nothing
+    has_index_cache(sys) || return nothing
+    ic = get_index_cache(sys)
+    ic === nothing && return nothing
     return timeseries_parameter_index(ic, sym)
 end
 
@@ -333,7 +337,7 @@ function _all_ts_idxs!(ts_idxs, ::ScalarSymbolic, sys, sym::Symbol)
             any(isequal(sym), getname.(observables(sys)))
         push!(ts_idxs, ContinuousTimeseries())
     elseif is_timeseries_parameter(sys, sym)
-        push!(ts_idxs, timeseries_parameter_index(sys, s).timeseries_idx)
+        push!(ts_idxs, timeseries_parameter_index(sys, sym).timeseries_idx)
     end
 end
 function _all_ts_idxs!(ts_idxs, ::NotSymbolic, sys, sym::AbstractArray)
@@ -3340,13 +3344,11 @@ function extend(
     T = SciMLBase.parameterless_type(basesys)
     ivs = independent_variables(basesys)
     if !(sys isa T)
-        if length(ivs) == 0
-            sys = convert_system(T, sys)
-        elseif length(ivs) == 1
-            sys = convert_system(T, sys, ivs[1])
-        else
-            throw("Extending multivariate systems is not supported")
-        end
+        throw(
+            ArgumentError(
+                "Cannot extend a `$(typeof(basesys))` with a `$(typeof(sys))`; both systems must have the same type."
+            )
+        )
     end
 
     # collect fields common to all system types

--- a/lib/ModelingToolkitBase/src/systems/callbacks.jl
+++ b/lib/ModelingToolkitBase/src/systems/callbacks.jl
@@ -113,13 +113,15 @@ end
 function (s::SymbolicUtils.Substituter)(aff::AffectSystem)
     sys = aff.system
     @set! sys.eqs = s(get_eqs(sys))
-    @set! sys.parameter_dependencies = (get_parameter_dependencies(sys))
-    @set! sys.defaults = Dict([k => s(v) for (k, v) in defaults(sys)])
-    @set! sys.guesses = Dict([k => s(v) for (k, v) in guesses(sys)])
+    @set! sys.observed = s(get_observed(sys))
+    @set! sys.bindings = Dict(s(k) => s(v) for (k, v) in get_bindings(sys))
+    @set! sys.initial_conditions = Dict(
+        s(k) => s(v) for (k, v) in get_initial_conditions(sys)
+    )
+    @set! sys.guesses = Dict(s(k) => s(v) for (k, v) in get_guesses(sys))
     @set! sys.unknowns = s(get_unknowns(sys))
     @set! sys.ps = s(get_ps(sys))
     return AffectSystem(sys, s(aff.unknowns), s(aff.parameters), s(aff.discretes))
-
 end
 
 function AffectSystem(spec::SymbolicAffect; iv = nothing, alg_eqs = Equation[], kwargs...)

--- a/lib/ModelingToolkitBase/src/systems/codegen.jl
+++ b/lib/ModelingToolkitBase/src/systems/codegen.jl
@@ -1783,7 +1783,7 @@ struct BandedAMatrixWrapper{O, F <: GeneratedFunctionWrapper}
 end
 
 function BandedAMatrixWrapper(f::Expr, nr::Int, bands::NTuple{2, Int})
-    return Expr(:call, BandedAMatrixWrapper, f, sz, bands)
+    return Expr(:call, BandedAMatrixWrapper, f, nr, bands)
 end
 
 function (f::BandedAMatrixWrapper{OOPArgs})(out::BandedMatrix, args::Vararg{Any, OOPArgs}) where {OOPArgs}

--- a/lib/ModelingToolkitBase/src/systems/connectors.jl
+++ b/lib/ModelingToolkitBase/src/systems/connectors.jl
@@ -1063,12 +1063,8 @@ function expand_connections(sys::AbstractSystem, ::Val{with_source_info} = Val(f
     sys, (csets, domain_csets) = generate_connection_set(sys)
     # generate equations, and stream equations
     ceqs, instream_csets = generate_connection_equations_and_stream_connections(sys, csets)
-    if with_source_info
-        source_visitor = SourceInformationVisitor()
-        eqs = equations(sys, source_visitor)
-    else
-        eqs = equations(sys)
-    end
+    source_visitor = SourceInformationVisitor()
+    eqs = with_source_info ? equations(sys, source_visitor) : equations(sys)
     stream_eqs, instream_subs = expand_instream(instream_csets, sys; tol = tol, eqs)
 
     if with_source_info
@@ -1092,6 +1088,7 @@ function expand_connections(sys::AbstractSystem, ::Val{with_source_info} = Val(f
         end
         source_info = EquationSourceInformation(sources, is_connection_equation)
     else
+        source_info = nothing
         eqs = [eqs; ceqs; stream_eqs]
     end
     if !isempty(instream_subs)

--- a/lib/ModelingToolkitBase/src/systems/diffeqs/basic_transformations.jl
+++ b/lib/ModelingToolkitBase/src/systems/diffeqs/basic_transformations.jl
@@ -218,7 +218,9 @@ function fractional_to_ordinary(
 
     function fto_helper(sub_eq, sub_var, α; initial = 0)
         alpha_0 = α
+        α == 1 && throw(ArgumentError("`fractional_to_ordinary` requires non-integer orders, got α = 1"))
 
+        coeff = 1.0
         if (α > 1)
             coeff = 1 / (α - 1)
             m = 2

--- a/lib/ModelingToolkitBase/src/systems/imperative_affect.jl
+++ b/lib/ModelingToolkitBase/src/systems/imperative_affect.jl
@@ -299,7 +299,7 @@ function compile_functional_affect(
                 push!(exprs_dedup, exp)
                 push!(seen, sym)
             elseif !affect.skip_checks
-                @warn "Expression $(expr) is aliased as $sym, which has already been used. The first definition will be used."
+                @warn "Expression $(exp) is aliased as $sym, which has already been used. The first definition will be used."
             end
         end
         return (syms_dedup, exprs_dedup)
@@ -376,7 +376,7 @@ scalarize_affects(affects::ImperativeAffect) = affects
 function SU.search_variables!(vars, aff::ImperativeAffect; kwargs...)
     for var in Iterators.flatten((observed(aff), modified(aff)))
         if symbolic_type(var) == NotSymbolic()
-            SU.search_variables!(vars, v; kwargs...)
+            SU.search_variables!(vars, var; kwargs...)
         end
     end
     return

--- a/lib/ModelingToolkitBase/src/systems/index_cache.jl
+++ b/lib/ModelingToolkitBase/src/systems/index_cache.jl
@@ -841,9 +841,8 @@ function reorder_dimension_by_tunables!(
             throw(ArgumentError("`syms` must be a permutation of `tunable_parameters(sys)`. Found $sym which is not a tunable parameter."))
         end
 
-        dstidx = ntuple(
-            i -> i == dim ? (dsti:(dsti + length(sym) - 1)) : (:), Val(ndims(arr))
-        )
+        dstrange = dsti:(dsti + length(sym) - 1)
+        dstidx = ntuple(i -> i == dim ? dstrange : (:), Val(ndims(arr)))
         destv = @view dest[dstidx...]
         dsti += length(sym)
         arridx = ntuple(i -> i == dim ? (idx.idx) : (:), Val(ndims(arr)))

--- a/lib/ModelingToolkitBase/src/systems/parameter_buffer.jl
+++ b/lib/ModelingToolkitBase/src/systems/parameter_buffer.jl
@@ -279,16 +279,18 @@ function narrow_buffer_type(
 end
 
 function narrow_buffer_type(buffer::BlockedArray; p_constructor = identity)
-    if eltype(buffer) <: AbstractArray
-        buffer = narrow_buffer_type.(buffer; p_constructor)
+    narrowed = if eltype(buffer) <: AbstractArray
+        narrow_buffer_type.(buffer; p_constructor)
+    else
+        buffer
     end
     type = Union{}
-    for x in buffer
+    for x in narrowed
         type = promote_type(type, typeof(x))
     end
-    tmp = p_constructor(type.(buffer))
-    blocks = ntuple(Val(ndims(buffer))) do i
-        bsizes = blocksizes(buffer, i)
+    tmp = p_constructor(type.(narrowed))
+    blocks = ntuple(Val(ndims(narrowed))) do i
+        bsizes = blocksizes(narrowed, i)
         p_constructor(Int.(bsizes))
     end
     return BlockedArray(tmp, blocks...)
@@ -542,6 +544,12 @@ function SymbolicIndexingInterface.set_parameter!(
     return nothing
 end
 
+function restore_static_buffers(oldbufs::Tuple, newbufs::Tuple)
+    return ntuple(Val(length(newbufs))) do i
+        similar_type.(oldbufs[i], eltype(newbufs[i]))(newbufs[i])
+    end
+end
+
 function narrow_buffer_type_and_fallback_undefs(
         oldbuf::AbstractVector, newbuf::AbstractVector
     )
@@ -769,15 +777,9 @@ function __remake_buffer(indp, oldbuf::MTKParameters, idxs, vals; validate = tru
     if !ArrayInterface.ismutable(oldbuf)
         @set! newbuf.tunable = similar_type(oldbuf.tunable, eltype(newbuf.tunable))(newbuf.tunable)
         @set! newbuf.initials = similar_type(oldbuf.initials, eltype(newbuf.initials))(newbuf.initials)
-        @set! newbuf.discrete = ntuple(Val(length(newbuf.discrete))) do i
-            similar_type.(oldbuf.discrete[i], eltype(newbuf.discrete[i]))(newbuf.discrete[i])
-        end
-        @set! newbuf.constant = ntuple(Val(length(newbuf.constant))) do i
-            similar_type.(oldbuf.constant[i], eltype(newbuf.constant[i]))(newbuf.constant[i])
-        end
-        @set! newbuf.nonnumeric = ntuple(Val(length(newbuf.nonnumeric))) do i
-            similar_type.(oldbuf.nonnumeric[i], eltype(newbuf.nonnumeric[i]))(newbuf.nonnumeric[i])
-        end
+        @set! newbuf.discrete = restore_static_buffers(oldbuf.discrete, newbuf.discrete)
+        @set! newbuf.constant = restore_static_buffers(oldbuf.constant, newbuf.constant)
+        @set! newbuf.nonnumeric = restore_static_buffers(oldbuf.nonnumeric, newbuf.nonnumeric)
     end
     return newbuf
 end

--- a/lib/ModelingToolkitBase/src/systems/problem_utils.jl
+++ b/lib/ModelingToolkitBase/src/systems/problem_utils.jl
@@ -998,12 +998,11 @@ function CopyParamsByTemplate(srcsys::AbstractSystem, syms::AbstractArray{Symbol
         end
         portion = symidx.portion
         _bufidx = symidx.idx
+        subidx = nothing
         bufidx::UnitRange{Int} = if _bufidx isa AbstractVector{Int}
             @assert isequal(vec(_bufidx), first(_bufidx):last(_bufidx))
-            subidx = nothing
             first(_bufidx):last(_bufidx)
         elseif _bufidx isa Int
-            subidx = nothing
             _bufidx:_bufidx
         elseif _bufidx isa NTuple{2, Int}
             subidx = _bufidx[1]

--- a/lib/ModelingToolkitBase/src/utils.jl
+++ b/lib/ModelingToolkitBase/src/utils.jl
@@ -618,9 +618,7 @@ end
 Throw error when difference/derivative operation occurs in the R.H.S.
 """
 @noinline function throw_invalid_operator(opvar, eq, op::Type)
-    if op === Differential
-        optext = "derivative"
-    end
+    optext = op === Differential ? "derivative" : "difference"
     msg = "The $optext variable must be isolated to the left-hand " *
         "side of the equation like `$opvar ~ ...`. You may want to use `mtkcompile` or the DAE form.\nGot $eq."
     throw(InvalidSystemException(msg))

--- a/lib/ModelingToolkitBase/test/abstractsystem.jl
+++ b/lib/ModelingToolkitBase/test/abstractsystem.jl
@@ -59,3 +59,15 @@ ivs = independent_variables(MyMVS([t, x], "sys", []))
     @test any(isequal(csys.p2), csyms)
     @test any(isequal(csys.p2), collect(MT.bound_parameters(csys)))
 end
+
+using ModelingToolkitBase: t_nounits as t, D_nounits as D
+
+struct NotASystem <: ModelingToolkitBase.AbstractSystem end
+
+@testset "`extend` rejects systems of different types" begin
+    @variables x(t)
+    @named sys = System([D(x) ~ x], t)
+    @test_throws ArgumentError extend(
+        NotASystem(), sys; name = :ext, description = "", gui_metadata = nothing
+    )
+end

--- a/lib/ModelingToolkitBase/test/basic_transformations.jl
+++ b/lib/ModelingToolkitBase/test/basic_transformations.jl
@@ -475,3 +475,8 @@ end
     @test arguments(arguments(eqrhs)[1])[1] === Symbolics.SConst(Symbolics.SConst(Float32[1.23456, 2.34567]))
     @test observed(sys32)[1].rhs === norm(Symbolics.SConst(ComplexF32(2.3564 + 12.34345im)))
 end
+
+@testset "`fractional_to_ordinary` rejects integer order 1" begin
+    @variables x(t)
+    @test_throws ArgumentError fractional_to_ordinary(x, x, 1, 1.0e-7, 1)
+end

--- a/lib/ModelingToolkitBase/test/code_generation.jl
+++ b/lib/ModelingToolkitBase/test/code_generation.jl
@@ -169,3 +169,8 @@ end
     @test ModelingToolkitBase.observed_equations_used_by(sys, [equations(sys)[1].rhs]) ==
         [1, 2]
 end
+
+@testset "`BandedAMatrixWrapper` on an `Expr`" begin
+    ex = ModelingToolkitBase.BandedAMatrixWrapper(:(f()), 3, (1, 1))
+    @test ex == Expr(:call, ModelingToolkitBase.BandedAMatrixWrapper, :(f()), 3, (1, 1))
+end

--- a/lib/ModelingToolkitBase/test/discrete_system.jl
+++ b/lib/ModelingToolkitBase/test/discrete_system.jl
@@ -335,3 +335,20 @@ end
     sol = solve(discprob, FunctionMap())
     @test SciMLBase.successful_retcode(sol)
 end
+
+@testset "`Shift(steps)` constructor" begin
+    s = Shift(2)
+    @test s.t === nothing
+    @test s.steps == 2
+end
+
+@testset "`throw_invalid_operator` names non-derivative operators" begin
+    @variables x(t)
+    err = try
+        ModelingToolkitBase.throw_invalid_operator(Shift(t)(x), x ~ Shift(t)(x), Shift)
+    catch e
+        e
+    end
+    @test err isa ModelingToolkitBase.InvalidSystemException
+    @test occursin("difference variable", sprint(showerror, err))
+end

--- a/lib/ModelingToolkitBase/test/modelingtoolkitize.jl
+++ b/lib/ModelingToolkitBase/test/modelingtoolkitize.jl
@@ -513,3 +513,9 @@ sys = modelingtoolkitize(prob)
     sprob2.f(mtkvals, sprob2.u0, sprob2.p, tspan[1])
     @test mtkvals ≈ truevals
 end
+
+@testset "unsupported parameter containers" begin
+    err = ModelingToolkitBase.ModelingtoolkitizeParametersNotSupportedError
+    @test_throws err ModelingToolkitBase.define_params(:p, t)
+    @test occursin("Symbol", sprint(showerror, err(Symbol)))
+end

--- a/lib/ModelingToolkitBase/test/symbolic_events.jl
+++ b/lib/ModelingToolkitBase/test/symbolic_events.jl
@@ -8,6 +8,7 @@ using ModelingToolkitBase: SymbolicContinuousCallback,
     affects, affect_negs, system, observed, AffectSystem
 import DiffEqNoiseProcess
 using Symbolics
+using Symbolics: unwrap
 
 using StableRNGs
 import SciMLBase

--- a/lib/ModelingToolkitBase/test/symbolic_events.jl
+++ b/lib/ModelingToolkitBase/test/symbolic_events.jl
@@ -1973,3 +1973,42 @@ if !@isdefined(ModelingToolkit)
         @test sol[gi] ≈ [1, 2, 3, 2, 1]
     end
 end
+
+@testset "`ImperativeAffect` internals" begin
+    @variables x(t) y(t)
+    @parameters p
+    @named sys = System([D(x) ~ p * x, D(y) ~ x], t)
+    sys = complete(sys)
+
+    @testset "`search_variables!` descends into non-symbolic entries" begin
+        aff = ModelingToolkitBase.ImperativeAffect(
+            (m, o, c, i) -> m; observed = (; xy = [x, y])
+        )
+        vars = Set{ModelingToolkitBase.SymbolicT}()
+        SymbolicUtils.search_variables!(vars, aff)
+        @test isequal(vars, Set(unwrap.([x, y])))
+    end
+
+    @testset "duplicate observed aliases warn" begin
+        aff = ModelingToolkitBase.ImperativeAffect(
+            (m, o, c, i) -> m, [x, y], [:a, :a], [], Symbol[], nothing, false
+        )
+        @test_logs (:warn, r"is aliased as a") match_mode = :any ModelingToolkitBase.compile_functional_affect(
+            aff, sys
+        )
+    end
+
+    @testset "`Substituter` on an `AffectSystem`" begin
+        @parameters q
+        aff = ModelingToolkitBase.AffectSystem(
+            ModelingToolkitBase.SymbolicAffect([x ~ p]); iv = t, parent_sys = sys
+        )
+        subs = SymbolicUtils.Substituter{false}(
+            Dict(unwrap(p) => unwrap(q)), SymbolicUtils.default_substitute_filter
+        )
+        newaff = subs(aff)
+        @test isequal(only(observed(newaff.system)).rhs, unwrap(q))
+        @test isequal(parameters(newaff.system), [unwrap(q)])
+        @test isequal(newaff.parameters, [unwrap(q)])
+    end
+end


### PR DESCRIPTION
> This PR should be ignored until reviewed by @ChrisRackauckas.

## What changed and why

`JET.report_package(ModelingToolkitBase; target_modules = (ModelingToolkitBase,), mode = :typo)` (the check `run_qa` runs in the ModelingToolkitBase QA group, red on master since #4832 — see https://github.com/SciML/ModelingToolkit.jl/issues/5063) reports 263 problems. 234 of them are spurious `may be undefined` reports on Moshi `@match` temporaries (tracked in the issue; fix is upstream in Moshi). This PR fixes the other 29, which are genuine:

- `Shift(steps)` called `new` from an outer constructor (`UndefVarError` for `Shift(2)`).
- `_all_ts_idxs!(…, sym::Symbol)` used `s` instead of `sym` (unreachable branch, no test).
- `BandedAMatrixWrapper(::Expr, nr, bands)` used `sz` instead of `nr`.
- `compile_functional_affect`'s duplicate-alias `@warn` interpolated `expr` instead of `exp`; `search_variables!(vars, ::ImperativeAffect)` recursed on `v` instead of `var`.
- `define_params` fallback threw the undefined `ModelingtoolkitizeParametersNotSupportedError`; the type is now defined with a `showerror`.
- `extend` on systems of different types called the removed `convert_system`; it now throws an `ArgumentError`.
- The `Substituter` method for `AffectSystem` used the removed `parameter_dependencies`/`defaults` fields; it now substitutes `eqs`, `observed` (where the compiled affect equations live), `bindings`, `initial_conditions`, `guesses`, `unknowns`, `ps`.
- `throw_invalid_operator` left `optext` undefined for non-`Differential` operators; `fractional_to_ordinary` left `coeff` undefined for `α == 1` (now an `ArgumentError`; previously an `InexactError` from `floor(Int, -Inf)` further down).
- Locals bound only on some branches (`ic`, `subidx`, `source_visitor`, `source_info`, `mass_matrix`) and locals captured by closures after reassignment (`dsti`, `buffer`, `newbuf` — these were `Core.Box`ed) are restructured so they are defined on every path. No behaviour change.

## Verification

JET on this branch, Julia 1.12.7 / JET 0.12.1 / Moshi 0.3.12, same call as `run_qa`:

- master: `NREPORTS=263` (1036 s)
- this branch: `NREPORTS=234` (1020 s); the remaining reports are all `##And#N#…`/`##Call#N#…` Moshi temporaries
- this branch + the Moshi fix branch (https://github.com/ChrisRackauckas-Claude/Moshi.jl/tree/flat-match-conditions): `NREPORTS=0` (330 s)

The QA group itself therefore still fails on this PR until Moshi is fixed; I am not changing the test.

New tests (`test/discrete_system.jl`, `test/code_generation.jl`, `test/modelingtoolkitize.jl`, `test/abstractsystem.jl`, `test/basic_transformations.jl`, `test/symbolic_events.jl`), run as one script against master and against this branch:

```
master:      Some tests did not pass: 0 passed, 4 failed, 6 errored, 0 broken.
this branch: new regression tests | 14 passed, 14 total
```

Test groups run locally with `GROUP=<group> julia +1.12 --project=. -e 'using Pkg; Pkg.test()'` in `lib/ModelingToolkitBase`:

| group | this branch | master CI (run 33444273161) |
|---|---|---|
| `InterfaceI` | 1610 passed, 5 broken, 44m55s | 1601 passed, 5 broken |
| `InterfaceII` | all 26 files pass; `Optimal Control + Constraints Tests` 31 passed, 2 broken (same as master) | same |
| `SymbolicIndexingInterface` | 64 + 1824 + 118 + 53 passed | same |

(The 9 extra `InterfaceI` passes are the new tests; the broken counts are pre-existing `@test_broken`s.)

Runic (`julia -m Runic --check --diff` on the changed files) reports only a pre-existing hunk in `src/systems/parameter_buffer.jl:120` that is identical on master; `typos` on the diff is clean.

## Not verified

- Other test groups (Initialization, Extended, Regression*, Downstream, the root ModelingToolkit groups) and Julia 1.10.
- The `!ArrayInterface.ismutable(oldbuf)` path in `remake_buffer` (`restore_static_buffers`) is a pure extraction of the existing closures; I did not find a test that exercises it.

## Things to push back on

- `extend` with mismatched system types now throws `ArgumentError` rather than trying (and failing) to convert.
- `fractional_to_ordinary` with `α == 1` now throws `ArgumentError` up front.

🤖 Generated with [Claude Code](https://claude.com/claude-code) 2.1.259 (model: claude-fable-5-1)
Session: https://claude.ai/code/session_01FeJYXni9MkJhPFA9yxYvfn
