### PR TITLE
Release ModelingToolkit 11.43.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ModelingToolkit"
 uuid = "961ee093-0014-501f-94e3-6117800e7a78"
-version = "11.43.0"
+version = "11.43.1"
 authors = ["Yingbo Ma <mayingbo5@gmail.com>", "Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
 
 [deps]


### PR DESCRIPTION
Bumps `ModelingToolkit` 11.43.0 -> 11.43.1 (patch).

Source files changed since 11.43.0:
- `src/problems/sccnonlinearproblem.jl`

Commits:
- Add constraints_to_penalties: lower constraints to quadratic penalty costs (#5111)
- Fix QA: approve the `limited`/`constraints_to_penalties` API additions (#5116)
- Concretize initialization problems once at construction (#5062)
- Make tovar public (#5120)
- Fix SciCompDSL model macro hygiene (#5058)
- Release ModelingToolkitBase 1.71.0 (#5126)
- Forward ProblemTypeCtx metadata to OptimizationProblem (#5115)
- Release ModelingToolkitBase 1.71.1 (#5127)

Version bump only; no code changes in this PR.


🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-opus-5[1m])

https://claude.ai/code/session_014FEzNTLFutCmTEAZ3zBg5R
