### PR TITLE
Release ModelingToolkitBase 1.69.1

### DIFF
--- a/lib/ModelingToolkitBase/Project.toml
+++ b/lib/ModelingToolkitBase/Project.toml
@@ -1,7 +1,7 @@
 name = "ModelingToolkitBase"
 uuid = "7771a370-6774-4173-bd38-47e70ca0b839"
 authors = ["Yingbo Ma <mayingbo5@gmail.com>", "Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
-version = "1.69.0"
+version = "1.69.1"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"


### PR DESCRIPTION
Bumps `ModelingToolkitBase` 1.69.0 -> 1.69.1 (patch).

Source files changed since 1.69.0:
- `src/ModelingToolkitBase.jl`
- `src/discretedomain.jl`
- `src/systems/codegen.jl`

Commits:
- Keep the system tspan through SDE structural simplification (#5091)
- Fixes to better support 32-bit builds (#5060)
- Add 32-bit InterfaceI CI lane via test_groups.toml (#5092)
- Mark `InitializationMetadata` inactive for Enzyme (#5094)
- Require Symbolics 7.39.1 (32-bit hash fix) (#5096)
- Qualify unbound_inputs @ref in the interactive simulation tutorial (#5099)

Version bump only; no code changes in this PR.


🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-opus-5[1m])

https://claude.ai/code/session_014FEzNTLFutCmTEAZ3zBg5R
