### PR TITLE
Add `weights` kwarg for multi-cost scalarization in OptimizationProblem

### DIFF
--- a/lib/ModelingToolkitBase/src/problems/docs.jl
+++ b/lib/ModelingToolkitBase/src/problems/docs.jl
@@ -288,6 +288,16 @@ const CONSJ_KWARGS = """
   constraints.
 """
 
+const WEIGHTS_KWARGS = """
+- `weights`: An optional vector of weights for scalarizing a system with multiple costs.
+  If provided, the generated objective is `sum(weights .* get_costs(sys))` plus the
+  recursively consolidated costs of all subsystems, replacing the system's `consolidate`
+  function for this lowering. `weights` must have one entry per top-level cost of `sys`.
+  Entries may be real numbers or symbolic parameters of `sys`; symbolic weights must be
+  declared as `@parameters` of the system so that they are part of the parameter object
+  and can be updated via `remake` between solves.
+"""
+
 const CONSSPARSE_KWARGS = """
 - `cons_sparse`: Identical to the `sparse` keyword, but specifically for jacobian/hessian
   functions of the constraints.

--- a/lib/ModelingToolkitBase/src/problems/optimizationproblem.jl
+++ b/lib/ModelingToolkitBase/src/problems/optimizationproblem.jl
@@ -1,4 +1,4 @@
-"""$(function_docstring(OptimizationFunction, false, [:jac, :grad, :hess, :cons_h, :cons_j]))"""
+"""$(function_docstring(OptimizationFunction, false, [:jac, :grad, :hess, :cons_h, :cons_j]; extra_kwargs = WEIGHTS_KWARGS))"""
 function SciMLBase.OptimizationFunction(sys::System, args...; kwargs...)
     return OptimizationFunction{true}(sys, args...; kwargs...)
 end
@@ -11,14 +11,16 @@ function SciMLBase.OptimizationFunction{iip}(
         linenumbers = true, eval_expression = false,
         eval_module = @__MODULE__,
         simplify = false, check_compatibility = true, checkbounds = false,
-        expression = Val{false}, optimize = nothing,
+        expression = Val{false}, optimize = nothing, weights = nothing,
         compiler_options::CompilerOptions = CompilerOptions(), kwargs...
     ) where {iip}
     opts = SciMLFunctionOptions(;
         u0, p, t, sparse, simplify, expression, check_compatibility,
         eval_expression, eval_module, compiler_options, checkbounds, optimize, kwargs...,
     )
-    return OptimizationFunction{iip}(sys, opts; grad, hess, cons_j, cons_h, cons_sparse)
+    return OptimizationFunction{iip}(
+        sys, opts; grad, hess, cons_j, cons_h, cons_sparse, weights
+    )
 end
 
 """
@@ -30,10 +32,14 @@ Public entry point that builds an `OptimizationFunction` directly from a pre-ass
 function SciMLBase.OptimizationFunction{iip}(
         sys::System, opts::SciMLFunctionOptions{E};
         grad::Bool = false, hess::Bool = false, cons_j::Bool = false, cons_h::Bool = false,
-        cons_sparse::Bool = false
+        cons_sparse::Bool = false, weights = nothing
     ) where {iip, E}
     check_complete(sys, OptimizationFunction)
     opts.check_compatibility && check_compatible_system(OptimizationFunction, sys)
+
+    if weights !== nothing
+        sys = system_with_cost_weights(sys, weights)
+    end
 
     cstr = constraints(sys)
 
