### PR TITLE
Qualify unbound_inputs @ref in the interactive simulation tutorial

### DIFF
--- a/docs/src/examples/interactive_simulation.md
+++ b/docs/src/examples/interactive_simulation.md
@@ -121,7 +121,7 @@ end
 ```
 
 When you do not already know which variable carries the external signal — a model built by
-someone else, or one assembled programmatically — [`unbound_inputs`](@ref) reports the input
+someone else, or one assembled programmatically — [`unbound_inputs`](@ref ModelingToolkit.unbound_inputs) reports the input
 variables that the connection structure leaves external, and its result can be passed
 straight to `mtkcompile`:
 


### PR DESCRIPTION
Qualify the `unbound_inputs` Documenter `@ref` in the interactive simulation tutorial.

`makedocs` aborts at `:cross_references`:

```
Cannot resolve @ref for [`unbound_inputs`](@ref) in docs/src/examples/interactive_simulation.md.
No docstring found in doc for binding `Main.unbound_inputs`.
```

The name is already documented as `ModelingToolkit.unbound_inputs` in `docs/src/API/System.md`. Point the tutorial link there.

> Please ignore this PR until it has been reviewed by @ChrisRackauckas.

## Verification

Failing-before: https://github.com/SciML/ModelingToolkit.jl/actions/runs/34304213085 (Documentation on master, `[:cross_references]`).

I did not rebuild the full ModelingToolkit docs locally (~1.5 h on CI). After merge, Documentation CI is the check.

## Links

- Failing run: https://github.com/SciML/ModelingToolkit.jl/actions/runs/34304213085

🤖 Generated with Grok Build 1.0.24 (model: grok-4.6)
Session: `01a08654-45f1-7a53-849c-56a7f1531d56` (local Grok Build session; no public conversation URL)
