### PR TITLE
Fix getbounds for scalar bounds on array variables

### DIFF
--- a/lib/ModelingToolkitBase/src/variables.jl
+++ b/lib/ModelingToolkitBase/src/variables.jl
@@ -450,8 +450,11 @@ function getbounds(x::SymbolicT)
     bounds = getmetadata(arrx, VariableBounds, nothing)::NTuple{2, Any}
     idxs = @views unwrap_const.(arguments(x)[2:end])
     return map(bounds) do b
-        @assert !symbolic_has_known_size(arrx) || SU.shape(arrx) == SU.shape(b)
-        return b[idxs...]
+        if SU.is_array_shape(SU.shape(b))
+            @assert !symbolic_has_known_size(arrx) || SU.shape(arrx) == SU.shape(b)
+            return b[idxs...]
+        end
+        return b
     end
 end
 

--- a/lib/ModelingToolkitBase/test/test_variable_metadata.jl
+++ b/lib/ModelingToolkitBase/test/test_variable_metadata.jl
@@ -45,6 +45,16 @@ for i in eachindex(y)
     @test b[1] == -1 && b[2] == [1.0 Inf; 2.0 3.0][i]
 end
 
+# A scalar bound on an array variable applies to each element.
+@variables y[1:2, 1:2] [bounds = (-1, 1)]
+@test hasbounds(y)
+@test getbounds(y) == (-1, 1)
+for i in eachindex(y)
+    @test hasbounds(y[i])
+    @test getbounds(y[i]) == (-1, 1)
+end
+@test getbounds(y[1:2, 1]) == (-1, 1)
+
 @variables y[1:2] [bounds = (-Inf * ones(2), [1.0, Inf])]
 @test hasbounds(y)
 @test getbounds(y)[1] == [-Inf, -Inf]


### PR DESCRIPTION
## Summary

`getbounds` asserted that each bound's symbolic shape matches the array variable's shape, then indexed into the bound. A scalar bound such as `bounds = (-1, 1)` on `@variables x[1:2,1:2]` therefore threw `AssertionError` on every `getbounds(x[i, j])` — even though `docs/src/API/variables.md` documents that a scalar array bound applies to each element of the array. This also crashed `generate_nonlinear_bounds` when building nonlinear stepping data for systems with scalar-bounded array unknowns.

Only bounds that are actually array-shaped are now shape-checked and indexed; scalar bounds are returned unchanged so they apply to each element.

## Verification

Regression test added to `lib/ModelingToolkitBase/test/test_variable_metadata.jl`. Failing on unfixed code (registry MTKBase 1.70.0 / stashed fix), verified in a `ModelingToolkit v11.43.0` environment:

```text
Error During Test at none:7
  Test threw exception
  Expression: hasbounds(y[i])
  AssertionError: !(symbolic_has_known_size(arrx)) || SU.shape(arrx) == SU.shape(b)
   @ ModelingToolkitBase lib/ModelingToolkitBase/src/variables.jl:453
```

Passing with the fix — scalar bounds return `(-1, 1)` elementwise and array bounds still index correctly (`getbounds(z[1,2]) == (0, 1)` for `bounds = (fill(0,2,2), fill(1,2,2))`).

This unblocks the first of two MTKBase issues currently failing SciML/ProcessSimulator.jl CI; the second (torn-graph Jacobian sparsity shape) is covered by #5051.

Generated with Devin CLI 3000.10.21 (model: SWE-2 Max), session: /home/crackauc/.local/share/devin/cli/summaries/history_4c9fddb81d834736.md