### PR TITLE
Recognize copied symbolic missing bindings

### DIFF
--- a/lib/ModelingToolkitBase/src/problems/initializationproblem.jl
+++ b/lib/ModelingToolkitBase/src/problems/initializationproblem.jl
@@ -132,7 +132,7 @@ function InitializationProblem{iip, specialize}(
 
     uninit = as_atomic_array_set(unknowns(sys))
     for (k, v) in bindings(sys)
-        v === COMMON_MISSING || continue
+        isequal(v, COMMON_MISSING) || continue
         push!(uninit, k)
     end
     setdiff!(uninit, as_atomic_array_set(unknowns(isys)))

--- a/lib/ModelingToolkitBase/src/systems/abstractsystem.jl
+++ b/lib/ModelingToolkitBase/src/systems/abstractsystem.jl
@@ -578,7 +578,7 @@ function add_initialization_parameters(sys::AbstractSystem; split = true, _unhac
     end
 
     for (k, v) in bindings(sys)
-        v === COMMON_MISSING || continue
+        isequal(v, COMMON_MISSING) || continue
         if split
             push!(all_initialvars, k)
         else
@@ -1889,7 +1889,7 @@ function set_defaults(sys::AbstractSystem, pairs)
         u = unwrap(val)
         if u === nothing || u === COMMON_NOTHING
             continue
-        elseif u === missing || u === COMMON_MISSING
+        elseif u === missing || isequal(u, COMMON_MISSING)
             binds[var] = COMMON_MISSING
         elseif u isa SymbolicT && !SU.isconst(u)
             binds[var] = u

--- a/lib/ModelingToolkitBase/src/systems/nonlinear/initializesystem.jl
+++ b/lib/ModelingToolkitBase/src/systems/nonlinear/initializesystem.jl
@@ -285,7 +285,7 @@ function generate_initializesystem_timeindependent(
     end
     # Anything with a binding of `missing` is solvable.
     for (k, v) in binds
-        if v === COMMON_MISSING
+        if isequal(v, COMMON_MISSING)
             push!(init_vars_set, k)
             delete!(init_ps, k)
             continue
@@ -319,7 +319,7 @@ function generate_initializesystem_timeindependent(
             continue
         end
 
-        if v === COMMON_MISSING
+        if isequal(v, COMMON_MISSING)
             push!(init_vars_set, k)
             delete!(init_ps, k)
             continue
@@ -409,7 +409,7 @@ function initsys_sort_system_bindings!(
     )
     # Anything with a binding of `missing` is solvable.
     for (k, v) in binds
-        if v === COMMON_MISSING
+        if isequal(v, COMMON_MISSING)
             push!(init_vars_set, k)
             delete!(init_ps, k)
             @assert Initial(k) in init_ps
@@ -448,7 +448,7 @@ function timevaring_initsys_process_op!(
     )
     for (k, v) in op
         # Late binding `missing` also makes the key solvable
-        if v === COMMON_MISSING
+        if isequal(v, COMMON_MISSING)
             push!(init_vars_set, k)
             delete!(init_ps, k)
             continue

--- a/lib/ModelingToolkitBase/src/systems/optimal_control_interface.jl
+++ b/lib/ModelingToolkitBase/src/systems/optimal_control_interface.jl
@@ -528,7 +528,7 @@ function process_DynamicOptProblem(
     # Resolve parameter bindings so observed equations and constraints
     # referencing pre-binding names can be fully substituted.
     for (k, v) in bindings(sys)
-        v === COMMON_MISSING && continue
+        isequal(v, COMMON_MISSING) && continue
         haskey(pmap, v) && !haskey(pmap, k) && (pmap[k] = pmap[v])
     end
 

--- a/lib/ModelingToolkitBase/src/systems/problem_utils.jl
+++ b/lib/ModelingToolkitBase/src/systems/problem_utils.jl
@@ -2026,7 +2026,7 @@ function maybe_build_initialization_problem(
     missingvars = Set{SymbolicT}()
     temp_op = copy(op)
     for (k, v) in op
-        v === COMMON_MISSING || continue
+        isequal(v, COMMON_MISSING) || continue
         push!(missingvars, k)
         delete!(temp_op, k)
     end
@@ -2057,7 +2057,7 @@ function maybe_build_initialization_problem(
         has_possibly_indexed_key(op, v) || push!(missingvars, v)
     end
     for (k, v) in binds
-        v === COMMON_MISSING && !has_possibly_indexed_key(op, k) && push!(missingvars, k)
+        isequal(v, COMMON_MISSING) && !has_possibly_indexed_key(op, k) && push!(missingvars, k)
     end
     for p in as_atomic_array_set(parameters(sys))
         haskey(binds, p) && continue

--- a/lib/ModelingToolkitBase/src/utils.jl
+++ b/lib/ModelingToolkitBase/src/utils.jl
@@ -340,7 +340,7 @@ function check_bindings(atomic_ps::AtomicArraySet{Dict{SymbolicT, Nothing}}, bin
     for p in atomic_ps
         val = get(bindings, p, COMMON_NOTHING)
         val === COMMON_NOTHING && continue
-        if val === COMMON_MISSING
+        if isequal(val, COMMON_MISSING)
             if !is_variable_floatingpoint(p)
                 throw(
                     ArgumentError(
@@ -541,7 +541,7 @@ function collect_defaults!(initial_conditions::SymmapT, bindings::SymmapT, v::Sy
             Moshi.Match.@match def begin
                 # `get!` here is just shorthand for "if the key doesn't exist, add this
                 # value".
-                BSImpl.Const() => if def === COMMON_MISSING
+                BSImpl.Const() => if isequal(def, COMMON_MISSING)
                     get!(bindings, v, def)
                 else
                     get!(initial_conditions, v, def)
@@ -1703,7 +1703,7 @@ Identical to `no_override_merge!` but `COMMON_MISSING` values in `b` are ignored
 """
 function no_override_merge_except_missing!(a::AbstractDict, b::AbstractDict)
     for (k, v) in b
-        v === COMMON_MISSING && continue
+        isequal(v, COMMON_MISSING) && continue
         if haskey(a, k)
             throw(ArgumentError("Cannot merge without overriding: common key $k."))
         end

--- a/lib/ModelingToolkitBase/test/initializationsystem.jl
+++ b/lib/ModelingToolkitBase/test/initializationsystem.jl
@@ -11,6 +11,22 @@ import DiffEqNoiseProcess
 using Setfield: @set!
 import SymbolicUtils as SU
 
+@testset "Remake with copied missing parameter bindings" begin
+    @variables x(t) = 1.0
+    @parameters k = 1.0 N
+    @named raw = System(
+        [D(x) ~ -k * x / N], t;
+        bindings = [N => missing], initial_conditions = [N => 10.0]
+    )
+    sys = complete(raw)
+    prob = ODEProblem(sys, [], (0.0, 1.0))
+    for original in (prob, deepcopy(prob))
+        remade = remake(original; p = [k => 2.0])
+        @test remade.ps[k] == 2.0
+        @test remade.ps[N] == 10.0
+    end
+end
+
 struct FwdDiffTag end
 const DualT{T} = ForwardDiff.Dual{ForwardDiff.Tag{FwdDiffTag, T}, T, 1}
 const ERRMOD = @isdefined(ModelingToolkit) ? ModelingToolkit.StateSelection : ModelingToolkitBase


### PR DESCRIPTION
## What changed

Recognize symbolic missing bindings by `isequal`, not object identity. Deep-copying a problem can copy the symbolic constant wrapping `missing`; initialization then incorrectly treats a solvable parameter as a bound parameter and omits it from the initialization unknowns. This breaks parameter remakes used by ensembles, including constant states eliminated to solvable parameters.

The regression exercises both the original problem and its deep copy with the same parameter remake. No new public API or dependencies.

## Verification

Julia 1.11.9, local environments with identical dependency versions and only the ModelingToolkit/ModelingToolkitBase source paths changed:

```sh
GROUP=Initialization julia --project=EMA-deepcopy-main-env -e 'using Pkg; Pkg.test("ModelingToolkitBase")'
```

Unfixed production source at c4c04fe910a1d0509eb41395b8d6b40dc9f25068, with the new test added:

```text
Remake with copied missing parameter bindings: Error During Test
ArgumentError: Symbol N is not present in the system.
InitializationSystem Test | 663 pass, 1 error, 12 existing broken
Remake with copied missing parameter bindings | 2 pass, 1 error
```

With the fix before rebasing:

```text
Guess Propagation | 11/11
InitializationSystem Test | 665 pass, 12 existing broken
Initial Values Test | 65/65
Testing ModelingToolkitBase tests passed
```

`GROUP=QA` passed JET 54/54 and Aqua 21/21. Runic, `git diff --check`, and `typos` over the diff excluding Git index-hash metadata passed. No tests were skipped or weakened by this change.

After rebasing onto upstream 2b4f11a, the complete native Initialization group passed again:

```text
Guess Propagation | 11/11
InitializationSystem Test | 667 pass, 12 existing broken
Initial Values Test | 65/65
Testing ModelingToolkitBase tests passed
```

The corresponding QA rerun passed JET 54/54 and Aqua 21/21, exit 0. Upstream subsequently advanced to e76112cc0; the refreshed branch is 2e20892791e27e88bce578cbeff33395d3faff04.

Latest refresh verification at 2e20892791e27e88bce578cbeff33395d3faff04, on upstream e76112cc0:

```sh
GROUP=Initialization julia --project=EMA-deepcopy-current-env -e 'using Pkg; Pkg.test("ModelingToolkitBase")'
GROUP=QA julia --project=EMA-deepcopy-current-env -e 'using Pkg; Pkg.test("ModelingToolkitBase")'
```

```text
Guess Propagation | 11/11
InitializationSystem Test | 667 pass, 12 existing broken
Initial Values Test | 65/65
Testing ModelingToolkitBase tests passed

JET Tests | 54/54
Aqua Tests | 21/21
Testing ModelingToolkitBase tests passed
```

Both commands exited 0 (Initialization 1747.0s, QA 785.9s, excluding environment setup). The focused original/copied-problem remake check also exited 0. Runic, diff spelling, and `git diff --check` passed on the refreshed branch. Validation-only absolute paths generated by QA were restored and are not part of the change.

## Historical reduction

The explicit missing-binding failure reproduces across the MTK 11 main-branch merge boundary: the equivalent pre-merge defaults model passes 2/2; the post-merge binding model errors only on the deep-copied problem. The constant-state manifestation has a narrower verified boundary: the same standalone constant-state model passes 2/2 immediately before https://github.com/SciML/ModelingToolkit.jl/commit/0b01708ffb4c545b888f859bdcbc505350f723ef and fails 1 pass/1 error immediately after it, with `N#0(t) ... is not an unknown`. Those adjacent runs use identical dependencies and ModelingToolkitBase source; only ModelingToolkit root source differs. Zero-variable elimination exposes the existing missing-binding identity bug.

## Not verified

Full ModelingToolkit root suite and GPU paths were not run for this patch. Full downstream EMA docs remain in progress and are not claimed successful. The Carcione reduction also uncovered a separate SBML assignment-rule initialization failure, fixed at https://github.com/SciML/SBMLToolkit.jl/pull/240 . Combining that fix with the SBML parameter-default fix at https://github.com/SciML/SBMLToolkit.jl/pull/239 and this MTK fix passes two explicit solver-return-code checks (default and changed mu), both reaching the requested final time. This patch changes no documentation, docstrings, or public API, so the MTK documentation was not built.

Please ignore this draft until reviewed by @ChrisRackauckas.

🤖 Generated with Codex CLI 0.153.4 (model: gpt-6-astra; session: local transcript `/home/crackauc/.codex/sessions/2026/09/05/rollout-2026-09-05T05-08-31-01a070d3-9e50-71c2-98f5-129385e50fb7.jsonl`).
