### PR TITLE
Make split_parameters eltype assertions wordsize-agnostic (fixes x86 CI)

### DIFF
--- a/lib/ModelingToolkitBase/test/split_parameters.jl
+++ b/lib/ModelingToolkitBase/test/split_parameters.jl
@@ -13,18 +13,18 @@ using Symbolics
 x = [1, 2.0, false, [1, 2, 3], Parameter(1.0)]
 
 y = ModelingToolkitBase.promote_to_concrete(x)
-@test eltype(y) == Union{Float64, Parameter{Float64}, Vector{Int64}}
+@test eltype(y) == Union{Float64, Parameter{Float64}, Vector{Int}}
 
 y = ModelingToolkitBase.promote_to_concrete(x; tofloat = false)
-@test eltype(y) == Union{Bool, Float64, Int64, Parameter{Float64}, Vector{Int64}}
+@test eltype(y) == Union{Bool, Float64, Int, Parameter{Float64}, Vector{Int}}
 
 x = [1, 2.0, false, [1, 2, 3]]
 y = ModelingToolkitBase.promote_to_concrete(x)
-@test eltype(y) == Union{Float64, Vector{Int64}}
+@test eltype(y) == Union{Float64, Vector{Int}}
 
 x = Any[1, 2.0, false]
 y = ModelingToolkitBase.promote_to_concrete(x; tofloat = false)
-@test eltype(y) == Union{Bool, Float64, Int64}
+@test eltype(y) == Union{Bool, Float64, Int}
 
 y = ModelingToolkitBase.promote_to_concrete(x; use_union = false)
 @test eltype(y) == Float64


### PR DESCRIPTION
## Summary

`lib/ModelingToolkitBase/test/split_parameters.jl` asserts exact eltypes like `Union{Float64, Parameter{Float64}, Vector{Int64}}`. On 32-bit Julia (`InterfaceI`, `ubuntu-latest, x86`), literal arrays are `Vector{Int32}` and `promote_to_concrete` returns `Vector{Int32}` in the union, so all four assertions fail on master (`1504 passed, 4 failed`).

Assert `Int`/`Vector{Int}` — identical to `Int64`/`Vector{Int64}` on 64-bit, correct on 32-bit.

#### Test plan
- [x] Verified on Julia 1.13.0 x86: `eltype(promote_to_concrete([1, 2.0, false, [1,2,3], Parameter(1.0)])) == Union{Float64, Parameter{Float64}, Vector{Int32}}` and all four updated assertions pass
- [x] On 64-bit `Int === Int64`, so the assertions are unchanged there

🤖 Generated with Devin CLI (model: SWE-2 Max) — local session, no shareable URL