### PR TITLE
Fix scalarized array initial conditions

### DIFF
--- a/lib/ModelingToolkitBase/src/systems/nonlinear/initializesystem.jl
+++ b/lib/ModelingToolkitBase/src/systems/nonlinear/initializesystem.jl
@@ -498,6 +498,7 @@ function timevaring_initsys_process_op!(
             for i in SU.stable_eachindex(k)
                 v[i] === COMMON_NOTHING && continue
                 push!(eqs_ics, subk[i] ~ ik[i])
+                write_possibly_indexed_array!(op, ik[i], v[i], COMMON_FALSE)
             end
             continue
         end

--- a/lib/ModelingToolkitBase/test/initializationsystem.jl
+++ b/lib/ModelingToolkitBase/test/initializationsystem.jl
@@ -1976,6 +1976,22 @@ end
     @test SciMLBase.successful_retcode(sol)
 end
 
+@testset "Scalarized array initial conditions" begin
+    @independent_variables indexed_t
+    @variables indexed_y(indexed_t)[1:10]
+    indexed_D = Differential(indexed_t)
+
+    @mtkcompile indexed_system = System(
+        [indexed_D(indexed_y[1]) ~ -indexed_y[1]], indexed_t
+    )
+    indexed_state = only(unknowns(indexed_system))
+    indexed_problem = ODEProblem(
+        indexed_system, [indexed_state => 1.0], (0.0, 1.0)
+    )
+
+    @test indexed_problem.u0 == [1.0]
+end
+
 @testset "Initial conditions removed with ` => nothing` aren't retained" begin
     @variables x(t)[1:2]
     @mtkcompile sys = System([D(x[1]) ~ -x[1], x[1] + x[2] ~ 3], t; initial_conditions = [x => ones(2)])


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed

Preserve explicitly supplied elements of scalarized symbolic-array initial conditions when constructing the initialization problem. `timevaring_initsys_process_op!` now writes each supplied array element into the matching `Initial(...)` parameter, while retaining the existing state linkage for unspecified elements.

The regression test covers a ten-element symbolic array whose simplified ODE system retains only the first element. Constructing an `ODEProblem` with that scalarized state set to `1.0` must retain `u0 == [1.0]`.

## Root cause and bisect

The operating-point map combines scalarized array entries under the parent array. Initialization added equations such as `y[1] ~ Initial(y)[1]`, but left `Initial(y)[1]` linked to the state instead of assigning its explicit value. Trivial eager initialization therefore reconstructed the state from a zero-valued initial parameter.

An automated clean-depot bisect identified [17bac294e9f5ff0f9ef5ed2e323d032e5139319c](https://github.com/SciML/ModelingToolkit.jl/commit/17bac294e9f5ff0f9ef5ed2e323d032e5139319c) as the first bad ModelingToolkit commit. Its parent [da3ab50d0dce4ac0fb79e1bfc29eadbdbca80aa3](https://github.com/SciML/ModelingToolkit.jl/commit/da3ab50d0dce4ac0fb79e1bfc29eadbdbca80aa3) passes. The bad commit widened compatibility from SciMLBase 2 to 3, exposing this existing ModelingToolkit initialization-path defect through SciMLBase 3's eager handling of trivial initialization.

## Verification

All commands used Julia 1.12.7 with `TMPDIR=/home/crackauc/tmp` and an isolated depot.

### Regression test fails before the fix

```text
$ julia +1.12.7 --startup-file=no --project=. test_candidate.jl
Scalarized array initial conditions: Test Failed
  Expression: indexed_problem.u0 == [1.0]
   Evaluated: [0.0] == [1.0]
Test Summary:                       | Fail  Total  Time
Scalarized array initial conditions |    1      1  7.6s
```

### The same test passes after the fix

```text
$ julia +1.12.7 --startup-file=no --project=. test_candidate.jl
Test Summary:                       | Pass  Total  Time
Scalarized array initial conditions |    1      1  5.4s
```

### Clean-master reproducer after the fix

```text
$ julia +1.12.7 --startup-file=no --project=. .validation/indexed_array_u0.jl
state = (y(t))[1]
problem.u0 = [1.0]
```

### Required gates

```text
$ GROUP=QA julia +1.12.7 --startup-file=no --project=. -e 'using Pkg; Pkg.test()'
Test Summary: | Pass  Total      Time
QA            |   40     40  28m16.1s
Testing ModelingToolkit tests passed

$ GROUP=Initialization julia +1.12.7 --startup-file=no --project=. -e 'using Pkg; Pkg.test()'
Test Summary:  | Pass  Broken  Total      Time
Initialization |  848      12    860  59m53.9s
Testing ModelingToolkit tests passed

$ julia +1.12.7 --startup-file=no --project=@runic -m Runic --check --diff \
    lib/ModelingToolkitBase/src/systems/nonlinear/initializesystem.jl \
    lib/ModelingToolkitBase/test/initializationsystem.jl
[exit 0]

$ typos --diff
[exit 0]

$ git diff --check
[exit 0]
```

Documentation was not built because this changes no public API, docstring, or documentation page. No dependency or license boundary changes are involved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://chatgpt.com/codex/tasks/01a03a17-ad6f-7131-82fc-d0fd57ea6512
