### PR TITLE
Add AGENTS.md with code generation conventions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,46 @@
+# AGENTS.md
+
+Repository-specific conventions for ModelingToolkit.jl. See `CONTRIBUTING.md` for the
+style and formatting rules that apply to every SciML repository.
+
+## Code generation
+
+### Never `gensym` a name that ends up in generated code
+
+Names embedded in an `Expr` that is handed to `eval_or_rgf` / `RuntimeGeneratedFunction`
+must be fixed symbols, not `gensym`s. A `gensym` embeds a process-global counter, so the
+same system lowers to a different `Expr` in the precompile process than in the user
+session. That defeats the `RuntimeGeneratedFunctions` Expr-hash cache: precompiled bodies
+are never hit, every `Expr` is a distinct type, and constructing the same problem twice
+recompiles the generated function.
+
+Use a fixed sentinel instead, prefixed `__mtk_` (see `generated_argument_name`) or
+suffixed `ₘₜₖ` (see `HOMOTOPY_LAMBDA`, `__log_assertions_ₘₜₖ`). Both make a collision with
+a user-chosen symbol implausible; where a collision would silently produce wrong code
+rather than an error, guard against it explicitly as `lower_homotopy` does.
+
+`gensym` remains fine for names that never reach generated code, such as the default
+`name` of a system built by `modelingtoolkitize`.
+
+### Build `Expr`s by pushing, not splatting
+
+Prefer `push!`/`append!` onto `expr.args` over `Expr(head, xs...)`. The splat is a
+dynamic call whose argument count is unknown to the compiler, so it inflates codegen time
+and infers poorly:
+
+```julia
+# no
+Expr(:tuple, buffers...)
+
+# yes
+tup = Expr(:tuple)
+append!(tup.args, buffers)
+```
+
+### Keep codegen-side containers concretely typed vectors
+
+Collections that codegen iterates over — parameter groups, buffer lists, argument lists —
+should be a concretely typed `Vector`, not a tuple of tuples. Tuples force the whole
+surrounding loop to specialize on the shape of each individual system, which is
+catastrophic for inference and compile time. Reserve tuples for values that genuinely
+need to be heterogeneous or statically sized in the *generated* code.


### PR DESCRIPTION
## What changed and why

Adds a root `AGENTS.md` — the repository had none. It records three code-generation
conventions raised in review of https://github.com/SciML/ModelingToolkit.jl/pull/5045:

1. **Never `gensym` a name that ends up in generated code.** A `gensym` embeds a
   process-global counter, so the same system lowers to a different `Expr` in the
   precompile process than in the user session, defeating the
   `RuntimeGeneratedFunctions` Expr-hash cache. Use a fixed sentinel (`__mtk_` prefix
   as in `generated_argument_name`, or the `ₘₜₖ` suffix as in `HOMOTOPY_LAMBDA`).
2. **Build `Expr`s by pushing onto `args`, not splatting.**
3. **Keep codegen-side containers concretely typed vectors, not tuples of tuples.**

@ChrisRackauckas asked for the `gensym` rule to be written down in
https://github.com/SciML/ModelingToolkit.jl/pull/5045#discussion_r3977935020 ("Yeah we
do want to avoid gensym, good catch, should probably agents.md that"). The other two
come from @AayushSabharwal's review comments on the same PR.

The `gensym` claim is not just style — it is measured. On #5045, before that PR's
`gensym`s were replaced with fixed sentinels, building the same system twice produced
two distinct `RuntimeGeneratedFunction` types:

```text
RuntimeGeneratedFunction{(Symbol("##problem#280"), Symbol("##initialization_solution#281")), …, (0x8298bbd3, 0xbcbc4d5b, 0x7a096718, 0x43533499, 0x57e4022b), Nothing}
RuntimeGeneratedFunction{(Symbol("##problem#287"), Symbol("##initialization_solution#288")), …, (0x44632bf6, 0x42fe7ec6, 0x4d5618c1, 0xb6d83a49, 0x2afa037a), Nothing}
```

After the fixed sentinels, the two types are identical.

## Verification

Documentation only — no code changes, so no test suite applies.

```sh
$ typos AGENTS.md
$ echo $?
0
$ git diff --check
```

## What I did not verify

Nothing was run beyond `typos` and `git diff --check`; there is no executable content
in this PR. No docs build was run — `AGENTS.md` is not part of the rendered
documentation.

## Anything a reviewer should push back on

- Whether the root is the right home for this, versus a nested `AGENTS.md` under
  `lib/ModelingToolkitBase/src/systems/`. The rules are about codegen specifically, but
  codegen lives in more than one directory.
- The `gensym` rule carves out an exception for names that never reach generated code
  (e.g. the default `name` of a `modelingtoolkitize`d system). If that exception is
  wrong, the wording needs tightening — `src/systems/problem_utils.jl:2638` and
  `src/systems/abstractsystem.jl` still `gensym` in places I have not audited.

**Ignore this draft until reviewed by @ChrisRackauckas.**

🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-opus-5[1m])

https://claude.ai/code/session_01GdSpCLd7NBZuuePJmcDzU7