### PR TITLE
Release SciCompDSL 1.0.4

### DIFF
--- a/lib/SciCompDSL/Project.toml
+++ b/lib/SciCompDSL/Project.toml
@@ -1,7 +1,7 @@
 name = "SciCompDSL"
 uuid = "91a8cdf1-4ca6-467b-a780-87fda3fff15e"
 authors = ["Aayush Sabharwal <aayush.sabharwal@gmail.com>"]
-version = "1.0.3"
+version = "1.0.4"
 
 [deps]
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"


### PR DESCRIPTION
Bumps `SciCompDSL` 1.0.3 -> 1.0.4 (patch).

Source files changed since 1.0.3:
- `src/model_parsing.jl`

Commits:
- Drop stale [compat] majors; do not admit yanked majors (#5025)
- Use Optim owner namespace in OptimizationSystem tests (#5022)
- Fix modelingtoolkitize Optim imports (#5016)
- Fix AbstractSystem interface test on Julia LTS (#5021)
- Use public owner APIs in Pyomo extension (#5020)
- Release 11.40.1 (#5029)
- Develop all MTK lib/* in Downstream CI; drop MOL_Interface2 (#5030)
- fix: use the typed `ImmutableDict` constructor in `shift2term` (#5035)
- Release ModelingToolkitBase 1.68.1 (#5036)
- Widen OrderedCollections compat for StateSelection / MTKBase resolution (#5037)

Version bump only; no code changes in this PR.


🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-opus-5[1m])

https://claude.ai/code/session_014FEzNTLFutCmTEAZ3zBg5R
