### PR TITLE
fix: preserve structured parameters for vector remake

### DIFF
--- a/lib/ModelingToolkitBase/src/systems/nonlinear/initializesystem.jl
+++ b/lib/ModelingToolkitBase/src/systems/nonlinear/initializesystem.jl
@@ -823,7 +823,20 @@ function _late_binding_update_u0_p_impl(
     else
         allsyms = nothing
         # if `p` is not provided or is symbolic
-        p === missing || eltype(p) <: Pair || return newu0, newp
+        if p !== missing && !(eltype(p) <: Pair)
+            _unwrap_mtk_parameters(p) isa MTKParameters && return newu0, newp
+            oldp = parameter_values(prob)
+            unwrapped_oldp = _unwrap_mtk_parameters(oldp)
+            if unwrapped_oldp isa MTKParameters
+                newp = SciMLStructures.replace(
+                    SciMLStructures.Tunable(), copy(unwrapped_oldp), newp
+                )
+                if oldp isa SciMLBase.DespecializedParameters
+                    newp = SciMLBase.DespecializedParameters(newp)
+                end
+            end
+            return newu0, newp
+        end
         (newu0 === nothing || isempty(newu0)) && return newu0, newp
         initdata === nothing && return newu0, newp
         meta = initdata.metadata

--- a/lib/ModelingToolkitBase/test/initializationsystem.jl
+++ b/lib/ModelingToolkitBase/test/initializationsystem.jl
@@ -1567,6 +1567,19 @@ end
     @test SciMLBase.successful_retcode(solve(newprob))
 end
 
+@testset "Remake with a parameter vector preserves structured parameters" begin
+    @variables remake_x(t) = 1.0
+    @parameters remake_a = 1.0
+    @named remake_sys = System([D(remake_x) ~ remake_a * remake_x], t)
+    remake_sys = complete(remake_sys)
+
+    prob = ODEProblem(remake_sys, [], (0.0, 1.0))
+    remade = remake(prob; p = [2.0])
+
+    @test remade.ps[remake_a] == 2.0
+    @test remade.ps[Initial(remake_x)] == 1.0
+end
+
 @testset "Issue#3295: Incomplete initialization of pure-ODE systems" begin
     @variables X(t) Y(t)
     @parameters p d


### PR DESCRIPTION
> **Ignore until reviewed by @ChrisRackauckas.**

## What changed

`SciMLBase.remake(prob; p = vector)` can produce a raw replacement vector while ModelingToolkit's initialization reconstruction still expects a structured parameter container with an `Initials` portion. This change copies the problem's existing `MTKParameters` and replaces only its public `SciMLStructures.Tunable()` portion before rebuilding initialization data. Existing initial, discrete, cache, and other parameter portions are preserved.

The regression test checks both sides of that contract: the requested tunable value changes, while the defaulted state's initial parameter remains available.

## Regression evidence

This public-API MWE was run against clean `master` at `6eb5708070bb3da974b286bf1399f37f6f8689b0` and against this branch:

```julia
using ModelingToolkit
using SciMLBase: remake
using Test

@independent_variables t
@variables x(t) = 1.0
@parameters a = 1.0
D = Differential(t)
@named system = ODESystem([D(x) ~ a * x], t)
problem = ODEProblem(complete(system), [], (0.0, 1.0))
remade = remake(problem; p = [2.0])

@test remade.ps[a] == 2.0
```

Exact command for both runs, using Julia 1.12.7 and a fresh isolated depot:

```sh
export TMPDIR=/home/crackauc/tmp
export JULIA_DEPOT_PATH="$PWD/.validation/depot"
export JULIA_PKG_PRECOMPILE_AUTO=0
/usr/bin/time -f 'wall=%e exit=%x maxrss_kb=%M' \
  timeout --signal=TERM --kill-after=30 3600 \
  /home/crackauc/.juliaup/bin/julia +1.12.7 --startup-file=no --project=. \
  .validation/vector_parameter_remake.jl
```

Before the fix:

```text
ERROR: LoadError: FieldError: type Array has no field `initials`, available fields: `ref`, `size`
wall=743.90 exit=1 maxrss_kb=5422260
```

After the fix:

```text
problem.p = MTKParameters(...)([1.0], [0.0, 1.0], (), (), (), ())
remade.p = MTKParameters(...)([2.0], [0.0, 1.0], (), (), (), ())
wall=529.99 exit=0 maxrss_kb=5487796
```

## Validation

```sh
GROUP=Initialization /home/crackauc/.juliaup/bin/julia +1.12.7 \
  --startup-file=no --project=. -e 'using Pkg; Pkg.test()'
```

```text
Test Summary:  | Pass  Broken  Total      Time
Initialization |  849      12    861  54m50.7s
Testing ModelingToolkit tests passed
wall=3473.71 exit=0 maxrss_kb=6046600
```

```sh
GROUP=QA /home/crackauc/.juliaup/bin/julia +1.12.7 \
  --startup-file=no --project=. -e 'using Pkg; Pkg.test()'
```

```text
Test Summary: | Pass  Total     Time
QA            |   40     40  7m50.5s
Testing ModelingToolkit tests passed
wall=506.15 exit=0 maxrss_kb=3592740
```

The following also exited successfully with no findings:

```sh
/home/crackauc/.juliaup/bin/julia +1.12.7 --startup-file=no \
  --project=.validation/tools-env -m Runic --check --diff \
  lib/ModelingToolkitBase/src/systems/nonlinear/initializesystem.jl \
  lib/ModelingToolkitBase/test/initializationsystem.jl
typos --format brief \
  lib/ModelingToolkitBase/src/systems/nonlinear/initializesystem.jl \
  lib/ModelingToolkitBase/test/initializationsystem.jl
git diff --check
```

I did not run `GROUP=Everything`. A docs build was not run because this changes no public API, docstring, or rendered documentation. There are no dependency or license changes.

## Bisect note

I could not establish a valid first-good boundary under the required Julia 1.12.7. Source blame pointed at https://github.com/SciML/ModelingToolkit.jl/commit/d060e81440653e421642d854e12dc7bc929cfc89, but that commit's parent already fails this remake path with an earlier `getindex(::Nothing, ::Int64)` exception. ModelingToolkit v9.61.0 fails before reaching `remake` because its historical dependency set is incompatible with Julia 1.12.7. This PR therefore does not claim an introducing commit.

The behavior choice here is deliberate: a raw parameter vector updates only the tunable portion and preserves existing initial values, matching the current direct-array semantics rather than treating the vector as a symbolic initial-value map.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://chatgpt.com/codex/tasks/01a03a17-ad6f-7131-82fc-d0fd57ea6512
