### PR TITLE
Make tovar public

### DIFF
--- a/docs/src/API/variables.md
+++ b/docs/src/API/variables.md
@@ -345,6 +345,7 @@ variables programmatically.
 
 ```@docs
 ModelingToolkitBase.toparam
+ModelingToolkitBase.tovar
 ModelingToolkitBase.tobrownian
 ```
 

--- a/lib/ModelingToolkitBase/src/ModelingToolkitBase.jl
+++ b/lib/ModelingToolkitBase/src/ModelingToolkitBase.jl
@@ -516,7 +516,7 @@ const set_scalar_metadata = setmetadata
 @public convert_bindings_for_time_independent_system, get_w
 @public Both
 @public SymbolicADDisallowed, check_symbolic_ad_allowed
-@public tobrownian, toparam
+@public tobrownian, toparam, tovar
 @public ProblemTypeCtx
 @public HomotopyCtx, homotopy_enabled, strip_homotopy
 


### PR DESCRIPTION
> **Note:** please ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

`toparam` is public and documented; its inverse `tovar` (mark a symbolic as an unknown) was not, although downstream discretizers need it. The NeuralPDE parser rewrite (https://github.com/SciML/NeuralPDE.jl/issues/1161) uses it to promote `PDESystem` parameters to optimization unknowns for inverse problems, and ExplicitImports rejects the non-public import. This adds `tovar` to the `@public` list and to the variables API docs next to `toparam`. No code change.

## Verification

Two-line change (public declaration and a docs entry); `tovar` already has a docstring so `checkdocs` is satisfied. Not run: the ModelingToolkitBase test suite (no behavior change).

🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-fable-5-1)

https://claude.ai/code/session_01WYPUXLxE9jVu2jXLFRd8ax
