### PR TITLE
Release ModelingToolkitBase 1.68.3

### DIFF
--- a/lib/ModelingToolkitBase/Project.toml
+++ b/lib/ModelingToolkitBase/Project.toml
@@ -1,7 +1,7 @@
 name = "ModelingToolkitBase"
 uuid = "7771a370-6774-4173-bd38-47e70ca0b839"
 authors = ["Yingbo Ma <mayingbo5@gmail.com>", "Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
-version = "1.68.2"
+version = "1.68.3"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"


### PR DESCRIPTION
Bumps `ModelingToolkitBase` 1.68.2 -> 1.68.3 (patch).

Source files changed since 1.68.2:
- `src/ModelingToolkitBase.jl`
- `src/discretedomain.jl`
- `src/modelingtoolkitize/common.jl`
- `src/problems/bvproblem.jl`
- `src/systems/abstractsystem.jl`
- `src/systems/callbacks.jl`
- `src/systems/codegen.jl`
- `src/systems/connectors.jl`
- `src/systems/diffeqs/basic_transformations.jl`
- `src/systems/imperative_affect.jl`
- `src/systems/index_cache.jl`
- `src/systems/nonlinear/initializesystem.jl`

Commits:
- qa: approve newly exported Symbolics API (#5050)
- Update redirected documentation links (#5054)
- qa: fix ModelingToolkitBase import checks (#5028)
- docs: replace stale Pantelides link (#5056)
- Precompile ODEProblem construction and DAE initialization in MTK workloads (#5061)
- Release 11.41.0 (#5069)

Version bump only; no code changes in this PR.


🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-opus-5[1m])

https://claude.ai/code/session_014FEzNTLFutCmTEAZ3zBg5R
