### PR TITLE
Test namespace nesting on segments, not raw string prefixes

### DIFF
--- a/lib/ModelingToolkitBase/src/inputoutput.jl
+++ b/lib/ModelingToolkitBase/src/inputoutput.jl
@@ -153,11 +153,24 @@ end
 Determine whether `var` is in the same namespace as `u`, or a namespace internal to the namespace of `u`.
 Example: `sys.u ~ sys.inner.u` will bind `sys.inner.u`, but `sys.u` remains an unbound, external signal. The namespaced signal `sys.inner.u` lives in a namespace internal to `sys`.
 """
+"""
+    is_inner_namespace_string(nu, nv)
+
+Return whether namespace `nv` is nested inside namespace `nu`.
+
+The test is on separator-delimited segments rather than raw characters: `"a₊bc"` is not
+inside `"a₊b"` even though one string is a prefix of the other.
+"""
+function is_inner_namespace_string(nu, nv)
+    isempty(nu) && return !isempty(nv)
+    return startswith(nv, nu * NAMESPACE_SEPARATOR)
+end
+
 function same_or_inner_namespace(u, var)
     nu = get_namespace(u)
     nv = get_namespace(var)
     return nu == nv ||           # namespaces are the same
-        startswith(nv, nu) || # or nv starts with nu, i.e., nv is an inner namespace to nu
+        is_inner_namespace_string(nu, nv) || # or nv is an inner namespace to nu
         occursin(NAMESPACE_SEPARATOR, string(getname(var))) &&
         !occursin(NAMESPACE_SEPARATOR, string(getname(u))) # or u is top level but var is internal
 end
@@ -166,7 +179,7 @@ function inner_namespace(u, var)
     nu = get_namespace(u)
     nv = get_namespace(var)
     nu == nv && return false
-    return startswith(nv, nu) || # or nv starts with nu, i.e., nv is an inner namespace to nu
+    return is_inner_namespace_string(nu, nv) || # or nv is an inner namespace to nu
         occursin(NAMESPACE_SEPARATOR, string(getname(var))) &&
         !occursin(NAMESPACE_SEPARATOR, string(getname(u))) # or u is top level but var is internal
 end

--- a/lib/ModelingToolkitBase/test/input_output_handling.jl
+++ b/lib/ModelingToolkitBase/test/input_output_handling.jl
@@ -572,3 +572,39 @@ if !@isdefined(ModelingToolkit)
         @test out in Set(unknowns(reduced_alg)) || out in Set(observables(reduced_alg))
     end
 end
+
+@testset "unbound_inputs does not depend on sibling name spelling" begin
+    # Two systems with identical structure. They differ only in the names given to the
+    # input connector and its sibling: in the first pair the sibling's name has the
+    # input's name as a string prefix ("flange" / "f"), in the second it does not
+    # ("port" / "V"). Namespace nesting is a property of the separator-delimited
+    # segments, so neither pair may be treated as nested and the two systems must be
+    # classified the same way.
+    @independent_variables tv
+    @variables f_u(tv) [input = true] flange_u(tv) V_u(tv) [input = true] port_u(tv)
+
+    inner_f = System(Equation[], tv, [f_u], []; name = :f)
+    inner_flange = System(Equation[], tv, [flange_u], []; name = :flange)
+    prefixed = System(
+        [inner_flange.flange_u ~ -inner_f.f_u], tv;
+        systems = [inner_f, inner_flange], name = :prefixed
+    )
+
+    inner_V = System(Equation[], tv, [V_u], []; name = :V)
+    inner_port = System(Equation[], tv, [port_u], []; name = :port)
+    unprefixed = System(
+        [inner_port.port_u ~ -inner_V.V_u], tv;
+        systems = [inner_V, inner_port], name = :unprefixed
+    )
+
+    @test length(unbound_inputs(prefixed)) == length(unbound_inputs(unprefixed))
+    @test is_bound(prefixed, inner_f.f_u) == is_bound(unprefixed, inner_V.V_u)
+end
+
+@testset "namespace nesting is tested on separator-delimited segments" begin
+    @test ModelingToolkitBase.is_inner_namespace_string("a", "a₊b")
+    @test !ModelingToolkitBase.is_inner_namespace_string("a₊b", "a₊bc")
+    @test !ModelingToolkitBase.is_inner_namespace_string("a₊b", "a₊b")
+    @test ModelingToolkitBase.is_inner_namespace_string("", "a")
+    @test !ModelingToolkitBase.is_inner_namespace_string("", "")
+end


### PR DESCRIPTION
## What changed and why

`same_or_inner_namespace` and `inner_namespace` decided whether one namespace is nested
inside another with `startswith` on the raw namespace strings:

```julia
startswith(nv, nu) || # or nv starts with nu, i.e., nv is an inner namespace to nu
```

so `"force₊flange"` was treated as nested inside `"force₊f"`. Whether an input got reported
as bound therefore depended on whether a sibling subsystem's name happened to begin with the
input connector's name. Nesting is now tested on separator-delimited segments.

Two systems with identical structure, differing only in those names:

| input connector | sibling | `unbound_inputs` before | after |
|---|---|---|---|
| `f` | `flange` | `[f₊u(t)]` | `[]` |
| `V` | `port` | `[]` | `[]` |

## This is not sufficient, and I would like your read on the rest — @AayushSabharwal

The consistency is real but it goes the unhelpful way. Measured on two standard-library
models, each leaving the driving component's `RealInput` unconnected:

| model | `unbound_inputs` before | after |
|---|---|---|
| mass-spring-damper, unconnected `Force` | `[force₊f₊u(t)]` | `[]` |
| RC circuit, unconnected `Voltage` | `[]` | `[]` |

The `Force` case worked only because `"force₊flange"` collided with `"force₊f"`. With that
accident removed, `unbound_inputs` returns nothing for either — consistent, but no longer
able to answer "which input does the user still have to supply?".

The reason is upstream of the string handling. `is_bound` counts a variable as bound when it
"appears in an equation together with variables from other subsystems", and every library
source component has exactly such an equation as its own definition — `v ~ V.u` for
`Voltage`, `flange.f ~ -f.u` for `Force`. Under a faithful reading of that rule, an
unconnected library component's input is always bound, so the namespace heuristic can only
ever get the useful answer by accident.

**The question:** should discovery be based on the connection structure instead — an input
being external iff its connector participates in no `connect` — rather than on which
variables share an equation? `get_eqs` on an uncompiled hierarchy does still carry the
`connect` nodes, so the information is there before flattening; I stopped short of building
on it because which primitive MTK wants here is your call, not mine. If there is already a
right way to ask this that I have missed, I am happy to redo it that way.

Filed first as #5088, closed in favour of this PR.

## Verification

New tests in `lib/ModelingToolkitBase/test/input_output_handling.jl` (InterfaceI group):
the two structurally identical systems must be classified identically, plus unit tests for
the segment predicate.

```
prefixed   unbound = []
unprefixed unbound = []
INVARIANT lengths equal: true
INVARIANT is_bound equal: true
HELPER a<a₊b: true  a₊b<a₊bc: false
```

Before the change the first two lines differ (`[f₊u(t)]` vs `[]`), so the invariant test
fails on master and passes here.

Runic `--check` and `typos` clean on both files touched.

## Not verified

I could not run the MTKBase test suite against this checkout: `ModelingToolkitBase` on master
requires `ImplicitDiscreteSolve` 2.3.0, which is not registered yet, so the environment does
not resolve. The measurements above were taken by applying the identical patch to the
released `ModelingToolkitBase` and exercising it against ModelingToolkitStandardLibrary. CI
should be treated as the real check here.

## Related

https://github.com/SciML/ModelingToolkit.jl/pull/5087 documents `mtkcompile(sys; inputs)` as
the interface for streaming external inputs. Naming the input explicitly is unaffected by any
of this and always works. A follow-up documenting `unbound_inputs` as the discovery fallback
is written but deliberately not opened until this question is settled — as it stands, the
docs would be pointing at something that returns nothing for the models they describe.

---

This PR should be ignored until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019wKpyZHy9u4QhR4ePiVmam
