### PR TITLE
Document unbound_inputs as the fallback for discovering an input

### DIFF
--- a/docs/src/examples/interactive_simulation.md
+++ b/docs/src/examples/interactive_simulation.md
@@ -90,7 +90,7 @@ components. Leave the driving component's input connector unconnected and name i
 
 ```julia
 using ModelingToolkit, OrdinaryDiffEq
-using ModelingToolkit: t_nounits as t
+using ModelingToolkit: t_nounits as t, unbound_inputs
 using ModelingToolkitStandardLibrary.Mechanical.Translational: Mass, Spring, Damper, Fixed, Force
 
 @named mass = Mass(m = 1)
@@ -119,6 +119,20 @@ for level in (0.0, 10.0, -10.0, 0.0)
     current_velocity = integrator[mass.v]
 end
 ```
+
+When you do not already know which variable carries the external signal — a model built by
+someone else, or one assembled programmatically — [`unbound_inputs`](@ref) reports the input
+variables that the connection structure leaves external, and its result can be passed
+straight to `mtkcompile`:
+
+```julia
+unbound_inputs(model)                              # [force₊f₊u(t)]
+sys = mtkcompile(model; inputs = unbound_inputs(model))
+```
+
+This inspects the connection graph of the uncompiled hierarchy, so call it before
+`mtkcompile`. It is a heuristic rather than a guarantee: check what it returns, and name the
+input explicitly when you already know it.
 
 ## Reading observed quantities from the integrator
 


### PR DESCRIPTION
## What changed and why

https://github.com/SciML/ModelingToolkit.jl/pull/5087 tells you to name the input variable
to `mtkcompile`, which assumes you already know which variable carries the external signal.
For a model you did not build, or one assembled programmatically, that is exactly the part
you are missing. `unbound_inputs` reports the input variables the connection structure
leaves external, and its result can be passed straight to `mtkcompile`:

```julia
unbound_inputs(model)                              # [force₊f₊u(t)]
sys = mtkcompile(model; inputs = unbound_inputs(model))
```

Fifteen lines added to `docs/src/examples/interactive_simulation.md`, plus `unbound_inputs`
in that example's import line. No code changes.

## Verification

The page uses plain ```julia fences, so Documenter does not execute them. The snippet was
run by hand against ModelingToolkit 11.41.0 and ModelingToolkitStandardLibrary, on the same
mass-spring-damper model the surrounding section already uses:

```
unbound_inputs(model) = [force₊f₊u(t)]
VERIFIED via unbound_inputs: t=4.0 s=0.08628 saved=81 retcode=Success
```

so the discovered name compiles, drives through `integrator.ps[...]` and `step!`, and the
solve completes.

`typos` clean.

## What I did not verify, and one thing a reviewer should weigh

**I did not get a clean full docs build for this branch.** My local run hit pre-existing
failures in `docs/src/tutorials/bifurcation_diagram_computation.md`, an unrelated page, so I
stopped it. This PR touches one markdown file and adds no executed block, but CI is the real
check here.

**More importantly — this describes behaviour that
https://github.com/SciML/ModelingToolkit.jl/pull/5089 changes.** As of current master,
`unbound_inputs` returns `[force₊f₊u(t)]` for this model, so the page is accurate today.
#5089 makes namespace nesting segment-aware, and with it this same call returns `[]`,
because the `Force` case works on master only through a string-prefix collision
(`"force₊flange"` vs `"force₊f"`). The underlying semantics question is tracked in
https://github.com/SciML/ModelingToolkit.jl/issues/5088.

So this page and #5089 must not land independently: if #5089 merges first, this section
needs rewriting to whatever discovery mechanism replaces it, and if this merges first the
docs go stale the moment #5089 does. Sequencing is the reviewer's call — I am opening it now
on request rather than holding it behind #5088 as I had originally planned.

---

This PR should be ignored until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019wKpyZHy9u4QhR4ePiVmam
