### PR TITLE
Run the Optimization test group on a dedicated GitHub-hosted runner

### DIFF
--- a/lib/ModelingToolkitBase/test/test_groups.toml
+++ b/lib/ModelingToolkitBase/test/test_groups.toml
@@ -29,6 +29,12 @@ versions = ["lts", "1", "pre"]
 
 [Optimization]
 versions = ["lts", "1", "pre"]
+# Slow group (the Pyomo cart-pole solve in dynamic_optimization.jl alone needs ~1900
+# Ipopt iterations, see #5076): 60-70 min on an idle self-hosted runner and past the
+# 120 min timeout whenever the shared pool is busy, but 15-41 min on a dedicated
+# GitHub-hosted runner. `ubuntu-24.04` forces GitHub-hosted since the self-hosted pool
+# only carries the `ubuntu-latest` label.
+runner = "ubuntu-24.04"
 
 [QA]
 versions = ["lts", "1"]

--- a/test/test_groups.toml
+++ b/test/test_groups.toml
@@ -24,6 +24,12 @@ versions = ["lts", "1", "pre"]
 
 [Optimization]
 versions = ["lts", "1", "pre"]
+# Slow group (the Pyomo cart-pole solve in dynamic_optimization.jl alone needs ~1900
+# Ipopt iterations, see #5076): 60-70 min on an idle self-hosted runner and past the
+# 120 min timeout whenever the shared pool is busy, but 15-41 min on a dedicated
+# GitHub-hosted runner. `ubuntu-24.04` forces GitHub-hosted since the self-hosted pool
+# only carries the `ubuntu-latest` label.
+runner = "ubuntu-24.04"
 
 [Downstream]
 versions = ["lts", "1", "pre"]


### PR DESCRIPTION
> **Ignore this PR until it has been reviewed by @ChrisRackauckas.**

## What changed and why

CI-config only. The `Optimization` test group (root and `lib/ModelingToolkitBase`) is routed to a dedicated GitHub-hosted `ubuntu-24.04` runner, as `Initialization` and `FMI` already are, in both `test_groups.toml` files. No timeout change: on the dedicated runner the group fits comfortably in the default 120 min.

The group has been hitting the 120 min timeout on the shared self-hosted pool for weeks, independent of code changes:

- On master, the root `Optimization (julia 1)` job was cancelled at exactly 2 h on 2026-08-15, 08-17 (×3) and 08-18 (×2); the last two green runs took 87 min and 59 min (durations from https://github.com/SciML/ModelingToolkit.jl/actions/workflows/Tests.yml).
- On https://github.com/SciML/ModelingToolkit.jl/pull/5074 (which only fixes the CasADi compat), all three `lib/ModelingToolkitBase [Optimization]` lanes and the root `julia 1` / `julia pre` lanes were cancelled at 2 h, while the root `julia lts` lane passed in 66 min on an idle runner. The sublibrary LTS lane ran the identical test files with identical resolved package versions (I diffed the two logs) yet was 2-10× slower per Ipopt solve, so the difference is runner contention, not the tests.

The dominant single cost inside the group is the Pyomo cart-pole solve, which needs ~1900 Ipopt iterations (38 min on a self-hosted 4 vCPU runner); that is a convergence problem tracked separately in https://github.com/SciML/ModelingToolkit.jl/issues/5076.

## Verification

The first push of this branch (with an additional `timeout = 240`, since dropped) ran all six Optimization lanes on `ubuntu-24.04`:

| lane | duration |
|---|---|
| root `Optimization (julia lts)` | 24 min |
| root `Optimization (julia 1)` | 41 min |
| root `Optimization (julia pre)` | 36 min |
| `lib/ModelingToolkitBase [Optimization] / Julia lts` | 15 min |
| `lib/ModelingToolkitBase [Optimization] / Julia 1` | 32 min |
| `lib/ModelingToolkitBase [Optimization] / Julia pre` | 28 min |

All six passed (the `julia 1` / `pre` lanes load CasADi 1.3.1 and run the CasADi tests). Run: https://github.com/SciML/ModelingToolkit.jl/actions?query=branch%3Aoptimization-group-runner-timeout. The amended push only removes the timeout line and reworks the comment, so the second CI run should reproduce these numbers.

Locally: `typos` on the diff and `git diff --check` are clean; nothing else applies to a TOML-only change.

## Not verified

- Nothing GPU/credential related. The red `lib/ModelingToolkitBase [QA] / Julia 1` and `downgrade-mtkbase (QA)` lanes are red on master for unrelated reasons (https://github.com/SciML/ModelingToolkit.jl/issues/5063, https://github.com/SciML/ModelingToolkit.jl/issues/5064).

🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-fable-5-1)

https://claude.ai/code/session_01QKPWYcoJxFVbcRRLtTYntV
