### PR TITLE
Import SciMLBase in the OptimizationSystem test file

### DIFF
--- a/lib/ModelingToolkitBase/test/optimization/optimizationsystem.jl
+++ b/lib/ModelingToolkitBase/test/optimization/optimizationsystem.jl
@@ -1,4 +1,4 @@
-using ModelingToolkitBase, SparseArrays, Test, Optimization, OptimizationMOI,
+using ModelingToolkitBase, SciMLBase, SparseArrays, Test, Optimization, OptimizationMOI,
     Ipopt, AmplNLWriter, SymbolicIndexingInterface,
     LinearAlgebra, ADTypes, ForwardDiff
 using OptimizationOptimJL: Optim


### PR DESCRIPTION
> **Note:** this PR should be ignored until reviewed by @ChrisRackauckas.

Follow-up to https://github.com/SciML/ModelingToolkit.jl/pull/5115. The `ProblemTypeCtx` testset there calls `SciMLBase.problem_type`, but the OptimizationSystem test file never imported `SciMLBase`. Under `@safetestset` the testset runs in a fresh module, so both assertions error. The fix adds `SciMLBase` to the file's `using` line, matching the other ModelingToolkitBase test files that use it directly.

## Verification

Run in a scratch environment with `SciMLBase` dev'd at the `problem_type` branch (https://github.com/SciML/SciMLBase.jl/pull/1600, unreleased, which is why the package's own test target cannot resolve yet), by including the whole test file with only `Test` loaded, as `@safetestset` does.

**Before (file as on master):**
```
`ProblemTypeCtx` is forwarded to `OptimizationProblem`: Error During Test at /home/crackauc/sandbox/tmp_20260912_031948_64225/ModelingToolkit.jl/lib/ModelingToolkitBase/test/optimization/optimizationsystem.jl:622
  Test threw exception
  Expression: SciMLBase.problem_type(prob) == "A"
  UndefVarError: `SciMLBase` not defined in `Main`
Test Summary:                                          | Error  Total  Time
`ProblemTypeCtx` is forwarded to `OptimizationProblem` |     2      2  2.5s
```

**After (this PR):** every testset in the file passes, including the two added on master today:
```
Test Summary:            | Pass  Total  Time
constraints_to_penalties |   20     20  5.8s
Test Summary:                                          | Pass  Total  Time
`ProblemTypeCtx` is forwarded to `OptimizationProblem` |    2      2  0.6s
```

Runic and typos pass on the file. Not verified: the full MTKBase CI groups, which cannot resolve until SciMLBase 3.54 is released.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-fable-5-1)

https://claude.ai/code/session_01WYPUXLxE9jVu2jXLFRd8ax
