### PR TITLE
Build `ODEProblem` from array differential equations with `complete` only

### DIFF
--- a/lib/ModelingToolkitBase/Project.toml
+++ b/lib/ModelingToolkitBase/Project.toml
@@ -1,7 +1,7 @@
 name = "ModelingToolkitBase"
 uuid = "7771a370-6774-4173-bd38-47e70ca0b839"
 authors = ["Yingbo Ma <mayingbo5@gmail.com>", "Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
-version = "1.69.0"
+version = "1.70.0"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/lib/ModelingToolkitBase/src/problems/odeproblem.jl
+++ b/lib/ModelingToolkitBase/src/problems/odeproblem.jl
@@ -106,8 +106,15 @@ function SciMLBase.ODEFunction{iip, spec}(
 
     observedfun = ObservedFunctionCache(sys, codegen_opts; steady_state)
 
-    _W_sparsity = W_sparsity(sys)
-    W_prototype = calculate_W_prototype(_W_sparsity; u0, sparse)
+    # The W sparsity pattern is a symbolic computation over every scalar equation; only
+    # pay for it when something consumes it.
+    if sparse || sparsity
+        _W_sparsity = W_sparsity(sys)
+        W_prototype = calculate_W_prototype(_W_sparsity; u0, sparse)
+    else
+        _W_sparsity = nothing
+        W_prototype = nothing
+    end
 
     args = (; f)
     kwargs = (;

--- a/lib/ModelingToolkitBase/src/systems/abstractsystem.jl
+++ b/lib/ModelingToolkitBase/src/systems/abstractsystem.jl
@@ -2192,7 +2192,9 @@ end
 $(TYPEDSIGNATURES)
 
 Like `equations(sys)`, but also substitutes the observed equations eliminated from the
-equations during `mtkcompile`. These equations matches generated numerical code.
+equations during `mtkcompile`. These equations matches generated numerical code: an array
+equation such as `D(u[2:4]) ~ f` is expanded into one scalar equation per element, the
+rows it occupies in the generated code and in the mass matrix.
 
 See also [`equations`](@ref) and [`ModelingToolkitBase.get_eqs`](@ref).
 """
@@ -2209,11 +2211,12 @@ function full_equations(sys::AbstractSystem; simplify = false)
         for (eq, rhs_idx) in zip(eqs, info.eqs_idxs)
             push!(new_eqs, eq.lhs ~ ir[rhs_idx])
         end
-        return new_eqs
+        return scalarize_array_equations(new_eqs)
     end
-    empty_substitutions(sys) && return equations(sys)
+    empty_substitutions(sys) && return scalarize_array_equations(equations(sys))
     subs = get_substitutions(sys)
     neweqs = map(equations(sys)) do eq
+        eq = explicit_array_derivative_form(eq)
         if iscall(eq.lhs) && operation(eq.lhs) isa Union{Shift, Differential}
             return substitute_and_simplify(eq.lhs, subs, simplify) ~
                 substitute_and_simplify(
@@ -2229,7 +2232,7 @@ function full_equations(sys::AbstractSystem; simplify = false)
         end
         eq
     end
-    return neweqs
+    return scalarize_array_equations(neweqs)
 end
 
 """
@@ -3281,8 +3284,16 @@ function Base.eltype(::Type{<:TreeIterator{ModelingToolkitBase.AbstractSystem}})
     return ModelingToolkitBase.AbstractSystem
 end
 
-function check_array_equations_unknowns(eqs, dvs)
-    if any(eq -> eq isa Equation && Symbolics.isarraysymbolic(eq.lhs), eqs)
+"""
+    $(TYPEDSIGNATURES)
+
+Throw if `eqs` contain array equations or `dvs` contain array unknowns, which most problem
+constructors need `mtkcompile` to scalarize first. `allow_array_equations` skips the check
+on the equations, for code generators that expand an array equation into one output row
+per element themselves.
+"""
+function check_array_equations_unknowns(eqs, dvs; allow_array_equations::Bool = false)
+    if !allow_array_equations && any(eq -> eq isa Equation && Symbolics.isarraysymbolic(eq.lhs), eqs)
         throw(ArgumentError("The system has array equations. Call `mtkcompile` to handle such equations or scalarize them manually."))
     end
     return if any(x -> Symbolics.isarraysymbolic(x), dvs)

--- a/lib/ModelingToolkitBase/src/systems/codegen.jl
+++ b/lib/ModelingToolkitBase/src/systems/codegen.jl
@@ -1696,7 +1696,7 @@ Base.@nospecializeinfer function build_explicit_observed_function(
             if SU.is_array_shape(SU.shape(x))
                 # `D(u[2:4])` has no single `toterm` name; the derivatives that can be
                 # requested are those of its elements.
-                dop = operation(eq.lhs)
+                dop = operation(eq.lhs)::Union{Differential, Shift}
                 for idx in SU.stable_eachindex(x)
                     push!(dervars, default_toterm(dop(x[idx])))
                 end

--- a/lib/ModelingToolkitBase/src/systems/codegen.jl
+++ b/lib/ModelingToolkitBase/src/systems/codegen.jl
@@ -177,8 +177,13 @@ function generate_rhs(
         end
     else
         if !override_discrete && !is_discrete_system(sys)
+            # An array differential equation `D(u[2:4]) ~ f` (or `D(u[2:4]) .- f ~ 0`)
+            # stays one equation: its right-hand side is written to a contiguous block
+            # of `du` below, the same way implicit-DAE residuals are packed.
+            eqs = map(explicit_array_derivative_form, eqs)
             check_operator_variables(eqs, Differential)
             check_lhs(eqs, Differential, Set(dvs))
+            assemble_residuals = any(is_array_equation, eqs)
         end
         rhss = [eq.rhs for eq in eqs]
     end
@@ -639,16 +644,30 @@ applied to the symbolic mass matrix. Returns a `Diagonal` or `LinearAlgebra.I` w
 possible.
 """
 function calculate_massmatrix(sys::System; simplify = false)
-    eqs = [eq for eq in equations(sys)]
-    M = zeros(length(eqs), length(eqs))
-    for (i, eq) in enumerate(eqs)
+    eqs = equations(sys)
+    # An array equation stands for one row per element, laid out as `generate_rhs`
+    # packs them: the rows of consecutive equations follow each other.
+    n = count_equation_rows(eqs)
+    M = zeros(n, n)
+    i = 0
+    for eq in eqs
+        eq = explicit_array_derivative_form(eq)
         if iscall(eq.lhs) && operation(eq.lhs) isa Differential
-            st = var_from_nested_derivative(eq.lhs)[1]
-            j = variable_index(sys, st)
-            M[i, j] = 1
+            x = only(arguments(eq.lhs))
+            if SU.is_array_shape(SU.shape(x))
+                for idx in SU.stable_eachindex(x)
+                    i += 1
+                    M[i, variable_index(sys, x[idx])] = 1
+                end
+            else
+                st = var_from_nested_derivative(eq.lhs)[1]
+                i += 1
+                M[i, variable_index(sys, st)] = 1
+            end
         else
             _iszero(eq.lhs) ||
                 error("Only semi-explicit constant mass matrices are currently supported. Faulty equation: $eq.")
+            i += equation_row_count(eq)
         end
     end
     M = simplify ? Symbolics.simplify.(M) : M
@@ -1671,8 +1690,19 @@ Base.@nospecializeinfer function build_explicit_observed_function(
         end
     else
         for eq in equations(sys)
+            eq = explicit_array_derivative_form(eq)
             isdiffeq(eq) || continue
-            push!(dervars, default_toterm(eq.lhs))
+            x = only(arguments(eq.lhs))
+            if SU.is_array_shape(SU.shape(x))
+                # `D(u[2:4])` has no single `toterm` name; the derivatives that can be
+                # requested are those of its elements.
+                dop = operation(eq.lhs)
+                for idx in SU.stable_eachindex(x)
+                    push!(dervars, default_toterm(dop(x[idx])))
+                end
+            else
+                push!(dervars, default_toterm(eq.lhs))
+            end
         end
     end
     pred = CheckInvalidAndTrackNamespaced(

--- a/lib/ModelingToolkitBase/src/systems/problem_utils.jl
+++ b/lib/ModelingToolkitBase/src/systems/problem_utils.jl
@@ -2197,9 +2197,12 @@ function __process_SciMLProblem(
     iv = has_iv(sys) ? get_iv(sys) : nothing
     eqs = equations(sys)
 
-    # Implicit-DAE codegen expands an array equation into one output row per element, so
-    # array equations are usable there. Every other problem type still needs `mtkcompile`.
-    implicit_dae || check_array_equations_unknowns(eqs, dvs)
+    # Implicit-DAE and explicit-ODE codegen expand an array equation into one output row
+    # per element, so array equations are usable there. Every other problem type still
+    # needs `mtkcompile`.
+    implicit_dae || check_array_equations_unknowns(
+        eqs, dvs; allow_array_equations = constructor <: ODEFunction
+    )
 
     op = build_operating_point(sys, op; fast_path = true)
 

--- a/lib/ModelingToolkitBase/src/utils.jl
+++ b/lib/ModelingToolkitBase/src/utils.jl
@@ -748,7 +748,7 @@ function check_operator_variables(eqs, ::Type{op}) where {op}
             # `D(u[2:4])` stands for the derivatives of its elements, which must not be
             # differentiated again by another equation, as a slice or as a scalar.
             if isdifferential(v) && SU.is_array_shape(SU.shape(only(arguments(v))))
-                dop = operation(v)
+                dop = operation(v)::Differential
                 x = only(arguments(v))
                 for idx in SU.stable_eachindex(x)
                     el = dop(x[idx])

--- a/lib/ModelingToolkitBase/src/utils.jl
+++ b/lib/ModelingToolkitBase/src/utils.jl
@@ -192,11 +192,93 @@ function check_variables(dvs, iv)
     return
 end
 
+"""
+    $(TYPEDSIGNATURES)
+
+Whether `eq` is an array equation: its left-hand side is array-valued, so it stands for
+one scalar equation per element.
+"""
+is_array_equation(eq::Equation) = SU.is_array_shape(SU.shape(eq.lhs))
+
+_array_add(a::SymbolicT, b::SymbolicT) = _iszero(a) ? b : _iszero(b) ? a : unwrap(wrap(a) .+ wrap(b))
+function _array_sub(a::SymbolicT, b::SymbolicT)
+    _iszero(b) && return a
+    _iszero(a) && return unwrap(.-(wrap(b)))
+    return unwrap(wrap(a) .- wrap(b))
+end
+
+"""
+    $(TYPEDSIGNATURES)
+
+Rewrite an array differential equation given in residual form, `D(x) .- f ~ 0` or
+`D(x) .+ g ~ 0` (as a finite-difference discretization emits it), into the explicit form
+`D(x) ~ f` that ODE code generation and the mass matrix are built from. Scalar equations,
+array equations already of the form `D(x) ~ f` and array equations whose left-hand side
+is not a broadcast sum or difference involving a derivative are returned unchanged.
+"""
+function explicit_array_derivative_form(eq::Equation)
+    lhs = eq.lhs
+    is_array_equation(eq) && iscall(lhs) || return eq
+    op = operation(lhs)
+    op isa Differential && return eq
+    op === broadcast || return eq
+    args = arguments(lhs)
+    length(args) == 3 || return eq
+    bop = unwrap_const(args[1])
+    bop === (-) || bop === (+) || return eq
+    a, b = args[2], args[3]
+    rhs = eq.rhs
+    if isdifferential(a)
+        dx = a
+        f = bop === (-) ? _array_add(rhs, b) : _array_sub(rhs, b)
+    elseif isdifferential(b)
+        dx = b
+        f = bop === (-) ? _array_sub(a, rhs) : _array_sub(rhs, a)
+    else
+        return eq
+    end
+    # A scalar derivative broadcast against an array is not an array differential equation.
+    SU.is_array_shape(SU.shape(dx)) || return eq
+    return Equation(dx, f)
+end
+
+"""
+    $(TYPEDSIGNATURES)
+
+Expand the array equations in `eqs` into one scalar equation per element, so that the
+result has one equation per row of the generated code and of the mass matrix. Array
+differential equations in residual form are first rewritten to `D(x) ~ f`. Returns `eqs`
+itself when it has no array equations.
+"""
+function scalarize_array_equations(eqs::Vector{Equation})
+    any(is_array_equation, eqs) || return eqs
+    new_eqs = Equation[]
+    sizehint!(new_eqs, count_equation_rows(eqs))
+    for eq in eqs
+        if is_array_equation(eq)
+            append!(new_eqs, vec(Symbolics.scalarize(explicit_array_derivative_form(eq))))
+        else
+            push!(new_eqs, eq)
+        end
+    end
+    return new_eqs
+end
+
 function check_lhs(eq::Equation, ::Type{Differential}, dvs::Set)
     v = unwrap(eq.lhs)
     _iszero(v) && return
-    op = operation(v)
-    op isa Differential && isone(op.order) && only(arguments(v)) in dvs && return
+    if iscall(v)
+        op = operation(v)
+        if op isa Differential && isone(op.order)
+            x = only(arguments(v))
+            if SU.is_array_shape(SU.shape(x))
+                # `D(u[2:4])` names the slice; each of its elements must be an unknown.
+                all(idx -> x[idx] in dvs, SU.stable_eachindex(x)) && return
+            elseif x in dvs
+                return
+            end
+        end
+    end
     error(lazy"$v is not a valid LHS. Please run mtkcompile before simulation.")
 end
 function check_lhs(eqs::Vector{Equation}, ::Type{Differential}, dvs::Set)
@@ -663,9 +745,22 @@ function check_operator_variables(eqs, ::Type{op}) where {op}
         is_tmp_fine ||
             error(lazy"The LHS cannot contain nondifferentiated variables. Please run `mtkcompile` or use the DAE form.\nGot $eq")
         for v in tmp
-            v in ops &&
-                error(lazy"The LHS operator must be unique. Please run `mtkcompile` or use the DAE form. $v appears in LHS more than once.")
-            push!(ops, v)
+            # `D(u[2:4])` stands for the derivatives of its elements, which must not be
+            # differentiated again by another equation, as a slice or as a scalar.
+            if isdifferential(v) && SU.is_array_shape(SU.shape(only(arguments(v))))
+                dop = operation(v)
+                x = only(arguments(v))
+                for idx in SU.stable_eachindex(x)
+                    el = dop(x[idx])
+                    el in ops &&
+                        error(lazy"The LHS operator must be unique. Please run `mtkcompile` or use the DAE form. $el appears in LHS more than once.")
+                    push!(ops, el)
+                end
+            else
+                v in ops &&
+                    error(lazy"The LHS operator must be unique. Please run `mtkcompile` or use the DAE form. $v appears in LHS more than once.")
+                push!(ops, v)
+            end
         end
         empty!(tmp)
         empty!(visited)

--- a/lib/ModelingToolkitBase/test/array_equation_dae.jl
+++ b/lib/ModelingToolkitBase/test/array_equation_dae.jl
@@ -3,7 +3,6 @@ using ModelingToolkitBase: unwrap, complete, unknowns
 using Symbolics
 using SciMLBase
 using OrdinaryDiffEqBDF: DFBDF
-using DiffEqBase: BrownFullBasicInit
 
 # A system whose interior is written as one array equation over slices, as produced by a
 # finite-difference PDE discretization that does not scalarize.
@@ -71,9 +70,15 @@ end
     )
     tend = 0.1
     prob = DAEProblem(sys, op, (0.0, tend); build_initializeprob = false)
-    # `du0` above is not consistent; the solver's own DAE initialization supplies it.
+    # Supply a consistent `du0` by hand (boundary values are already zero) so the solve
+    # does not depend on the solver's own DAE initialization.
+    du0 = zeros(n)
+    dx = 1 / (n - 1)
+    u0 = prob.u0
+    du0[2:(n - 1)] .= (u0[1:(n - 2)] .- 2 .* u0[2:(n - 1)] .+ u0[3:n]) ./ dx^2
+    prob = remake(prob; du0)
     sol = solve(
-        prob, DFBDF(); initializealg = BrownFullBasicInit(),
+        prob, DFBDF(); initializealg = SciMLBase.NoInit(),
         reltol = 1.0e-8, abstol = 1.0e-8, saveat = [tend]
     )
     @test SciMLBase.successful_retcode(sol)
@@ -145,8 +150,10 @@ end
     prob.f(out, du, prob.u0, prob.p, 0.0)
     @test maximum(abs, out) < 1.0e-1
 
+    du0 = zeros(n)
+    du0[2:(n - 1)] .= (prob.u0[1:(n - 2)] .- 2 .* prob.u0[2:(n - 1)] .+ prob.u0[3:n]) ./ dx^2
     sol = solve(
-        prob, DFBDF(); initializealg = BrownFullBasicInit(), reltol = 1.0e-8,
+        remake(prob; du0), DFBDF(); initializealg = SciMLBase.NoInit(), reltol = 1.0e-8,
         abstol = 1.0e-8, saveat = [0.1]
     )
     @test SciMLBase.successful_retcode(sol)

--- a/lib/ModelingToolkitBase/test/array_equation_dae.jl
+++ b/lib/ModelingToolkitBase/test/array_equation_dae.jl
@@ -49,12 +49,16 @@ end
     @test any(!iszero, out)
 end
 
-@testset "other problem types still require scalarized equations" begin
+@testset "array unknowns still require `mtkcompile`" begin
     n = 11
-    sys, u, t, D = heat_array_system(n)
-    op = [u[i] => 0.0 for i in 1:n]
-    # ODEProblem cannot consume array equations; the guard must remain in place
-    @test_throws Exception ODEProblem(sys, op, (0.0, 0.1); build_initializeprob = false)
+    @independent_variables t
+    @variables u(t)[1:n]
+    D = Differential(t)
+    @named sys = System([D(u) ~ -u], t, [u], [])
+    sys = complete(sys)
+    op = [u => zeros(n), D(u) => zeros(n)]
+    # the equation is fine, but `u` as a single array unknown is not
+    @test_throws ["array unknowns"] ODEProblem(sys, op, (0.0, 0.1); build_initializeprob = false)
 end
 
 @testset "array-equation DAE solves to the analytic solution" begin

--- a/lib/ModelingToolkitBase/test/array_equation_ode.jl
+++ b/lib/ModelingToolkitBase/test/array_equation_ode.jl
@@ -1,0 +1,235 @@
+using ModelingToolkitBase, Test
+using ModelingToolkitBase: complete, unknowns, generate_rhs, GeneratedFunctionOptions,
+    calculate_massmatrix, full_equations, scalarize_array_equations
+using Symbolics
+using SciMLBase
+using LinearAlgebra
+using SparseArrays: nnz
+using OrdinaryDiffEqTsit5: Tsit5
+using OrdinaryDiffEqRosenbrock: Rodas5P
+
+# Array differential equations reach `ODEProblem` from `complete(sys)` directly, without
+# `mtkcompile` scalarizing them: the equation stays one equation, and its right-hand side
+# is written to a contiguous block of `du`.
+
+# Interior of the 1D heat equation as one array equation over slices, as a
+# finite-difference discretization emits it. `:explicit` is `D(u[2:n-1]) ~ lap`,
+# `:residual` is the cardinalized `D(u[2:n-1]) .- lap ~ 0`.
+function heat_array_system(n, form)
+    @independent_variables t
+    @variables u(t)[1:n]
+    D = Differential(t)
+    dx = 1 / (n - 1)
+    lap = (u[1:(n - 2)] .- 2 .* u[2:(n - 1)] .+ u[3:n]) ./ dx^2
+    interior = if form === :explicit
+        D(u[2:(n - 1)]) ~ lap
+    else
+        broadcast(-, D(u[2:(n - 1)]), lap) ~ zeros(n - 2)
+    end
+    eqs = [0 ~ u[1], interior, 0 ~ u[n]]
+    @named sys = System(eqs, t, collect(u), [])
+    return sys, u, t, D
+end
+
+count_expr_nodes(ex) = ex isa Expr ? 1 + sum(count_expr_nodes, ex.args; init = 0) : 0
+function contains_symbol(ex, s::Symbol)
+    ex === s && return true
+    ex isa Expr || return false
+    return any(arg -> contains_symbol(arg, s), ex.args)
+end
+
+@testset "`D(u) ~ f` over a whole array" begin
+    n = 5
+    @independent_variables t
+    @variables u(t)[1:n]
+    D = Differential(t)
+    @named sys = System([D(u) ~ -u], t, collect(u), [])
+    sys = complete(sys)
+    @test length(equations(sys)) == 1
+    @test length(full_equations(sys)) == n
+
+    prob = ODEProblem(sys, [u => ones(n)], (0.0, 1.0); build_initializeprob = false)
+    @test prob.f.mass_matrix === I
+    du = zeros(n)
+    prob.f(du, prob.u0, prob.p, 0.0)
+    @test du ≈ -ones(n)
+    @test prob.f(prob.u0, prob.p, 0.0) ≈ -ones(n)
+
+    sol = solve(prob, Tsit5(); reltol = 1.0e-8, abstol = 1.0e-8)
+    @test SciMLBase.successful_retcode(sol)
+    @test sol.u[end] ≈ fill(exp(-1.0), n) rtol = 1.0e-6
+
+    # the default initialization problem is built from the scalarized equations
+    prob2 = ODEProblem(sys, [u => ones(n)], (0.0, 1.0))
+    @test prob2.f.initialization_data !== nothing
+    sol2 = solve(prob2, Tsit5(); reltol = 1.0e-8, abstol = 1.0e-8)
+    @test SciMLBase.successful_retcode(sol2)
+    @test sol2.u[end] ≈ fill(exp(-1.0), n) rtol = 1.0e-6
+end
+
+@testset "heat equation over a slice, $form form" for form in (:explicit, :residual)
+    n = 21
+    sys, u, t, D = heat_array_system(n, form)
+    sys = complete(sys)
+    xs = range(0.0, 1.0, length = n)
+    tend = 0.1
+    u0 = sinpi.(xs)
+
+    M = calculate_massmatrix(sys)
+    @test M isa Diagonal
+    @test diag(M) == [0; ones(n - 2); 0]
+
+    prob = ODEProblem(sys, [u => u0], (0.0, tend); build_initializeprob = false)
+    @test length(prob.u0) == n
+    @test prob.f.mass_matrix isa Diagonal
+    du = zeros(n)
+    prob.f(du, prob.u0, prob.p, 0.0)
+    dx = step(xs)
+    lap = (u0[1:(n - 2)] .- 2 .* u0[2:(n - 1)] .+ u0[3:n]) ./ dx^2
+    @test du[2:(n - 1)] ≈ lap
+    @test du[1] == u0[1] == 0.0
+    @test du[n] == u0[n] == 0.0
+    @test prob.f(prob.u0, prob.p, 0.0) ≈ du
+
+    sol = solve(prob, Rodas5P(); reltol = 1.0e-8, abstol = 1.0e-8, saveat = [tend])
+    @test SciMLBase.successful_retcode(sol)
+    exact = [exp(-pi^2 * tend) * sinpi(xi) for xi in xs]
+    # second-order spatial discretization on 21 points
+    @test maximum(abs.(sol.u[end] .- exact)) < 1.0e-3
+
+    # parity with the scalarized equations, through `mtkcompile` (which, without
+    # ModelingToolkit loaded, needs the explicit form) and through `complete`
+    explicit_sys, = heat_array_system(n, :explicit)
+    csys = mtkcompile(explicit_sys)
+    @test all(eq -> !Symbolics.isarraysymbolic(eq.lhs), equations(csys))
+    cprob = ODEProblem(csys, [u => u0], (0.0, tend); build_initializeprob = false)
+    csol = solve(cprob, Rodas5P(); reltol = 1.0e-8, abstol = 1.0e-8, saveat = [tend])
+    @test sol[u][end] ≈ csol[u][end] atol = 1.0e-10
+
+    scalar_sys, = heat_array_system(n, form)
+    @named ssys = System(scalarize_array_equations(equations(scalar_sys)), t, collect(u), [])
+    ssys = complete(ssys)
+    @test length(equations(ssys)) == n
+    sprob = ODEProblem(ssys, [u => u0], (0.0, tend); build_initializeprob = false)
+    @test sprob.f.mass_matrix == prob.f.mass_matrix
+    sdu = zeros(n)
+    sprob.f(sdu, sprob.u0, sprob.p, 0.0)
+    @test sdu ≈ du
+
+    # the default initialization problem handles the array equation
+    iprob = ODEProblem(sys, [u => u0], (0.0, tend); warn_initialize_determined = false)
+    isol = solve(iprob, Rodas5P(); reltol = 1.0e-8, abstol = 1.0e-8, saveat = [tend])
+    @test SciMLBase.successful_retcode(isol)
+    @test isol[u][end] ≈ csol[u][end] atol = 1.0e-10
+end
+
+@testset "generated code is independent of the array length" begin
+    sizes = map((24, 48, 96)) do n
+        sys, = heat_array_system(n, :explicit)
+        sys = complete(sys)
+        f_oop, f_iip = generate_rhs(sys, GeneratedFunctionOptions(; expression = Val{true}))
+        @test !contains_symbol(f_iip, :array_literal)
+        (count_expr_nodes(f_oop), count_expr_nodes(f_iip))
+    end
+    @test allequal(sizes)
+end
+
+@testset "array equations over a 2D slice" begin
+    n = 6
+    @independent_variables t
+    @variables w(t)[1:n, 1:n]
+    D = Differential(t)
+    dx = 1 / (n - 1)
+    inner = 2:(n - 1)
+    lap = (
+        w[1:(n - 2), inner] .+ w[3:n, inner] .+ w[inner, 1:(n - 2)] .+
+            w[inner, 3:n] .- 4 .* w[inner, inner]
+    ) ./ dx^2
+    eqs = Equation[D(w[inner, inner]) ~ lap]
+    for i in 1:n
+        push!(eqs, 0 ~ w[i, 1])
+        push!(eqs, 0 ~ w[i, n])
+    end
+    for j in inner
+        push!(eqs, 0 ~ w[1, j])
+        push!(eqs, 0 ~ w[n, j])
+    end
+    @named sys2d = System(eqs, t, vec(collect(w)), [])
+    sys2d = complete(sys2d)
+    w0 = [sinpi(x) * sinpi(y) for x in range(0, 1, length = n), y in range(0, 1, length = n)]
+
+    prob = ODEProblem(sys2d, [w => w0], (0.0, 0.01); build_initializeprob = false)
+    @test length(prob.u0) == n * n
+    @test count(isone, prob.f.mass_matrix) == (n - 2)^2
+    du = zeros(n * n)
+    prob.f(du, prob.u0, prob.p, 0.0)
+    @test all(isfinite, du)
+
+    # same rows as the scalarized equations
+    @named ssys = System(scalarize_array_equations(eqs), t, vec(collect(w)), [])
+    ssys = complete(ssys)
+    sprob = ODEProblem(ssys, [w => w0], (0.0, 0.01); build_initializeprob = false)
+    @test sprob.f.mass_matrix == prob.f.mass_matrix
+    sdu = zeros(n * n)
+    sprob.f(sdu, sprob.u0, sprob.p, 0.0)
+    @test sdu ≈ du
+
+    sol = solve(prob, Rodas5P())
+    @test SciMLBase.successful_retcode(sol)
+end
+
+@testset "symbolic jacobian and sparsity from array equations" begin
+    n = 11
+    sys, u, t, D = heat_array_system(n, :explicit)
+    sys = complete(sys)
+    u0 = sinpi.(range(0.0, 1.0, length = n))
+    prob = ODEProblem(
+        sys, [u => u0], (0.0, 0.1);
+        jac = true, sparse = true, build_initializeprob = false
+    )
+    J = similar(prob.f.jac_prototype)
+    prob.f.jac(J, prob.u0, prob.p, 0.0)
+    # tridiagonal interior rows plus the two boundary rows
+    @test size(J) == (n, n)
+    @test nnz(J) == 3 * (n - 2) + 2
+    dx = 1 / (n - 1)
+    @test J[2, 1] ≈ 1 / dx^2
+    @test J[2, 2] ≈ -2 / dx^2
+    @test J[1, 1] ≈ 1
+    sol = solve(prob, Rodas5P(); reltol = 1.0e-8, abstol = 1.0e-8, saveat = [0.1])
+    @test SciMLBase.successful_retcode(sol)
+end
+
+@testset "`full_equations` expands array equations into rows" begin
+    n = 7
+    for form in (:explicit, :residual)
+        sys, u, t, D = heat_array_system(n, form)
+        sys = complete(sys)
+        eqs = full_equations(sys)
+        @test length(eqs) == n
+        @test all(eq -> !Symbolics.isarraysymbolic(eq.lhs), eqs)
+        # the residual form is rewritten to `D(u[i]) ~ f_i`
+        @test all(isequal(D(u[i]), eqs[i].lhs) for i in 2:(n - 1))
+    end
+end
+
+@testset "invalid array differential equations are rejected" begin
+    @independent_variables t
+    @variables u(t)[1:4]
+    D = Differential(t)
+    opts = GeneratedFunctionOptions(; expression = Val{true})
+
+    # a derivative that appears both in a slice and on its own
+    @named dup = System([D(u[1:3]) ~ -u[1:3], D(u[3]) ~ 0, 0 ~ u[4]], t, collect(u), [])
+    @test_throws ["LHS operator must be unique"] generate_rhs(complete(dup), opts)
+
+    # a slice whose elements are not all unknowns
+    @named notunknown = System([D(u[1:3]) ~ -u[1:3]], t, collect(u[1:2]), [])
+    @test_throws ["not a valid LHS"] generate_rhs(complete(notunknown), opts)
+
+    # array unknowns still need `mtkcompile`
+    @named arrunknown = System([D(u) ~ -u], t, [u], [])
+    @test_throws ["array unknowns"] ODEProblem(
+        complete(arrunknown), [u => ones(4)], (0.0, 1.0); build_initializeprob = false
+    )
+end

--- a/lib/ModelingToolkitBase/test/odesystem.jl
+++ b/lib/ModelingToolkitBase/test/odesystem.jl
@@ -1360,16 +1360,16 @@ end
 @testset "Issue #2597" begin
     @variables x(t)[1:2] = ones(2) y(t) = 1.0
 
+    # `ODEProblem` accepts the array equation `D(x) ~ x` from `complete`, but the
+    # unknowns must be scalars: the array unknown `x` still needs `mtkcompile`.
     for eqs in [D(x) ~ x, collect(D(x) .~ x)]
         for dvs in [[x], collect(x)]
             @named sys = System(eqs, t, dvs, [])
             sys = complete(sys)
-            if eqs isa Vector && length(eqs) == 2 && length(dvs) == 2
+            if length(dvs) == 2
                 @test_nowarn ODEProblem(sys, [], (0.0, 1.0))
             else
-                @test_throws [
-                    r"array (equations|unknowns)", "mtkcompile", "scalarize",
-                ] ODEProblem(
+                @test_throws ["array unknowns", "mtkcompile", "scalarize"] ODEProblem(
                     sys, [], (0.0, 1.0)
                 )
             end
@@ -1379,12 +1379,10 @@ end
         for dvs in [[x, y], [x..., y]]
             @named sys = System(eqs, t, dvs, [])
             sys = complete(sys)
-            if eqs isa Vector && length(eqs) == 3 && length(dvs) == 3
+            if length(dvs) == 3
                 @test_nowarn ODEProblem(sys, [], (0.0, 1.0))
             else
-                @test_throws [
-                    r"array (equations|unknowns)", "mtkcompile", "scalarize",
-                ] ODEProblem(
+                @test_throws ["array unknowns", "mtkcompile", "scalarize"] ODEProblem(
                     sys, [], (0.0, 1.0)
                 )
             end

--- a/lib/ModelingToolkitBase/test/runtests.jl
+++ b/lib/ModelingToolkitBase/test/runtests.jl
@@ -86,6 +86,8 @@ end
 
     if GROUP == "All" || GROUP == "InterfaceII"
         @safetestset "Code Generation Test" include("code_generation.jl")
+        @safetestset "Array Equation DAEProblem Test" include("array_equation_dae.jl")
+        @safetestset "Array Equation ODEProblem Test" include("array_equation_ode.jl")
         @safetestset "IndexCache Test" include("index_cache.jl")
         @safetestset "Variable Utils Test" include("variable_utils.jl")
         @safetestset "Variable Metadata Test" include("test_variable_metadata.jl")


### PR DESCRIPTION
## Summary

Rewritten (no longer stacked on #5100, which is closed): this PR makes `ODEProblem(complete(sys), ...)` work for systems whose differential equations are written over array slices, the same way `DAEProblem` already does, without `mtkcompile` and without any new keyword.

For a finite-difference discretization such as `D(u[2:(n - 1)]) ~ lap(u)` (or the residual form `D(u[2:(n - 1)]) .- lap(u) ~ 0` that MethodOfLines emits), `ODEProblem` used to throw "The system has array equations. Call `mtkcompile`", and `mtkcompile` scalarizes, so the generated code and compile time grow with `n`. Now the array equation stays one equation and the generated function is independent of `n`.

Making `mtkcompile` (tearing / index reduction) keep array equations intact is separate work; this PR stops at `complete` → `ODEProblem`.

### What changes (all in ModelingToolkitBase)

- `generate_rhs` (explicit ODE branch): array equations are rewritten to `D(x) ~ f` (`explicit_array_derivative_form`, which handles `D(x) .- f ~ 0` and `D(x) .+ g ~ 0`), then the right-hand sides are packed into `du` with `array_residual_maker` — the same contiguous-region assembly the implicit-DAE path uses. `check_lhs` accepts `D(x)` where `x` is an array or slice whose elements are all unknowns; `check_operator_variables` checks uniqueness of the derivatives element-wise, so `D(u[1:3])` together with `D(u[3])` is still rejected.
- `calculate_massmatrix` gives an array equation one row per element (identity rows for differential equations, zero rows for `zeros(n) ~ g`), laid out like the generated code.
- `__process_SciMLProblem` skips the array-equation check for `ODEFunction` constructors (array *unknowns* are still rejected: pass `collect(u)` as unknowns, as for `DAEProblem`).
- `full_equations` expands array equations into scalar rows (after the residual → explicit rewrite), so the symbolic jacobian, sparsity pattern, `tgrad` and the initialization system see one equation per row. `jac = true, sparse = true` and the default initialization problem work from such systems.
- `ODEFunction` only computes `W_sparsity` when `sparse` or `sparsity` is set; it was computed unconditionally and is an O(n) symbolic computation that nothing consumed otherwise.
- `build_explicit_observed_function` records the element derivatives of a slice equation instead of calling `default_toterm` on `D(u[2:4])` (which has no `toterm` name and threw).

### Example

```julia
using ModelingToolkit, OrdinaryDiffEqRosenbrock
using ModelingToolkit: t_nounits as t, D_nounits as D

n = 96
@variables u(t)[1:n]
dx = 1 / (n - 1)
lap = (u[1:(n - 2)] .- 2 .* u[2:(n - 1)] .+ u[3:n]) ./ dx^2
@named heat = System([0 ~ u[1], D(u[2:(n - 1)]) ~ lap, 0 ~ u[n]], t, collect(u), [])
sys = complete(heat)

prob = ODEProblem(sys, [u => sinpi.(range(0, 1, length = n))], (0.0, 0.1))
prob.f.mass_matrix   # Diagonal([0, 1, ..., 1, 0])
sol = solve(prob, Rodas5P())
```

`D(u) ~ -u` over a whole array gives `mass_matrix === I` and solves with `Tsit5`.

### Tests

`lib/ModelingToolkitBase/test/array_equation_ode.jl` (new; `array_equation_dae.jl` is also now wired into `runtests.jl`):
- `D(u) ~ -u` from `complete`: `mass_matrix === I`, in-place and out-of-place functions, solution with `Tsit5`, with and without the default initialization problem;
- heat equation over a slice in explicit and residual form: diagonal mass matrix, `du` equals the discrete Laplacian, solution matches the analytic solution, the `mtkcompile` path and a hand-scalarized `complete` path to `1e-10`, default initialization works;
- the generated in-place and out-of-place `Expr`s have the same node count for `n = 24, 48, 96` and contain no `array_literal`;
- a 2D slice `D(w[2:n-1, 2:n-1]) ~ lap` matches the scalarized system row for row;
- `jac = true, sparse = true` gives the tridiagonal-plus-boundary pattern and solves;
- `full_equations` returns `n` scalar rows for both forms;
- duplicated derivatives, slices with non-unknown elements and array unknowns are rejected.

Checked separately against the real (tearing) `mtkcompile` from ModelingToolkit for `n = 21, 41`: `complete` → `ODEProblem` → `Rodas5P` agrees with `mtkcompile` → `ODEProblem` → `Tsit5` to `2e-11`, with and without the initialization problem.

### Notes

- Algebraic equations from `complete` still have to be written `0 ~ g` (as before for scalar systems); `u[1] ~ 0` keeps raising "The LHS cannot contain nondifferentiated variables". MethodOfLines emits its boundary conditions in the latter form, so its `ODEProblem` path needs either that rewrite on the MethodOfLines side or a follow-up here.
- Initialization from array equations is built from the scalarized rows, so it is correct but not O(1) in `n`; `build_initializeprob = false` gives the O(1) construction.

Made with [Cursor](https://cursor.com)