### PR TITLE
Add 32-bit InterfaceI CI lane via test_groups.toml

### DIFF
--- a/test/test_groups.toml
+++ b/test/test_groups.toml
@@ -6,6 +6,12 @@
 [InterfaceI]
 versions = ["lts", "1", "pre"]
 
+["InterfaceI 32-bit"]
+group = "InterfaceI"
+versions = ["1"]
+os = ["ubuntu-latest"]
+arch = "x86"
+
 [InterfaceII]
 versions = ["lts", "1", "pre"]
 


### PR DESCRIPTION

## Summary
- Add a `["InterfaceI 32-bit"]` matrix-only alias (`group = "InterfaceI"`, `arch = "x86"`, Linux only) so this package exercises 32-bit Julia via SciML/.github `@v1`.
- No `[Core]` group in this matrix; alias targets the primary `InterfaceI` lane.

## Test plan
- [ ] CI shows a job with `, x86)` for this group
- [ ] Job green, or failure is a real Int32/WordSize bug to fix
