### PR TITLE
Mark `InitializationMetadata` inactive for Enzyme

### DIFF
--- a/lib/ModelingToolkitBase/src/ModelingToolkitBase.jl
+++ b/lib/ModelingToolkitBase/src/ModelingToolkitBase.jl
@@ -535,6 +535,18 @@ end
 # (which transitively carries the symbolic `System`) trips a
 # `MethodError MixedDuplicated(::System, ::System)` in `create_activity_wrapper`.
 EnzymeCore.EnzymeRules.inactive_type(::Type{<:AbstractSystem}) = true
+# `InitializationMetadata` is rebuild-only data: the operating point, guesses and
+# extra initialization equations captured at problem construction, plus the
+# index-template reconstructors `remake` uses to rebuild the initialization
+# problem. Nothing in it is read by the generated RHS and none of it carries
+# derivative information (derivatives w.r.t. `u0`/`p`/`Initial`s flow through the
+# reconstructors' arguments, not their fields). Enzyme cannot prove that on its
+# own because of the `Dict{SymbolicT, SymbolicT}` maps, so without this rule every
+# `Duplicated` use of an `ODEFunction` (e.g. SciMLSensitivity's `EnzymeVJP`,
+# once per adjoint RHS evaluation) allocates and re-zeroes a shadow of the whole
+# metadata: ~100 µs per call against a ~5 ns RHS for a 32-state linear ODE,
+# an 8x slowdown of `GaussAdjoint(EnzymeVJP)` gradients.
+EnzymeCore.EnzymeRules.inactive_type(::Type{<:InitializationMetadata}) = true
 
 function __init__()
     SU.hashcons(unwrap(t_nounits), true)

--- a/lib/ModelingToolkitBase/test/initializationsystem.jl
+++ b/lib/ModelingToolkitBase/test/initializationsystem.jl
@@ -2288,3 +2288,17 @@ if @isdefined(ModelingToolkit)
         @test_nowarn ODEProblem(sys, [], (0.0, 1.0))
     end
 end
+
+@testset "InitializationMetadata is inactive for Enzyme" begin
+    # `EnzymeVJP` differentiates the whole `ODEFunction` as `Duplicated`; the
+    # rebuild-only initialization metadata must not get a shadow that is
+    # re-zeroed on every adjoint RHS evaluation.
+    @variables x(t) = 1.0
+    @parameters k = 2.0
+    @mtkcompile sys = System([D(x) ~ -k * x], t)
+    prob = ODEProblem(sys, [], (0.0, 1.0))
+    meta = prob.f.initialization_data.metadata
+    @test meta isa ModelingToolkitBase.InitializationMetadata
+    @test ModelingToolkitBase.EnzymeCore.EnzymeRules.inactive_type(typeof(meta))
+    @test ModelingToolkitBase.EnzymeCore.EnzymeRules.inactive_type(typeof(sys))
+end


### PR DESCRIPTION
## What

Adds `EnzymeCore.EnzymeRules.inactive_type(::Type{<:InitializationMetadata}) = true`
next to the existing `AbstractSystem` rule, plus a test.

## Why

`SciMLSensitivity`'s in-place `EnzymeVJP` passes the full `ODEFunction` to
`Enzyme.autodiff` as `Duplicated(Void(f), shadow)` and calls `Enzyme.remake_zero!(shadow)`
before every VJP. For an MTK-generated `ODEFunction` the shadow is dominated by
`f.initialization_data.metadata::InitializationMetadata`, because its
`op`/`guesses` maps are `Dict{SymbolicT, SymbolicT}` whose values Enzyme cannot
prove constant. Measured on a chain of 32 linear ODEs (`D(x_i) = -k_i x_i + x_{i-1}`,
51 save points, Tsit5, abstol = reltol = 1e-8), Julia 1.12.7:

| piece | time |
|---|---|
| plain RHS call | 5 ns |
| `remake_zero!` of the `Void(f)` shadow | 188 µs |
| of which `initialization_data.metadata` | 97 µs |
| one `EnzymeVJP` call | 187 µs |
| `GaussAdjoint(EnzymeVJP)` gradient, full `ODEFunction` | 259 ms |
| same, `initialization_data` stripped from the differentiated function | 33 ms |
| `GaussAdjoint(ReverseDiffVJP(true))` gradient, for reference | 19 ms |

Gradients agree to 1.7e-10 against forward sensitivities in all cases.

This also matters for SciMLSensitivity's automatic `sensealg` choice, which selects
`GaussAdjoint(autojacvec = EnzymeVJP())` for in-place ODEs once
`length(u0) + length(tunables) > 100`: without this rule that default is
~14x slower than the `ReverseDiffVJP(true)` alternative on MTK problems.

## Why this is safe

`inactive_type` states that no derivative information is *stored in* values of the
type. Every field is either construction-time data (`op`, `guesses`,
`additional_initialization_eqs`, flags) or a callable holding `ParameterIndex`
templates and setters (`oop_reconstruct_u0_p`, `get_updated_u0`,
`set_initial_unknowns!`). Derivatives w.r.t. `u0`, `p` and `Initial`s flow through
those callables' *arguments*, which stay active, exactly as for the `AbstractSystem`
rule directly above (a `System` also carries defaults with numeric values).
Verified by re-running DyadModelOptimizer's Enzyme calibration tests that tune
`Initial()`s through `remake` + initialization with the rule applied: all 35 pass (`test/calibrate/ad.jl`, "SingleShooting with different problem types", which
includes "optimize initial u0 on ODE" and "mixed Initial and parameter tunables" across
FiniteDiff, ForwardDiff, Zygote and Enzyme), with `Enzyme.make_zero(meta) === meta` confirmed.

Reproduced on the current tips as well (SciMLSensitivity master `6fcf58d1`, Enzyme main
`c5f5b55d`, ModelingToolkit v11.42.0 / ModelingToolkitBase v1.69.0, SciMLBase v3.53.1):

| variant | `GaussAdjoint(EnzymeVJP)` gradient, N = 32 |
|---|---|
| full `ODEFunction` | 255 ms |
| with this rule | 60 ms |
| `initialization_data` stripped from the differentiated function | 32 ms |

The remaining gap is the shadow of `initialization_data.initializeprob` (a `NonlinearProblem`
with live arrays), which a follow-up on the SciMLSensitivity side could avoid by differentiating
`f` without its `initialization_data` in the VJP; the RHS never touches it either.

Written by Claude Code on Sebastian's behalf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
