### PR TITLE
Document observed access and plotting from a live integrator

### DIFF
--- a/docs/src/examples/interactive_simulation.md
+++ b/docs/src/examples/interactive_simulation.md
@@ -48,6 +48,42 @@ times.
 Use `reinit!` when the simulation really is restarting from a new initial condition or time,
 not to divide one continuous run into display intervals.
 
+## Reading observed quantities from the integrator
+
+A live display usually needs quantities that structural simplification eliminated from the
+state vector. Those are available from the integrator through the same symbolic indexing
+that a solution supports, so the display code does not have to reconstruct them:
+
+```julia
+@variables pos(t) vel(t) energy(t)
+@parameters input
+@mtkcompile osc = System(
+    [D(pos) ~ vel, D(vel) ~ -pos + input, energy ~ (pos^2 + vel^2) / 2], t
+)
+
+oscprob = ODEProblem(osc, [pos => 1.0, vel => 0.0, input => 0.0], (0.0, 10.0))
+integrator = init(oscprob, Tsit5())
+step!(integrator, 1.0, true)
+
+integrator[energy]                       # current value of an observed equation
+integrator(integrator.t; idxs = energy)  # the same quantity from the step's interpolant
+integrator([integrator.tprev, integrator.t]; idxs = [pos, energy])
+```
+
+`plot(integrator)` accepts the same `idxs` specifications as `plot(sol)`, including observed
+equations, lists, phase-plane tuples and a plot function:
+
+```julia
+using Plots
+
+plot(integrator; idxs = energy)
+plot(integrator; idxs = [pos, energy])
+plot(integrator; idxs = (pos, vel))
+```
+
+`plot(integrator)` draws only the step the integrator is currently on, which is what an
+animation loop wants. Plot `integrator.sol` instead to draw the whole accumulated history.
+
 ## Parameters and time-varying inputs
 
 A value declared with `@parameters` is treated as time-invariant when a saved solution evaluates


### PR DESCRIPTION
## What changed and why

`docs/src/examples/interactive_simulation.md` (added in
https://github.com/SciML/ModelingToolkit.jl/pull/5055) shows how to keep one integrator
alive and read a state variable from it, but not how to reach the quantities structural
simplification removed from the state vector — which is what a live display usually wants.
That was the follow-up raised in
https://github.com/SciML/ModelingToolkit.jl/issues/5006#issuecomment-5491174422: the plot
recipe was not observed-aware, so the plot could not be updated from the integrator.

This adds a section covering `integrator[obs]`, `integrator(t; idxs = obs)`, and
`plot(integrator; idxs = ...)` with the same specifications `plot(sol)` takes, plus the one
semantic point that catches people out: `plot(integrator)` draws the current step, not the
accumulated history — plot `integrator.sol` for that.

## Dependencies

The behavior this documents does not exist in the released packages. It needs:

- https://github.com/SciML/SciMLBase.jl/pull/1581 — SciMLBase 3.52.0,
  observed-aware integrator plot recipe and `symbolic_interpolation`
- https://github.com/SciML/OrdinaryDiffEq.jl/pull/4469 — OrdinaryDiffEqCore
  4.17.0, symbolic `idxs` in `integrator(t; idxs)`

This should not merge before both are registered.

## Verification

The page uses plain ```julia fences, so Documenter does not execute them. I ran every added
line by hand against the two branches above:

```
integrator[energy] = 0.49999995413823406
integrator(integrator.t; idxs = energy) = 0.49999995413823406
integrator([integrator.tprev, integrator.t]; idxs = [pos, energy]) =
    [0.5938966746905806 0.5403021534151953; 0.4999999541414679 0.49999995413823406]
plot(integrator; idxs = energy) isa Plots.Plot = true
plot(integrator; idxs = [pos, energy]) isa Plots.Plot = true
plot(integrator; idxs = (pos, vel)) isa Plots.Plot = true
```

`energy` is the observed equation `(pos^2 + vel^2) / 2` on an undamped oscillator with
`input = 0`, so `0.5` is the conserved value the example should report.

Full docs build (`julia --project=docs docs/make.jl`) exits 0 with no errors.

Also run: `typos` on the changed file.

## Not verified

Nothing beyond the docs build was run; this PR is documentation only and changes no code.

---

This PR should be ignored until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019wKpyZHy9u4QhR4ePiVmam
