### PR TITLE
Fall back to the solver default when an integrator carries no tolerances

### DIFF
--- a/lib/ModelingToolkitBase/src/systems/callbacks.jl
+++ b/lib/ModelingToolkitBase/src/systems/callbacks.jl
@@ -921,6 +921,9 @@ residuals floor at the same roundoff level the ODE solver already lives with; ho
 affect solve to a tighter tolerance than the integration itself makes a solvable callback
 report as unsolvable.
 
+Not every integrator has tolerances at all: `JumpProcesses`' `SSAIntegrator` stores `opts` as
+`(callback = ...,)`, so the field is simply absent and the nonlinear solver's default is used.
+
 Two values need translating before the nonlinear solver can be given them:
 
   - `false` is what `OrdinaryDiffEqCore` stores for a tolerance that was not supplied under a
@@ -937,7 +940,9 @@ Two values need translating before the nonlinear solver can be given them:
     integration.
 """
 function affect_tolerance(integ, name::Symbol)
-    tol = getproperty(integ.opts, name)
+    opts = integ.opts
+    hasproperty(opts, name) || return nothing
+    tol = getproperty(opts, name)
     tol isa Bool && return nothing
     tol isa AbstractArray && return isempty(tol) ? nothing : minimum(tol)
     return tol

--- a/lib/ModelingToolkitBase/test/jumpsystem.jl
+++ b/lib/ModelingToolkitBase/test/jumpsystem.jl
@@ -1678,3 +1678,22 @@ end
         k, [X => 3], [X => -3, Y => 1]; scale_rates = true
     )
 end
+
+@testset "Implicit affect on an SSA integrator" begin
+    @parameters d
+    @variables A(t) B(t) Bobs(t)
+
+    # `A ~ Pre(A) / 2` is not mass-action so it stays a callback affect, and it does not
+    # write `B`, leaving the appended observed equation algebraic: hence an `ImplicitAffect`.
+    j = ConstantRateJump(d * A, [A ~ Pre(A) / 2])
+    @named js = JumpSystem([j], t, [A, B], [d], observed = [Bobs ~ 2 * B])
+    js = complete(js)
+    jprob = JumpProblem(
+        js, [A => 100.0, B => 3.0, d => 1.0], (0.0, 10.0); aggregator = Direct(), rng
+    )
+
+    sol = solve(jprob, SSAStepper())
+    @test SciMLBase.successful_retcode(sol)
+    @test sol[A][end] < sol[A][1]
+    @test all(sol[Bobs] .≈ 2 .* sol[B])
+end

--- a/lib/ModelingToolkitBase/test/symbolic_events.jl
+++ b/lib/ModelingToolkitBase/test/symbolic_events.jl
@@ -1568,6 +1568,10 @@ if @isdefined(ModelingToolkit)
         @test affect_tolerance((; opts = (; abstol = 1.0e-8)), :abstol) == 1.0e-8
         @test affect_tolerance((; opts = (; abstol = [1.0e-6, 1.0e-9])), :abstol) == 1.0e-9
         @test affect_tolerance((; opts = (; abstol = Float64[])), :abstol) === nothing
+        # An `SSAIntegrator` has no tolerances at all: its `opts` is `(callback = ...,)`.
+        ssa_opts = (; opts = (; callback = nothing))
+        @test affect_tolerance(ssa_opts, :abstol) === nothing
+        @test affect_tolerance(ssa_opts, :reltol) === nothing
     end
 end
 


### PR DESCRIPTION
## What changed and why

`ModelingToolkitBase` master is red: `lib/ModelingToolkitBase` `InterfaceII` fails on Julia 1, lts and pre with

```
JumpSystem Test: Error During Test
  LoadError: FieldError: type NamedTuple has no field `abstol`, available fields: `callback`
  [2] affect_tolerance @ lib/ModelingToolkitBase/src/systems/callbacks.jl:939
```

(master run https://github.com/SciML/ModelingToolkit.jl/actions/runs/34284400093, `jumpsystem.jl:109`).

`affect_tolerance` reads `integ.opts.abstol` / `.reltol` directly. The second commit of
https://github.com/SciML/ModelingToolkit.jl/pull/5080 dropped the `hasproperty` guards on the
premise that "every SciMLBase integrator carries `.opts` with `abstol`/`reltol`". `JumpProcesses`'
`SSAIntegrator` does not: it stores

```julia
opts = (callback = CallbackSet(callback),)
```

(`JumpProcesses/src/SSA_stepper.jl:236`) — a plain `NamedTuple` with no tolerances at all. Any
`ImplicitAffect` fired from an SSA solve therefore threw `FieldError` instead of running.

The fix returns `nothing` when the tolerance field is absent, which is what the rest of the
function already does for the "no usable tolerance" cases and is the pre-#5080 behaviour
(the nonlinear solver's own default). #5080's intent is untouched for every integrator that does
carry tolerances.

## Verification

Julia 1.12.7, local checkout of master at `88d9ad9300`.

### Failing before the fix

The new `jumpsystem.jl` testset, run against the unmodified `callbacks.jl` (fix stashed):

```
Implicit affect on an SSA integrator: Error During Test at string:1
  Got exception outside of a @test
  FieldError: type NamedTuple has no field `abstol`, available fields: `callback`
  Stacktrace:
   [2] affect_tolerance @ lib/ModelingToolkitBase/src/systems/callbacks.jl:940 [inlined]
   ...
Test Summary:                        | Error  Total   Time
Implicit affect on an SSA integrator |     1      1  22.0s
```

The two new `affect_tolerance` cases in `symbolic_events.jl`, same unmodified source:

```
affect_tolerance on an SSA-shaped integrator: Error During Test
  Expression: affect_tolerance(ssa_opts, :abstol) === nothing
  FieldError: type NamedTuple has no field `abstol`, available fields: `callback`
affect_tolerance on an SSA-shaped integrator: Error During Test
  Expression: affect_tolerance(ssa_opts, :reltol) === nothing
  FieldError: type NamedTuple has no field `reltol`, available fields: `callback`
Test Summary:                                | Error  Total  Time
affect_tolerance on an SSA-shaped integrator |     2      2  1.6s
```

### Passing after the fix

```
Test Summary:                        | Pass  Total   Time
Implicit affect on an SSA integrator |    3      3  28.4s

Test Summary:                                | Pass  Total  Time
affect_tolerance on an SSA-shaped integrator |    2      2  0.0s
```

### Test groups

All three green, on the branch head:

```
# lib/ModelingToolkitBase, GROUP=InterfaceII  (the group that is red on master)
JumpSystem Test | 4207   4207  9m51.8s
3670.69 seconds
     Testing ModelingToolkitBase tests passed

# lib/ModelingToolkitBase, GROUP=InterfaceI
2448.19 seconds
     Testing ModelingToolkitBase tests passed

# repo root, GROUP=InterfaceI  (runs symbolic_events.jl with ModelingToolkit loaded)
Test Summary: | Pass  Broken  Total      Time
InterfaceI    | 1509       3   1512  46m49.5s
     Testing ModelingToolkit tests passed
```

Zero `Error During Test` / `Test Failed` lines in either MTKBase log. The 3 `Broken` in the root
group are pre-existing `@test_broken`s, untouched here.

### Formatting / spelling

```
julia -m Runic --check lib/ModelingToolkitBase/src/systems/callbacks.jl \
    lib/ModelingToolkitBase/test/jumpsystem.jl lib/ModelingToolkitBase/test/symbolic_events.jl
# exit 0
typos <the same three files>
# exit 0
```

## What I did not verify

- Julia lts and pre — ran on 1.12.7 only.
- `QA` (Aqua/JET), Downgrade, Downstream, GPU and docs jobs: not run. The MTKBase `QA` job is red
  on master for an unrelated reason (see below); `affect_tolerance` is unchanged in signature and
  gains only a `hasproperty` check, so it should not move the JET count, but I did not measure it.
- Every other MTKBase test group (`Core`, `Initialization`, `SymbolicIndexing`, …) and the other
  root groups.

## Note for reviewers

- The `symbolic_events.jl` addition sits inside a testset gated on `@isdefined(ModelingToolkit)`,
  so it runs in the root MTK `InterfaceI` group rather than in the MTKBase one.
- Unrelated and pre-existing: the MTKBase `QA` job is also red on master (JET, "234 possible
  errors found"). It is tracked in https://github.com/SciML/ModelingToolkit.jl/issues/5063 and
  blocked on https://github.com/Roger-luo/Moshi.jl/pull/93; nothing here touches it.

**This PR should be ignored until reviewed by @ChrisRackauckas.**

🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-opus-5[1m], harness: Claude Code 2.1.267)

https://claude.ai/code/session_01FeJYXni9MkJhPFA9yxYvfn
