### PR TITLE
Release ModelingToolkit 11.42.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ModelingToolkit"
 uuid = "961ee093-0014-501f-94e3-6117800e7a78"
-version = "11.42.0"
+version = "11.42.1"
 authors = ["Yingbo Ma <mayingbo5@gmail.com>", "Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
 
 [deps]


### PR DESCRIPTION
Bumps `ModelingToolkit` 11.42.0 -> 11.42.1 (patch).

Source files changed since 11.42.0:
- `src/structural_transformation/symbolics_tearing.jl`
- `src/systems/codegen.jl`

Commits:
- Fixes to better support 32-bit builds (#5060)
- Add 32-bit InterfaceI CI lane via test_groups.toml (#5092)
- Mark `InitializationMetadata` inactive for Enzyme (#5094)
- Require Symbolics 7.39.1 (32-bit hash fix) (#5096)
- Qualify unbound_inputs @ref in the interactive simulation tutorial (#5099)

Version bump only; no code changes in this PR.


🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-opus-5[1m])

https://claude.ai/code/session_014FEzNTLFutCmTEAZ3zBg5R
