### PR TITLE
Release 11.41.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ModelingToolkit"
 uuid = "961ee093-0014-501f-94e3-6117800e7a78"
-version = "11.40.1"
+version = "11.41.0"
 authors = ["Yingbo Ma <mayingbo5@gmail.com>", "Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
 
 [deps]


### PR DESCRIPTION
Re-cut as a minor. 11.40.1 never registered: its registration PR (JuliaRegistries/General#166107) has been open since 2026-08-26 carrying a failed AutoMerge verdict, and re-triggering updated the tree without producing a fresh evaluation. Moving to a new version leaves that stale PR behind.

Contents: precompile ODEProblem construction and DAE initialization in the MTK workloads (#5061).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014FEzNTLFutCmTEAZ3zBg5R