@@ -105,7 +111,7 @@ function SciMLBase.OptimizationFunction{iip}(
     return maybe_codegen_scimlfn(Val{E}, OptimizationFunction{iip}, args; kwargs...)
 end
 
-"""$(problem_docstring(SciMLBase.OptimizationProblem, OptimizationFunction, false; init = false))"""
+"""$(problem_docstring(SciMLBase.OptimizationProblem, OptimizationFunction, false; init = false, extra_kwargs = WEIGHTS_KWARGS))"""
 function SciMLBase.OptimizationProblem(sys::System, args...; kwargs...)
     return OptimizationProblem{true}(sys, args...; kwargs...)
 end
@@ -178,4 +184,67 @@ function check_compatible_system(
     check_no_jumps(sys, T)
     check_no_noise(sys, T)
     return check_no_equations(sys, T)
+end
+
+"""
+    $(TYPEDSIGNATURES)
+
+Return a `consolidate` function computing `sum(weights .* costs)` plus the sum of the
+consolidated `subcosts` of all subsystems. See [`system_with_cost_weights`](@ref).
+"""
+function weighted_consolidate(weights)
+    ws = unwrap.(weights)
+    return function (costs, subcosts)
+        return _sum_costs(SymbolicT[w * c for (w, c) in zip(ws, costs)]) +
+            _sum_costs(subcosts)
+    end
+end
+
+"""
+    $(TYPEDSIGNATURES)
+
+Return a copy of `sys` whose `consolidate` function computes the `weights`-weighted sum of
+the top-level costs of `sys` instead of deferring to the system's own `consolidate`. The
+costs of subsystems are still consolidated recursively by their own `consolidate` and
+added to the result.
+
+`weights` must have one entry per top-level cost of `sys` (that is,
+`length(weights) == length(get_costs(sys))`). Entries may be real numbers or symbolic
+parameters of `sys`. Symbolic weights must be declared as parameters of `sys` so that
+they are discoverable in the parameter object (`prob.p`) and can be updated via `remake`
+between solves.
+"""
+function system_with_cost_weights(sys::System, weights)
+    weights isa AbstractVector || throw(
+        ArgumentError(
+            "`weights` must be a vector with one entry per cost of `sys`."
+        )
+    )
+    cs = get_costs(sys)
+    length(weights) == length(cs) || throw(
+        ArgumentError(
+            "Expected `weights` to have one entry per cost of `sys`, but got \
+            $(length(weights)) weights for $(length(cs)) costs."
+        )
+    )
+    for w in weights
+        # `Num <: Number`, so `unwrap` before checking for numeric weights.
+        w = unwrap(w)
+        w isa Number && continue
+        symbolic_type(w) === NotSymbolic() && throw(
+            ArgumentError(
+                "Entries of `weights` must be real numbers or symbolic parameters of \
+                `sys`; got `$w`."
+            )
+        )
+        is_parameter(sys, w) || throw(
+            ArgumentError(
+                "Symbolic weight `$w` is not a parameter of `sys`. Declare it via \
+                `@parameters` in the system so that it can be provided and updated \
+                through the parameter object."
+            )
+        )
+    end
+    @set! sys.consolidate = weighted_consolidate(weights)
+    return sys
 end

--- a/lib/ModelingToolkitBase/test/optimization/optimizationsystem.jl
+++ b/lib/ModelingToolkitBase/test/optimization/optimizationsystem.jl
@@ -471,3 +471,48 @@ end
     prob.f.hess(iip_hess, prob.u0, prob.p)
     @test iip_hess ≈ symbolic_hess_value
 end
+
+@testset "Multi-cost `weights`" begin
+    @variables x
+    @parameters w1 w2
+    costs = [(x - 1)^2, (x - 2)^2]
+
+    sys = complete(OptimizationSystem(costs, [x], []; name = :wsys))
+    prob = OptimizationProblem(sys, [x => 0.0]; weights = [1, 3], grad = true)
+    # objective is (x - 1)^2 + 3 * (x - 2)^2, minimized at (1 + 3 * 2) / (1 + 3)
+    @test prob.f.f([1.5], prob.p) ≈ 1.0 * (0.5)^2 + 3 * (0.5)^2
+    sol = solve(prob, Optim.LBFGS())
+    @test sol.u[1] ≈ 1.75 atol = 1.0e-4
+
+    # `weights` is also accepted by `OptimizationFunction` and affects grad/hess
+    f = OptimizationFunction{false}(sys; grad = true, hess = true, weights = [1, 3])
+    @test f.f([1.5], nothing) ≈ 1.0
+    @test f.grad([1.5], nothing) ≈ [2 * (1.5 - 1) + 6 * (1.5 - 2)]
+    @test f.hess([1.5], nothing) ≈ reshape([8.0], 1, 1)
+
+    # default path is unchanged
+    prob_default = OptimizationProblem(sys, [x => 0.0]; grad = true)
+    @test prob_default.f.f([1.5], prob_default.p) ≈ 2 * (0.5)^2
+    sol_default = solve(prob_default, Optim.LBFGS())
+    @test sol_default.u[1] ≈ 1.5 atol = 1.0e-4
+
+    @test_throws ArgumentError OptimizationProblem(sys, [x => 0.0]; weights = [1.0])
+
+    # symbolic weights must be declared parameters, and are updatable via `remake`
+    ssys = complete(OptimizationSystem(costs, [x], [w1, w2]; name = :ssys))
+    @test_throws ArgumentError OptimizationProblem(
+        sys, [x => 0.0]; weights = [w1, w2]
+    )
+    sprob = OptimizationProblem(
+        ssys, [x => 0.0, w1 => 1.0, w2 => 3.0]; weights = [w1, w2], grad = true
+    )
+    @test occursin("w1", string(sprob.f.expr))
+    @test sprob.f.f([1.5], sprob.p) ≈ 1.0
+    sol = solve(sprob, Optim.LBFGS())
+    @test sol.u[1] ≈ 1.75 atol = 1.0e-4
+
+    sprob2 = remake(sprob; p = Dict(w1 => 3.0, w2 => 1.0))
+    @test sprob2.f.f([1.5], sprob2.p) ≈ 3 * (0.5)^2 + (0.5)^2
+    sol2 = solve(sprob2, Optim.LBFGS())
+    @test sol2.u[1] ≈ 1.25 atol = 1.0e-4
+end


### PR DESCRIPTION
## Summary

Adds an optional `weights` keyword to `OptimizationFunction{iip}(sys; ...)` and `OptimizationProblem(sys, op; ...)` in `lib/ModelingToolkitBase` for scalarizing systems with multiple costs, motivated by https://github.com/SciML/NeuralPDE.jl/issues/1161 (adaptive loss weighting in PINN training loops).

When `weights` is provided, the generated objective is `sum(weights .* get_costs(sys))` plus the recursively consolidated costs of all subsystems — i.e. `weights` replaces the top-level system's `consolidate` for this lowering, while subsystem costs still consolidate via their own `consolidate`. When `weights` is not provided, behavior is unchanged.

Design decisions:

- **Implementation**: inside `OptimizationFunction{iip}(sys, opts; weights)`, `system_with_cost_weights(sys, weights)` returns a copy of `sys` whose `consolidate` computes the weighted sum (via `@set!` on the `consolidate` field). Because `generate_cost`, `generate_cost_gradient`, `generate_cost_hessian`, `cost_hessian_sparsity`, and the symbolic `f.expr`/`cons_expr` all route through `cost(sys)`, the objective, its derivatives, and the recorded expression stay consistent with a single swap point. `prob.f.sys` is the weighted system, so `remake`/`cost(prob.f.sys)` reflect the weighting.
- **Symbolic weights**: entries of `weights` may be real numbers or symbolic parameters. Symbolic weights must be declared `@parameters` of `sys` (validated with a clear `ArgumentError`), which makes them discoverable in the generated parameter object — `prob.p` carries them and `remake(prob; p = Dict(w => newval))` updates the objective between solves without rebuilding the problem. This is the intended adaptive-loss mechanism.
- **Validation**: `weights` must be an `AbstractVector` with `length(weights) == length(get_costs(sys))`; non-numeric/non-symbolic entries and undeclared symbolic weights error clearly.
- **Plumbing**: `weights` flows from `OptimizationProblem` through `process_SciMLProblem`'s `kwargs...` to the `OptimizationFunction` wrapper unchanged; `SciMLFunctionOptions` drops it harmlessly and `filter_kwargs` keeps it out of `prob.kwargs`.

#### Test plan

Added `@testset "Multi-cost \`weights\`"` to `lib/ModelingToolkitBase/test/optimization/optimizationsystem.jl` covering: numeric weights on costs `[(x-1)^2, (x-2)^2]` (`weights = [1,3]` → argmin ≈ 1.75 verified by direct `prob.f.f` evaluation and an `Optim.LBFGS` solve); `weights` on `OptimizationFunction{false}` incl. consistent `grad`/`hess`; unchanged default path; length-mismatch `ArgumentError`; symbolic weights `[w1, w2]` declared as `@parameters`, solved, then re-solved via `remake(prob; p = Dict(w1 => 3.0, w2 => 1.0))` giving argmin ≈ 1.25 without rebuilding; and the undeclared-symbolic-weight `ArgumentError`.

Run output (whole file, `cd lib/ModelingToolkitBase/test/optimization && julia --project=. optimizationsystem.jl`, Julia 1.12.4):

```
Test Summary:        | Pass  Total   Time
Multi-cost `weights` |   14     14  12.6s
```

All other testsets in the file pass (exit code 0). Runic `--check` clean on the changed files; `typos` over the diff clean. Note: CasADi/Pyomo and the Python-dependent extensions fail to precompile in this environment (CondaPkg/pixi cannot reach the network), which is unrelated — the test file's own deps precompile fine.

🤖 Generated with [Devin](https://devin.ai) (harness: Devin CLI 3000.10.21, model: SWE-2 High, session: local Devin CLI session — no shareable URL)