### PR TITLE
Build variable dependencies in linear rather than quadratic time

### DIFF
--- a/lib/ModelingToolkitBase/src/problems/jumpproblem.jl
+++ b/lib/ModelingToolkitBase/src/problems/jumpproblem.jl
@@ -306,4 +306,4 @@ function modified_unknowns!(munknowns, jump::MassActionJump, sts)
 end
 
 isin(sts, st) = any(isequal(st), sts)
-isin(sts::Union{AbstractSet, Base.KeySet}, st) = st in sts
+isin(sts::AbstractSet, st) = st in sts

--- a/lib/ModelingToolkitBase/src/problems/jumpproblem.jl
+++ b/lib/ModelingToolkitBase/src/problems/jumpproblem.jl
@@ -293,14 +293,17 @@ the system. Return the modified `munknowns`.
 function modified_unknowns!(munknowns, jump::Union{ConstantRateJump, VariableRateJump}, sts)
     for eq in jump.affect!
         st = eq.lhs
-        any(isequal(st), sts) && push!(munknowns, st)
+        isin(sts, st) && push!(munknowns, st)
     end
     return munknowns
 end
 
 function modified_unknowns!(munknowns, jump::MassActionJump, sts)
     for (unknown, stoich) in jump.net_stoch
-        any(isequal(unknown), sts) && push!(munknowns, unknown)
+        isin(sts, unknown) && push!(munknowns, unknown)
     end
     return munknowns
 end
+
+isin(sts, st) = any(isequal(st), sts)
+isin(sts::Union{AbstractSet, Base.KeySet}, st) = st in sts

--- a/lib/ModelingToolkitBase/src/systems/dependency_graphs.jl
+++ b/lib/ModelingToolkitBase/src/systems/dependency_graphs.jl
@@ -160,9 +160,10 @@ function variable_dependencies(
         variablestoids
 
     deps = Set()
+    sts = Set(keys(vtois))
     badjlist = Vector{Vector{Int}}(undef, length(eqs))
     for (eidx, eq) in enumerate(eqs)
-        modified_unknowns!(deps, eq, variables)
+        modified_unknowns!(deps, eq, sts)
         badjlist[eidx] = sort!([vtois[var] for var in deps])
         empty!(deps)
     end


### PR DESCRIPTION
## Summary

`variable_dependencies` is currently O(equations x unknowns). This is because it does a linear lookup over the `variables` vector for each equation instead of reusing the already computed `vtois` dict. This PR addresses this in the obvious way. Passing `Set(keys(vtois))` to `modified_unknowns!` also allows Catalyst's `modified_unknowns!(munknowns, rx::Reaction, sts::Set)` to finally be dispatched.

## Benchmark

```julia
using ModelingToolkit, JumpProcesses, BenchmarkTools
import ModelingToolkit: t_nounits as t
const MTKB = ModelingToolkit.ModelingToolkitBase

function ring_system(n)
    @variables (X(t))[1:n]
    @parameters k[1:n]
    jumps = [
        ConstantRateJump(
            k[i] * X[i] * X[max(i-1,1)],
            [X[i] ~ X[i] - 1, X[mod1(i+1,n)] ~ X[mod1(i+1,n)] + 1]
        )
        for i in 1:n
    ]
    complete(JumpSystem(jumps, t, collect(X), collect(k); name=:ring))
end

function measure(n)
    sys = ring_system(n)
    jumps = MTKB.jumps(sys)
    vars = unknowns(sys)
    vtois = Dict(MTKB.value(v) => i for (i,v) in enumerate(vars))
    @belapsed MTKB.variable_dependencies($sys; eqs = $jumps, variablestoids = $vtois) samples=5 evals=1
end

for n in (64, 128, 256, 512, 1024, 2048)
    println(n, " | ", round(measure(n) * 1e3, digits = 3))
end
```

| n    | master  | this PR |
| ---- | ------- | ------- |
| 64   | 0.357   | 0.009   |
| 128  | 1.521   | 0.019   |
| 256  | 6.081   | 0.036   |
| 512  | 24.686  | 0.077   |
| 1024 | 100.225 | 0.156   |
| 2048 | 401.530 | 0.328   |

Ran on julia 1.12.4. I ran tests on MTKBase `InterfaceI` and `InterfaceII` and checked Runic formatting. I also checked `Catalyst.get_depgraph`.

## Notes
1. The same quadratic rather than linear time issue is also present in `equation_dependencies`: it calls `get_variables!(deps, target, variables)` which rebuilds `Set(varlist)` for each equation instead of just reusing a set. I had initially tried to fix it in the same PR via:
```julia
	varset = Set(ModelingToolkit.value(v) for v in variables)
	is_atomic(ex) = SymbolicUtils.default_is_atomic(ex) && ex in varset
```
and just calling `get_variables!(deps, target; is_atomic)`. On the benchmark above at n=2048, it reduces the runtime of `equation_dependencies` from 102ms to 2ms. The problem is that Catalyst dispatches on `MTK.get_variables!(deps::Set, rx::Reaction, variables)`, so this fix would cause `Catalyst.get_depgraph` to return an empty graph silently. The proper fix is to add an `AbstractSet` method to `Symbolics._get_is_atomic` and pass `varset` positionally.

2. `modified_unknowns!` is public API so I didn't change the signature, instead introducing an internal `isin` helper. I'm not sure this is the best solution here.

## Checklist

- [X] Appropriate tests were added
- [X] Any code changes were done in a way that does not break public API
- [X] All documentation related to code changes were updated
- [X] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [X] Any new documentation only uses public API