### PR TITLE
Release ModelingToolkitBase 1.69.2

### DIFF
--- a/lib/ModelingToolkitBase/Project.toml
+++ b/lib/ModelingToolkitBase/Project.toml
@@ -1,7 +1,7 @@
 name = "ModelingToolkitBase"
 uuid = "7771a370-6774-4173-bd38-47e70ca0b839"
 authors = ["Yingbo Ma <mayingbo5@gmail.com>", "Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
-version = "1.69.1"
+version = "1.69.2"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"


### PR DESCRIPTION
Bumps `ModelingToolkitBase` 1.69.1 -> 1.69.2 (patch).

Source files changed since 1.69.1:
- `src/systems/callbacks.jl`

Commits:
- Add AGENTS.md with code generation conventions (#5105)
- Fall back to the solver default when an integrator carries no tolerances (#5106)

Version bump only; no code changes in this PR.


🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-opus-5[1m])

https://claude.ai/code/session_014FEzNTLFutCmTEAZ3zBg5R
