### PR TITLE
Add constraints_to_penalties: lower constraints to quadratic penalty costs

### DIFF
--- a/docs/src/API/problems.md
+++ b/docs/src/API/problems.md
@@ -76,6 +76,7 @@ ModelingToolkit.ProblemTypeCtx
 SciMLBase.OptimizationFunction
 SciMLBase.OptimizationProblem
 SciMLBase.ODEInputFunction
+ModelingToolkit.constraints_to_penalties
 ```
 
 ## The state vector and parameter object

--- a/lib/ModelingToolkitBase/src/ModelingToolkitBase.jl
+++ b/lib/ModelingToolkitBase/src/ModelingToolkitBase.jl
@@ -404,7 +404,7 @@ export NonlinearProblem
 export AbstractNonlinearProblem
 export IntervalNonlinearFunction
 export IntervalNonlinearProblem
-export OptimizationProblem, constraints
+export OptimizationProblem, constraints, constraints_to_penalties
 export SteadyStateProblem
 export JumpProblem, SymbolicMassActionJump
 export flatten

--- a/lib/ModelingToolkitBase/src/problems/optimizationproblem.jl
+++ b/lib/ModelingToolkitBase/src/problems/optimizationproblem.jl
@@ -255,3 +255,112 @@ function system_with_cost_weights(sys::System, weights)
     @set! sys.consolidate = weighted_consolidate(weights)
     return sys
 end
+
+"""
+    constraints_to_penalties(sys::System; weights = 1.0)
+
+Return a new [`System`](@ref) in which every constraint of `sys` - including those of
+its subsystems - is removed from `constraints` and appended to `costs` as a weighted
+quadratic penalty term. This is the "classical PINN" formulation of a constrained
+problem: all constraint residuals are folded into the objective, producing an
+unconstrained system that can be solved by optimizers which do not accept explicit
+`cons`/`lcons`/`ucons` constraints.
+
+- `Equation` constraints `l ~ r` contribute `weights[i] * (l - r)^2`.
+- `Inequality` constraints contribute `weights[i] * max(residual, 0)^2`, where
+  `residual` is the constraint rewritten in canonical `residual ≲ 0` form via
+  `Symbolics.canonical_form`, so only violations of the constraint are penalized.
+
+`weights` may be a scalar applied to every constraint, or a vector with one entry per
+element of `constraints(sys)`, which orders a system's own constraints before its
+subsystems'. Symbolic weights (e.g. penalty parameters that should be tunable through
+the problem's parameter object) that are not already parameters or unknowns of the
+system are automatically added to its parameters.
+
+Penalty terms are appended to `costs(sys)` and are therefore combined with the rest of
+the objective through the system's `consolidate` function. Note that a finite `weights`
+makes the constraint satisfaction soft: increasing the magnitude of the weights enforces
+the constraints more tightly at the cost of a stiffer objective.
+
+# Example
+
+```julia
+using ModelingToolkitBase
+@variables x
+@named sys = OptimizationSystem((x - 2)^2, [x], []; constraints = [x ≲ 1])
+pen_sys = constraints_to_penalties(complete(sys); weights = 1.0e3)
+```
+"""
+function constraints_to_penalties(sys::System; weights = 1.0)
+    if weights isa Union{AbstractVector, Tuple} &&
+            length(weights) != length(constraints(sys))
+        throw(
+            ArgumentError(
+                """
+                Expected `weights` to be a scalar or have one entry per constraint of the \
+                system (including subsystem constraints). Got $(length(weights)) weights \
+                for $(length(constraints(sys))) constraints.
+                """
+            )
+        )
+    end
+    return _constraints_to_penalties(sys, weights)
+end
+
+function _constraints_to_penalties(sys::System, weights)
+    cstrs = get_constraints(sys)
+    own_weights = weights isa Union{AbstractVector, Tuple} ?
+        weights[1:length(cstrs)] : Iterators.repeated(weights, length(cstrs))
+    penalties = SymbolicT[]
+    new_ps = SymbolicT[]
+    for (cstr, w) in zip(cstrs, own_weights)
+        w = unwrap(w)
+        res = Symbolics.canonical_form(cstr).lhs
+        pen = cstr isa Equation ? w * res^2 : w * max(res, 0)^2
+        push!(penalties, value(pen))
+        _weight_parameters!(new_ps, sys, w)
+    end
+    @set! sys.costs = [get_costs(sys); penalties]
+    @set! sys.constraints = Union{Equation, Inequality}[]
+
+    subsystems = get_systems(sys)
+    if !isempty(subsystems)
+        newsystems = System[]
+        offset = length(cstrs)
+        for ssys in subsystems
+            subweights = weights
+            if weights isa Union{AbstractVector, Tuple}
+                nsub = length(constraints(ssys))
+                subweights = weights[(offset + 1):(offset + nsub)]
+                offset += nsub
+            end
+            push!(newsystems, _constraints_to_penalties(ssys, subweights))
+        end
+        @set! sys.systems = newsystems
+    end
+
+    if !isempty(new_ps)
+        @set! sys.ps = [get_ps(sys); new_ps]
+        if has_index_cache(sys) && get_index_cache(sys) !== nothing
+            # the `IndexCache` constructor reads `is_parameter` and family, so it must be
+            # cleared before rebuilding to avoid seeing the stale cache.
+            @set! sys.index_cache = nothing
+            @set! sys.index_cache = IndexCache(sys)
+        end
+    end
+    return sys
+end
+
+# Collect symbolic variables in a penalty weight that are not already parameters or
+# unknowns of `sys`, so they can be added to the system's parameters.
+function _weight_parameters!(new_ps::Vector{SymbolicT}, sys::System, w)
+    symbolic_type(w) === NotSymbolic() && return new_ps
+    for v in get_variables(w)
+        symbolic_type(v) === NotSymbolic() && continue
+        is_parameter(sys, v) && continue
+        any(Base.Fix2(isequal, v), get_unknowns(sys)) && continue
+        any(Base.Fix2(isequal, v), new_ps) && continue
+        push!(new_ps, v)
+    end
+    return new_ps
+end

--- a/lib/ModelingToolkitBase/test/optimization/optimizationsystem.jl
+++ b/lib/ModelingToolkitBase/test/optimization/optimizationsystem.jl
@@ -541,3 +541,74 @@ end
     @test sol.objective < 1.0e-8
     @test sol.u ≈ [1.0, 1.0] atol = 1.0e-4
 end
+
+@testset "constraints_to_penalties" begin
+    get_costs = ModelingToolkitBase.get_costs
+
+    # min (x - 2)^2 s.t. x <= 1: penalized argmin is (2 + w) / (1 + w)
+    @variables x
+    @named sys = OptimizationSystem((x - 2)^2, [x], []; constraints = [x ≲ 1.0])
+    sys = complete(sys)
+
+    psys = constraints_to_penalties(sys)
+    @test isempty(constraints(psys))
+    @test length(get_costs(psys)) == length(get_costs(sys)) + 1
+    @test isequal(unknowns(psys), unknowns(sys))
+    prob = OptimizationProblem(psys, [x => 0.0])
+    @test prob.lcons === nothing && prob.ucons === nothing
+    @test prob.f.cons === nothing
+    sol = solve(prob, Optim.NelderMead())
+    @test sol.u[1] ≈ 1.5 atol = 1.0e-4
+
+    # penalty magnitude scales with the weight
+    psys = constraints_to_penalties(sys; weights = 1.0e4)
+    prob = OptimizationProblem(psys, [x => 0.0])
+    sol = solve(prob, Optim.NelderMead())
+    @test sol.u[1] ≈ (2.0 + 1.0e4) / (1.0 + 1.0e4) atol = 1.0e-4
+
+    # without the penalty the unconstrained argmin is 2
+    @named usys = OptimizationSystem((x - 2)^2, [x], [])
+    usol = solve(OptimizationProblem(complete(usys), [x => 0.0]), Optim.NelderMead())
+    @test usol.u[1] ≈ 2.0 atol = 1.0e-4
+
+    # equality constraint: min (x - 2)^2 s.t. x ~ 0.5, argmin (2 + 0.5w) / (1 + w)
+    @named esys = OptimizationSystem((x - 2)^2, [x], []; constraints = [x ~ 0.5])
+    esys = complete(esys)
+    epsys = constraints_to_penalties(esys)
+    @test isempty(constraints(epsys))
+    @test length(get_costs(epsys)) == 2
+    sol = solve(OptimizationProblem(epsys, [x => 0.0]), Optim.NelderMead())
+    @test sol.u[1] ≈ 1.25 atol = 1.0e-4
+
+    # per-constraint weights
+    @variables y
+    @named msys = OptimizationSystem(
+        (x - 1)^2 + (y - 1)^2, [x, y], [];
+        constraints = [x + y ~ 0.0, y ≲ 0.25]
+    )
+    msys = complete(msys)
+    mpsys = constraints_to_penalties(msys; weights = [10.0, 2.0])
+    @test isempty(constraints(mpsys))
+    @test length(get_costs(mpsys)) == 3
+    @test_throws ArgumentError constraints_to_penalties(msys; weights = [1.0])
+
+    # symbolic weights are added to the system parameters
+    @parameters w
+    spsys = constraints_to_penalties(sys; weights = w)
+    @test any(isequal(w), parameters(spsys))
+    prob = OptimizationProblem(spsys, [x => 0.0, w => 1.0e4])
+    sol = solve(prob, Optim.NelderMead())
+    @test sol.u[1] ≈ (2.0 + 1.0e4) / (1.0 + 1.0e4) atol = 1.0e-4
+
+    # subsystem constraints are lowered recursively (`complete` flattens the
+    # hierarchy, so keep the system unflattened here)
+    @named sub = OptimizationSystem((y - 3)^2, [y], []; constraints = [y ≲ 1.5])
+    @named tpsys = OptimizationSystem(
+        (x - 2)^2, [x], []; constraints = [x ≲ 1.0], systems = [sub]
+    )
+    tpsys = constraints_to_penalties(tpsys)
+    @test isempty(constraints(tpsys))
+    @test length(get_costs(tpsys)) == 2
+    @test isempty(ModelingToolkitBase.get_constraints(only(ModelingToolkitBase.get_systems(tpsys))))
+    @test length(get_costs(only(ModelingToolkitBase.get_systems(tpsys)))) == 2
+end


### PR DESCRIPTION
## Summary

Adds `constraints_to_penalties(sys::System; weights = 1.0)` in `lib/ModelingToolkitBase`, a `System -> System` transformation that removes every constraint of `sys` (including subsystem constraints, recursively) and appends a weighted quadratic penalty term to `costs`. This is the "classical PINN" formulation of a constrained problem — all constraint residuals folded into the objective — giving an unconstrained system for optimizers that do not accept explicit `cons`/`lcons`/`ucons` constraints. It is deliberately available as an explicit alternative to the constrained-solver lowering used for e.g. Ipopt/MadNLP.

Motivation: https://github.com/SciML/NeuralPDE.jl/issues/1161

Semantics:

- `Equation` constraints `l ~ r` contribute `weights[i] * (l - r)^2`.
- `Inequality` constraints contribute `weights[i] * max(residual, 0)^2`, where `residual` is the constraint rewritten in canonical `residual ≲ 0` form via `Symbolics.canonical_form`, so only violations are penalized. `max` is a registered diadic symbolic function and codegens through `build_function` (already used in `connectors.jl`).
- `weights` may be a scalar applied to every constraint, or a vector with one entry per element of `constraints(sys)` (own constraints first, then subsystem constraints, recursively). Symbolic weights that are not already parameters or unknowns are automatically added to the system's parameters; when the system has an `IndexCache` (completed systems) it is rebuilt so the weights are tunable through the problem's parameter object.
- Penalty terms are appended to `costs(sys)` and are combined with the rest of the objective through the system's `consolidate` function.

The transform is implemented with `@set!` (the established system-rebuild pattern), so unknowns, parameters, consolidate, defaults and metadata are preserved, and a completed system stays completed.

#### Test plan

New `constraints_to_penalties` testset in `lib/ModelingToolkitBase/test/optimization/optimizationsystem.jl` (20 tests), run with `cd lib/ModelingToolkitBase/test/optimization && julia --project=. optimizationsystem.jl`:

- `min (x-2)^2` s.t. `x ≲ 1` lowered with `weights = 1.0`: `constraints` emptied, `costs` grew by 1, `OptimizationProblem` has `lcons === ucons === nothing` and `f.cons === nothing`, and unconstrained Nelder-Mead finds `x ≈ 1.5 = (2 + w)/(1 + w)` (vs `x ≈ 2` without the constraint).
- Weight scaling: `weights = 1e4` pulls the argmin to `(2 + 1e4)/(1 + 1e4) ≈ 1.0001`.
- Equality constraint `x ~ 0.5` gives the expected `argmin 1.25`.
- Vector weights distribute across constraints; wrong-length vectors throw `ArgumentError`.
- A symbolic weight is auto-added to `parameters` and is tunable via the problem's `p`.
- Subsystem constraints are lowered recursively on unflattened systems.

Observed output:

```
Test Summary:            | Pass  Total  Time
constraints_to_penalties |   20     20  6.1s
```

All other testsets in `optimizationsystem.jl` pass unchanged. Runic formatting clean (`Runic.main` `--check`/`--inplace` produced no diff) and `typos` clean over the changed files. The QA group (Aqua/ExplicitImports) passes; its JET subtest reports 234 pre-existing "possible errors" (all `##And#`/`##Call#` locals generated by Moshi `@match` in untouched files — none in `optimizationproblem.jl` or the new functions), which is a master pre-existing failure unrelated to this change. The docs build was not run locally; the change adds one `@docs` entry (`ModelingToolkit.constraints_to_penalties`, verified to resolve to `ModelingToolkitBase.constraints_to_penalties`).

🤖 Generated with [Devin](https://devin.ai) (harness: Devin CLI 3000.10.21, model: SWE-2 High, session: local Devin CLI session — no shareable URL)